### PR TITLE
Np 696 add contributor email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk8
   - openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -24,8 +24,8 @@ public class Contributor {
 
     }
 
-    private Contributor(Builder builder) {
-        if (builder.correspondingAuthor && (isNull(builder.email) || builder.email.isBlank())) {
+    private Contributor(Builder builder) throws MalformedContributorException {
+        if (isCorrespondAuthorWithEmail(builder)) {
             throw new MalformedContributorException(CORRESPONDING_AUTHOR_EMAIL_MISSING);
         }
         setIdentity(builder.identity);
@@ -34,6 +34,10 @@ public class Contributor {
         setSequence(builder.sequence);
         setCorrespondingAuthor(builder.correspondingAuthor);
         setEmail(builder.email);
+    }
+
+    private boolean isCorrespondAuthorWithEmail(Builder builder) {
+        return builder.correspondingAuthor && (isNull(builder.email) || builder.email.isBlank());
     }
 
     public Identity getIdentity() {
@@ -152,7 +156,7 @@ public class Contributor {
             return this;
         }
 
-        public Contributor build() {
+        public Contributor build() throws MalformedContributorException {
             return new Contributor(this);
         }
     }

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -1,5 +1,7 @@
 package no.unit.nva.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 
@@ -20,72 +22,75 @@ public class Contributor {
     private boolean correspondingAuthor;
     private String email;
 
-    public Contributor() {
+    /**
+     * Constructor designed to ensure valid data in the object, since we can only have a corresponding author
+     * with an email.
+     *
+     * @param identity            The identity of the contributor
+     * @param affiliations        The affiliation of the contributor
+     * @param role                The role that the contributor played
+     * @param sequence            The order of the contributor in the contributors listing
+     * @param correspondingAuthor Whether the contributor was a corresponding author
+     * @param email               Contact email for contributor, required if the contributor was a corresponding author
+     * @throws MalformedContributorException If the contributor is corresponding author, but no email is present
+     */
+    @JsonCreator
+    public Contributor(@JsonProperty("identity") Identity identity,
+                       @JsonProperty("affiliations") List<Organization> affiliations,
+                       @JsonProperty("role") Role role,
+                       @JsonProperty("sequence") Integer sequence,
+                       @JsonProperty("correspondingAuthor") boolean correspondingAuthor,
+                       @JsonProperty("email") String email) throws MalformedContributorException {
+        if (isCorrespondAuthorWithoutEmail(correspondingAuthor, email)) {
+            throw new MalformedContributorException(CORRESPONDING_AUTHOR_EMAIL_MISSING);
+        }
 
+        this.identity = identity;
+        this.affiliations = affiliations;
+        this.role = role;
+        this.sequence = sequence;
+        this.correspondingAuthor = correspondingAuthor;
+        this.email = email;
     }
 
     private Contributor(Builder builder) throws MalformedContributorException {
-        if (isCorrespondAuthorWithEmail(builder)) {
-            throw new MalformedContributorException(CORRESPONDING_AUTHOR_EMAIL_MISSING);
-        }
-        setIdentity(builder.identity);
-        setAffiliations(builder.affiliations);
-        setRole(builder.role);
-        setSequence(builder.sequence);
-        setCorrespondingAuthor(builder.correspondingAuthor);
-        setEmail(builder.email);
+        this(
+                builder.identity,
+                builder.affiliations,
+                builder.role,
+                builder.sequence,
+                builder.correspondingAuthor,
+                builder.email
+        );
     }
 
-    private boolean isCorrespondAuthorWithEmail(Builder builder) {
-        return builder.correspondingAuthor && (isNull(builder.email) || builder.email.isBlank());
+
+    private boolean isCorrespondAuthorWithoutEmail(boolean correspondingAuthor, String email) {
+        return correspondingAuthor && (isNull(email) || email.isBlank());
     }
 
     public Identity getIdentity() {
         return identity;
     }
 
-    public void setIdentity(Identity identity) {
-        this.identity = identity;
-    }
-
     public List<Organization> getAffiliations() {
         return affiliations;
-    }
-
-    public void setAffiliations(List<Organization> affiliations) {
-        this.affiliations = affiliations;
     }
 
     public Integer getSequence() {
         return sequence;
     }
 
-    public void setSequence(Integer sequence) {
-        this.sequence = sequence;
-    }
-
     public Role getRole() {
         return role;
-    }
-
-    public void setRole(Role role) {
-        this.role = role;
     }
 
     public boolean isCorrespondingAuthor() {
         return correspondingAuthor;
     }
 
-    public void setCorrespondingAuthor(boolean correspondingAuthor) {
-        this.correspondingAuthor = correspondingAuthor;
-    }
-
     public String getEmail() {
         return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     @Override

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -1,29 +1,39 @@
 package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.unit.nva.model.exceptions.MalformedContributorException;
 
 import java.util.List;
 import java.util.Objects;
 
+import static java.util.Objects.isNull;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Contributor {
 
+    public static final String CORRESPONDING_AUTHOR_EMAIL_MISSING =
+            "The Contributor is corresponding author, but no email for correspondence is set";
     private Identity identity;
     private List<Organization> affiliations;
     private Role role;
     private Integer sequence;
     private boolean correspondingAuthor;
+    private String email;
 
     public Contributor() {
 
     }
 
     private Contributor(Builder builder) {
+        if (builder.correspondingAuthor && (isNull(builder.email) || builder.email.isBlank())) {
+            throw new MalformedContributorException(CORRESPONDING_AUTHOR_EMAIL_MISSING);
+        }
         setIdentity(builder.identity);
         setAffiliations(builder.affiliations);
         setRole(builder.role);
         setSequence(builder.sequence);
         setCorrespondingAuthor(builder.correspondingAuthor);
+        setEmail(builder.email);
     }
 
     public Identity getIdentity() {
@@ -58,6 +68,22 @@ public class Contributor {
         this.role = role;
     }
 
+    public boolean isCorrespondingAuthor() {
+        return correspondingAuthor;
+    }
+
+    public void setCorrespondingAuthor(boolean correspondingAuthor) {
+        this.correspondingAuthor = correspondingAuthor;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -71,7 +97,8 @@ public class Contributor {
                 && Objects.equals(getIdentity(), that.getIdentity())
                 && Objects.equals(getAffiliations(), that.getAffiliations())
                 && getRole() == that.getRole()
-                && Objects.equals(getSequence(), that.getSequence());
+                && Objects.equals(getSequence(), that.getSequence())
+                && Objects.equals(getEmail(), that.getEmail());
     }
 
     @Override
@@ -80,15 +107,8 @@ public class Contributor {
                 getAffiliations(),
                 getRole(),
                 getSequence(),
-                isCorrespondingAuthor());
-    }
-
-    public boolean isCorrespondingAuthor() {
-        return correspondingAuthor;
-    }
-
-    public void setCorrespondingAuthor(boolean correspondingAuthor) {
-        this.correspondingAuthor = correspondingAuthor;
+                isCorrespondingAuthor(),
+                getEmail());
     }
 
     public static final class Builder {
@@ -97,6 +117,7 @@ public class Contributor {
         private Role role;
         private Integer sequence;
         private boolean correspondingAuthor;
+        private String email;
 
         public Builder() {
         }
@@ -123,6 +144,11 @@ public class Contributor {
 
         public Builder withCorrespondingAuthor(boolean correspondingAuthor) {
             this.correspondingAuthor = correspondingAuthor;
+            return this;
+        }
+
+        public Builder withEmail(String email) {
+            this.email = email;
             return this;
         }
 

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -12,6 +12,7 @@ public class Contributor {
     private List<Organization> affiliations;
     private Role role;
     private Integer sequence;
+    private boolean correspondingAuthor;
 
     public Contributor() {
 
@@ -20,8 +21,9 @@ public class Contributor {
     private Contributor(Builder builder) {
         setIdentity(builder.identity);
         setAffiliations(builder.affiliations);
-        setSequence(builder.sequence);
         setRole(builder.role);
+        setSequence(builder.sequence);
+        setCorrespondingAuthor(builder.correspondingAuthor);
     }
 
     public Identity getIdentity() {
@@ -61,11 +63,12 @@ public class Contributor {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Contributor)) {
             return false;
         }
         Contributor that = (Contributor) o;
-        return Objects.equals(getIdentity(), that.getIdentity())
+        return isCorrespondingAuthor() == that.isCorrespondingAuthor()
+                && Objects.equals(getIdentity(), that.getIdentity())
                 && Objects.equals(getAffiliations(), that.getAffiliations())
                 && getRole() == that.getRole()
                 && Objects.equals(getSequence(), that.getSequence());
@@ -73,14 +76,27 @@ public class Contributor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getIdentity(), getAffiliations(), getRole(), getSequence());
+        return Objects.hash(getIdentity(),
+                getAffiliations(),
+                getRole(),
+                getSequence(),
+                isCorrespondingAuthor());
+    }
+
+    public boolean isCorrespondingAuthor() {
+        return correspondingAuthor;
+    }
+
+    public void setCorrespondingAuthor(boolean correspondingAuthor) {
+        this.correspondingAuthor = correspondingAuthor;
     }
 
     public static final class Builder {
         private Identity identity;
         private List<Organization> affiliations;
-        private Integer sequence;
         private Role role;
+        private Integer sequence;
+        private boolean correspondingAuthor;
 
         public Builder() {
         }
@@ -90,8 +106,13 @@ public class Contributor {
             return this;
         }
 
-        public Builder withAffiliations(List<Organization> affiliation) {
-            this.affiliations = affiliation;
+        public Builder withAffiliations(List<Organization> affiliations) {
+            this.affiliations = affiliations;
+            return this;
+        }
+
+        public Builder withRole(Role role) {
+            this.role = role;
             return this;
         }
 
@@ -100,8 +121,8 @@ public class Contributor {
             return this;
         }
 
-        public Builder withRole(Role role) {
-            this.role = role;
+        public Builder withCorrespondingAuthor(boolean correspondingAuthor) {
+            this.correspondingAuthor = correspondingAuthor;
             return this;
         }
 

--- a/src/main/java/no/unit/nva/model/Level.java
+++ b/src/main/java/no/unit/nva/model/Level.java
@@ -19,10 +19,12 @@ public enum Level {
 
     /**
      * In cases where an integer is supplied, it must be checked that the level is correct.
+     *
      * @param integer The level value as integer
      * @return Level value
+     * @throws InvalidNpiLevelException In cases where the the input level is not a valid level
      */
-    public static Level getLevel(Integer integer) {
+    public static Level getLevel(Integer integer) throws InvalidNpiLevelException {
         return Arrays.stream(values())
                 .filter(levelInteger -> levelInteger.level.equals(integer)).findFirst()
                 .orElseThrow(() -> new InvalidNpiLevelException(

--- a/src/main/java/no/unit/nva/model/PublicationContext.java
+++ b/src/main/java/no/unit/nva/model/PublicationContext.java
@@ -1,6 +1,7 @@
 package no.unit.nva.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.unit.nva.model.exceptions.InvalidNpiLevelException;
 
 import java.util.Objects;
 
@@ -33,7 +34,7 @@ public class PublicationContext {
         return level;
     }
 
-    public void setLevelFromInteger(Integer level) {
+    public void setLevelFromInteger(Integer level) throws InvalidNpiLevelException {
         this.level = Level.getLevel(level);
     }
 

--- a/src/main/java/no/unit/nva/model/exceptions/InvalidNpiLevelException.java
+++ b/src/main/java/no/unit/nva/model/exceptions/InvalidNpiLevelException.java
@@ -1,6 +1,6 @@
 package no.unit.nva.model.exceptions;
 
-public class InvalidNpiLevelException extends RuntimeException {
+public class InvalidNpiLevelException extends Exception {
     public InvalidNpiLevelException(String message) {
         super(message);
     }

--- a/src/main/java/no/unit/nva/model/exceptions/MalformedContributorException.java
+++ b/src/main/java/no/unit/nva/model/exceptions/MalformedContributorException.java
@@ -1,6 +1,6 @@
 package no.unit.nva.model.exceptions;
 
-public class MalformedContributorException extends RuntimeException {
+public class MalformedContributorException extends Exception {
     public MalformedContributorException(String message) {
         super(message);
     }

--- a/src/main/java/no/unit/nva/model/exceptions/MalformedContributorException.java
+++ b/src/main/java/no/unit/nva/model/exceptions/MalformedContributorException.java
@@ -1,0 +1,7 @@
+package no.unit.nva.model.exceptions;
+
+public class MalformedContributorException extends RuntimeException {
+    public MalformedContributorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/publicationFrame.json
+++ b/src/main/resources/publicationFrame.json
@@ -64,7 +64,8 @@
     "hasApprovedBy": "approvedBy",
     "hasApplicationCode": "applicationCode",
     "hasSource": "source",
-    "hasMetadataSource": "metadataSource"
+    "hasMetadataSource": "metadataSource",
+    "isCorrespondingAuthor": "correspondingAuthor"
   },
   "@type": "Publication"
 }

--- a/src/main/resources/publicationFrame.json
+++ b/src/main/resources/publicationFrame.json
@@ -65,7 +65,8 @@
     "hasApplicationCode": "applicationCode",
     "hasSource": "source",
     "hasMetadataSource": "metadataSource",
-    "isCorrespondingAuthor": "correspondingAuthor"
+    "isCorrespondingAuthor": "correspondingAuthor",
+    "hasEmail": "email"
   },
   "@type": "Publication"
 }

--- a/src/test/java/no/unit/nva/model/ContributorTest.java
+++ b/src/test/java/no/unit/nva/model/ContributorTest.java
@@ -31,7 +31,7 @@ class ContributorTest {
 
     @DisplayName("Contributor builder constructs a valid object")
     @Test
-    void contributorBuilderReturnsValidContributorWhenInputIsValid() {
+    void contributorBuilderReturnsValidContributorWhenInputIsValid() throws MalformedContributorException {
         Identity identity = getIdentity();
         Organization organization = getOrganization();
         Contributor contributor = new Contributor.Builder()

--- a/src/test/java/no/unit/nva/model/ContributorTest.java
+++ b/src/test/java/no/unit/nva/model/ContributorTest.java
@@ -19,8 +19,13 @@ class ContributorTest {
 
     @DisplayName("Test the contributor default constructor exists")
     @Test
-    void contributorDefaultConstructorExists() {
-        new Contributor();
+    void contributorDefaultConstructorExists() throws MalformedContributorException {
+        new Contributor(getIdentity(),
+                Collections.singletonList(getOrganization()),
+                Role.CREATOR,
+                0,
+                true,
+                "jj@example.org");
     }
 
     @DisplayName("The Contributor inner builder exists")

--- a/src/test/java/no/unit/nva/model/ContributorTest.java
+++ b/src/test/java/no/unit/nva/model/ContributorTest.java
@@ -1,0 +1,92 @@
+package no.unit.nva.model;
+
+import no.unit.nva.model.exceptions.MalformedContributorException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContributorTest {
+
+    public static final String EXAMPLE_EMAIL = "ks@exmaple.org";
+    public static final int FIRST = 1;
+    public static final String EMPTY_STRING = "";
+
+    @DisplayName("Test the contributor default constructor exists")
+    @Test
+    void contributorDefaultConstructorExists() {
+        new Contributor();
+    }
+
+    @DisplayName("The Contributor inner builder exists")
+    @Test
+    void builderExists() {
+        new Contributor.Builder();
+    }
+
+    @DisplayName("Contributor builder constructs a valid object")
+    @Test
+    void contributorBuilderReturnsValidContributorWhenInputIsValid() {
+        Identity identity = getIdentity();
+        Organization organization = getOrganization();
+        Contributor contributor = new Contributor.Builder()
+                .withIdentity(identity)
+                .withAffiliations(Collections.singletonList(organization))
+                .withRole(Role.CREATOR)
+                .withSequence(FIRST)
+                .withCorrespondingAuthor(true)
+                .withEmail(EXAMPLE_EMAIL)
+                .build();
+        assertEquals(identity, contributor.getIdentity());
+        assertEquals(Collections.singletonList(organization), contributor.getAffiliations());
+        assertEquals(Role.CREATOR, contributor.getRole());
+        assertEquals(FIRST, contributor.getSequence());
+        assertEquals(EXAMPLE_EMAIL, contributor.getEmail());
+        assertTrue(contributor.isCorrespondingAuthor());
+    }
+
+    private static Organization getOrganization() {
+        return new Organization.Builder()
+                .withId(URI.create("https:/example.org/unit/123.0.0.1"))
+                .withLabels(Collections.singletonMap("en", "Some name"))
+                .build();
+    }
+
+    private static Identity getIdentity() {
+        return new Identity.Builder().withName("Smith, Kim").build();
+    }
+
+    @DisplayName("Contributor throws MalformedContributorException when corresponding author, but no email is set")
+    @Test
+    void contributorThrowsExceptionWhenCorrespondingAuthorNoEmail() {
+        MalformedContributorException exception = assertThrows(MalformedContributorException.class, () ->
+                new Contributor.Builder()
+                    .withIdentity(getIdentity())
+                    .withAffiliations(Collections.singletonList(getOrganization()))
+                    .withRole(Role.CREATOR)
+                    .withSequence(FIRST)
+                    .withCorrespondingAuthor(true)
+                    .build());
+        assertEquals(Contributor.CORRESPONDING_AUTHOR_EMAIL_MISSING, exception.getMessage());
+    }
+
+    @DisplayName("Contributor throws MalformedContributorException when corresponding author, but email is empty")
+    @Test
+    void contributorThrowsExceptionWhenCorrespondingAuthorEmptyEmail() {
+        MalformedContributorException exception = assertThrows(MalformedContributorException.class, () ->
+                new Contributor.Builder()
+                        .withIdentity(getIdentity())
+                        .withAffiliations(Collections.singletonList(getOrganization()))
+                        .withRole(Role.CREATOR)
+                        .withSequence(FIRST)
+                        .withCorrespondingAuthor(true)
+                        .withEmail(EMPTY_STRING)
+                        .build());
+        assertEquals(Contributor.CORRESPONDING_AUTHOR_EMAIL_MISSING, exception.getMessage());
+    }
+}

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -185,6 +185,7 @@ public class PublicationTest {
                 .withRole(Role.CREATOR)
                 .withAffiliations(Collections.singletonList(getOrganization()))
                 .withIdentity(getIdentity())
+                .withCorrespondingAuthor(true)
                 .build();
     }
 

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
+import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.util.ContextUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +47,7 @@ public class PublicationTest {
 
     @DisplayName("The Publication class object can (de-)serialize valid JSON input")
     @Test
-    void publicationClassReturnsDeserializedJsonWhenValidJsonInput() throws IOException {
+    void publicationClassReturnsDeserializedJsonWhenValidJsonInput() throws IOException, MalformedContributorException {
 
         UUID publicationIdentifier = UUID.randomUUID();
         UUID fileIdentifier = UUID.randomUUID();
@@ -70,7 +71,8 @@ public class PublicationTest {
 
     @DisplayName("The serialized Publication class can be framed to match the RDF data model")
     @Test
-    void objectMappingOfPublicationClassReturnsSerializedJsonWithJsonLdFrame() throws IOException {
+    void objectMappingOfPublicationClassReturnsSerializedJsonWithJsonLdFrame() throws IOException,
+            MalformedContributorException {
 
         UUID publicationIdentifier = UUID.randomUUID();
         UUID fileIdentifier = UUID.randomUUID();
@@ -94,7 +96,8 @@ public class PublicationTest {
         return JsonLdProcessor.frame(input, frame, options);
     }
 
-    private Publication getPublication(UUID publicationIdentifier, UUID fileIdentifier, Instant now) {
+    private Publication getPublication(UUID publicationIdentifier, UUID fileIdentifier, Instant now)
+            throws MalformedContributorException {
         return new Publication.Builder()
                 .withIdentifier(publicationIdentifier)
                 .withCreatedDate(now)
@@ -136,7 +139,7 @@ public class PublicationTest {
                 .build());
     }
 
-    private EntityDescription getEntityDescription() {
+    private EntityDescription getEntityDescription() throws MalformedContributorException {
         return new EntityDescription.Builder()
                 .withMainTitle("Hovedtittelen")
                 .withLanguage(URI.create("http://example.org/norsk"))
@@ -180,7 +183,7 @@ public class PublicationTest {
                 .build();
     }
 
-    private Contributor getContributor() {
+    private Contributor getContributor() throws MalformedContributorException {
         return new Contributor.Builder()
                 .withSequence(0)
                 .withRole(Role.CREATOR)

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -28,6 +28,7 @@ public class PublicationTest {
     public static final String PUBLICATION_CONTEXT_JSON = "src/main/resources/publicationContext.json";
     public static final String PUBLICATION_FRAME_JSON = "src/main/resources/publicationFrame.json";
     public static final String HTTPS_NVA_UNIT_NO_PUBLICATION_MAIN_TITLE = "https://nva.unit.no/publication#mainTitle";
+    public static final String EXAMPLE_EMAIL = "nn@example.org";
     private ObjectMapper objectMapper;
 
     /**
@@ -186,6 +187,7 @@ public class PublicationTest {
                 .withAffiliations(Collections.singletonList(getOrganization()))
                 .withIdentity(getIdentity())
                 .withCorrespondingAuthor(true)
+                .withEmail(EXAMPLE_EMAIL)
                 .build();
     }
 

--- a/src/test/java/no/unit/nva/model/exceptions/InvalidNpiLevelExceptionTest.java
+++ b/src/test/java/no/unit/nva/model/exceptions/InvalidNpiLevelExceptionTest.java
@@ -1,0 +1,23 @@
+package no.unit.nva.model.exceptions;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InvalidNpiLevelExceptionTest {
+
+    public static final String THE_MESSAGE = "The message";
+
+    @DisplayName("The InvalidNpiLevelException can be thrown and has a message")
+    @Test
+    void invalidNpiLevelExceptionIsThrownAndHasMessage() {
+        InvalidNpiLevelException exception = assertThrows(InvalidNpiLevelException.class, () -> {
+            throw new InvalidNpiLevelException(THE_MESSAGE);
+        });
+
+        assertEquals(THE_MESSAGE, exception.getMessage());
+    }
+}

--- a/src/test/java/no/unit/nva/model/exceptions/MalformedContributorExceptionTest.java
+++ b/src/test/java/no/unit/nva/model/exceptions/MalformedContributorExceptionTest.java
@@ -1,0 +1,23 @@
+package no.unit.nva.model.exceptions;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MalformedContributorExceptionTest {
+
+    public static final String THE_MESSAGE = "The message";
+
+    @DisplayName("The MalformedContributorException can be thrown and has a message")
+    @Test
+    void malformedContributorExceptionIsThrownAndHasMessage() {
+        MalformedContributorException exception = assertThrows(MalformedContributorException.class, () -> {
+            throw new MalformedContributorException(THE_MESSAGE);
+        });
+
+        assertEquals(THE_MESSAGE, exception.getMessage());
+    }
+}


### PR DESCRIPTION
This commit builds on NP-695-add-contributor-corresponding-author, and should be merged into that branch.

We add:

- Contributor.email
- MalformedContributorException
- constructor Contributor(Builder builder) is modified to check that the email has been set, or returns a MalformedContributorException with appropriate message
- add functionality to builder
- add tests to ensure that Contributors are well formed
- update Publication tests with new field
- update JSON-LD framing