### PR TITLE
periodical extends basic context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'de.fuerstenau.buildconfig'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-String versionNumber = '0.13.1'
+String versionNumber = '0.13.2'
 
 group 'com.github.bibsysdev'
 version versionNumber

--- a/src/main/java/no/unit/nva/model/contexttypes/Journal.java
+++ b/src/main/java/no/unit/nva/model/contexttypes/Journal.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import static java.util.Objects.isNull;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class Journal implements Periodical, BasicContext {
+public class Journal implements Periodical {
     private final URI id;
 
     @JsonCreator

--- a/src/main/java/no/unit/nva/model/contexttypes/Periodical.java
+++ b/src/main/java/no/unit/nva/model/contexttypes/Periodical.java
@@ -1,5 +1,5 @@
 package no.unit.nva.model.contexttypes;
 
-public interface Periodical {
+public interface Periodical extends BasicContext {
 
 }

--- a/src/main/java/no/unit/nva/model/contexttypes/UnconfirmedJournal.java
+++ b/src/main/java/no/unit/nva/model/contexttypes/UnconfirmedJournal.java
@@ -10,7 +10,7 @@ import nva.commons.core.JacocoGenerated;
 import java.util.Objects;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public class UnconfirmedJournal implements Periodical, BasicContext {
+public class UnconfirmedJournal implements Periodical {
     private final String title;
     private final String printIssn;
     private final String onlineIssn;


### PR DESCRIPTION
When we are referring to a Periodical in order to cover both the cases of Journal and Unconfirmed Journal, we are in a situation where a Periodical is not a PublicationContext.