### PR TITLE
Np 1979 drafted doi request status

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -278,19 +278,7 @@
       <property name="target"
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
-    <module name="JavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
-    </module>
-    <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
-    </module>
+
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -355,7 +355,7 @@ referencedSchemas:
       status:
         type: string
         enum:
-        - DRAFTED
+        - DRAFT
         - REQUESTED
         - APPROVED
         - REJECTED

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -355,6 +355,7 @@ referencedSchemas:
       status:
         type: string
         enum:
+        - DRAFTED
         - REQUESTED
         - APPROVED
         - REJECTED

--- a/src/main/java/no/unit/nva/model/DoiRequestStatus.java
+++ b/src/main/java/no/unit/nva/model/DoiRequestStatus.java
@@ -1,7 +1,6 @@
 package no.unit.nva.model;
 
 import static java.util.Collections.emptySet;
-import java.util.Locale;
 import java.util.Set;
 
 public enum DoiRequestStatus {
@@ -10,7 +9,6 @@ public enum DoiRequestStatus {
     REJECTED;
     public static final String ERROR_MESSAGE_NOT_ALLOWED_TO_CHANGE_STATUS_FROM_S_TO_S =
         "Not allowed to change status from %s to %s";
-    public static final Locale DEFAULT_LOCALE = Locale.getDefault();
     public static final String INVALID_DOI_REQUEST_STATUS_ERROR = "Invalid DoiRequest status: ";
     protected static final Set<DoiRequestStatus> validStatusChangeForRejected = Set.of(APPROVED);
     protected static final Set<DoiRequestStatus> validStatusChangeForRequested = Set.of(APPROVED, REJECTED);

--- a/src/main/java/no/unit/nva/model/DoiRequestStatus.java
+++ b/src/main/java/no/unit/nva/model/DoiRequestStatus.java
@@ -1,25 +1,39 @@
 package no.unit.nva.model;
 
 import static java.util.Collections.emptySet;
-
+import java.util.Locale;
 import java.util.Set;
 
 public enum DoiRequestStatus {
     REQUESTED,
     APPROVED,
     REJECTED;
+    public static final String ERROR_MESSAGE_NOT_ALLOWED_TO_CHANGE_STATUS_FROM_S_TO_S =
+        "Not allowed to change status from %s to %s";
+    public static final Locale DEFAULT_LOCALE = Locale.getDefault();
+    public static final String INVALID_DOI_REQUEST_STATUS_ERROR = "Invalid DoiRequest status: ";
     protected static final Set<DoiRequestStatus> validStatusChangeForRejected = Set.of(APPROVED);
     protected static final Set<DoiRequestStatus> validStatusChangeForRequested = Set.of(APPROVED, REJECTED);
     protected static final Set<DoiRequestStatus> validDefaultStatusChanges = emptySet();
-    public static final String ERROR_MESSAGE_NOT_ALLOWED_TO_CHANGE_STATUS_FROM_S_TO_S =
-        "Not allowed to change status from %s to %s";
+
+    public static DoiRequestStatus parse(String doiRequestStatus) {
+        DoiRequestStatus[] values = DoiRequestStatus.values();
+        String upperCased = doiRequestStatus.toUpperCase(DEFAULT_LOCALE);
+        for (DoiRequestStatus status : values) {
+            if (status.name().toUpperCase(DEFAULT_LOCALE).equals(upperCased)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException(INVALID_DOI_REQUEST_STATUS_ERROR + doiRequestStatus);
+    }
 
     public boolean isValidStatusChange(DoiRequestStatus requestedStatusChange) {
         return getValidTransitions(this).contains(requestedStatusChange);
     }
 
     /**
-     * Changes status for a DoiRequestStatus change. It will return the new DoiRequestStatus if the transition is valid.
+     * Changes status for a DoiRequestStatus change. It will return the new DoiRequestStatus if the transition is
+     * valid.
      *
      * @param requestedStatusChange requested DOIRequestStatus to transform to.
      * @return New DoiRequestStatus.

--- a/src/main/java/no/unit/nva/model/DoiRequestStatus.java
+++ b/src/main/java/no/unit/nva/model/DoiRequestStatus.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptySet;
 import java.util.Set;
 
 public enum DoiRequestStatus {
+    DRAFTED,
     REQUESTED,
     APPROVED,
     REJECTED;
@@ -11,6 +12,7 @@ public enum DoiRequestStatus {
         "Not allowed to change status from %s to %s";
     public static final String INVALID_DOI_REQUEST_STATUS_ERROR = "Invalid DoiRequest status: ";
     protected static final Set<DoiRequestStatus> validStatusChangeForRejected = Set.of(APPROVED);
+    private static final Set<DoiRequestStatus> validStatusChangeForDrafted = Set.of(REQUESTED);
     protected static final Set<DoiRequestStatus> validStatusChangeForRequested = Set.of(APPROVED, REJECTED);
     protected static final Set<DoiRequestStatus> validDefaultStatusChanges = emptySet();
 
@@ -50,6 +52,8 @@ public enum DoiRequestStatus {
 
     private Set<DoiRequestStatus> getValidTransitions(DoiRequestStatus fromRequestStatus) {
         switch (fromRequestStatus) {
+            case DRAFTED:
+                return validStatusChangeForDrafted;
             case REQUESTED:
                 return validStatusChangeForRequested;
             case REJECTED:

--- a/src/main/java/no/unit/nva/model/DoiRequestStatus.java
+++ b/src/main/java/no/unit/nva/model/DoiRequestStatus.java
@@ -18,9 +18,9 @@ public enum DoiRequestStatus {
 
     public static DoiRequestStatus parse(String doiRequestStatus) {
         DoiRequestStatus[] values = DoiRequestStatus.values();
-        String upperCased = doiRequestStatus.toUpperCase(DEFAULT_LOCALE);
+
         for (DoiRequestStatus status : values) {
-            if (status.name().toUpperCase(DEFAULT_LOCALE).equals(upperCased)) {
+            if (status.name().equalsIgnoreCase(doiRequestStatus)) {
                 return status;
             }
         }

--- a/src/main/java/no/unit/nva/model/DoiRequestStatus.java
+++ b/src/main/java/no/unit/nva/model/DoiRequestStatus.java
@@ -4,7 +4,7 @@ import static java.util.Collections.emptySet;
 import java.util.Set;
 
 public enum DoiRequestStatus {
-    DRAFTED,
+    DRAFT,
     REQUESTED,
     APPROVED,
     REJECTED;
@@ -52,7 +52,7 @@ public enum DoiRequestStatus {
 
     private Set<DoiRequestStatus> getValidTransitions(DoiRequestStatus fromRequestStatus) {
         switch (fromRequestStatus) {
-            case DRAFTED:
+            case DRAFT:
                 return validStatusChangeForDrafted;
             case REQUESTED:
                 return validStatusChangeForRequested;

--- a/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
+++ b/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
@@ -31,6 +31,7 @@ public class DoiRequestStatusTest {
         "REQUESTED,APPROVED,APPROVED",
         "REQUESTED,REJECTED,REJECTED",
         "REJECTED,APPROVED,APPROVED",
+        "DRAFTED,REQUESTED,REQUESTED"
     })
     @DisplayName("Should follow business rules for valid status changes on DoiRequestStatus")
     void validStatusChanges(DoiRequestStatus existingState,

--- a/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
+++ b/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
@@ -8,8 +8,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class DoiRequestStatusTest {
+
+    @ParameterizedTest(name = "parse returns DoiRequestStatus '{1}' for input: '{0}'")
+    @CsvSource({
+        "requested,REQUESTED",
+        "Requested,REQUESTED",
+        "reQueSted,REQUESTED",
+        "REjeCted,REJECTED",
+        "rejected,REJECTED",
+        "approved,APPROVED",
+        "Approved,APPROVED",
+    })
+    public void parseReturnsDoiRequestStatusIgnoringCase(String input, DoiRequestStatus expected){
+        DoiRequestStatus actual = DoiRequestStatus.parse(input);
+        assertThat(actual,is(equalTo(expected)));
+    }
 
     @ParameterizedTest
     // ExistingState , RequestedChange, ExpectedState

--- a/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
+++ b/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
@@ -31,7 +31,7 @@ public class DoiRequestStatusTest {
         "REQUESTED,APPROVED,APPROVED",
         "REQUESTED,REJECTED,REJECTED",
         "REJECTED,APPROVED,APPROVED",
-        "DRAFTED,REQUESTED,REQUESTED"
+        "DRAFT,REQUESTED,REQUESTED"
     })
     @DisplayName("Should follow business rules for valid status changes on DoiRequestStatus")
     void validStatusChanges(DoiRequestStatus existingState,

--- a/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
+++ b/src/test/java/no/unit/nva/model/DoiRequestStatusTest.java
@@ -4,11 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class DoiRequestStatusTest {
 
@@ -22,9 +20,9 @@ public class DoiRequestStatusTest {
         "approved,APPROVED",
         "Approved,APPROVED",
     })
-    public void parseReturnsDoiRequestStatusIgnoringCase(String input, DoiRequestStatus expected){
+    public void parseReturnsDoiRequestStatusIgnoringCase(String input, DoiRequestStatus expected) {
         DoiRequestStatus actual = DoiRequestStatus.parse(input);
-        assertThat(actual,is(equalTo(expected)));
+        assertThat(actual, is(equalTo(expected)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The DoiRequest and the Publication are now separate entries and the DoiRequest status should be defined by data found only in the DoiRequest entry. Also by separating a Draft DOI from a Requested DOi one can publish a Publication with a Draft DOI and request a findable DOi afterwards