### PR TITLE
Np 704 add checks for files and licenses

### DIFF
--- a/src/main/java/no/unit/nva/model/File.java
+++ b/src/main/java/no/unit/nva/model/File.java
@@ -1,14 +1,21 @@
 package no.unit.nva.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.unit.nva.model.exceptions.MissingLicenseException;
 
 import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
+import static java.util.Objects.isNull;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class File {
 
+    public static final String MISSING_LICENSE =
+            "The file is not annotated as an administrative agreement and should have a license";
     private UUID identifier;
     private String name;
     private String mimeType;
@@ -18,83 +25,88 @@ public class File {
     private boolean publisherAuthority;
     private Instant embargoDate;
 
-    public File() {
+    /**
+     * Constructor for File objects. A file object is valid if it has a license or is explicitly marked as
+     * being an administrative agreement.
+     *
+     * @param identifier              A UUID that identifies the file in storage
+     * @param name                    The original name of the file
+     * @param mimeType                The mimetype of the file
+     * @param size                    The size of the file
+     * @param license                 The license for the file, may be null if and only if the file is an
+     *                                administrative agreement
+     * @param administrativeAgreement True if the file is an administrative agreement
+     * @param publisherAuthority      True if the file owner has publisher authority
+     * @param embargoDate             The date after which the file may be published
+     */
+    @JsonCreator
+    public File(
+            @JsonProperty("identifier") UUID identifier,
+            @JsonProperty("name") String name,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("size") Long size,
+            @JsonProperty("license") License license,
+            @JsonProperty("administrativeAgreement") boolean administrativeAgreement,
+            @JsonProperty("publisherAuthority") boolean publisherAuthority,
+            @JsonProperty("embargoDate") Instant embargoDate) {
 
+        if (!administrativeAgreement && isNull(license)) {
+            throw new MissingLicenseException(MISSING_LICENSE);
+        }
+
+        this.identifier = identifier;
+        this.name = name;
+        this.mimeType = mimeType;
+        this.size = size;
+        this.license = license;
+        this.administrativeAgreement = administrativeAgreement;
+        this.publisherAuthority = publisherAuthority;
+        this.embargoDate = embargoDate;
     }
 
     private File(Builder builder) {
-        setIdentifier(builder.identifier);
-        setName(builder.name);
-        setMimeType(builder.mimeType);
-        setSize(builder.size);
-        setLicense(builder.license);
-        setAdministrativeAgreement(builder.administrativeAgreement);
-        setPublisherAuthority(builder.publisherAuthority);
-        setEmbargoDate(builder.embargoDate);
+        this(
+                builder.identifier,
+                builder.name,
+                builder.mimeType,
+                builder.size,
+                builder.license,
+                builder.administrativeAgreement,
+                builder.publisherAuthority,
+                builder.embargoDate
+        );
     }
 
     public UUID getIdentifier() {
         return identifier;
     }
 
-    public void setIdentifier(UUID identifier) {
-        this.identifier = identifier;
-    }
-
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public String getMimeType() {
         return mimeType;
     }
 
-    public void setMimeType(String mimeType) {
-        this.mimeType = mimeType;
-    }
-
     public Long getSize() {
         return size;
-    }
-
-    public void setSize(Long size) {
-        this.size = size;
     }
 
     public License getLicense() {
         return license;
     }
 
-    public void setLicense(License license) {
-        this.license = license;
-    }
-
     public boolean isAdministrativeAgreement() {
         return administrativeAgreement;
-    }
-
-    public void setAdministrativeAgreement(boolean administrativeAgreement) {
-        this.administrativeAgreement = administrativeAgreement;
     }
 
     public boolean isPublisherAuthority() {
         return publisherAuthority;
     }
 
-    public void setPublisherAuthority(boolean publisherAuthority) {
-        this.publisherAuthority = publisherAuthority;
-    }
-
     public Instant getEmbargoDate() {
         return embargoDate;
-    }
-
-    public void setEmbargoDate(Instant embargoDate) {
-        this.embargoDate = embargoDate;
     }
 
     @Override

--- a/src/main/java/no/unit/nva/model/Publication.java
+++ b/src/main/java/no/unit/nva/model/Publication.java
@@ -25,7 +25,6 @@ public class Publication {
     private URI handle;
     private URI link;
     private EntityDescription entityDescription;
-    private License license;
     private FileSet fileSet;
     private ResearchProject project;
 
@@ -45,7 +44,6 @@ public class Publication {
         setHandle(builder.handle);
         setLink(builder.link);
         setEntityDescription(builder.entityDescription);
-        setLicense(builder.license);
         setFileSet(builder.fileSet);
         setProject(builder.project);
     }
@@ -165,14 +163,6 @@ public class Publication {
         this.entityDescription = entityDescription;
     }
 
-    public License getLicense() {
-        return license;
-    }
-
-    public void setLicense(License license) {
-        this.license = license;
-    }
-
     public FileSet getFileSet() {
         return fileSet;
     }
@@ -209,7 +199,6 @@ public class Publication {
                 && Objects.equals(getHandle(), that.getHandle())
                 && Objects.equals(getLink(), that.getLink())
                 && Objects.equals(getEntityDescription(), that.getEntityDescription())
-                && Objects.equals(getLicense(), that.getLicense())
                 && Objects.equals(getFileSet(), that.getFileSet())
                 && Objects.equals(getProject(), that.getProject());
     }
@@ -227,7 +216,6 @@ public class Publication {
                 getHandle(),
                 getLink(),
                 getEntityDescription(),
-                getLicense(),
                 getFileSet(),
                 getProject());
     }
@@ -245,7 +233,6 @@ public class Publication {
         private URI handle;
         private URI link;
         private EntityDescription entityDescription;
-        private License license;
         private FileSet fileSet;
         private ResearchProject project;
 
@@ -304,11 +291,6 @@ public class Publication {
 
         public Builder withEntityDescription(EntityDescription entityDescription) {
             this.entityDescription = entityDescription;
-            return this;
-        }
-
-        public Builder withLicense(License license) {
-            this.license = license;
             return this;
         }
 

--- a/src/main/java/no/unit/nva/model/exceptions/MissingLicenseException.java
+++ b/src/main/java/no/unit/nva/model/exceptions/MissingLicenseException.java
@@ -1,0 +1,7 @@
+package no.unit.nva.model.exceptions;
+
+public class MissingLicenseException extends RuntimeException {
+    public MissingLicenseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/no/unit/nva/model/FileTest.java
+++ b/src/test/java/no/unit/nva/model/FileTest.java
@@ -1,0 +1,53 @@
+package no.unit.nva.model;
+
+import no.unit.nva.model.exceptions.MissingLicenseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+class FileTest {
+
+    public static final String FILE_NAME = "Some file name.txt";
+    public static final String MIME_TYPE = "application/pdf";
+    public static final long FILE_SIZE = 1L;
+
+    @DisplayName("The constructor exists")
+    @Test
+    void fileConstructorExists() {
+        new File(UUID.randomUUID(), FILE_NAME, MIME_TYPE, FILE_SIZE, getLicense(), false, true, null);
+    }
+
+    private License getLicense() {
+        return new License.Builder()
+                    .withIdentifier("NVA-TEST-LICENSE")
+                    .withLabels(Collections.singletonMap("en", "NVA-test-license"))
+                    .withLink(URI.create("https://example.org/nva-test-license"))
+                    .build();
+    }
+
+    @DisplayName("A file that is an administrative agreement does not need a license")
+    @Test
+    void fileWithAdministrativeAgreementAndNoLicenseIsValid() {
+        assertDoesNotThrow(() -> {
+            new File(UUID.randomUUID(), FILE_NAME, MIME_TYPE, FILE_SIZE, null, true, true, null);
+        });
+    }
+
+    @DisplayName("A file that is not an administrative agreement with no license throws MissingLicenseException")
+    @Test
+    void fileWithNoLicenseAndNotAdministrativeAgreementThrowsMissingLicenseException() {
+        MissingLicenseException exception = assertThrows(MissingLicenseException.class, () -> {
+            new File(UUID.randomUUID(), FILE_NAME, MIME_TYPE, FILE_SIZE, null, false, true, null);
+        });
+
+        assertEquals(File.MISSING_LICENSE, exception.getMessage());
+    }
+}

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -107,7 +107,6 @@ public class PublicationTest {
                 .withStatus(PublicationStatus.DRAFT)
                 .withPublisher(getOrganization())
                 .withFileSet(getFileSet(fileIdentifier))
-                .withLicense(getLicense())
                 .withEntityDescription(getEntityDescription())
                 .withOwner("eier@example.org")
                 .withProject(getProject())

--- a/src/test/java/no/unit/nva/model/exceptions/MissingLicenseExceptionTest.java
+++ b/src/test/java/no/unit/nva/model/exceptions/MissingLicenseExceptionTest.java
@@ -1,0 +1,22 @@
+package no.unit.nva.model.exceptions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+class MissingLicenseExceptionTest {
+    public static final String THE_MESSAGE = "The message";
+
+    @DisplayName("The MissingLicenseException can be thrown and has a message")
+    @Test
+    void missingLicenseExceptionIsThrownAndHasMessage() {
+        MissingLicenseException exception = assertThrows(MissingLicenseException.class, () -> {
+            throw new MissingLicenseException(THE_MESSAGE);
+        });
+
+        assertEquals(THE_MESSAGE, exception.getMessage());
+    }
+}


### PR DESCRIPTION
Files must have a license unless they are an administrative agreement.

The PR builds on the PR #15 .

In the PR,
- Create constructor that validates the presence of license AND/OR administrative agreement check
  - I suspect it's irrelevant to talk about an administrative agreement with a license, but no data is available
- update Builder
- Remove unused code
- Add custom exception MissingLicenseException
- Add tests
