### PR TITLE
Add support for subtypes

### DIFF
--- a/src/main/java/no/unit/nva/model/EntityDescription.java
+++ b/src/main/java/no/unit/nva/model/EntityDescription.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public class EntityDescription {
 
     private PublicationType publicationType;
+    private PublicationSubtype publicationSubtype;
     private String mainTitle;
     private Map<String, String> alternativeTitles;
     private URI language;
@@ -30,6 +31,7 @@ public class EntityDescription {
 
     private EntityDescription(Builder builder) {
         setPublicationType(builder.publicationType);
+        setPublicationSubtype(builder.publicationSubtype);
         setMainTitle(builder.mainTitle);
         setAlternativeTitles(builder.alternativeTitles);
         setLanguage(builder.language);
@@ -90,35 +92,6 @@ public class EntityDescription {
         this.contributors = contributors;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        EntityDescription that = (EntityDescription) o;
-        return Objects.equals(getPublicationType(), that.getPublicationType())
-                && Objects.equals(getMainTitle(), that.getMainTitle())
-                && Objects.equals(getAlternativeTitles(), that.getAlternativeTitles())
-                && Objects.equals(getLanguage(), that.getLanguage())
-                && Objects.equals(getDate(), that.getDate())
-                && Objects.equals(getContributors(), that.getContributors())
-                && Objects.equals(getAbstract(), that.getAbstract())
-                && Objects.equals(getNpiSubjectHeading(), that.getNpiSubjectHeading())
-                && Objects.equals(getAbstract(), that.getAbstract())
-                && Objects.equals(getTags(), that.getTags())
-                && Objects.equals(getDescription(), that.getDescription())
-                && Objects.equals(getReference(), that.getReference());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getPublicationType(), getMainTitle(), getAlternativeTitles(), getLanguage(), getDate(),
-                getContributors());
-    }
-
     public String getAbstract() {
         return mainLanguageAbstract;
     }
@@ -159,6 +132,53 @@ public class EntityDescription {
         this.reference = reference;
     }
 
+    public PublicationSubtype getPublicationSubtype() {
+        return publicationSubtype;
+    }
+
+    public void setPublicationSubtype(PublicationSubtype publicationSubtype) {
+        this.publicationSubtype = publicationSubtype;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EntityDescription)) {
+            return false;
+        }
+        EntityDescription that = (EntityDescription) o;
+        return getPublicationType() == that.getPublicationType()
+                && getPublicationSubtype() == that.getPublicationSubtype()
+                && Objects.equals(getMainTitle(), that.getMainTitle())
+                && Objects.equals(getAlternativeTitles(), that.getAlternativeTitles())
+                && Objects.equals(getLanguage(), that.getLanguage())
+                && Objects.equals(getDate(), that.getDate())
+                && Objects.equals(getContributors(), that.getContributors())
+                && Objects.equals(getAbstract(), that.getAbstract())
+                && Objects.equals(getNpiSubjectHeading(), that.getNpiSubjectHeading())
+                && Objects.equals(getTags(), that.getTags())
+                && Objects.equals(getDescription(), that.getDescription())
+                && Objects.equals(getReference(), that.getReference());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPublicationType(),
+                getPublicationSubtype(),
+                getMainTitle(),
+                getAlternativeTitles(),
+                getLanguage(),
+                getDate(),
+                getContributors(),
+                getAbstract(),
+                getNpiSubjectHeading(),
+                getTags(),
+                getDescription(),
+                getReference());
+    }
+
     public static final class Builder {
         private Reference reference;
         private String mainLanguageAbstract;
@@ -166,6 +186,7 @@ public class EntityDescription {
         private List<String> tags;
         private String npiSubjectHeading;
         private PublicationType publicationType;
+        private PublicationSubtype publicationSubtype;
         private String mainTitle;
         private Map<String, String> alternativeTitles;
         private URI language;
@@ -177,6 +198,11 @@ public class EntityDescription {
 
         public Builder withPublicationType(PublicationType type) {
             this.publicationType = type;
+            return this;
+        }
+
+        public Builder withPublicationSubtype(PublicationSubtype publicationSubtype) {
+            this.publicationSubtype = publicationSubtype;
             return this;
         }
 

--- a/src/main/java/no/unit/nva/model/EntityDescription.java
+++ b/src/main/java/no/unit/nva/model/EntityDescription.java
@@ -170,7 +170,8 @@ public class EntityDescription {
                 && Objects.equals(getNpiSubjectHeading(), that.getNpiSubjectHeading())
                 && Objects.equals(getTags(), that.getTags())
                 && Objects.equals(getDescription(), that.getDescription())
-                && Objects.equals(getReference(), that.getReference());
+                && Objects.equals(getReference(), that.getReference())
+                && Objects.equals(getMetadataSource(), that.getMetadataSource());
     }
 
     @Override
@@ -186,15 +187,11 @@ public class EntityDescription {
                 getNpiSubjectHeading(),
                 getTags(),
                 getDescription(),
-                getReference());
+                getReference(),
+                getMetadataSource());
     }
 
     public static final class Builder {
-        private Reference reference;
-        private String mainLanguageAbstract;
-        private String description;
-        private List<String> tags;
-        private String npiSubjectHeading;
         private PublicationType publicationType;
         private PublicationSubtype publicationSubtype;
         private String mainTitle;
@@ -202,13 +199,18 @@ public class EntityDescription {
         private URI language;
         private PublicationDate date;
         private List<Contributor> contributors;
+        private String mainLanguageAbstract;
+        private String npiSubjectHeading;
+        private List<String> tags;
+        private String description;
+        private Reference reference;
         private URI metadataSource;
 
         public Builder() {
         }
 
-        public Builder withPublicationType(PublicationType type) {
-            this.publicationType = type;
+        public Builder withPublicationType(PublicationType publicationType) {
+            this.publicationType = publicationType;
             return this;
         }
 
@@ -247,11 +249,6 @@ public class EntityDescription {
             return this;
         }
 
-        public Builder withDescription(String description) {
-            this.description = description;
-            return this;
-        }
-
         public Builder withNpiSubjectHeading(String npiSubjectHeading) {
             this.npiSubjectHeading = npiSubjectHeading;
             return this;
@@ -262,7 +259,12 @@ public class EntityDescription {
             return this;
         }
 
-        public Builder withJournalReference(Reference reference) {
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withReference(Reference reference) {
             this.reference = reference;
             return this;
         }

--- a/src/main/java/no/unit/nva/model/PublicationSubtype.java
+++ b/src/main/java/no/unit/nva/model/PublicationSubtype.java
@@ -1,0 +1,47 @@
+package no.unit.nva.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+public enum PublicationSubtype {
+    ARTICLE("Article"),
+    SHORT_COMMUNICATION("ShortCommunication"),
+    EDITORIAL("Editorial"),
+    LETTER("Letter"),
+    REVIEW("Review");
+
+    public static final String ERROR_MESSAGE_TEMPLATE = "%s not a valid PublicationSubtype, expected one of: %s";
+    public static final String DELIMITER = ", ";
+    private String value;
+
+    PublicationSubtype(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Lookup enum by value.
+     *
+     * @param value value
+     * @return enum
+     */
+    public static PublicationSubtype lookup(String value) {
+        return stream(values())
+                .filter(publicationType -> publicationType.getValue().equalsIgnoreCase(value))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        format(ERROR_MESSAGE_TEMPLATE, value, stream(PublicationType.values())
+                                .map(PublicationType::toString).collect(joining(DELIMITER)))));
+    }
+}

--- a/src/main/resources/publicationFrame.json
+++ b/src/main/resources/publicationFrame.json
@@ -13,6 +13,7 @@
     "hasPublisher": "publisher",
     "hasEntityDescription": "entityDescription",
     "hasPublicationType": "publicationType",
+    "hasPublicationSubtype": "publicationSubtype",
     "hasMainTitle": "mainTitle",
     "hasAlternativeTitle": {
       "@id": "alternativeTitles"

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -112,6 +112,7 @@ public class PublicationTest {
                 .withAlternativeTitles(Collections.singletonMap("en", "English title"))
                 .withDate(getPublicationDate())
                 .withPublicationType(PublicationType.JOURNAL_ARTICLE)
+                .withPublicationSubtype(PublicationSubtype.ARTICLE)
                 .withContributors(Collections.singletonList(getContributor()))
                 .withAbstract("En lang streng som beskriver innholdet i dokumentet metadataene omtaler.")
                 .withNpiSubjectHeading("010")

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -148,7 +148,7 @@ public class PublicationTest {
                 .withNpiSubjectHeading("010")
                 .withTags(Arrays.asList("dokumenter", "publikasjoner"))
                 .withDescription("En streng som beskriver innholdet i dokumentet på en annen måte enn abstrakt")
-                .withJournalReference(getJournalReference())
+                .withReference(getJournalReference())
                 .withMetadataSource(URI.create("https://example.org/doi?doi=123/123"))
                 .build();
     }


### PR DESCRIPTION
- Add PublicationSubtype enum
- Add field publicationSubtype to EntityDescription
  - update equals & hashcode
  - update inner Builder
- Update test helper methods
- Update JSON-LD frame

At a point when we have multiple PublicationTypes, we will need to consider how to handle the dependency between PublicationType and PublicationSubtype.