### PR TITLE
Add correspondingAuthor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk8
   - openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -58,6 +58,14 @@ public class Contributor {
         this.role = role;
     }
 
+    public boolean isCorrespondingAuthor() {
+        return correspondingAuthor;
+    }
+
+    public void setCorrespondingAuthor(boolean correspondingAuthor) {
+        this.correspondingAuthor = correspondingAuthor;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -81,14 +89,6 @@ public class Contributor {
                 getRole(),
                 getSequence(),
                 isCorrespondingAuthor());
-    }
-
-    public boolean isCorrespondingAuthor() {
-        return correspondingAuthor;
-    }
-
-    public void setCorrespondingAuthor(boolean correspondingAuthor) {
-        this.correspondingAuthor = correspondingAuthor;
     }
 
     public static final class Builder {

--- a/src/main/java/no/unit/nva/model/Contributor.java
+++ b/src/main/java/no/unit/nva/model/Contributor.java
@@ -12,6 +12,7 @@ public class Contributor {
     private List<Organization> affiliations;
     private Role role;
     private Integer sequence;
+    private boolean correspondingAuthor;
 
     public Contributor() {
 
@@ -20,8 +21,9 @@ public class Contributor {
     private Contributor(Builder builder) {
         setIdentity(builder.identity);
         setAffiliations(builder.affiliations);
-        setSequence(builder.sequence);
         setRole(builder.role);
+        setSequence(builder.sequence);
+        setCorrespondingAuthor(builder.correspondingAuthor);
     }
 
     public Identity getIdentity() {
@@ -61,11 +63,12 @@ public class Contributor {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Contributor)) {
             return false;
         }
         Contributor that = (Contributor) o;
-        return Objects.equals(getIdentity(), that.getIdentity())
+        return isCorrespondingAuthor() == that.isCorrespondingAuthor()
+                && Objects.equals(getIdentity(), that.getIdentity())
                 && Objects.equals(getAffiliations(), that.getAffiliations())
                 && getRole() == that.getRole()
                 && Objects.equals(getSequence(), that.getSequence());
@@ -73,14 +76,27 @@ public class Contributor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getIdentity(), getAffiliations(), getRole(), getSequence());
+        return Objects.hash(getIdentity(),
+                getAffiliations(),
+                getRole(),
+                getSequence(),
+                isCorrespondingAuthor());
+    }
+
+    public boolean isCorrespondingAuthor() {
+        return correspondingAuthor;
+    }
+
+    public void setCorrespondingAuthor(boolean correspondingAuthor) {
+        this.correspondingAuthor = correspondingAuthor;
     }
 
     public static final class Builder {
         private Identity identity;
         private List<Organization> affiliations;
-        private Integer sequence;
         private Role role;
+        private Integer sequence;
+        private boolean correspondingAuthor;
 
         public Builder() {
         }
@@ -90,8 +106,13 @@ public class Contributor {
             return this;
         }
 
-        public Builder withAffiliations(List<Organization> affiliation) {
-            this.affiliations = affiliation;
+        public Builder withAffiliations(List<Organization> affiliations) {
+            this.affiliations = affiliations;
+            return this;
+        }
+
+        public Builder withRole(Role role) {
+            this.role = role;
             return this;
         }
 
@@ -100,8 +121,8 @@ public class Contributor {
             return this;
         }
 
-        public Builder withRole(Role role) {
-            this.role = role;
+        public Builder withCorrespondingAuthor(boolean correspondingAuthor) {
+            this.correspondingAuthor = correspondingAuthor;
             return this;
         }
 

--- a/src/main/resources/publicationFrame.json
+++ b/src/main/resources/publicationFrame.json
@@ -64,7 +64,8 @@
     "hasApprovedBy": "approvedBy",
     "hasApplicationCode": "applicationCode",
     "hasSource": "source",
-    "hasMetadataSource": "metadataSource"
+    "hasMetadataSource": "metadataSource",
+    "isCorrespondingAuthor": "correspondingAuthor"
   },
   "@type": "Publication"
 }

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -185,6 +185,7 @@ public class PublicationTest {
                 .withRole(Role.CREATOR)
                 .withAffiliations(Collections.singletonList(getOrganization()))
                 .withIdentity(getIdentity())
+                .withCorrespondingAuthor(true)
                 .build();
     }
 


### PR DESCRIPTION
Here, we update the contributor object with a new field, correspondingAuthor, which contains information about whether a given contributor is to be understood as the corresponding author (that is to say the author that communicated with reviewers, publishers, etc.) This is a boolean value.

- new field Contributor.correspondingAuthor, boolean
- update builder, equals, hash
- update tests
- update JSON-LD frame
- removed java 8 from travis jobs