### PR TITLE
Fix range handling

### DIFF
--- a/src/main/java/no/unit/nva/model/exceptions/InvalidPageRangeException.java
+++ b/src/main/java/no/unit/nva/model/exceptions/InvalidPageRangeException.java
@@ -1,0 +1,10 @@
+package no.unit.nva.model.exceptions;
+
+public class InvalidPageRangeException extends Exception {
+
+    public static final String ERROR_TEMPLATE = "The supplied page range \"%s-%s\" is not valid";
+
+    public InvalidPageRangeException(String begin, String end) {
+        super(String.format(ERROR_TEMPLATE, begin, end));
+    }
+}

--- a/src/main/java/no/unit/nva/model/pages/MonographPages.java
+++ b/src/main/java/no/unit/nva/model/pages/MonographPages.java
@@ -5,6 +5,8 @@ import nva.commons.utils.JacocoGenerated;
 
 import java.util.Objects;
 
+import static java.util.Objects.isNull;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class MonographPages implements Pages {
     private Range introduction;
@@ -24,8 +26,18 @@ public class MonographPages implements Pages {
         return introduction;
     }
 
+    /**
+     * Because introductions are not obligatory, this constructor sets null to avoid an empty
+     * Range object in the serialized data.
+     * @param introduction a range object representing the extent of the introduction or null.
+     */
+    @SuppressWarnings("PMD.NullAssignment")
     public void setIntroduction(Range introduction) {
-        this.introduction = introduction;
+        if (isNull(introduction) || isNull(introduction.getBegin()) && isNull(introduction.getEnd())) {
+            this.introduction = null;
+        } else {
+            this.introduction = introduction;
+        }
     }
 
     public String getPages() {

--- a/src/main/java/no/unit/nva/model/pages/Range.java
+++ b/src/main/java/no/unit/nva/model/pages/Range.java
@@ -26,7 +26,8 @@ public class Range implements Pages {
      *
      * @param begin The beginning of the range.
      * @param end   The end of the range
-     * @throws InvalidPageRangeException thrown if one of beginning or end is null.
+     * @throws InvalidPageRangeException thrown if begin is null and end is not, or vice versa,
+     *                                   or if either or both values are empty.
      */
     @JsonCreator
     public Range(@JsonProperty("begin") String begin, @JsonProperty("end") String end) throws

--- a/src/main/java/no/unit/nva/model/pages/Range.java
+++ b/src/main/java/no/unit/nva/model/pages/Range.java
@@ -1,39 +1,97 @@
 package no.unit.nva.model.pages;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import nva.commons.utils.JacocoGenerated;
 
 import java.util.Objects;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Range implements Pages {
-    private String begin;
-    private String end;
+    public static final String EMPTY_STRING_PLACEHOLDER = "<empty string>";
+    public static final String NON_SPACE_WHITESPACE = "[\\n\\r\\t]+";
+    public static final String EMPTY_STRING = "";
 
-    public Range() {
+    private final String begin;
+    private final String end;
+
+    /**
+     * Default constructor for Range ensures that a range has a specified beginning and an end, and contains
+     * no unnecessary whitespace, nor members that are only whitespace.
+     *
+     * @param begin The beginning of the range.
+     * @param end   The end of the range
+     * @throws InvalidPageRangeException thrown if one of beginning or end is null.
+     */
+    @JsonCreator
+    public Range(@JsonProperty("begin") String begin, @JsonProperty("end") String end) throws
+            InvalidPageRangeException {
+        String sanitizedBegin = sanitize(begin);
+        String sanitizedEnd = sanitize(end);
+        if (oneValueIsNull(sanitizedBegin, sanitizedEnd) || oneOrBothValuesAreEmpty(sanitizedBegin, sanitizedEnd)) {
+            throw new InvalidPageRangeException(getErrorDisplayValue(sanitizedBegin),
+                    getErrorDisplayValue(sanitizedEnd));
+        }
+        this.begin = sanitizedBegin;
+        this.end = sanitizedEnd;
     }
 
-    private Range(Builder builder) {
-        setBegin(builder.begin);
-        setEnd(builder.end);
+    private String getErrorDisplayValue(String input) {
+        return nonNull(input) && input.isEmpty() ? EMPTY_STRING_PLACEHOLDER : input;
+    }
+
+    private boolean oneOrBothValuesAreEmpty(String begin, String end) {
+        return nonNull(begin) && begin.isEmpty() || nonNull(end) && end.isEmpty();
+    }
+
+    private boolean oneValueIsNull(String begin, String end) {
+        return isNull(begin) && nonNull(end) || nonNull(begin) && isNull(end);
+    }
+
+    private String sanitize(String input) {
+        return nonNull(input) ? removeWhiteSpace(input) : null;
+    }
+
+    private String removeWhiteSpace(String input) {
+        return input.replaceAll(NON_SPACE_WHITESPACE, EMPTY_STRING).trim();
+    }
+
+    private Range(Builder builder) throws InvalidPageRangeException {
+        this(builder.begin, builder.end);
     }
 
     public String getBegin() {
         return begin;
     }
 
-    public void setBegin(String begin) {
-        this.begin = begin;
-    }
-
     public String getEnd() {
         return end;
     }
 
-    public void setEnd(String end) {
-        this.end = end;
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Range)) {
+            return false;
+        }
+        Range range = (Range) o;
+        return Objects.equals(begin, range.begin)
+                && Objects.equals(end, range.end);
     }
 
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(begin, end);
+    }
 
     public static final class Builder {
         private String begin;
@@ -52,28 +110,8 @@ public class Range implements Pages {
             return this;
         }
 
-        public Range build() {
+        public Range build() throws InvalidPageRangeException {
             return new Range(this);
         }
-    }
-
-    @JacocoGenerated
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Range)) {
-            return false;
-        }
-        Range range = (Range) o;
-        return Objects.equals(getBegin(), range.getBegin())
-                && Objects.equals(getEnd(), range.getEnd());
-    }
-
-    @JacocoGenerated
-    @Override
-    public int hashCode() {
-        return Objects.hash(getBegin(), getEnd());
     }
 }

