### PR TITLE
Renamed mapper method

### DIFF
--- a/src/main/java/no/unit/nva/PublicationMapper.java
+++ b/src/main/java/no/unit/nva/PublicationMapper.java
@@ -62,13 +62,13 @@ public final class PublicationMapper {
     }
 
     /**
-     * Maps a publication and context to publication response.
+     * Maps a publication and context to specified type.
      *
      * @param publication   publication
      * @param context   jsonld context
      * @return  publication response
      */
-    public static <R extends WithContext> R toResponse(
+    public static <R extends WithContext> R convertValue(
         Publication publication, JsonNode context, Class<R> responseType) {
         R response = objectMapper.convertValue(publication, responseType);
         response.setContext(context);
@@ -76,16 +76,19 @@ public final class PublicationMapper {
     }
 
     /**
-     * Maps a publication to publication response with default context.
+     * Maps a publication to specified type with default context.
      *
      * @param publication   publication
      * @return  publication response
      */
-    public static <R extends WithContext> R toResponse(
+    public static <R extends WithContext> R convertValue(
         Publication publication, Class<R> responseType) {
+        return convertValue(publication, getContext(), responseType);
+    }
+
+    private static JsonNode getContext() {
         try {
-            JsonNode context = objectMapper.readTree(inputStreamFromResources(CONTEXT_PATH));
-            return toResponse(publication, context, responseType);
+            return objectMapper.readTree(inputStreamFromResources(CONTEXT_PATH));
         } catch (IOException e) {
             throw new IllegalStateException(CONTEXT_ERROR_MESSAGE + CONTEXT_PATH.toString(), e);
         }

--- a/src/test/java/no/unit/nva/PublicationMapperTest.java
+++ b/src/test/java/no/unit/nva/PublicationMapperTest.java
@@ -79,7 +79,7 @@ public class PublicationMapperTest {
     }
 
     @Test
-    public void canMapPublicationToCreatePublicationRequest() throws Exception {
+    public void convertValueReturnsCreatePublicationRequestWhenInputIsValidPublication() throws Exception {
         Publication publication = getPublication();
 
         CreatePublicationRequest request = PublicationMapper
@@ -93,7 +93,7 @@ public class PublicationMapperTest {
     }
 
     @Test
-    public void canMapPublicationToUpdatePublicationRequest() throws Exception {
+    public void convertValueReturnsUpdatePublicationRequestWhenInputIsValidPublication() throws Exception {
         Publication publication = getPublication();
 
         UpdatePublicationRequest request = PublicationMapper

--- a/src/test/java/no/unit/nva/PublicationMapperTest.java
+++ b/src/test/java/no/unit/nva/PublicationMapperTest.java
@@ -63,7 +63,7 @@ public class PublicationMapperTest {
         Publication publication = getPublication();
 
         PublicationResponse response = PublicationMapper
-            .toResponse(publication, SOME_CONTEXT, PublicationResponse.class);
+            .convertValue(publication, SOME_CONTEXT, PublicationResponse.class);
 
         assertNotNull(response);
     }
@@ -73,9 +73,37 @@ public class PublicationMapperTest {
         Publication publication = getPublication();
 
         PublicationResponse response = PublicationMapper
-            .toResponse(publication, PublicationResponse.class);
+            .convertValue(publication, PublicationResponse.class);
 
         assertNotNull(response);
+    }
+
+    @Test
+    public void canMapPublicationToCreatePublicationRequest() throws Exception {
+        Publication publication = getPublication();
+
+        CreatePublicationRequest request = PublicationMapper
+            .convertValue(publication, CreatePublicationRequest.class);
+
+        assertNotNull(request);
+        assertNotNull(request.getContext());
+        assertEquals(publication.getFileSet(), request.getFileSet());
+        assertEquals(publication.getProject(), request.getProject());
+        assertEquals(publication.getEntityDescription(), request.getEntityDescription());
+    }
+
+    @Test
+    public void canMapPublicationToUpdatePublicationRequest() throws Exception {
+        Publication publication = getPublication();
+
+        UpdatePublicationRequest request = PublicationMapper
+            .convertValue(publication, UpdatePublicationRequest.class);
+
+        assertNotNull(request);
+        assertNotNull(request.getContext());
+        assertEquals(publication.getFileSet(), request.getFileSet());
+        assertEquals(publication.getProject(), request.getProject());
+        assertEquals(publication.getEntityDescription(), request.getEntityDescription());
     }
 
 }


### PR DESCRIPTION
Renamed mapper method `toResponse`to `convertValue` and added tests for other types to convert.