### PR TITLE
Replace constructor with static reference to JsonUtils.objectMapper

### DIFF
--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -14,7 +14,7 @@ public class PublicationTest {
     public static final String PUBLICATION_CONTEXT_JSON = "src/main/resources/publicationContext.json";
     public static final String PUBLICATION_FRAME_JSON = "src/main/resources/publicationFrame.json";
 
-    protected final ObjectMapper objectMapper = nva.commons.utils.JsonUtils.objectMapper;
+    protected static final ObjectMapper objectMapper = nva.commons.utils.JsonUtils.objectMapper;
 
     protected JsonNode toPublicationWithContext(Publication publication) throws IOException {
         JsonNode document = objectMapper.readTree(objectMapper.writeValueAsString(publication));

--- a/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -1,11 +1,7 @@
 package no.unit.nva.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
@@ -17,20 +13,8 @@ import java.io.IOException;
 public class PublicationTest {
     public static final String PUBLICATION_CONTEXT_JSON = "src/main/resources/publicationContext.json";
     public static final String PUBLICATION_FRAME_JSON = "src/main/resources/publicationFrame.json";
-    protected final ObjectMapper objectMapper;
 
-    /**
-     * Constructor to be called when initializing tests that subclass this test superclass.
-     */
-    public PublicationTest() {
-        this.objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
+    protected final ObjectMapper objectMapper = nva.commons.utils.JsonUtils.objectMapper;
 
     protected JsonNode toPublicationWithContext(Publication publication) throws IOException {
         JsonNode document = objectMapper.readTree(objectMapper.writeValueAsString(publication));


### PR DESCRIPTION
Since we otherwise use nva.commons.util.JsonUtil.objectMapper, I replace the constructor with this.