### PR TITLE
Remove javadoc

### DIFF
--- a/src/main/java/no/unit/nva/model/instancetypes/Report.java
+++ b/src/main/java/no/unit/nva/model/instancetypes/Report.java
@@ -7,11 +7,6 @@ import no.unit.nva.model.pages.MonographPages;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Report extends NonPeerReviewedMonograph {
 
-    /**
-     * The constructor allows setting of pages and open access status, and sets peer-reviewed status to false.
-     *
-     * @param pages A {@link MonographPages} object.
-     */
     public Report(@JsonProperty("pages") MonographPages pages) {
         super(pages);
     }

--- a/src/main/java/no/unit/nva/model/instancetypes/ReportPolicy.java
+++ b/src/main/java/no/unit/nva/model/instancetypes/ReportPolicy.java
@@ -7,11 +7,6 @@ import no.unit.nva.model.pages.MonographPages;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ReportPolicy extends NonPeerReviewedMonograph {
 
-    /**
-     * Constructor for ReportPolicy.
-     *
-     * @param pages the Pages of the PublicationInstance.
-     */
     public ReportPolicy(@JsonProperty("pages") MonographPages pages) {
         super(pages);
     }

--- a/src/main/java/no/unit/nva/model/instancetypes/ReportResearch.java
+++ b/src/main/java/no/unit/nva/model/instancetypes/ReportResearch.java
@@ -7,11 +7,6 @@ import no.unit.nva.model.pages.MonographPages;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ReportResearch extends NonPeerReviewedMonograph {
 
-    /**
-     * Constructor for ReportResearch.
-     *
-     * @param pages the Pages of the PublicationInstance.
-     */
     public ReportResearch(@JsonProperty("pages") MonographPages pages) {
         super(pages);
     }

--- a/src/main/java/no/unit/nva/model/instancetypes/ReportWorkingPaper.java
+++ b/src/main/java/no/unit/nva/model/instancetypes/ReportWorkingPaper.java
@@ -7,10 +7,6 @@ import no.unit.nva.model.pages.MonographPages;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ReportWorkingPaper extends NonPeerReviewedMonograph {
 
-    /**
-     * Constructor for ReportWorkingPaper.
-     * @param pages {@link MonographPages} object for page count
-     */
     public ReportWorkingPaper(@JsonProperty("pages") MonographPages pages) {
         super(pages);
     }


### PR DESCRIPTION
Remove javadoc that had been required by checkstyle. These will not be maintained and the constructors they annotated are self-explanatory.