--- a/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.jsonldjava.utils.JsonUtils;
 import no.unit.nva.model.exceptions.InvalidIssnException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
@@ -32,8 +33,8 @@ public class PublicationJournalArticleTest extends PublicationTest {
     @DisplayName("The Publication class object can (de-)serialize valid JSON input")
     @Test
     public void publicationClassReturnsDeserializedJsonWhenValidJsonInput()
-        throws IOException, MalformedContributorException,
-            InvalidIssnException, InvalidPageTypeException {
+            throws IOException, MalformedContributorException, InvalidIssnException, InvalidPageTypeException,
+            InvalidPageRangeException {
 
         Publication publication = PublicationGenerator.generateJournalArticlePublication();
 
@@ -47,7 +48,7 @@ public class PublicationJournalArticleTest extends PublicationTest {
     @DisplayName("The serialized Publication class can be framed to match the RDF data model")
     @Test
     public void objectMappingOfPublicationClassReturnsSerializedJsonWithJsonLdFrame() throws IOException,
-            MalformedContributorException, InvalidIssnException, InvalidPageTypeException {
+            MalformedContributorException, InvalidIssnException, InvalidPageTypeException, InvalidPageRangeException {
 
         Publication publication = PublicationGenerator.generateJournalArticlePublication();
 

--- a/src/test/java/no/unit/nva/model/exceptions/InvalidPageRangeExceptionTest.java
+++ b/src/test/java/no/unit/nva/model/exceptions/InvalidPageRangeExceptionTest.java
@@ -1,0 +1,23 @@
+package no.unit.nva.model.exceptions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InvalidPageRangeExceptionTest {
+
+    @DisplayName("InvalidPageRangeException can be thrown and has message")
+    @Test
+    void invalidPageRangeExceptionHasMessageWhenThrown() {
+        String end = "somethingElse";
+        Executable executable = () -> {
+            throw new InvalidPageRangeException(null, end);
+        };
+        InvalidPageRangeException exception = assertThrows(InvalidPageRangeException.class, executable);
+        String expectedError = String.format(InvalidPageRangeException.ERROR_TEMPLATE, null, end);
+        assertEquals(expectedError, exception.getMessage());
+    }
+}

--- a/src/test/java/no/unit/nva/model/instancetypes/BookMonographTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/BookMonographTest.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.MonographPages;
 import no.unit.nva.model.pages.Pages;
@@ -10,8 +11,10 @@ import nva.commons.utils.JsonUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 
+import static java.util.Objects.nonNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -19,6 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BookMonographTest {
 
+    public static final String LATIN_NUMERAL_ONE = "i";
+    public static final String LATIN_NUMERAL_TWENTY_EIGHT = "xxviii";
+    public static final String THREE_HUNDRED_AND_NINETY_EIGHT = "398";
+    public static final String ONE = "1";
+    public static final String TWENTY_TWO = "22";
+    public static final String EMPTY_STRING = "";
     private final ObjectMapper objectMapper = JsonUtils.objectMapper;
 
     @DisplayName("BookMonograph exists")
@@ -29,14 +38,11 @@ class BookMonographTest {
 
     @DisplayName("BookMonograph: ObjectMapper correctly deserializes object")
     @Test
-    void objectMapperReturnsBookMonographWhenInputIsValid() throws JsonProcessingException {
-        String expectedIntroductionBegin = "i";
-        String expectedIntroductionEnd = "xxviii";
-        String expectedPages = "398";
-        Range expectedIntroductionObject = new Range.Builder()
-                .withBegin(expectedIntroductionBegin)
-                .withEnd(expectedIntroductionEnd)
-                .build();
+    void objectMapperReturnsBookMonographWhenInputIsValid() throws JsonProcessingException, InvalidPageRangeException {
+        String expectedIntroductionBegin = LATIN_NUMERAL_ONE;
+        String expectedIntroductionEnd = LATIN_NUMERAL_TWENTY_EIGHT;
+        String expectedPages = THREE_HUNDRED_AND_NINETY_EIGHT;
+        Range expectedIntroductionObject = getIntroduction(expectedIntroductionBegin, expectedIntroductionEnd);
         Pages expectedPagesObject = new MonographPages.Builder()
                 .withPages(expectedPages)
                 .withIllustrated(false)
@@ -56,41 +62,57 @@ class BookMonographTest {
     }
 
     @DisplayName("BookMonograph: ObjectMapper serializes valid input correctly")
-    @Test
-    void objectMapperReturnsExpectedJsonWhenInputIsValid() throws InvalidPageTypeException, JsonProcessingException {
-        String expectedIntroductionBegin = "i";
-        String expectedIntroductionEnd = "xxviii";
-        String expectedPages = "398";
-        Range expectedIntroductionObject = new Range.Builder()
-                .withBegin(expectedIntroductionBegin)
-                .withEnd(expectedIntroductionEnd)
-                .build();
-        Pages expectedPagesObject = new MonographPages.Builder()
-                .withPages(expectedPages)
-                .withIllustrated(true)
-                .withIntroduction(expectedIntroductionObject)
-                .build();
+    @ParameterizedTest
+    @CsvSource({
+            "i,xxviii,398,true,true,true,",
+            ",,231,false,true,true",
+            ",,123,true,false,false"
+    })
+
+    void objectMapperReturnsExpectedJsonWhenInputIsValid(String begin,
+                                                         String end,
+                                                         String pages,
+                                                         boolean illustrated,
+                                                         boolean peerReviewed,
+                                                         boolean openAccess) throws InvalidPageTypeException,
+            JsonProcessingException, InvalidPageRangeException {
         BookMonograph bookMonograph = new BookMonograph.Builder()
-                .withOpenAccess(true)
-                .withPeerReviewed(true)
-                .withPages(expectedPagesObject)
+                .withOpenAccess(openAccess)
+                .withPeerReviewed(peerReviewed)
+                .withPages(getPages(begin, end, pages, illustrated))
                 .build();
         String json = objectMapper.writeValueAsString(bookMonograph);
-        String expected = generateBookMonograph(expectedIntroductionBegin,
-                expectedIntroductionEnd,
-                expectedPages,
-                true,
-                true,
-                true);
+        String expected = generateBookMonograph(begin,
+                end,
+                pages,
+                illustrated,
+                peerReviewed,
+                openAccess);
         assertEquals(expected, json);
+    }
+
+    private Pages getPages(String begin, String end, String pages, boolean illustrated) throws
+            InvalidPageRangeException {
+        return new MonographPages.Builder()
+                    .withPages(pages)
+                    .withIllustrated(illustrated)
+                    .withIntroduction(getIntroduction(begin, end))
+                    .build();
+    }
+
+    private Range getIntroduction(String begin, String end) throws InvalidPageRangeException {
+        return new Range.Builder()
+                .withBegin(begin)
+                .withEnd(end)
+                .build();
     }
 
     @DisplayName("BookMonograph throws InvalidPageTypeException if pages is not MonographPages")
     @Test
-    void bookMonographThrowsInvalidPageTypeExceptionWhenInputIsRange() {
+    void bookMonographThrowsInvalidPageTypeExceptionWhenInputIsRange() throws InvalidPageRangeException {
         Range range = new Range.Builder()
-                .withBegin("1")
-                .withEnd("22")
+                .withBegin(ONE)
+                .withEnd(TWENTY_TWO)
                 .build();
         InvalidPageTypeException exception = assertThrows(
             InvalidPageTypeException.class, () -> new BookMonograph.Builder()
@@ -126,15 +148,19 @@ class BookMonographTest {
                                          boolean illustrated,
                                          boolean peerReviewed,
                                          boolean openAccess) {
+        String introduction = EMPTY_STRING;
+        if (nonNull(introductionBegin) && nonNull(introductionEnd)) {
+            introduction = "    \"introduction\" : {\n"
+                    + "      \"type\" : \"Range\",\n"
+                    + "      \"begin\" : \"" + introductionBegin + "\",\n"
+                    + "      \"end\" : \"" + introductionEnd + "\"\n"
+                    + "    },\n";
+        }
         return "{\n"
                 + "  \"type\" : \"BookMonograph\",\n"
                 + "  \"pages\" : {\n"
                 + "    \"type\" : \"MonographPages\",\n"
-                + "    \"introduction\" : {\n"
-                + "      \"type\" : \"Range\",\n"
-                + "      \"begin\" : \"" + introductionBegin + "\",\n"
-                + "      \"end\" : \"" + introductionEnd + "\"\n"
-                + "    },\n"
+                + introduction
                 + "    \"pages\" : \"" + pages + "\",\n"
                 + "    \"illustrated\" : " + illustrated + "\n"
                 + "  },\n"

--- a/src/test/java/no/unit/nva/model/instancetypes/JournalLeaderTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/JournalLeaderTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.model.instancetypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
@@ -17,7 +18,7 @@ class JournalLeaderTest {
     @DisplayName("JournalLeader can be created")
     @Test
     void journalLeaderReturnsValidJournalLeaderWhenInputDataIsValid() throws InvalidPageTypeException,
-            JsonProcessingException {
+            JsonProcessingException, InvalidPageRangeException {
         String type = "JournalLeader";
         String volume = "22";
         String issue = "5";
@@ -32,8 +33,7 @@ class JournalLeaderTest {
                 .withBegin(begin)
                 .withEnd(end)
                 .build();
-        boolean peerReviewed = true;
-        JournalLeader journalLeader = new JournalLeader(volume, issue, articleNumber, pages, peerReviewed);
+        JournalLeader journalLeader = new JournalLeader(volume, issue, articleNumber, pages, true);
         assertEquals(expected, journalLeader);
     }
 }

--- a/src/test/java/no/unit/nva/model/instancetypes/JournalLetterTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/JournalLetterTest.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.Range;
 import no.unit.nva.model.util.JournalNonPeerReviewedContentUtil;
@@ -18,7 +19,7 @@ class JournalLetterTest {
     @DisplayName("Journal letters to editor can be created from JSON")
     @Test
     void journalLetterReturnsObjectWhenJsonInputIsCorrectlySerialized() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         JournalLetter expected = generateJournalLetter("1", "3", "123", "2", "3");
         String json = objectMapper.writeValueAsString(expected);
         JournalLetter journalLetter = objectMapper.readValue(json, JournalLetter.class);
@@ -28,7 +29,7 @@ class JournalLetterTest {
     @DisplayName("Journal letters cannot be peer reviewed")
     @Test
     void journalLetterSetsPeerReviewedToFalseWhenPeerReviewIsTrue() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         ObjectMapper objectMapper = new ObjectMapper();
         String type = "JournalLetter";
         String volume = "1";
@@ -47,7 +48,7 @@ class JournalLetterTest {
                                                 String issue,
                                                 String articleNumber,
                                                 String begin,
-                                                String end) throws InvalidPageTypeException {
+                                                String end) throws InvalidPageTypeException, InvalidPageRangeException {
         Range pages = new Range.Builder()
                 .withBegin(begin)
                 .withEnd(end)

--- a/src/test/java/no/unit/nva/model/instancetypes/JournalReviewTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/JournalReviewTest.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.Range;
 import no.unit.nva.model.util.JournalNonPeerReviewedContentUtil;
@@ -18,7 +19,7 @@ class JournalReviewTest {
     @DisplayName("Journal review can be created from JSON")
     @Test
     void journalReviewReturnsObjectWhenJsonInputIsCorrectlySerialized() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         JournalReview expected =
                 generateJournalReview("1", "3", "123", "2", "3");
         String json = objectMapper.writeValueAsString(expected);
@@ -30,7 +31,7 @@ class JournalReviewTest {
     @DisplayName("Journal review cannot be peer reviewed")
     @Test
     void journalReviewSetsPeerReviewedToFalseWhenPeerReviewIsTrue() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         ObjectMapper objectMapper = new ObjectMapper();
         String type = "JournalReview";
         String volume = "1";
@@ -47,10 +48,10 @@ class JournalReviewTest {
     }
 
     private JournalReview generateJournalReview(String volume,
-                                                            String issue,
-                                                            String articleNumber,
-                                                            String begin,
-                                                            String end) throws InvalidPageTypeException {
+                                                String issue,
+                                                String articleNumber,
+                                                String begin,
+                                                String end) throws InvalidPageTypeException, InvalidPageRangeException {
         Range pages = new Range.Builder()
                 .withBegin(begin)
                 .withEnd(end)

--- a/src/test/java/no/unit/nva/model/instancetypes/JournalShortCommunicationTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/JournalShortCommunicationTest.java
@@ -2,6 +2,7 @@ package no.unit.nva.model.instancetypes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.Range;
 import no.unit.nva.model.util.JournalNonPeerReviewedContentUtil;
@@ -18,7 +19,7 @@ class JournalShortCommunicationTest {
     @DisplayName("Journal short communication can be created from JSON")
     @Test
     void journalShortCommunicationReturnsObjectWhenJsonInputIsCorrectlySerialized() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         JournalShortCommunication expected =
                 generateJournalShortCommunication("1", "3", "123", "2", "3");
         String json = objectMapper.writeValueAsString(expected);
@@ -30,7 +31,7 @@ class JournalShortCommunicationTest {
     @DisplayName("Journal short communication cannot be peer reviewed")
     @Test
     void journalShortCommunicationSetsPeerReviewedToFalseWhenPeerReviewIsTrue() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         ObjectMapper objectMapper = new ObjectMapper();
         String type = "JournalShortCommunication";
         String volume = "1";
@@ -50,7 +51,7 @@ class JournalShortCommunicationTest {
                                                 String issue,
                                                 String articleNumber,
                                                 String begin,
-                                                String end) throws InvalidPageTypeException {
+                                                String end) throws InvalidPageTypeException, InvalidPageRangeException {
         Range pages = new Range.Builder()
                 .withBegin(begin)
                 .withEnd(end)

--- a/src/test/java/no/unit/nva/model/instancetypes/PublicationInstanceTest.java
+++ b/src/test/java/no/unit/nva/model/instancetypes/PublicationInstanceTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
+
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.pages.MonographPages;
 import no.unit.nva.model.pages.Range;
@@ -23,7 +25,7 @@ class PublicationInstanceTest {
     @DisplayName("Publication instance can be serialized with Range object")
     @Test
     void publicationInstanceReturnsSerializedJsonWhenValidRangeIsInput() throws JsonProcessingException,
-            InvalidPageTypeException {
+            InvalidPageTypeException, InvalidPageRangeException {
         PublicationInstance publicationInstance = new JournalArticle();
 
         Range range = new Range.Builder()
@@ -40,7 +42,7 @@ class PublicationInstanceTest {
 
     @DisplayName("Publication instance cannot be serialized when pages is not a Range object")
     @Test
-    void journalArticleThrowsInvalidPageExceptionWhenValidMonographPagesIsInput() {
+    void journalArticleThrowsInvalidPageExceptionWhenValidMonographPagesIsInput() throws InvalidPageRangeException {
         PublicationInstance publicationInstance = new JournalArticle();
 
         MonographPages monographPages = new MonographPages.Builder()
@@ -52,8 +54,6 @@ class PublicationInstanceTest {
                 .withPages("90")
                 .build();
 
-        assertThrows(InvalidPageTypeException.class, () -> {
-            publicationInstance.setPages(monographPages);
-        });
+        assertThrows(InvalidPageTypeException.class, () -> publicationInstance.setPages(monographPages));
     }
 }

--- a/src/test/java/no/unit/nva/model/pages/RangeTest.java
+++ b/src/test/java/no/unit/nva/model/pages/RangeTest.java
@@ -1,0 +1,86 @@
+package no.unit.nva.model.pages;
+
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static no.unit.nva.model.pages.Range.EMPTY_STRING_PLACEHOLDER;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RangeTest {
+
+    @DisplayName("Range accepts strings as definitions of extent")
+    @ParameterizedTest
+    @CsvSource({
+            "begin,end", "1,7", "a,b", "A,Z", "i,ix"
+    })
+    void rangeReturnsRangeObjectWhenInputIsValid(String begin, String end) throws InvalidPageRangeException {
+        Range actual = new Range(begin, end);
+        Range expected = new Range.Builder()
+                .withBegin(begin)
+                .withEnd(end)
+                .build();
+        assertEquals(expected, actual);
+    }
+
+    @DisplayName("Range allows two null arguments")
+    @Test
+    void rangeDoesNotThrowInvalidPageRangeExceptionWhenBothArgumentsAreNull() {
+        assertDoesNotThrow(() -> new Range(null, null));
+    }
+
+    @DisplayName("Range throws InvalidPageRangeException if begin value is empty or just whitespace")
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"", " ", "\t", "\n", "\r\n"})
+    void rangeThrowsInvalidPageRangeExceptionWhenBeginIsEmptyString(String begin) {
+        String end = "ix";
+        Executable executable = () -> new Range(begin, end);
+        InvalidPageRangeException exception = assertThrows(InvalidPageRangeException.class, executable);
+        String expectedMessage = String.format(InvalidPageRangeException.ERROR_TEMPLATE, EMPTY_STRING_PLACEHOLDER, end);
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @DisplayName("Range throws InvalidPageRangeException if end value is empty or just whitespace")
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"", " ", "\t", "\n", "\r\n"})
+    void rangeThrowsInvalidPageRangeExceptionWhenEndtIsEmptyString(String end) {
+        String begin = "i";
+        Executable executable = () -> new Range(begin, end);
+        InvalidPageRangeException exception = assertThrows(InvalidPageRangeException.class, executable);
+        String expectedMessage = String.format(InvalidPageRangeException.ERROR_TEMPLATE,
+                begin, EMPTY_STRING_PLACEHOLDER);
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @DisplayName("Range throws InvalidPageRangeException when both begin and end values are empty")
+    @Test
+    void rangeThrowsInvalidPageRangeExceptionWhenBeginAndEndAreEmptyStrings() {
+        String begin = "";
+        String end = "";
+        Executable executable = () -> new Range(begin, end);
+        InvalidPageRangeException exception = assertThrows(InvalidPageRangeException.class, executable);
+        String expectedMessage = String.format(InvalidPageRangeException.ERROR_TEMPLATE,
+                EMPTY_STRING_PLACEHOLDER, EMPTY_STRING_PLACEHOLDER);
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @DisplayName("Range throws InvalidPageRangeException if only one of the inputs is null")
+    @ParameterizedTest
+    @CsvSource({",x", "i,"})
+    void rangeThrowsInvalidPageRangeExceptionWhenOnlyOneValueIsNull(String begin, String end) {
+        Executable executable = () -> new Range(begin, end);
+        InvalidPageRangeException exception = assertThrows(InvalidPageRangeException.class, executable);
+        String expectedMessage = String.format(InvalidPageRangeException.ERROR_TEMPLATE, begin, end);
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+}

--- a/src/test/java/no/unit/nva/model/util/PublicationGenerator.java
+++ b/src/test/java/no/unit/nva/model/util/PublicationGenerator.java
@@ -32,6 +32,7 @@ import no.unit.nva.model.ResearchProject;
 import no.unit.nva.model.Role;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidIssnException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.InvalidPageTypeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
@@ -48,8 +49,8 @@ public class PublicationGenerator {
 
     }
 
-    public static Publication generateJournalArticlePublication()
-        throws InvalidIssnException, MalformedContributorException, InvalidPageTypeException {
+    public static Publication generateJournalArticlePublication() throws InvalidIssnException,
+            MalformedContributorException, InvalidPageTypeException, InvalidPageRangeException {
         return generatePublication(UUID.randomUUID(), UUID.randomUUID(), Instant.now(),
                 generateEntityDescriptionJournalArticle());
     }
@@ -116,7 +117,7 @@ public class PublicationGenerator {
     }
 
     public static EntityDescription generateEntityDescriptionJournalArticle() throws InvalidIssnException,
-            InvalidPageTypeException, MalformedContributorException {
+            InvalidPageTypeException, MalformedContributorException, InvalidPageRangeException {
         return getEntityDescription(getJournalReference());
     }
 
@@ -143,7 +144,8 @@ public class PublicationGenerator {
             .build();
     }
 
-    public static Reference getJournalReference() throws InvalidIssnException, InvalidPageTypeException {
+    public static Reference getJournalReference() throws InvalidIssnException, InvalidPageTypeException,
+            InvalidPageRangeException {
         return new Reference.Builder()
             .withPublishingContext(getPublishingContextJournal())
             .withDoi(SOME_URI)
@@ -159,7 +161,8 @@ public class PublicationGenerator {
                 .build();
     }
 
-    public static PublicationInstance getPublicationInstanceJournalArticle() throws InvalidPageTypeException {
+    public static PublicationInstance getPublicationInstanceJournalArticle() throws InvalidPageTypeException,
+            InvalidPageRangeException {
         return new JournalArticle.Builder()
             .withArticleNumber("1234456")
             .withIssue("2")
@@ -255,7 +258,7 @@ public class PublicationGenerator {
             .build();
     }
 
-    public static Range getPages() {
+    public static Range getPages() throws InvalidPageRangeException {
         return new Range.Builder()
             .withBegin("1")
             .withEnd("15")


### PR DESCRIPTION
Given the requested changes in the. BookMonograph branch, it turned out that there was some odd cases that appeared as I wrote. the tests. This PR is the. result of the discoveries from. the QA:

- Ranges can be null
- Ranges cannot be null and a value (in either order)
- Ranges cannot be empty strings
- Range data is sanitized

As a result, we add:

- checks for the. above
- InvalidPageRangeException
- Some minor tweaks to the tests (incorporated from the BookMonograph QA)
- Additional testing for the cases mentioned above