### PR TITLE
Make dates and UUIDs in documentation/*.json files static

### DIFF
--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "5a0d2a7d-d0f3-4d3c-918f-067d6a37eef7",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:54.905638Z",
-  "modifiedDate" : "2020-09-18T07:35:54.905803Z",
-  "publishedDate" : "2020-09-18T07:35:54.905828Z",
-  "indexedDate" : "2020-09-18T07:35:54.905788Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:54.905654Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -96,7 +97,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "bd32cbe5-b663-4fb2-93ad-3ea76b4feeef",
+      "identifier" : "05a9cb5a-a339-4980-8320-717b82bd47ad",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -110,7 +111,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:54.905745Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -124,13 +125,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:54.905820Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:54.905803Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:54.905654Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -77,6 +77,7 @@
       "doi" : "https://example.org/doi/12313/2313",
       "publicationInstance" : {
         "type" : "BookAnthology",
+        "textbookContent" : true,
         "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
@@ -97,7 +98,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "05a9cb5a-a339-4980-8320-717b82bd47ad",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "66efa170-58c4-4041-a3f5-5a85499ac10a",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -77,6 +77,7 @@
       "doi" : "https://example.org/doi/12313/2313",
       "publicationInstance" : {
         "type" : "BookMonograph",
+        "textbookContent" : true,
         "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
@@ -97,7 +98,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "2271db95-2750-4ff1-8001-e7486e40f586",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "17db02f3-08ed-4259-94a2-5cfac7cfd477",
+  "identifier" : "66efa170-58c4-4041-a3f5-5a85499ac10a",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.050208Z",
-  "modifiedDate" : "2020-09-18T07:35:55.050459Z",
-  "publishedDate" : "2020-09-18T07:35:55.050490Z",
-  "indexedDate" : "2020-09-18T07:35:55.050444Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.050232Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -96,7 +97,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "4194faf5-6f9b-40cb-9d9b-f595001ca0f2",
+      "identifier" : "2271db95-2750-4ff1-8001-e7486e40f586",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -110,7 +111,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.050395Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -124,13 +125,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.050475Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.050459Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.050232Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "4786455a-a606-4a3d-8e3f-85c318456c18",
+  "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.081030Z",
-  "modifiedDate" : "2020-09-18T07:35:55.081185Z",
-  "publishedDate" : "2020-09-18T07:35:55.081206Z",
-  "indexedDate" : "2020-09-18T07:35:55.081173Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.081043Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -84,7 +85,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "80857118-7f4c-4106-b65a-763f27354be5",
+      "identifier" : "d416613d-d05c-47dc-a41a-83194df056ff",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -98,7 +99,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.081154Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -112,13 +113,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.081198Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.081185Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.081043Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -70,6 +70,7 @@
       "doi" : "https://example.org/doi/12313/2313",
       "publicationInstance" : {
         "type" : "ChapterArticle",
+        "textbookContent" : true,
         "peerReviewed" : true,
         "pages" : {
           "type" : "Range",
@@ -85,7 +86,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "d416613d-d05c-47dc-a41a-83194df056ff",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "84712cbc-dd2d-433d-a8fc-dc42bc4765be",
+  "identifier" : "e8bbc0e4-ede8-4e4b-a90c-4094abd4e3b0",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.111945Z",
-  "modifiedDate" : "2020-09-18T07:35:55.112122Z",
-  "publishedDate" : "2020-09-18T07:35:55.112143Z",
-  "indexedDate" : "2020-09-18T07:35:55.112111Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.111963Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -95,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "a5179b67-40ea-4b2d-8461-86b06aa39f5c",
+      "identifier" : "29d6796d-ebb4-4b70-b24b-f4d21caa5263",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -109,7 +110,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.112080Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -123,13 +124,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.112135Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.112122Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.111963Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "e8bbc0e4-ede8-4e4b-a90c-4094abd4e3b0",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -96,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "29d6796d-ebb4-4b70-b24b-f4d21caa5263",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "513e90e7-4b26-4747-869c-44c5c6071d53",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -96,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "95983e37-d15f-441c-bd64-2c7bea659cdd",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "37dc496a-e771-41e1-a329-c52d98497417",
+  "identifier" : "513e90e7-4b26-4747-869c-44c5c6071d53",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.118282Z",
-  "modifiedDate" : "2020-09-18T07:35:55.118456Z",
-  "publishedDate" : "2020-09-18T07:35:55.118481Z",
-  "indexedDate" : "2020-09-18T07:35:55.118447Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.118316Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -95,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "439cc697-2dfc-4d79-8069-dfb33eadc5b7",
+      "identifier" : "95983e37-d15f-441c-bd64-2c7bea659cdd",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -109,7 +110,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.118414Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -123,13 +124,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.118471Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.118456Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.118316Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "74991152-b8ce-46d6-bd54-fcd0b2e93c67",
+  "identifier" : "d3c27245-0a60-4b48-b69c-f06c1b68f870",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.134443Z",
-  "modifiedDate" : "2020-09-18T07:35:55.134553Z",
-  "publishedDate" : "2020-09-18T07:35:55.134568Z",
-  "indexedDate" : "2020-09-18T07:35:55.134548Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.134450Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -95,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "b366ca39-1291-4e50-b8df-25392a595284",
+      "identifier" : "aad77c64-604c-4340-b794-68cc962c6359",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -109,7 +110,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.134517Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -123,13 +124,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.134560Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.134553Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.134450Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "d3c27245-0a60-4b48-b69c-f06c1b68f870",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -96,7 +96,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "aad77c64-604c-4340-b794-68cc962c6359",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "8600137d-af45-46ee-81de-53b86e6e70eb",
+  "identifier" : "4e4e0411-ebb1-4599-8702-7795c28ca3a7",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.139603Z",
-  "modifiedDate" : "2020-09-18T07:35:55.139729Z",
-  "publishedDate" : "2020-09-18T07:35:55.139744Z",
-  "indexedDate" : "2020-09-18T07:35:55.139723Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.139611Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -93,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "959791aa-b384-44c3-a8b3-c1dbc02b8532",
+      "identifier" : "a28a35b3-eede-42b4-b8cb-a07bf562c997",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -107,7 +108,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.139693Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -121,13 +122,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.139737Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.139729Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.139611Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "4e4e0411-ebb1-4599-8702-7795c28ca3a7",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -94,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "a28a35b3-eede-42b4-b8cb-a07bf562c997",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "cb4feb4a-ebdc-4256-8e0e-96c9e5bbeb9e",
+  "identifier" : "70c74e50-b9ba-48c2-a370-9b156478caa8",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.144297Z",
-  "modifiedDate" : "2020-09-18T07:35:55.144407Z",
-  "publishedDate" : "2020-09-18T07:35:55.144425Z",
-  "indexedDate" : "2020-09-18T07:35:55.144402Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.144305Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -93,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "5ab07e62-61d9-4b19-aaae-332b7ba023df",
+      "identifier" : "52e48c0f-1975-43fc-be62-61eba755d00b",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -107,7 +108,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.144389Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -121,13 +122,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.144418Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.144407Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.144305Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "70c74e50-b9ba-48c2-a370-9b156478caa8",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -94,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "52e48c0f-1975-43fc-be62-61eba755d00b",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "2ad7836d-fa65-4147-b55c-0aaad7ad3310",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -94,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "9a9e3463-c831-4a5f-87e3-eb456d9f7330",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "4313c2e6-f5f2-418d-b643-aa76cae8b705",
+  "identifier" : "2ad7836d-fa65-4147-b55c-0aaad7ad3310",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.148997Z",
-  "modifiedDate" : "2020-09-18T07:35:55.149127Z",
-  "publishedDate" : "2020-09-18T07:35:55.149144Z",
-  "indexedDate" : "2020-09-18T07:35:55.149115Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.149005Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -93,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "de0f5e2d-0a66-401d-9469-3a478cecd8ac",
+      "identifier" : "9a9e3463-c831-4a5f-87e3-eb456d9f7330",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -107,7 +108,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.149089Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -121,13 +122,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.149135Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.149127Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.149005Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "1dabcdb2-21fe-4e20-808b-5c14de27b0e1",
+  "identifier" : "4b85b379-25cc-4041-bde2-af466f697095",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.154060Z",
-  "modifiedDate" : "2020-09-18T07:35:55.154219Z",
-  "publishedDate" : "2020-09-18T07:35:55.154239Z",
-  "indexedDate" : "2020-09-18T07:35:55.154211Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.154068Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -93,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "95d23503-6b38-4eb4-8558-3d0b61d41303",
+      "identifier" : "82109937-71cb-4cdc-b539-264fbf0559f0",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -107,7 +108,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.154174Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -121,13 +122,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.154231Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.154219Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.154068Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "4b85b379-25cc-4041-bde2-af466f697095",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -94,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "82109937-71cb-4cdc-b539-264fbf0559f0",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "ca301ee8-bd15-4696-a73a-d50ad44d7d6e",
+  "identifier" : "625d870d-9c6f-44ff-be89-fbd5bf5eb177",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.169469Z",
-  "modifiedDate" : "2020-09-18T07:35:55.169584Z",
-  "publishedDate" : "2020-09-18T07:35:55.169600Z",
-  "indexedDate" : "2020-09-18T07:35:55.169578Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.169475Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -93,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "62db1fde-b369-40d2-8c48-7ac287543152",
+      "identifier" : "21881262-cb0c-43f3-8623-15cc09623d37",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -107,7 +108,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.169541Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -121,13 +122,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.169593Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.169584Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.169475Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "625d870d-9c6f-44ff-be89-fbd5bf5eb177",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -94,7 +94,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "21881262-cb0c-43f3-8623-15cc09623d37",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "1493cee4-3702-49fe-8069-27558732bc0d",
+  "identifier" : "b5c0436c-4098-4a1e-bd63-55ff6c3c47be",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.175787Z",
-  "modifiedDate" : "2020-09-18T07:35:55.175913Z",
-  "publishedDate" : "2020-09-18T07:35:55.175930Z",
-  "indexedDate" : "2020-09-18T07:35:55.175907Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.175793Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -98,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "32ba6137-3a50-4f91-8ef9-379984f98ca8",
+      "identifier" : "eb38ddaf-227b-4663-b3d6-5a7359f14047",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -112,7 +113,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.175876Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -126,13 +127,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.175920Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.175913Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.175793Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "b5c0436c-4098-4a1e-bd63-55ff6c3c47be",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -99,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "eb38ddaf-227b-4663-b3d6-5a7359f14047",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "954fe380-021d-4431-a45d-b1ddea235932",
+  "identifier" : "5f792896-e635-4a10-b3ef-6c2b81cbafa0",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.181699Z",
-  "modifiedDate" : "2020-09-18T07:35:55.181776Z",
-  "publishedDate" : "2020-09-18T07:35:55.181785Z",
-  "indexedDate" : "2020-09-18T07:35:55.181773Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.181704Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -98,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "309bcbbe-cc2d-4f2f-9b84-8d7583aea3b0",
+      "identifier" : "1badff10-bc68-41d6-9a04-e14fe4f7d761",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -112,7 +113,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.181766Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -126,13 +127,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.181780Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.181776Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.181704Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "5f792896-e635-4a10-b3ef-6c2b81cbafa0",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -99,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "1badff10-bc68-41d6-9a04-e14fe4f7d761",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "c41ef548-aca0-479c-b074-1276fd5bbfa7",
+  "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -99,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "7bd7ecc7-e052-46bf-bb7b-49f092db59c0",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,6 +1,6 @@
 {
   "type" : "Publication",
-  "identifier" : "be84ed22-2f64-463a-9d4b-ffd421fbe93b",
+  "identifier" : "c41ef548-aca0-479c-b074-1276fd5bbfa7",
   "status" : "Published",
   "owner" : "me@example.org",
   "publisher" : {
@@ -10,16 +10,17 @@
       "no" : "Eksempelforlaget"
     }
   },
-  "createdDate" : "2020-09-18T07:35:55.186527Z",
-  "modifiedDate" : "2020-09-18T07:35:55.186617Z",
-  "publishedDate" : "2020-09-18T07:35:55.186628Z",
-  "indexedDate" : "2020-09-18T07:35:55.186614Z",
+  "createdDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
   "handle" : "https://example.org/fakeHandle/13213",
   "doi" : "https://example.org/yet/another/fake/doi/1231/12311",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
-    "date" : "2020-09-18T07:35:55.186532Z"
+    "date" : "2020-09-23T09:51:23.044996ZZ",
+    "messages" : [ ]
   },
   "link" : "https://this.should.have.been.removed",
   "entityDescription" : {
@@ -98,7 +99,7 @@
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
-      "identifier" : "5139f044-55a3-4d75-ba84-c8a78db4f834",
+      "identifier" : "7bd7ecc7-e052-46bf-bb7b-49f092db59c0",
       "name" : "new document(1)",
       "mimeType" : "application/pdf",
       "size" : 2,
@@ -112,7 +113,7 @@
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : true,
-      "embargoDate" : "2020-09-18T07:35:55.186596Z"
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "project" : {
@@ -126,13 +127,13 @@
     } ],
     "approvals" : [ {
       "type" : "Approval",
-      "date" : "2020-09-18T07:35:55.186622Z",
+      "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
       "applicationCode" : "123123"
     } ]
   },
   "publisherId" : "http://example.org/org/123",
-  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-18T07:35:55.186617Z",
-  "doiRequestStatusDate" : "APPROVED#2020-09-18T07:35:55.186532Z"
+  "publisherOwnerDate" : "http://example.org/org/123#me@example.org#2020-09-23T09:51:23.044996ZZ",
+  "doiRequestStatusDate" : "APPROVED#2020-09-23T09:51:23.044996ZZ"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -714,10 +714,10 @@ referencedSchemas:
     - type
     type: object
     properties:
-      peerReviewed:
-        type: boolean
       pages:
         $ref: '#/components/schemas/Pages'
+      peerReviewed:
+        type: boolean
       type:
         type: string
     discriminator:

--- a/src/test/java/no/unit/nva/PublicationTest.java
+++ b/src/test/java/no/unit/nva/PublicationTest.java
@@ -10,9 +10,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -25,6 +26,9 @@ import static org.hamcrest.core.IsNot.not;
 
 public class PublicationTest extends ModelTest {
 
+    public static final String TIMESTAMP_REGEX = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+";
+    public static final String SOME_TIMESTAMP = "2020-09-23T09:51:23.044996Z";
+    public static final String DOCUMENTATION_PATH_TEMPLATE = "documentation/%s.json";
     ObjectMapper objectMapper = JsonUtils.objectMapper;
 
     @DisplayName("Test that each publication type can be round-tripped to and from JSON")
@@ -158,8 +162,9 @@ public class PublicationTest extends ModelTest {
 
 
     private void writePublicationToFile(String instanceType, Publication publication) throws IOException {
-        String path = String.format("documentation/%s.json", instanceType);
-        File file = new File(path);
-        objectMapper.writeValue(file, publication);
+        String path = String.format(DOCUMENTATION_PATH_TEMPLATE, instanceType);
+        var publicationJson = objectMapper.writeValueAsString(publication)
+                .replaceAll(TIMESTAMP_REGEX, SOME_TIMESTAMP);
+        Files.write(Paths.get(path), publicationJson.getBytes());
     }
 }

--- a/src/test/java/no/unit/nva/PublicationTest.java
+++ b/src/test/java/no/unit/nva/PublicationTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.unit.nva.model.File;
 import no.unit.nva.model.ModelTest;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationStatus;
@@ -15,6 +16,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static no.unit.nva.hamcrest.DoesNotHaveNullOrEmptyFields.doesNotHaveNullOrEmptyFields;
@@ -29,6 +31,8 @@ public class PublicationTest extends ModelTest {
     public static final String TIMESTAMP_REGEX = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+";
     public static final String SOME_TIMESTAMP = "2020-09-23T09:51:23.044996Z";
     public static final String DOCUMENTATION_PATH_TEMPLATE = "documentation/%s.json";
+    public static final UUID REPLACEMENT_IDENTIFIER_1 = UUID.fromString("c443030e-9d56-43d8-afd1-8c89105af555");
+    public static final UUID REPLACEMENT_IDENTIFIER_2 = UUID.fromString("5032710d-a326-43d3-a8fb-57a451873c78");
     ObjectMapper objectMapper = JsonUtils.objectMapper;
 
     @DisplayName("Test that each publication type can be round-tripped to and from JSON")
@@ -162,9 +166,23 @@ public class PublicationTest extends ModelTest {
 
 
     private void writePublicationToFile(String instanceType, Publication publication) throws IOException {
+        publication.setIdentifier(REPLACEMENT_IDENTIFIER_1);
+        publication.getFileSet().getFiles().forEach(file -> publication.getFileSet()
+                .setFiles(List.of(copyWithNewIdentifier(file))));
         String path = String.format(DOCUMENTATION_PATH_TEMPLATE, instanceType);
         var publicationJson = objectMapper.writeValueAsString(publication)
                 .replaceAll(TIMESTAMP_REGEX, SOME_TIMESTAMP);
         Files.write(Paths.get(path), publicationJson.getBytes());
+    }
+
+    private File copyWithNewIdentifier(File file) {
+        return new File(PublicationTest.REPLACEMENT_IDENTIFIER_2,
+                file.getName(),
+                file.getMimeType(),
+                file.getSize(),
+                file.getLicense(),
+                file.isAdministrativeAgreement(),
+                file.isPublisherAuthority(),
+                file.getEmbargoDate());
     }
 }


### PR DESCRIPTION
Make dates and UUIDs in generated documents static, removing the unnecessary changes in these files because the dates and UUIDs are autogenerated for each test pass.