### PR TITLE
Upgrade wrapper and use jvm toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ configurations {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
 def junitVersion = '5.6.2'
 def jacksonVersion = '2.10.2'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu May 14 09:25:08 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade wrapper
Use java toolchain — see https://docs.gradle.org/current/userguide/toolchains.html