### PR TITLE
Move venue to ArtisticDesign

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version '0.14.23'
+version '0.14.24'
 
 
 repositories {

--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version '0.14.24'
+version '0.15.0'
 
 
 repositories {

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,104 +1,112 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "sTz2MabIsQuLbx92CSf",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "yB2mrxFFqOEBFo",
   "resourceOwner" : {
-    "owner" : "sTz2MabIsQuLbx92CSf",
-    "ownerAffiliation" : "https://www.example.org/doloresfuga"
+    "owner" : "yB2mrxFFqOEBFo",
+    "ownerAffiliation" : "https://www.example.org/autdoloribus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/temporibusvoluptatum",
+    "id" : "https://www.example.org/repellenduscumque",
     "labels" : {
-      "7PyJO8XVa3Fd53jOP" : "wU0VlYalsas"
+      "Yip2ohcQ6xAezRTTVr" : "aimmN1jaClsYYMy"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nihilvelit",
-  "doi" : "https://doi.org/10.1234/repudiandae",
+  "handle" : "https://www.example.org/earumiure",
+  "doi" : "https://doi.org/10.1234/officia",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "hN6dXyXFpJYnp6wfS",
-      "author" : "pZQ2ezkoBZgDUNcdM",
+      "text" : "9PxnlzxvUTjpt",
+      "author" : "SIlJJVSajHBS3s7K5P",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/aliquamquidem",
+  "link" : "https://www.example.org/itaquearchitecto",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pMEUZlSvSBdpDG",
+    "mainTitle" : "sAArJXa9IU",
     "alternativeTitles" : {
-      "pl" : "SOPrTDKHWl"
+      "nb" : "FvLKopFURVSVRRJU4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Ef0Hd00ri8uLiONzq6T",
-      "month" : "saCL8kClPjFf",
-      "day" : "4UZDJUknIIVqa4fC"
+      "year" : "1xsn7e8rHN2pU",
+      "month" : "hwQdypQEopiVL86",
+      "day" : "VMg3N6rT4ns"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uqPfSZEMbu5W",
-        "name" : "0LzvAwW5jbP82fUt",
-        "nameType" : "Organizational",
-        "orcId" : "ObOYhpbs6b",
-        "arpId" : "IJvJUKMNKCS1"
+        "id" : "https://www.example.com/0uHyiFsYtiV",
+        "name" : "JLt4mESg73i8",
+        "nameType" : "Personal",
+        "orcId" : "pMA0zxo1SM",
+        "arpId" : "9GzlvmYAG3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/00fyKaGlcnfYM",
+        "id" : "https://www.example.com/r4zqtGx1GtlPQI9wkD",
         "labels" : {
-          "7okCNJz4jGaYgSbKYp" : "QQxTHjpofcG6fakbA7"
+          "Ffef19QuNSja2oR" : "hijRE7s5m4CgN"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 3,
+      "role" : "Funder",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/tB9dORFhHbxZH",
-        "name" : "3QbRMICDcie9",
-        "nameType" : "Personal",
-        "orcId" : "FQPAtRAe6c4bxd7e",
-        "arpId" : "braEYGG1S09oTAkUd"
+        "id" : "https://www.example.com/rMJzdeQgE9mCystg",
+        "name" : "hKflYBm9UanR2o0ZLRP",
+        "nameType" : "Organizational",
+        "orcId" : "TG3gXmGHS3oi",
+        "arpId" : "QG1TFP4p9YNsb8YZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0RAm1yF0ZQZs3dxV",
+        "id" : "https://www.example.com/b5T1vHNa6PBkW",
         "labels" : {
-          "a0edtbqhgTQyFB" : "hwQtMyPBpG"
+          "7Fw68WTPMNv6" : "gNLIaLMQQ17cc"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 7,
+      "role" : "Researcher",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "UgUKfCA485ugCbOk7i",
-    "tags" : [ "ui4vAXKkemRbH" ],
-    "description" : "uXvJ0KIHlQJuYyG",
+    "npiSubjectHeading" : "wYJOkaYE2Eb5Ppdz8j",
+    "tags" : [ "r1kq5Vlsgvjsnmm7Y" ],
+    "description" : "MLRTTbW8wj2JO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "Artistic",
+        "type" : "Artistic"
+      },
+      "doi" : "https://www.example.com/A2EtsQeefNCFH1YRs",
+      "publicationInstance" : {
+        "type" : "ArtisticDesign",
+        "subtype" : {
+          "type" : "WebDesign"
+        },
+        "description" : "p4PUC0mSeLLK54nkOar",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "eMMXPXQ9X0wJjIb92fQ",
+            "label" : "dT2VTcB7kYL",
             "country" : "Germany"
           },
           "time" : {
@@ -106,12 +114,12 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 349735114
+          "sequence" : 1720930259
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "pp2R9uDl5Yxo1p6B888",
+            "label" : "AHYvHam6j5RS",
             "country" : "Germany"
           },
           "time" : {
@@ -119,40 +127,32 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1702204558
-        } ]
-      },
-      "doi" : "https://www.example.com/tGbXtpAAAhNISE",
-      "publicationInstance" : {
-        "type" : "ArtisticDesign",
-        "subtype" : {
-          "type" : "ProductDesign"
-        },
-        "description" : "mf2mPrilfxO9x",
+          "sequence" : 920081138
+        } ],
+        "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
-        },
-        "peerReviewed" : false
+        }
       }
     },
-    "metadataSource" : "https://www.example.com/dr5ASA9CE1bZHu",
-    "abstract" : "wAcGoWe8TFGyZ"
+    "metadataSource" : "https://www.example.com/MsqFSRpoauicM7r",
+    "abstract" : "tENS7o6DpqgGs2Zv"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "D9PgqYN4qybDjVFKSn",
-      "mimeType" : "mTOo9QIJTD4nYcC",
-      "size" : 338643493,
+      "name" : "W4q7G4Pt474",
+      "mimeType" : "56OqTkQz9t11k",
+      "size" : 1249310242,
       "license" : {
         "type" : "License",
-        "identifier" : "d40h3vchSGQMM3I",
+        "identifier" : "m2IYzoeW2E82lbjY",
         "labels" : {
-          "3fft6el5xC30QdrHxmG" : "UJjqmSFnVRR"
+          "jFVgBz3ycI" : "4HYbtF7qcad5I16TTc"
         },
-        "link" : "https://www.example.com/lInyXT4qlONERG7z"
+        "link" : "https://www.example.com/EMBIWlDv8685yAFlGeW"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -161,19 +161,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/itaquetempore",
-    "name" : "JXPjphdOmDygr2V",
+    "id" : "https://www.example.org/quiaest",
+    "name" : "BD45lQZ3JJryU5Aos",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "VOtbtzxGE94mQmBBl1R",
-      "id" : "CURoPUSRSREMH"
+      "source" : "d4qGxb5dykTiSQ8FK",
+      "id" : "boFMWcILXYc73v"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "dRIUUA3sW1Us"
+      "applicationCode" : "6PtLgAn73FIz"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -181,6 +181,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consequaturomnis" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/etmaiores" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -2,111 +2,111 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
-  "owner" : "yB2mrxFFqOEBFo",
+  "owner" : "kMbeCPEa90Ytfbxd",
   "resourceOwner" : {
-    "owner" : "yB2mrxFFqOEBFo",
-    "ownerAffiliation" : "https://www.example.org/autdoloribus"
+    "owner" : "kMbeCPEa90Ytfbxd",
+    "ownerAffiliation" : "https://www.example.org/voluptaseos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repellenduscumque",
+    "id" : "https://www.example.org/ipsamcumque",
     "labels" : {
-      "Yip2ohcQ6xAezRTTVr" : "aimmN1jaClsYYMy"
+      "G3tab7B0DMp" : "JUR9PAZ3HP9"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/earumiure",
-  "doi" : "https://doi.org/10.1234/officia",
+  "handle" : "https://www.example.org/exercitationematque",
+  "doi" : "https://doi.org/10.1234/nam",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "9PxnlzxvUTjpt",
-      "author" : "SIlJJVSajHBS3s7K5P",
+      "text" : "Ge1xHU5lH4AA6K8YxB",
+      "author" : "IwNzgPzt4ysT",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/itaquearchitecto",
+  "link" : "https://www.example.org/ducimusmagni",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sAArJXa9IU",
+    "mainTitle" : "7ZY6PGmQJjdNLQz4ua",
     "alternativeTitles" : {
-      "nb" : "FvLKopFURVSVRRJU4"
+      "nb" : "oL0narqEib"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "1xsn7e8rHN2pU",
-      "month" : "hwQdypQEopiVL86",
-      "day" : "VMg3N6rT4ns"
+      "year" : "gJywmkDxDc",
+      "month" : "RbBKoz7SHMY7lqHMq",
+      "day" : "LivBAHhKcGQce0k"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0uHyiFsYtiV",
-        "name" : "JLt4mESg73i8",
-        "nameType" : "Personal",
-        "orcId" : "pMA0zxo1SM",
-        "arpId" : "9GzlvmYAG3"
+        "id" : "https://www.example.com/Xl3Fo6dhMrWhJ44",
+        "name" : "es7o29lWtreX",
+        "nameType" : "Organizational",
+        "orcId" : "4tS6CpfB8WAsRoD3C0y",
+        "arpId" : "wuDL21oFfVDGddCRr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/r4zqtGx1GtlPQI9wkD",
+        "id" : "https://www.example.com/86T0UBdBqCo",
         "labels" : {
-          "Ffef19QuNSja2oR" : "hijRE7s5m4CgN"
+          "4FeoGiMXHghmxP" : "DCn8EyQaY4"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 4,
+      "role" : "ProjectMember",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rMJzdeQgE9mCystg",
-        "name" : "hKflYBm9UanR2o0ZLRP",
-        "nameType" : "Organizational",
-        "orcId" : "TG3gXmGHS3oi",
-        "arpId" : "QG1TFP4p9YNsb8YZ"
+        "id" : "https://www.example.com/1QSv7RhGdZSLoA3",
+        "name" : "NwkHYP3TCHZM",
+        "nameType" : "Personal",
+        "orcId" : "NkTX4uRuseIuFC88ziX",
+        "arpId" : "M3K4f1Ffz5abK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/b5T1vHNa6PBkW",
+        "id" : "https://www.example.com/XDhKnColbTxwUcC",
         "labels" : {
-          "7Fw68WTPMNv6" : "gNLIaLMQQ17cc"
+          "uhCHzvoogwO" : "yXnIKbINrtwlzW4"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 6,
+      "role" : "Advisor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "wYJOkaYE2Eb5Ppdz8j",
-    "tags" : [ "r1kq5Vlsgvjsnmm7Y" ],
-    "description" : "MLRTTbW8wj2JO",
+    "npiSubjectHeading" : "6Q6oBDcDr2KXHsG",
+    "tags" : [ "b59cKNIMpiz2" ],
+    "description" : "WgHYulUMYydxe0OyJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/A2EtsQeefNCFH1YRs",
+      "doi" : "https://www.example.com/PzMQYeSYSlX",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "WebDesign"
+          "type" : "InteractionDesign"
         },
-        "description" : "p4PUC0mSeLLK54nkOar",
+        "description" : "dICmcCEUtdb",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "dT2VTcB7kYL",
+            "label" : "nf3sWGuTz0JM9E4C87",
             "country" : "Germany"
           },
           "time" : {
@@ -114,12 +114,12 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1720930259
+          "sequence" : 1374081706
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "AHYvHam6j5RS",
+            "label" : "XIvlO9FG4F",
             "country" : "Germany"
           },
           "time" : {
@@ -127,7 +127,7 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 920081138
+          "sequence" : 171106499
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -135,45 +135,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/MsqFSRpoauicM7r",
-    "abstract" : "tENS7o6DpqgGs2Zv"
+    "metadataSource" : "https://www.example.com/UFS0BZKYPSkZl",
+    "abstract" : "UoEaJraT985xH"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "W4q7G4Pt474",
-      "mimeType" : "56OqTkQz9t11k",
-      "size" : 1249310242,
+      "name" : "TDpHhj3EVlovSRpG4",
+      "mimeType" : "8hyFWSswU9W5c2uZ4sD",
+      "size" : 1073301771,
       "license" : {
         "type" : "License",
-        "identifier" : "m2IYzoeW2E82lbjY",
+        "identifier" : "NzG0HYyLQAv9F",
         "labels" : {
-          "jFVgBz3ycI" : "4HYbtF7qcad5I16TTc"
+          "6vmhj168Ia" : "CQVzOrSdsZ7kOHe"
         },
-        "link" : "https://www.example.com/EMBIWlDv8685yAFlGeW"
+        "link" : "https://www.example.com/rYOOGyVXMiQTk"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiaest",
-    "name" : "BD45lQZ3JJryU5Aos",
+    "id" : "https://www.example.org/sequimagni",
+    "name" : "b8xhu9QqqilhRp3rcM",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "d4qGxb5dykTiSQ8FK",
-      "id" : "boFMWcILXYc73v"
+      "source" : "y1XHUuwTPdryCclOqy2",
+      "id" : "kE93Q6Re1nmIaKiOlwz"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "6PtLgAn73FIz"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "TzZI8ikJZ11slyfkg"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -181,6 +181,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etmaiores" ],
+  "subjects" : [ "https://www.example.org/quisnesciunt" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -2,111 +2,111 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
-  "owner" : "kMbeCPEa90Ytfbxd",
+  "owner" : "VuGfXB0gzh82",
   "resourceOwner" : {
-    "owner" : "kMbeCPEa90Ytfbxd",
-    "ownerAffiliation" : "https://www.example.org/voluptaseos"
+    "owner" : "VuGfXB0gzh82",
+    "ownerAffiliation" : "https://www.example.org/quasquasi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ipsamcumque",
+    "id" : "https://www.example.org/sedaut",
     "labels" : {
-      "G3tab7B0DMp" : "JUR9PAZ3HP9"
+      "LklP2t8m6yXL" : "b8rTeY14yGgsGmX"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/exercitationematque",
-  "doi" : "https://doi.org/10.1234/nam",
+  "handle" : "https://www.example.org/eoslaborum",
+  "doi" : "https://doi.org/10.1234/aliquid",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Ge1xHU5lH4AA6K8YxB",
-      "author" : "IwNzgPzt4ysT",
+      "text" : "P9ae5HnUhOgO",
+      "author" : "LY2utZQDEJK2xbBpqG",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/ducimusmagni",
+  "link" : "https://www.example.org/magnamreiciendis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7ZY6PGmQJjdNLQz4ua",
+    "mainTitle" : "u9um30rxRhJM5Or",
     "alternativeTitles" : {
-      "nb" : "oL0narqEib"
+      "nl" : "jKg2GIDjIIRX33j"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "gJywmkDxDc",
-      "month" : "RbBKoz7SHMY7lqHMq",
-      "day" : "LivBAHhKcGQce0k"
+      "year" : "9elqpLVWhzEEPAtB",
+      "month" : "iLfnet13fUaat28",
+      "day" : "aNEKCTPGdP9E3aBgN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Xl3Fo6dhMrWhJ44",
-        "name" : "es7o29lWtreX",
-        "nameType" : "Organizational",
-        "orcId" : "4tS6CpfB8WAsRoD3C0y",
-        "arpId" : "wuDL21oFfVDGddCRr"
+        "id" : "https://www.example.com/pyDcIzzbBThisOoq",
+        "name" : "OUzLFRkpJhE8S",
+        "nameType" : "Personal",
+        "orcId" : "pM5p6xLJU9Dcj9y",
+        "arpId" : "SLAY2UA42E4VoA7BH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/86T0UBdBqCo",
+        "id" : "https://www.example.com/KmRJTt7UX39Sz8jib",
         "labels" : {
-          "4FeoGiMXHghmxP" : "DCn8EyQaY4"
+          "dFjlK5AtWvD2V5b2" : "ygYAmmQxUNXtghNG"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 6,
+      "role" : "Illustrator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/1QSv7RhGdZSLoA3",
-        "name" : "NwkHYP3TCHZM",
-        "nameType" : "Personal",
-        "orcId" : "NkTX4uRuseIuFC88ziX",
-        "arpId" : "M3K4f1Ffz5abK"
+        "id" : "https://www.example.com/SHJZyOlXGSQnIEEj",
+        "name" : "ZoEYeBR2J1WdbTii1",
+        "nameType" : "Organizational",
+        "orcId" : "WWjnW3rw7dq638k",
+        "arpId" : "dn8mvPzibcCJ8Nafmj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XDhKnColbTxwUcC",
+        "id" : "https://www.example.com/RjQdzmQh96Je",
         "labels" : {
-          "uhCHzvoogwO" : "yXnIKbINrtwlzW4"
+          "Mo4bxeqcka2A" : "KQSHYrYg4JV3vYz"
         }
       } ],
       "role" : "Advisor",
-      "sequence" : 0,
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6Q6oBDcDr2KXHsG",
-    "tags" : [ "b59cKNIMpiz2" ],
-    "description" : "WgHYulUMYydxe0OyJ",
+    "npiSubjectHeading" : "q5pJVDm2A3D",
+    "tags" : [ "nyNrDn8O3xQ2mfcB5Fz" ],
+    "description" : "lgl1Kj1qhD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/PzMQYeSYSlX",
+      "doi" : "https://www.example.com/VAkNq1mxm2uNGY",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "InteractionDesign"
+          "type" : "InteriorDesign"
         },
-        "description" : "dICmcCEUtdb",
+        "description" : "IrJWy6B2jc",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "nf3sWGuTz0JM9E4C87",
+            "label" : "RfCHuYwqEr",
             "country" : "Germany"
           },
           "time" : {
@@ -114,12 +114,12 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1374081706
+          "sequence" : 402488475
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XIvlO9FG4F",
+            "label" : "jA4msVBjKtm",
             "country" : "Germany"
           },
           "time" : {
@@ -127,53 +127,53 @@
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 171106499
+          "sequence" : 930881737
         } ],
-        "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
-        }
+        },
+        "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/UFS0BZKYPSkZl",
-    "abstract" : "UoEaJraT985xH"
+    "metadataSource" : "https://www.example.com/KZiPgZ3gnAml",
+    "abstract" : "wuyBtYb6hyz55VhqEO6"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "TDpHhj3EVlovSRpG4",
-      "mimeType" : "8hyFWSswU9W5c2uZ4sD",
-      "size" : 1073301771,
+      "name" : "wFRvwy5icUTrF8",
+      "mimeType" : "Y6sItAAn8mkf7",
+      "size" : 56221604,
       "license" : {
         "type" : "License",
-        "identifier" : "NzG0HYyLQAv9F",
+        "identifier" : "l0cpQaV98yXLnZ",
         "labels" : {
-          "6vmhj168Ia" : "CQVzOrSdsZ7kOHe"
+          "ObYYs1WCvbhKZ" : "VjNv9HsmC5UGY"
         },
-        "link" : "https://www.example.com/rYOOGyVXMiQTk"
+        "link" : "https://www.example.com/473tTP7YkOMRk6Jtc3"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sequimagni",
-    "name" : "b8xhu9QqqilhRp3rcM",
+    "id" : "https://www.example.org/facilisab",
+    "name" : "BhtdpzDPc7ldzLxPg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "y1XHUuwTPdryCclOqy2",
-      "id" : "kE93Q6Re1nmIaKiOlwz"
+      "source" : "LTgSLy9w0KuAYWLamUb",
+      "id" : "w2ZYYYZChHYeOGRUnwe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "TzZI8ikJZ11slyfkg"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "RWmzxuqK5D16"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -181,6 +181,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quisnesciunt" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/rationefugiat" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,144 +1,144 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "oTLYwfmfT8A66g",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "fSfg4G6Rq9OB",
   "resourceOwner" : {
-    "owner" : "oTLYwfmfT8A66g",
-    "ownerAffiliation" : "https://www.example.org/nesciuntpraesentium"
+    "owner" : "fSfg4G6Rq9OB",
+    "ownerAffiliation" : "https://www.example.org/molestiaeconsequatur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quidemet",
+    "id" : "https://www.example.org/quiavoluptatum",
     "labels" : {
-      "KVvvOZ071fieW3NR" : "Fxu7q0LFXXmnb5b"
+      "9sLe6e2iPo3YiABFa" : "2yw6kuCdDHEvNW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/atquevoluptas",
-  "doi" : "https://doi.org/10.1234/porro",
+  "handle" : "https://www.example.org/commodiipsum",
+  "doi" : "https://doi.org/10.1234/repellendus",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "HwBhaKCY5LcmZZhv",
-      "author" : "DbGZsEiqQI2uiFsM",
+      "text" : "muQnf2sFhhbdla",
+      "author" : "bY68dDPsEeWx",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/nequeveritatis",
+  "link" : "https://www.example.org/eaomnis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sBuaa8KcTkPXUbcm",
+    "mainTitle" : "3bB8c62BNt5i2Y3",
     "alternativeTitles" : {
-      "af" : "d67xTvuHLVj9md2AQOW"
+      "zh" : "TeHBgkad9JoMaq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "RCX6G8Jnnw",
-      "month" : "1xOBXdZqwSIO",
-      "day" : "dUTkvBN24iGoJQK1Tc1"
+      "year" : "mf8m1Jws0TOymO",
+      "month" : "FpUc8wKzueV6",
+      "day" : "4V0mu7tTxdyxl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/nMK78Gg6Oec",
-        "name" : "DwXyD27XArZcAL",
-        "nameType" : "Organizational",
-        "orcId" : "Rrh183y8dgzn",
-        "arpId" : "xpJZOVNtEP"
+        "id" : "https://www.example.com/ACgoOAImoWEITjgTH4t",
+        "name" : "0ECT6P6Bf0OfddiJUiS",
+        "nameType" : "Personal",
+        "orcId" : "i2vI3rR36snFz",
+        "arpId" : "SiOWB2Cz5J31BrWO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XKL3IJdgHT5",
+        "id" : "https://www.example.com/bMQDCWxg7KyTwwWUA",
         "labels" : {
-          "ufA0rhvNWE" : "R1LyBwTapQGox"
+          "ke2ZMc9JQHmeN" : "HJYIoFjuZ9i"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 4,
+      "role" : "WorkPackageLeader",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Q8r4PG4Vv4",
-        "name" : "fLc57dtTb24",
-        "nameType" : "Organizational",
-        "orcId" : "kKRo4cFhRdtDgy",
-        "arpId" : "z6iwcusL5sUP84"
+        "id" : "https://www.example.com/4LGaFc9Iv2w",
+        "name" : "tZ3UcVBo99PQF",
+        "nameType" : "Personal",
+        "orcId" : "7nOK8UBYDMp",
+        "arpId" : "jxjTuzGCeEGekXepCu1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CRlx7zGCe8ZNdICoL",
+        "id" : "https://www.example.com/gqAFxc7qwKCCOvS",
         "labels" : {
-          "1uXmBiVuVvnHjXZMK" : "PAQKOuVNDUse"
+          "8UYltXeCWzYWFNFTvW" : "Mt7YybnEAlVxf7"
         }
       } ],
-      "role" : "ProjectLeader",
+      "role" : "WorkPackageLeader",
       "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "26v1DmRF02H4pJD",
-    "tags" : [ "9B9bJUPy8tAMLbXW" ],
-    "description" : "8GLMEdPLHt2kod",
+    "npiSubjectHeading" : "i0cmxYxaTO2a4XJR2g",
+    "tags" : [ "sLPDbYegJYI9UV" ],
+    "description" : "IXUgcsh28Spb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SFOgrie0uYabzQyj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2mKDAFhs0KuZW5XfsC"
         },
-        "seriesNumber" : "inMqerpLtleCua0Bkf",
+        "seriesNumber" : "URAlGxIcQWWtQF",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/LXf0RPgJFmkz"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GOqyvTNbOqVb33wg"
         },
-        "isbnList" : [ "9780650351943" ]
+        "isbnList" : [ "9790864871458" ]
       },
-      "doi" : "https://www.example.com/kRvxZn8tmGZ1NkOs2",
+      "doi" : "https://www.example.com/J8EBqmDNnrncDHJi",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "pv4RwiWijAcRK1vi",
-            "end" : "CUkUWuTA9cGZh"
+            "begin" : "QM8MEgT7yp",
+            "end" : "fhJd8Pq4e8r0Pstjv"
           },
-          "pages" : "mheAPNuCcmcKV",
-          "illustrated" : false
+          "pages" : "e8KroN1SItni",
+          "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/5TbYY5AE08",
-    "abstract" : "yZVssumgmOye1S"
+    "metadataSource" : "https://www.example.com/FiDdH99HEWV",
+    "abstract" : "TtdjNNY0YjBJQytYd"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "W3G7ICjsIS35n",
-      "mimeType" : "24M94ZTDNYhIjmM145q",
-      "size" : 915372556,
+      "name" : "AHyiekYraOrGTjXz",
+      "mimeType" : "p90RlXeidk7GKZY9CN",
+      "size" : 966471007,
       "license" : {
         "type" : "License",
-        "identifier" : "8zrjazB1wVgkirr",
+        "identifier" : "MycWNvj0YI6E66ky7j",
         "labels" : {
-          "di1FtDjhrP8yMtixK" : "rhPze6P3aMiqb"
+          "5WsAYwtw3Ex40" : "82mIcrg9Gv0T27Gg5"
         },
-        "link" : "https://www.example.com/7rGDKgHrBjZvMrEl"
+        "link" : "https://www.example.com/LsrA9E8vGok"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quilaborum",
-    "name" : "Jgyy4Lgx78VTf6",
+    "id" : "https://www.example.org/autemvoluptas",
+    "name" : "MFeZWWD5v1",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Tw8Pb1uv32aQnllC",
-      "id" : "hiOqDF686NeIOIeg4mX"
+      "source" : "7A1NML2pojzXq5vSg2s",
+      "id" : "9OTwBBpwMLUlnzX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "VE5u7XfgCflC3MK9e"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "fbhTLnTxdgyrzPmG5"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/undeeum" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/idiure" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,144 +1,144 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "0by0cIILzv82iBKJbIc",
+  "status" : "NEW",
+  "owner" : "Pihmwj6zHabef",
   "resourceOwner" : {
-    "owner" : "0by0cIILzv82iBKJbIc",
-    "ownerAffiliation" : "https://www.example.org/remillum"
+    "owner" : "Pihmwj6zHabef",
+    "ownerAffiliation" : "https://www.example.org/saepeplaceat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/itaqueofficia",
+    "id" : "https://www.example.org/officiareprehenderit",
     "labels" : {
-      "wx6qGmgzHK7qw" : "O4W9Le8GCUjTaiOnZN"
+      "P4YFNnHQA9I1Z" : "kRLRo1TQI9"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/voluptasquia",
-  "doi" : "https://doi.org/10.1234/voluptates",
+  "handle" : "https://www.example.org/suscipitbeatae",
+  "doi" : "https://doi.org/10.1234/facilis",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "CLDlrJMm7NO",
-      "author" : "2yNu0afT5I",
+      "text" : "KUtqyQrtbOp",
+      "author" : "WciTLpiCtiDvbVpbfj",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/etinventore",
+  "link" : "https://www.example.org/solutaanimi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pypirVRtshf5P",
+    "mainTitle" : "k1nYghmjfVFKnZD1KY2",
     "alternativeTitles" : {
-      "es" : "OQi41CtGPnFfse35s"
+      "it" : "4p0zzwlvlR0h1k96lW0"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "GDHXnREtLLp",
-      "month" : "O76nBFfc80USE3kfIh",
-      "day" : "5eSuScZCgE70ciPPrI"
+      "year" : "389ElNCKpO1IXvfKUL",
+      "month" : "DG10cehYTB",
+      "day" : "uBezVDhPoiDTSDuLMl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/RhgpOX0HI29rjnyw5f",
-        "name" : "Vf5qOZ3TanipGfOyaLt",
+        "id" : "https://www.example.com/Doabis8uraavEJ",
+        "name" : "iilAFD1aPY9x",
         "nameType" : "Organizational",
-        "orcId" : "8RVmJFE3yXKy",
-        "arpId" : "RwLnCLUFTkXAauQz"
+        "orcId" : "LRjUroGLJKehXrATuFI",
+        "arpId" : "VUnKNxZeOz8FNPjI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5NbixZ8NUttRb",
+        "id" : "https://www.example.com/ujfu40S5rmI8Z5",
         "labels" : {
-          "m4tzoUTLykrQG" : "DOWDRkYBtPAh"
+          "chCTJUDc7ZDT" : "0I6RKaatQdUqY"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 1,
+      "role" : "Advisor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UTvHuebWCHz",
-        "name" : "GbKggpjYejv",
+        "id" : "https://www.example.com/rDnt87lb7GV",
+        "name" : "vDy0tT6qhFCpt4",
         "nameType" : "Organizational",
-        "orcId" : "pnk77hG3m0A",
-        "arpId" : "51Fz4gDJJG"
+        "orcId" : "BgF95a0gLqEXiVpdT8c",
+        "arpId" : "hCSGdnMfWiDwTmmI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/f3a8OYX3Kui",
+        "id" : "https://www.example.com/4fLD7CpIeTw5n",
         "labels" : {
-          "xdaEp7uoVb" : "i536OhiUqo"
+          "lwBtyrtI8ekKFGqOlA1" : "oBy5gZ637X9TZbhD"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 2,
+      "role" : "ProjectLeader",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "bA52437ozQ50Pmlk",
-    "tags" : [ "ozcox53tViNZos" ],
-    "description" : "Segb519PZF",
+    "npiSubjectHeading" : "7u99NuiRvOZJn1WO",
+    "tags" : [ "htMoMecPaDplBQ5GX" ],
+    "description" : "OjKuLd5Vi9y2U46H",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xDxSWfR020HH6JBG1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/g3l30qwlFQUGM"
         },
-        "seriesNumber" : "S364gBN9WT2YtBZO",
+        "seriesNumber" : "vdk2CMRj5JCaCQg5vj",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/IOyPLHAqzd1tOSWs"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xm3cLKxSTMGnh13tn"
         },
-        "isbnList" : [ "9781050054045" ]
+        "isbnList" : [ "9790718107610" ]
       },
-      "doi" : "https://www.example.com/VwlVtsFxDAXAB",
+      "doi" : "https://www.example.com/WDEueG9c0R71bI",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rB1kz3FgS28syWebes",
-            "end" : "lv4cDX3WTX6"
+            "begin" : "XHO03FhOziadVRW2o",
+            "end" : "VFrqOHOefLdgV9RLqj"
           },
-          "pages" : "1kpZI4Xud18BkyHOH",
-          "illustrated" : false
+          "pages" : "lMBqtzy6x7YaCNNtcYW",
+          "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/XiZICkYbimr9",
-    "abstract" : "2qZK4P4cM0CnAab450"
+    "metadataSource" : "https://www.example.com/yItPLqPEmU",
+    "abstract" : "y6NHwhyWBrvh"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "cMEPFevYFXH",
-      "mimeType" : "POX5FkIy1TRB7txtrJ",
-      "size" : 972740290,
+      "name" : "P8221kK9ivgWKx",
+      "mimeType" : "KtYhDWDwTR5jhytDXF",
+      "size" : 1089073674,
       "license" : {
         "type" : "License",
-        "identifier" : "qBsrbysPeSzuqyj83Rj",
+        "identifier" : "QCGlxeOMZhTEKtfs",
         "labels" : {
-          "aWDsRrIwx3S2D1k" : "RHh9j6FFd5CKGwnuDX"
+          "yG6DBlYHxmHJch1LpC" : "DmZ2AIRmwsUWgT"
         },
-        "link" : "https://www.example.com/klN39B4PovB1FJV"
+        "link" : "https://www.example.com/578QLi5YpezvISykUry"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/illoiste",
-    "name" : "fhNAj5fA2PwbPwu",
+    "id" : "https://www.example.org/etrerum",
+    "name" : "7HmvulYj8kseoe",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2IQEzR4fWGp7BAE",
-      "id" : "yWdA2JLTTv547"
+      "source" : "ioR4TC2bCQ",
+      "id" : "q8NWOkwEAmDj"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "OndQtdFtsn"
+      "applicationCode" : "WpncCHsq6K4JaP1y"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sitqui" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/evenietassumenda" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -2,143 +2,143 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
-  "owner" : "EjV0HNUH11lZg6pyl",
+  "owner" : "oTLYwfmfT8A66g",
   "resourceOwner" : {
-    "owner" : "EjV0HNUH11lZg6pyl",
-    "ownerAffiliation" : "https://www.example.org/quammolestiae"
+    "owner" : "oTLYwfmfT8A66g",
+    "ownerAffiliation" : "https://www.example.org/nesciuntpraesentium"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dignissimosdoloribus",
+    "id" : "https://www.example.org/quidemet",
     "labels" : {
-      "UG4MYDqZRR2aM2ad" : "KEbDbrZyn47HteLT"
+      "KVvvOZ071fieW3NR" : "Fxu7q0LFXXmnb5b"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/abqui",
-  "doi" : "https://doi.org/10.1234/veniam",
+  "handle" : "https://www.example.org/atquevoluptas",
+  "doi" : "https://doi.org/10.1234/porro",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Bdtu78PnowCRq2",
-      "author" : "U1RiTu63DCo",
+      "text" : "HwBhaKCY5LcmZZhv",
+      "author" : "DbGZsEiqQI2uiFsM",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quopariatur",
+  "link" : "https://www.example.org/nequeveritatis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9EXp2xZBLrAqoG6L98",
+    "mainTitle" : "sBuaa8KcTkPXUbcm",
     "alternativeTitles" : {
-      "it" : "mwJoKdMjRrLR5"
+      "af" : "d67xTvuHLVj9md2AQOW"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "vW5aqKo4s83rEfff",
-      "month" : "aRNnw8U9iqFZ8gaN",
-      "day" : "kvPVeC35aYVE9"
+      "year" : "RCX6G8Jnnw",
+      "month" : "1xOBXdZqwSIO",
+      "day" : "dUTkvBN24iGoJQK1Tc1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5Mkd6UFQK75Xkc7",
-        "name" : "IApREEVEffAMP6jTwe",
+        "id" : "https://www.example.com/nMK78Gg6Oec",
+        "name" : "DwXyD27XArZcAL",
         "nameType" : "Organizational",
-        "orcId" : "lohmgwH0n4yS",
-        "arpId" : "TeQh2s6Hq6xlzfd"
+        "orcId" : "Rrh183y8dgzn",
+        "arpId" : "xpJZOVNtEP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/C55WDAtVUh2Ao3sMtZ",
+        "id" : "https://www.example.com/XKL3IJdgHT5",
         "labels" : {
-          "nAPAv0Jaj7" : "tcAdvbcZutWusNPy3iV"
+          "ufA0rhvNWE" : "R1LyBwTapQGox"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 1,
+      "role" : "DataCollector",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ISGNGVQ7JyZQEeGnTP7",
-        "name" : "VkJH3kHsn5oPspvR",
-        "nameType" : "Personal",
-        "orcId" : "xZCDbSkQxI7idym",
-        "arpId" : "XMUaTZC5jq"
+        "id" : "https://www.example.com/Q8r4PG4Vv4",
+        "name" : "fLc57dtTb24",
+        "nameType" : "Organizational",
+        "orcId" : "kKRo4cFhRdtDgy",
+        "arpId" : "z6iwcusL5sUP84"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/fgZ4IVJWqzhC",
+        "id" : "https://www.example.com/CRlx7zGCe8ZNdICoL",
         "labels" : {
-          "IogkyYNBed5O1" : "4ZWo92sV65eu"
+          "1uXmBiVuVvnHjXZMK" : "PAQKOuVNDUse"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 3,
+      "role" : "ProjectLeader",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "VPO55EPjanz",
-    "tags" : [ "HMaeF2odcFkjsY1" ],
-    "description" : "FgIztHNCQIj0eTMq",
+    "npiSubjectHeading" : "26v1DmRF02H4pJD",
+    "tags" : [ "9B9bJUPy8tAMLbXW" ],
+    "description" : "8GLMEdPLHt2kod",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/luuIuaXJh6pRfBS"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SFOgrie0uYabzQyj"
         },
-        "seriesNumber" : "4KbOf4o9D8Z7",
+        "seriesNumber" : "inMqerpLtleCua0Bkf",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/z1mSgDWquLj1HJZ5Zb"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/LXf0RPgJFmkz"
         },
-        "isbnList" : [ "9791909847469" ]
+        "isbnList" : [ "9780650351943" ]
       },
-      "doi" : "https://www.example.com/w2KmGOGNpXL",
+      "doi" : "https://www.example.com/kRvxZn8tmGZ1NkOs2",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "eza1KAW3kBS3P7",
-            "end" : "1irNnR8MrG6osT"
+            "begin" : "pv4RwiWijAcRK1vi",
+            "end" : "CUkUWuTA9cGZh"
           },
-          "pages" : "Ghyar05zLZBP2kIQwtR",
-          "illustrated" : true
+          "pages" : "mheAPNuCcmcKV",
+          "illustrated" : false
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/89cUPKYoz2jf93t1Uo",
-    "abstract" : "0na9GubizwJZyfgL"
+    "metadataSource" : "https://www.example.com/5TbYY5AE08",
+    "abstract" : "yZVssumgmOye1S"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wGFfhaQ5yTNk",
-      "mimeType" : "hXMHFA8D4yB",
-      "size" : 1625099148,
+      "name" : "W3G7ICjsIS35n",
+      "mimeType" : "24M94ZTDNYhIjmM145q",
+      "size" : 915372556,
       "license" : {
         "type" : "License",
-        "identifier" : "Ok4StgHsX5jZc8ILOFc",
+        "identifier" : "8zrjazB1wVgkirr",
         "labels" : {
-          "ulvI6aeDzIQ" : "SNeooXRE5U3fWFF"
+          "di1FtDjhrP8yMtixK" : "rhPze6P3aMiqb"
         },
-        "link" : "https://www.example.com/qihTuXMb2dw"
+        "link" : "https://www.example.com/7rGDKgHrBjZvMrEl"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cumdoloribus",
-    "name" : "cxJTD5ylQNCT",
+    "id" : "https://www.example.org/quilaborum",
+    "name" : "Jgyy4Lgx78VTf6",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "1lQOegDw1E",
-      "id" : "8q2R6ZMMgxJ"
+      "source" : "Tw8Pb1uv32aQnllC",
+      "id" : "hiOqDF686NeIOIeg4mX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "HIxATZUwAaAu"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "VE5u7XfgCflC3MK9e"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/blanditiiset" ],
+  "subjects" : [ "https://www.example.org/undeeum" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,165 +1,165 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "Pihmwj6zHabef",
+  "status" : "DRAFT",
+  "owner" : "EjV0HNUH11lZg6pyl",
   "resourceOwner" : {
-    "owner" : "Pihmwj6zHabef",
-    "ownerAffiliation" : "https://www.example.org/saepeplaceat"
+    "owner" : "EjV0HNUH11lZg6pyl",
+    "ownerAffiliation" : "https://www.example.org/quammolestiae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/officiareprehenderit",
+    "id" : "https://www.example.org/dignissimosdoloribus",
     "labels" : {
-      "P4YFNnHQA9I1Z" : "kRLRo1TQI9"
+      "UG4MYDqZRR2aM2ad" : "KEbDbrZyn47HteLT"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suscipitbeatae",
-  "doi" : "https://doi.org/10.1234/facilis",
+  "handle" : "https://www.example.org/abqui",
+  "doi" : "https://doi.org/10.1234/veniam",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "KUtqyQrtbOp",
-      "author" : "WciTLpiCtiDvbVpbfj",
+      "text" : "Bdtu78PnowCRq2",
+      "author" : "U1RiTu63DCo",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/solutaanimi",
+  "link" : "https://www.example.org/quopariatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "k1nYghmjfVFKnZD1KY2",
+    "mainTitle" : "9EXp2xZBLrAqoG6L98",
     "alternativeTitles" : {
-      "it" : "4p0zzwlvlR0h1k96lW0"
+      "it" : "mwJoKdMjRrLR5"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "389ElNCKpO1IXvfKUL",
-      "month" : "DG10cehYTB",
-      "day" : "uBezVDhPoiDTSDuLMl"
+      "year" : "vW5aqKo4s83rEfff",
+      "month" : "aRNnw8U9iqFZ8gaN",
+      "day" : "kvPVeC35aYVE9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Doabis8uraavEJ",
-        "name" : "iilAFD1aPY9x",
+        "id" : "https://www.example.com/5Mkd6UFQK75Xkc7",
+        "name" : "IApREEVEffAMP6jTwe",
         "nameType" : "Organizational",
-        "orcId" : "LRjUroGLJKehXrATuFI",
-        "arpId" : "VUnKNxZeOz8FNPjI"
+        "orcId" : "lohmgwH0n4yS",
+        "arpId" : "TeQh2s6Hq6xlzfd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ujfu40S5rmI8Z5",
+        "id" : "https://www.example.com/C55WDAtVUh2Ao3sMtZ",
         "labels" : {
-          "chCTJUDc7ZDT" : "0I6RKaatQdUqY"
+          "nAPAv0Jaj7" : "tcAdvbcZutWusNPy3iV"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 2,
+      "role" : "Researcher",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rDnt87lb7GV",
-        "name" : "vDy0tT6qhFCpt4",
-        "nameType" : "Organizational",
-        "orcId" : "BgF95a0gLqEXiVpdT8c",
-        "arpId" : "hCSGdnMfWiDwTmmI"
+        "id" : "https://www.example.com/ISGNGVQ7JyZQEeGnTP7",
+        "name" : "VkJH3kHsn5oPspvR",
+        "nameType" : "Personal",
+        "orcId" : "xZCDbSkQxI7idym",
+        "arpId" : "XMUaTZC5jq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4fLD7CpIeTw5n",
+        "id" : "https://www.example.com/fgZ4IVJWqzhC",
         "labels" : {
-          "lwBtyrtI8ekKFGqOlA1" : "oBy5gZ637X9TZbhD"
+          "IogkyYNBed5O1" : "4ZWo92sV65eu"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 4,
+      "role" : "Editor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "7u99NuiRvOZJn1WO",
-    "tags" : [ "htMoMecPaDplBQ5GX" ],
-    "description" : "OjKuLd5Vi9y2U46H",
+    "npiSubjectHeading" : "VPO55EPjanz",
+    "tags" : [ "HMaeF2odcFkjsY1" ],
+    "description" : "FgIztHNCQIj0eTMq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/g3l30qwlFQUGM"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/luuIuaXJh6pRfBS"
         },
-        "seriesNumber" : "vdk2CMRj5JCaCQg5vj",
+        "seriesNumber" : "4KbOf4o9D8Z7",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xm3cLKxSTMGnh13tn"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/z1mSgDWquLj1HJZ5Zb"
         },
-        "isbnList" : [ "9790718107610" ]
+        "isbnList" : [ "9791909847469" ]
       },
-      "doi" : "https://www.example.com/WDEueG9c0R71bI",
+      "doi" : "https://www.example.com/w2KmGOGNpXL",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "XHO03FhOziadVRW2o",
-            "end" : "VFrqOHOefLdgV9RLqj"
+            "begin" : "eza1KAW3kBS3P7",
+            "end" : "1irNnR8MrG6osT"
           },
-          "pages" : "lMBqtzy6x7YaCNNtcYW",
+          "pages" : "Ghyar05zLZBP2kIQwtR",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/yItPLqPEmU",
-    "abstract" : "y6NHwhyWBrvh"
+    "metadataSource" : "https://www.example.com/89cUPKYoz2jf93t1Uo",
+    "abstract" : "0na9GubizwJZyfgL"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "P8221kK9ivgWKx",
-      "mimeType" : "KtYhDWDwTR5jhytDXF",
-      "size" : 1089073674,
+      "name" : "wGFfhaQ5yTNk",
+      "mimeType" : "hXMHFA8D4yB",
+      "size" : 1625099148,
       "license" : {
         "type" : "License",
-        "identifier" : "QCGlxeOMZhTEKtfs",
+        "identifier" : "Ok4StgHsX5jZc8ILOFc",
         "labels" : {
-          "yG6DBlYHxmHJch1LpC" : "DmZ2AIRmwsUWgT"
+          "ulvI6aeDzIQ" : "SNeooXRE5U3fWFF"
         },
-        "link" : "https://www.example.com/578QLi5YpezvISykUry"
+        "link" : "https://www.example.com/qihTuXMb2dw"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etrerum",
-    "name" : "7HmvulYj8kseoe",
+    "id" : "https://www.example.org/cumdoloribus",
+    "name" : "cxJTD5ylQNCT",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ioR4TC2bCQ",
-      "id" : "q8NWOkwEAmDj"
+      "source" : "1lQOegDw1E",
+      "id" : "8q2R6ZMMgxJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "WpncCHsq6K4JaP1y"
+      "applicationCode" : "HIxATZUwAaAu"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/evenietassumenda" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/blanditiiset" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -2,143 +2,143 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
-  "owner" : "4HLLOqn9qEI",
+  "owner" : "ukNIMAmQ654E",
   "resourceOwner" : {
-    "owner" : "4HLLOqn9qEI",
-    "ownerAffiliation" : "https://www.example.org/blanditiiset"
+    "owner" : "ukNIMAmQ654E",
+    "ownerAffiliation" : "https://www.example.org/doloreut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemid",
+    "id" : "https://www.example.org/aliquamsunt",
     "labels" : {
-      "ucJ4VClm7H163V57nD" : "xs2gkw3Y8sHRQG5tJZr"
+      "M2j4V43QY8ZI" : "ah8XaaOgbE"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consequaturdoloremque",
-  "doi" : "https://doi.org/10.1234/soluta",
+  "handle" : "https://www.example.org/nesciuntcorporis",
+  "doi" : "https://doi.org/10.1234/inventore",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "kELLv6R9DG3pW",
-      "author" : "4HyGZwPBxs6",
+      "text" : "AbBgn2Y51lBQu",
+      "author" : "RpD2t7ViPUvctdpSSS",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/voluptatumexpedita",
+  "link" : "https://www.example.org/maximesaepe",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ydOqPnxLze",
+    "mainTitle" : "8RAEa0xVOSa",
     "alternativeTitles" : {
-      "cs" : "q06uuyB9WkWklw"
+      "cs" : "haNvyTiQb5pf"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "mxNYV9TQfi",
-      "month" : "wzNrys866QvLN",
-      "day" : "acu2dhBw9TD5G"
+      "year" : "GwMKzfl3uDxrgg",
+      "month" : "svc4v2c4VdlFJrk8h",
+      "day" : "Kgn88tZ6CSN7UbGy7K"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SS7fhKBMA0l",
-        "name" : "xJQZQfFSGFiFMxssahl",
+        "id" : "https://www.example.com/ig66U1IevsRI4QvV",
+        "name" : "I5B8JSyWUS95DWawi",
         "nameType" : "Personal",
-        "orcId" : "2JTMjEZXXvK80db",
-        "arpId" : "Qkk2A5Iw9NRCHPqBB5g"
+        "orcId" : "miEdiIFqOQDUu",
+        "arpId" : "DXUVaW0W6JFtkgehY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tzMUUVu9mMvO5FQwGlY",
+        "id" : "https://www.example.com/aOKmTagA05VBOvyZtL",
         "labels" : {
-          "4AGGCeYLJK" : "7Sabg26DNajC6FHhh"
+          "tDSYtkbgMtcF0TYc2" : "EL5DUVUt1ZCR"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 2,
+      "role" : "DataCollector",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DoM5wE2z8GWe",
-        "name" : "GpKwHJqLhKr6VNgBG",
-        "nameType" : "Personal",
-        "orcId" : "J0uV6HHWQIDKioJ",
-        "arpId" : "Uog4VqHxp2"
+        "id" : "https://www.example.com/pdNYu16Vl5W",
+        "name" : "XKRRNJPWJJEmWsVM6iz",
+        "nameType" : "Organizational",
+        "orcId" : "okKRyVHF41u",
+        "arpId" : "wE7vgtRy9cs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0BtsJNUQgLniqm",
+        "id" : "https://www.example.com/PnIjyYHPZLEslc",
         "labels" : {
-          "Ps2sNao984afeQRF3nF" : "gR0Tzj2VLuWWK20"
+          "0vpo5F4K8H8Hp" : "GN3zVR4YsJz2pAt3"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 1,
+      "role" : "Designer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "14DME2OwwDcmOtJrckU",
-    "tags" : [ "ktVqgT8X4QXC7ru" ],
-    "description" : "JMborNHd0jlmP",
+    "npiSubjectHeading" : "ASlz1tbLUCmm",
+    "tags" : [ "OdeynxfhR6LB4d" ],
+    "description" : "AVHgATWoOQou7VSw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/oHPsCamVIURpfGN"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JD5qMbZmkJd"
         },
-        "seriesNumber" : "q4VrnFM8x5w",
+        "seriesNumber" : "OBPhF8oHDz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Ir1rzBKsdcOJSuI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/p8TACHWXsmYJsZ1dJJ"
         },
-        "isbnList" : [ "9781010326212" ]
+        "isbnList" : [ "9790257477809" ]
       },
-      "doi" : "https://www.example.com/fiUMlOimxO74nJxGsv",
+      "doi" : "https://www.example.com/oGmbJfpJ5YfAL25Amwo",
       "publicationInstance" : {
         "type" : "BookAnthology",
-        "peerReviewed" : true,
+        "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "TSK8WEx55iXZKOvn",
-            "end" : "tJMVKYSpzV54qugGu"
+            "begin" : "XjyLtnZ3USV",
+            "end" : "qRU3rM92yvA"
           },
-          "pages" : "PcdYKuodirM49GI",
+          "pages" : "CTTyaKVbUMlU",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/L2pkATPSpJ",
-    "abstract" : "0zoBXH2gsAeOTg"
+    "metadataSource" : "https://www.example.com/O6WmMGDRAGTIF",
+    "abstract" : "4GzNu5Ee1M20BHhiu1"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "OZHFIKDUD4HT",
-      "mimeType" : "qfC6YtnRWSaiZ8ASGqp",
-      "size" : 338448659,
+      "name" : "XKR8zjtPUwQy4YL",
+      "mimeType" : "2UI5ZjZgmN",
+      "size" : 1358820997,
       "license" : {
         "type" : "License",
-        "identifier" : "91vUOIvswNioEY",
+        "identifier" : "5zsWRv5AWunHhSh2",
         "labels" : {
-          "v7N4COuA3eJy0ta0UFq" : "FqhFiZiVq2AcuYQOL0"
+          "sgpAIZVRMjEMM4N" : "XUfUErgLypylhJGC7U"
         },
-        "link" : "https://www.example.com/TyECFSgjFCNld7hJ"
+        "link" : "https://www.example.com/ZsY2DCbVzMoZ2iSnz"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/impeditdolor",
-    "name" : "EybRPjszjpo1Jtzf7T",
+    "id" : "https://www.example.org/oditdignissimos",
+    "name" : "IEKy4CfHoz",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SQubkWf3mY6kMwOOQ",
-      "id" : "oKBPOknk6b"
+      "source" : "TVbYTobp0uKGd7nxV",
+      "id" : "yD0YodC34eK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "YCzy7HLXRIwFZK63bq"
+      "applicationCode" : "CAx1GtkLDD"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etipsum" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/quiut" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -2,110 +2,110 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
-  "owner" : "jgRI9N5HErEh",
+  "owner" : "4HLLOqn9qEI",
   "resourceOwner" : {
-    "owner" : "jgRI9N5HErEh",
-    "ownerAffiliation" : "https://www.example.org/etunde"
+    "owner" : "4HLLOqn9qEI",
+    "ownerAffiliation" : "https://www.example.org/blanditiiset"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/temporibussunt",
+    "id" : "https://www.example.org/voluptatemid",
     "labels" : {
-      "Zmnn7oxZqMDBCpho" : "4fiVry1SxIBPZIe9Du"
+      "ucJ4VClm7H163V57nD" : "xs2gkw3Y8sHRQG5tJZr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
-  "modifiedDate" : "2008-10-01T12:56:46Z",
+  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/delenitisapiente",
-  "doi" : "https://doi.org/10.1234/possimus",
+  "handle" : "https://www.example.org/consequaturdoloremque",
+  "doi" : "https://doi.org/10.1234/soluta",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Nee5WpZ0fva4SvKAax",
-      "author" : "hjXruKUwvrb3",
+      "text" : "kELLv6R9DG3pW",
+      "author" : "4HyGZwPBxs6",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/pariaturdistinctio",
+  "link" : "https://www.example.org/voluptatumexpedita",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zPM6vzkBEZglZMg",
+    "mainTitle" : "ydOqPnxLze",
     "alternativeTitles" : {
-      "no" : "ijElN8gna2OKNha"
+      "cs" : "q06uuyB9WkWklw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/hun",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "OLD9HT76QT",
-      "month" : "QAtTiUbq5Dd",
-      "day" : "PjYB5a1m6HTx0x1QRJ"
+      "year" : "mxNYV9TQfi",
+      "month" : "wzNrys866QvLN",
+      "day" : "acu2dhBw9TD5G"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8Xglc44bMuy2CCWns",
-        "name" : "SwkblyeAKix",
-        "nameType" : "Organizational",
-        "orcId" : "Ce78Ji8eKb0oQ1hC",
-        "arpId" : "V8uLZaMNpzpEzaT9uZF"
+        "id" : "https://www.example.com/SS7fhKBMA0l",
+        "name" : "xJQZQfFSGFiFMxssahl",
+        "nameType" : "Personal",
+        "orcId" : "2JTMjEZXXvK80db",
+        "arpId" : "Qkk2A5Iw9NRCHPqBB5g"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dYOFfmTeuYFrqpv",
+        "id" : "https://www.example.com/tzMUUVu9mMvO5FQwGlY",
         "labels" : {
-          "xwgF948jSX9cPHq" : "lKtCkLyLid7PJ"
+          "4AGGCeYLJK" : "7Sabg26DNajC6FHhh"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 7,
+      "role" : "WorkPackageLeader",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/GGbk9vIgPe",
-        "name" : "xcMLIzmNFnbqD",
+        "id" : "https://www.example.com/DoM5wE2z8GWe",
+        "name" : "GpKwHJqLhKr6VNgBG",
         "nameType" : "Personal",
-        "orcId" : "adkDry069wM",
-        "arpId" : "0CMKyKsYXvON"
+        "orcId" : "J0uV6HHWQIDKioJ",
+        "arpId" : "Uog4VqHxp2"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aEiOUPC6Faq26",
+        "id" : "https://www.example.com/0BtsJNUQgLniqm",
         "labels" : {
-          "G4lViVP3CysKgX8fAZ" : "8js7LmaVPXkjOl"
+          "Ps2sNao984afeQRF3nF" : "gR0Tzj2VLuWWK20"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 9,
+      "role" : "ProjectLeader",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ujPMdVtvOFLKX4DfNul",
-    "tags" : [ "Z4ttZTgGTjkc5e6LMY" ],
-    "description" : "zsnEG9CKNXxf",
+    "npiSubjectHeading" : "14DME2OwwDcmOtJrckU",
+    "tags" : [ "ktVqgT8X4QXC7ru" ],
+    "description" : "JMborNHd0jlmP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FuIwrL6Zb4wzontVCTT"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/oHPsCamVIURpfGN"
         },
-        "seriesNumber" : "ezZrF48hHiFM8",
+        "seriesNumber" : "q4VrnFM8x5w",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FyFjFb4F5ChruQBAx"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Ir1rzBKsdcOJSuI"
         },
-        "isbnList" : [ "9781858130569" ]
+        "isbnList" : [ "9781010326212" ]
       },
-      "doi" : "https://www.example.com/i54voclSwz0p",
+      "doi" : "https://www.example.com/fiUMlOimxO74nJxGsv",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "peerReviewed" : true,
@@ -113,32 +113,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "AZs4UOk8uxb",
-            "end" : "neqGqvMisq0Q"
+            "begin" : "TSK8WEx55iXZKOvn",
+            "end" : "tJMVKYSpzV54qugGu"
           },
-          "pages" : "wcO0LxMu4iADjWW4M",
+          "pages" : "PcdYKuodirM49GI",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/NIcjrETcHbbnu",
-    "abstract" : "I7puOlN1i9LYg78Rx"
+    "metadataSource" : "https://www.example.com/L2pkATPSpJ",
+    "abstract" : "0zoBXH2gsAeOTg"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "h1bO99mY9ePL",
-      "mimeType" : "5xEbwjHmB7BirSo",
-      "size" : 1034787060,
+      "name" : "OZHFIKDUD4HT",
+      "mimeType" : "qfC6YtnRWSaiZ8ASGqp",
+      "size" : 338448659,
       "license" : {
         "type" : "License",
-        "identifier" : "M6OeZaWykcPT6qGqQ3",
+        "identifier" : "91vUOIvswNioEY",
         "labels" : {
-          "ppfnWKmwGV3" : "PBiZmDVTPLq9ulJZRm"
+          "v7N4COuA3eJy0ta0UFq" : "FqhFiZiVq2AcuYQOL0"
         },
-        "link" : "https://www.example.com/74yMUvDh2wO"
+        "link" : "https://www.example.com/TyECFSgjFCNld7hJ"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dolorsaepe",
-    "name" : "4EOONtmPpBFIggXYr3e",
+    "id" : "https://www.example.org/impeditdolor",
+    "name" : "EybRPjszjpo1Jtzf7T",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ErpBhvZRhKkn",
-      "id" : "RIvcUDbmIxQv"
+      "source" : "SQubkWf3mY6kMwOOQ",
+      "id" : "oKBPOknk6b"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "UGJsPDROzt21x95"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "YCzy7HLXRIwFZK63bq"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ipsamrecusandae" ],
+  "subjects" : [ "https://www.example.org/etipsum" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "mrPvLR2TXQJRDjp",
+  "status" : "PUBLISHED",
+  "owner" : "jgRI9N5HErEh",
   "resourceOwner" : {
-    "owner" : "mrPvLR2TXQJRDjp",
-    "ownerAffiliation" : "https://www.example.org/fuganon"
+    "owner" : "jgRI9N5HErEh",
+    "ownerAffiliation" : "https://www.example.org/etunde"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nemoalias",
+    "id" : "https://www.example.org/temporibussunt",
     "labels" : {
-      "OXBOOYaByMLl9rh" : "GNG8pIoc2qjRNOZB6E"
+      "Zmnn7oxZqMDBCpho" : "4fiVry1SxIBPZIe9Du"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
-  "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "modifiedDate" : "2008-10-01T12:56:46Z",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/beataelaborum",
-  "doi" : "https://doi.org/10.1234/nemo",
+  "handle" : "https://www.example.org/delenitisapiente",
+  "doi" : "https://doi.org/10.1234/possimus",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "fqEIHA6QcBjyNDkw26",
-      "author" : "gIIEBHr9bU",
+      "text" : "Nee5WpZ0fva4SvKAax",
+      "author" : "hjXruKUwvrb3",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloresdolores",
+  "link" : "https://www.example.org/pariaturdistinctio",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "H5FhNI24OXM1u",
+    "mainTitle" : "zPM6vzkBEZglZMg",
     "alternativeTitles" : {
-      "pl" : "etHe8rUJsbl5nCeS"
+      "no" : "ijElN8gna2OKNha"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "HOnvjAZSWj19",
-      "month" : "lPRnu30odVK",
-      "day" : "ONLTztR6re"
+      "year" : "OLD9HT76QT",
+      "month" : "QAtTiUbq5Dd",
+      "day" : "PjYB5a1m6HTx0x1QRJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UIoCnTEbkzBg3Zi7f",
-        "name" : "jcMzVfM7sPVp",
+        "id" : "https://www.example.com/8Xglc44bMuy2CCWns",
+        "name" : "SwkblyeAKix",
         "nameType" : "Organizational",
-        "orcId" : "lr9BnSQ8uLauJjL0",
-        "arpId" : "GtO7eNsbBXsdgs"
+        "orcId" : "Ce78Ji8eKb0oQ1hC",
+        "arpId" : "V8uLZaMNpzpEzaT9uZF"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tr5PttBo9EevMRrrP",
+        "id" : "https://www.example.com/dYOFfmTeuYFrqpv",
         "labels" : {
-          "Rg9N6Y5zsFSb" : "paz0vvqMTDyxCwN"
+          "xwgF948jSX9cPHq" : "lKtCkLyLid7PJ"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 5,
+      "role" : "Advisor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BXkjWwVtfpT",
-        "name" : "F62HChv2l632k",
+        "id" : "https://www.example.com/GGbk9vIgPe",
+        "name" : "xcMLIzmNFnbqD",
         "nameType" : "Personal",
-        "orcId" : "wMdi0tzkIu3UWXow",
-        "arpId" : "cOjPA1iNpcc"
+        "orcId" : "adkDry069wM",
+        "arpId" : "0CMKyKsYXvON"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/buhHRCw3HSMRpuXbZA",
+        "id" : "https://www.example.com/aEiOUPC6Faq26",
         "labels" : {
-          "g3Kd2yQlFv" : "veN1qfMXdW"
+          "G4lViVP3CysKgX8fAZ" : "8js7LmaVPXkjOl"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 5,
+      "role" : "Sponsor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "t1uevMPCEtr0",
-    "tags" : [ "siFXjwFIsCK" ],
-    "description" : "DZ1hfJ32KFEow",
+    "npiSubjectHeading" : "ujPMdVtvOFLKX4DfNul",
+    "tags" : [ "Z4ttZTgGTjkc5e6LMY" ],
+    "description" : "zsnEG9CKNXxf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/B5kAtuvxHjPNNaXmmn"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FuIwrL6Zb4wzontVCTT"
         },
-        "seriesNumber" : "g2G9R9QsPQMg22",
+        "seriesNumber" : "ezZrF48hHiFM8",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wIXOwZJru2lBqs229"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FyFjFb4F5ChruQBAx"
         },
-        "isbnList" : [ "9790906219248" ]
+        "isbnList" : [ "9781858130569" ]
       },
-      "doi" : "https://www.example.com/QcKOBw42wFGz",
+      "doi" : "https://www.example.com/i54voclSwz0p",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "peerReviewed" : true,
@@ -113,32 +113,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "66QtygHT2vxqTXbg",
-            "end" : "zy6KppPbfHIpOjt9B"
+            "begin" : "AZs4UOk8uxb",
+            "end" : "neqGqvMisq0Q"
           },
-          "pages" : "usscnRseh5e9q7",
+          "pages" : "wcO0LxMu4iADjWW4M",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/YFmbALBuSPZE",
-    "abstract" : "ZB1aEOhxwzjr1RcIA"
+    "metadataSource" : "https://www.example.com/NIcjrETcHbbnu",
+    "abstract" : "I7puOlN1i9LYg78Rx"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "1zr4Ig7krR1",
-      "mimeType" : "0g7aVjcpqoynrp",
-      "size" : 2096875866,
+      "name" : "h1bO99mY9ePL",
+      "mimeType" : "5xEbwjHmB7BirSo",
+      "size" : 1034787060,
       "license" : {
         "type" : "License",
-        "identifier" : "wjLDdDglBT1e",
+        "identifier" : "M6OeZaWykcPT6qGqQ3",
         "labels" : {
-          "dlrv9xRUi03SdAk" : "aTmkV5BhpAkwy"
+          "ppfnWKmwGV3" : "PBiZmDVTPLq9ulJZRm"
         },
-        "link" : "https://www.example.com/WIpXVzBr9v7Es"
+        "link" : "https://www.example.com/74yMUvDh2wO"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autdolorem",
-    "name" : "5GxFNApmeW",
+    "id" : "https://www.example.org/dolorsaepe",
+    "name" : "4EOONtmPpBFIggXYr3e",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "KKyX3yS9jYUA",
-      "id" : "2ru5muf3VvTiBEhB5"
+      "source" : "ErpBhvZRhKkn",
+      "id" : "RIvcUDbmIxQv"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "MJQy3r8E7dSxnIDs"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "UGJsPDROzt21x95"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/omnistenetur" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/ipsamrecusandae" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
-  "owner" : "jmAtTvJ9WZnp1aFxa8",
+  "owner" : "yrb9nC4p1tN1Q",
   "resourceOwner" : {
-    "owner" : "jmAtTvJ9WZnp1aFxa8",
-    "ownerAffiliation" : "https://www.example.org/quoa"
+    "owner" : "yrb9nC4p1tN1Q",
+    "ownerAffiliation" : "https://www.example.org/quodautem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/minussit",
+    "id" : "https://www.example.org/aspernaturet",
     "labels" : {
-      "FSvtmkBKsYig1BMLA" : "CorIUolXPin5m0Iidjz"
+      "NvbxTp1TiWUHG" : "vuxxoGfoXNsDUt"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/culpadolores",
-  "doi" : "https://doi.org/10.1234/aperiam",
+  "handle" : "https://www.example.org/natusexercitationem",
+  "doi" : "https://doi.org/10.1234/aut",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,120 +27,120 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "9Wz0pjwqjpTkrFMulCP",
-      "author" : "iXcMrYxSyu3L6KqIibg",
+      "text" : "1tKJX1xrt4k",
+      "author" : "wzapSWL77HEGU0kQ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/dolorummolestias",
+  "link" : "https://www.example.org/consequaturcupiditate",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0knooRbVfZvnnGBn",
+    "mainTitle" : "vfWKnbSOLtAT5j",
     "alternativeTitles" : {
-      "el" : "0oHHEdZnsm31WOKka"
+      "se" : "rBSwOZ9nFPQSWOD52F"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "EjEQdJjSwr",
-      "month" : "AQpWE1pMhGePVLv",
-      "day" : "OL7xyNduA8yXC5JiqXV"
+      "year" : "thMtZMRJZhXACHd4",
+      "month" : "D3H67ylyzn",
+      "day" : "8rkoUYUWMC7QcFuSg"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/JAW1cnnopTjlxlxE",
-        "name" : "5glWYmwGyhpN4",
+        "id" : "https://www.example.com/De89Cw3EeF",
+        "name" : "M0IZVXXm8EG",
         "nameType" : "Personal",
-        "orcId" : "Rn5R5pXjHaialCZt",
-        "arpId" : "e4WnHUvG1NuLN7du"
+        "orcId" : "rVPNEWaLokf",
+        "arpId" : "T3QoQ1fKuAWBKnZBj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/EyAYrOwd3D7e",
+        "id" : "https://www.example.com/tnr73XXI3d8S",
         "labels" : {
-          "wRDvQ8Is8R9" : "cNbgtWT1MQA0"
+          "l7FDcXirG2" : "p1vXEPAuR2rHeK"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 6,
+      "role" : "Advisor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MZThpuMTWKQncpH650k",
-        "name" : "rcOiNjeVWyioDE22m",
-        "nameType" : "Personal",
-        "orcId" : "VQTgaPoHb4GPgssx",
-        "arpId" : "CSd8F8cYTOMtCL"
+        "id" : "https://www.example.com/flXTZzWel3C2rYR",
+        "name" : "nemGq5WYj91JJgyKeX",
+        "nameType" : "Organizational",
+        "orcId" : "BdmNIR1PBB",
+        "arpId" : "QhAa25oTatVr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/TiA6IlnGn4Y5Bmv",
+        "id" : "https://www.example.com/3fHUWXRvWT8EN6b",
         "labels" : {
-          "pDzUzos7vYD" : "GtCKlzIkaT1"
+          "MuRVigltjNPLcD8Zhxi" : "GDlrAnsyvtmtyA"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 8,
+      "role" : "RightsHolder",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "0gp9S4GYLHm5D",
-    "tags" : [ "Ws9epUuxtlfJ" ],
-    "description" : "fW6CE8XOjL",
+    "npiSubjectHeading" : "pP15qQX5VDU",
+    "tags" : [ "DUXKT4ggD0xT" ],
+    "description" : "QTP6yfzCtT3bHUq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rnFRp8TbEowNpSI2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iB7hOnNAgqEbvEQM8"
         },
-        "seriesNumber" : "lXq2u5l9G0h",
+        "seriesNumber" : "LhRVeLYuBNhtV",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yigmyfjrwdBYWw"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fwa0HlWIJQ"
         },
-        "isbnList" : [ "9791927598305" ]
+        "isbnList" : [ "9780874598100" ]
       },
-      "doi" : "https://www.example.com/xPRuFaFtR50F2",
+      "doi" : "https://www.example.com/wfgqk6JIUSqh",
       "publicationInstance" : {
         "type" : "BookMonograph",
         "contentType" : "Popular Science Monograph",
         "originalResearch" : false,
-        "peerReviewed" : false,
+        "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "3cntnjQU4Jlbm",
-            "end" : "hvDiT7hyySxt"
+            "begin" : "YR7y5qeGmz",
+            "end" : "wEUGhqR0iqqvf8si"
           },
-          "pages" : "Ogn7XBkjwIZMB",
-          "illustrated" : true
+          "pages" : "7PzL7cwXOIlH",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/YWIGfblnLDI08NCasf",
-    "abstract" : "FSELbWuH9NJ6Lmg"
+    "metadataSource" : "https://www.example.com/xak1m2fqN0pmQ",
+    "abstract" : "CGVvXI4AD97B"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "hAYMa1dnsp06Xu",
-      "mimeType" : "Cxg7qoXcRuJLqdGl",
-      "size" : 820563688,
+      "name" : "Ac6aaEXTPKvzS",
+      "mimeType" : "UtWo65PwREBSEg",
+      "size" : 861437951,
       "license" : {
         "type" : "License",
-        "identifier" : "XGWOT9k0eQ1cGkyJ",
+        "identifier" : "qUXIjUJRb9X1",
         "labels" : {
-          "vfkR7DvPQq" : "0Y7b07qSWVmbc"
+          "vYFvGcqMftluIP" : "rBGbCyLYMu2Qy"
         },
-        "link" : "https://www.example.com/hZ9DXPRrkbVkVRALAk2"
+        "link" : "https://www.example.com/hiAokooBftJiDUzk7Bf"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -149,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/officiatempore",
-    "name" : "EeDmqmJdPI7AIaoVE",
+    "id" : "https://www.example.org/laboriosamvoluptatibus",
+    "name" : "MDIwYDBVsuiCqTT6i2I",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "8Rvl6UZBS5CuM",
-      "id" : "fuSel9yDLBi"
+      "source" : "wgBzb4TfVPYWXAb6pL",
+      "id" : "TuopoJasTwWplobdR"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "otzVrvFIDf"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "IBpDi28nUfnxWewJTU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dignissimosnihil" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/voluptatemnemo" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "yrb9nC4p1tN1Q",
+  "status" : "NEW",
+  "owner" : "JyftdbwSu4Evt",
   "resourceOwner" : {
-    "owner" : "yrb9nC4p1tN1Q",
-    "ownerAffiliation" : "https://www.example.org/quodautem"
+    "owner" : "JyftdbwSu4Evt",
+    "ownerAffiliation" : "https://www.example.org/asperioresquis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aspernaturet",
+    "id" : "https://www.example.org/explicaboqui",
     "labels" : {
-      "NvbxTp1TiWUHG" : "vuxxoGfoXNsDUt"
+      "v1qDSCmDw24zx0vC" : "ofFYLwaxVjj"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/natusexercitationem",
-  "doi" : "https://doi.org/10.1234/aut",
+  "handle" : "https://www.example.org/placeatdolorum",
+  "doi" : "https://doi.org/10.1234/ea",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,120 +27,120 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "1tKJX1xrt4k",
-      "author" : "wzapSWL77HEGU0kQ",
+      "text" : "beOCUWbNPedmX5w",
+      "author" : "4xwidbc7aIuxrIJ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/consequaturcupiditate",
+  "link" : "https://www.example.org/molestiaset",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vfWKnbSOLtAT5j",
+    "mainTitle" : "occIazSSAj1pU9",
     "alternativeTitles" : {
-      "se" : "rBSwOZ9nFPQSWOD52F"
+      "ru" : "MJmA7NfvgwO3dLFfpJI"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "thMtZMRJZhXACHd4",
-      "month" : "D3H67ylyzn",
-      "day" : "8rkoUYUWMC7QcFuSg"
+      "year" : "06kjed7KsRYQDgAWC",
+      "month" : "HcHZfwQNimQ",
+      "day" : "H9VnqHu11gl9S2xSs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/De89Cw3EeF",
-        "name" : "M0IZVXXm8EG",
+        "id" : "https://www.example.com/sOK1dNTacL37T",
+        "name" : "EOu29nKCyvTq9pxu",
         "nameType" : "Personal",
-        "orcId" : "rVPNEWaLokf",
-        "arpId" : "T3QoQ1fKuAWBKnZBj"
+        "orcId" : "8wJvQ04ACRMXpuAhq",
+        "arpId" : "OJAnb1pBXFV2C3p"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tnr73XXI3d8S",
+        "id" : "https://www.example.com/WgnwNh60dJt3kzBl8y",
         "labels" : {
-          "l7FDcXirG2" : "p1vXEPAuR2rHeK"
+          "FXdBQ6TvlM3MjxL" : "gVtEI18iN02e2TE"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 3,
+      "role" : "Editor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/flXTZzWel3C2rYR",
-        "name" : "nemGq5WYj91JJgyKeX",
+        "id" : "https://www.example.com/Y98VFZn3WHgZfN0",
+        "name" : "2wb6grzgZ60wjizwMA2",
         "nameType" : "Organizational",
-        "orcId" : "BdmNIR1PBB",
-        "arpId" : "QhAa25oTatVr"
+        "orcId" : "COpSM3mdJwyE0HQKV",
+        "arpId" : "wtcTEjmaFi32x"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3fHUWXRvWT8EN6b",
+        "id" : "https://www.example.com/7ChoAJdQ3qnjz9QE",
         "labels" : {
-          "MuRVigltjNPLcD8Zhxi" : "GDlrAnsyvtmtyA"
+          "cLYgYBrCxU8rUvr1S" : "Q3zveT7av9okhz571l4"
         }
       } ],
-      "role" : "RightsHolder",
+      "role" : "ProgrammeParticipant",
       "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "pP15qQX5VDU",
-    "tags" : [ "DUXKT4ggD0xT" ],
-    "description" : "QTP6yfzCtT3bHUq",
+    "npiSubjectHeading" : "RzQ5xwi2WsD",
+    "tags" : [ "ob7wQeX1pP6Cr" ],
+    "description" : "0TyNWC5rqXN0MGi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iB7hOnNAgqEbvEQM8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/M3N1EmhP6R"
         },
-        "seriesNumber" : "LhRVeLYuBNhtV",
+        "seriesNumber" : "N1jrtSukbZJ2",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fwa0HlWIJQ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/sGI0YkaRdSajrw8p"
         },
-        "isbnList" : [ "9780874598100" ]
+        "isbnList" : [ "9791920764653" ]
       },
-      "doi" : "https://www.example.com/wfgqk6JIUSqh",
+      "doi" : "https://www.example.com/rlRfQpoaYa6eJkXIc",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Popular Science Monograph",
+        "contentType" : "Non-fiction Monograph",
         "originalResearch" : false,
-        "peerReviewed" : true,
+        "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "YR7y5qeGmz",
-            "end" : "wEUGhqR0iqqvf8si"
+            "begin" : "F7A5feN6WwB1Q",
+            "end" : "sMl4MKcQjz6"
           },
-          "pages" : "7PzL7cwXOIlH",
+          "pages" : "avck5HCnCo1zh81",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/xak1m2fqN0pmQ",
-    "abstract" : "CGVvXI4AD97B"
+    "metadataSource" : "https://www.example.com/yfrvkkRVSHUxd4",
+    "abstract" : "Fm0X9eNcm3"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Ac6aaEXTPKvzS",
-      "mimeType" : "UtWo65PwREBSEg",
-      "size" : 861437951,
+      "name" : "ZdfqvaMxf0LrFm03N",
+      "mimeType" : "sZtrbBXhLs69tf0TRuB",
+      "size" : 78628992,
       "license" : {
         "type" : "License",
-        "identifier" : "qUXIjUJRb9X1",
+        "identifier" : "JjHtzCzZ3sicNAhw",
         "labels" : {
-          "vYFvGcqMftluIP" : "rBGbCyLYMu2Qy"
+          "yQpaVukElk" : "SVAR7Pmmqs7nMT"
         },
-        "link" : "https://www.example.com/hiAokooBftJiDUzk7Bf"
+        "link" : "https://www.example.com/2P8QOsmIELc"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -149,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laboriosamvoluptatibus",
-    "name" : "MDIwYDBVsuiCqTT6i2I",
+    "id" : "https://www.example.org/consecteturnobis",
+    "name" : "Q0eBUV6JNl",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "wgBzb4TfVPYWXAb6pL",
-      "id" : "TuopoJasTwWplobdR"
+      "source" : "hgMNgl9vKwb491x",
+      "id" : "806YzEgoXqje4qC3"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "REK",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "IBpDi28nUfnxWewJTU"
+      "applicationCode" : "ROkbtD22Fsl"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatemnemo" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/aliasaut" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "I9hviHk8iEZ",
+  "status" : "NEW",
+  "owner" : "Mk1qCqfnUjw6lY",
   "resourceOwner" : {
-    "owner" : "I9hviHk8iEZ",
-    "ownerAffiliation" : "https://www.example.org/dictaut"
+    "owner" : "Mk1qCqfnUjw6lY",
+    "ownerAffiliation" : "https://www.example.org/molestiaecupiditate"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/animiaccusantium",
+    "id" : "https://www.example.org/illumquaerat",
     "labels" : {
-      "X4sd1EbTi0E2U" : "CGlOP2A4WOARbsWk"
+      "DvQiaF35A3y" : "wOxv1hzh1hCzmj9402"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eaquequibusdam",
-  "doi" : "https://doi.org/10.1234/sed",
+  "handle" : "https://www.example.org/inet",
+  "doi" : "https://doi.org/10.1234/dolore",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,141 +27,141 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "rC6hEy0iGmu7GmGMZc",
-      "author" : "DY5NVrsqrz",
+      "text" : "8Z8WPtLgyAWJx",
+      "author" : "fFRSlC9YobVTe5jx",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/possimusnihil",
+  "link" : "https://www.example.org/ipsaquia",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fDh2dfocxJJI",
+    "mainTitle" : "Cu7BZprsmu",
     "alternativeTitles" : {
-      "de" : "56HoDEZ19Ch4g2o"
+      "hu" : "GJM6FDr3XOH5"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "HIFMZTyNZfyQJXPo",
-      "month" : "FR0PNoICc55r",
-      "day" : "s6li2mIE7eydiqCPVv4"
+      "year" : "ZWQIpwqbeCfBj8VbW",
+      "month" : "ZfIY2oCKpZPxR7gxJ",
+      "day" : "lbOhCBr3Mm0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HeNnBr1WU6F48jyk",
-        "name" : "8G2DG3vnlSgeLt",
+        "id" : "https://www.example.com/0UQjPptWCfU",
+        "name" : "AU05rl0IvTiGHqDIW9T",
         "nameType" : "Personal",
-        "orcId" : "1cOg1xfJkXavgvBe5",
-        "arpId" : "LL1gAe7VXNEcThmA8n"
+        "orcId" : "Wbz6A3eGkTUAxuOuL",
+        "arpId" : "GgXxQVu9inYZCRkS7j"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/EgBDE7l7ZIf5",
+        "id" : "https://www.example.com/9xfWCbdjbkf",
         "labels" : {
-          "NpUu6LB9rA1iS5DQU" : "TAWpXssGrGbi11evS8"
+          "yOpkZJ2Hg137vdiQm3" : "Ff8LS1ctcNbFdqANUiC"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 1,
+      "role" : "InterviewSubject",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ImpsHObBDHYPYkSO3T",
-        "name" : "AqEogET9y6d5sP",
+        "id" : "https://www.example.com/BMultmVO6sK",
+        "name" : "W34MEMNzZ19fFyvx2sq",
         "nameType" : "Organizational",
-        "orcId" : "SMkcSUQutMcSB",
-        "arpId" : "hSRX3fqehnw0GQ7I8k"
+        "orcId" : "hI0hUTl3WX1HQA36cDl",
+        "arpId" : "gQTKSvxT9MwuLLdoHIC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DyuWv0ycqUhTfQus",
+        "id" : "https://www.example.com/LStX8yt93NoQlAk",
         "labels" : {
-          "oxjrJJOjr3qfWQbe0r" : "Xse9baNiTFHUf"
+          "er7sKSjYEodDl2QM" : "qXqDHDrml4oAL3fhR"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 6,
+      "role" : "Editor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "w9Wu7OT4uyH3wc",
-    "tags" : [ "aKo1Jh2r0hHfx7p" ],
-    "description" : "p3bEVw30K0D",
+    "npiSubjectHeading" : "4OSyv4QEls0",
+    "tags" : [ "l0kwls2bY5zrJP" ],
+    "description" : "sYk5aqFzLOb6WTcSaW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7IIRF7sP5igq80hjW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SbDbIyC6N0pcR3X"
         },
-        "seriesNumber" : "5kUZ4GDXet0AhVb0",
+        "seriesNumber" : "YhDwf9ghTkJqVip6jQY",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Q093bD2scwx1s"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ksN5XXXrkiTq7cO1vM"
         },
-        "isbnList" : [ "9781037910845" ]
+        "isbnList" : [ "9780530740324" ]
       },
-      "doi" : "https://www.example.com/cR8BwjEORgqWCAf",
+      "doi" : "https://www.example.com/h9Lkets1XmM0wLKc3Ki",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Textbook",
+        "contentType" : "Encyclopedia",
         "originalResearch" : false,
-        "peerReviewed" : true,
+        "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "mzPQG2xoFTD",
-            "end" : "EC2eZbVf2UFfI"
+            "begin" : "5AQ7SosP3YSEoAr2e0",
+            "end" : "TJbDtC6Cl4n"
           },
-          "pages" : "EwoGMBW4tHDKcv",
+          "pages" : "T1VwJZ8FAUwLGAL9a8",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/5Yeb2II4p7ktqil",
-    "abstract" : "1eeFvuYs4SqsJpHpJR"
+    "metadataSource" : "https://www.example.com/7td6WE3q5JjbbMJirD",
+    "abstract" : "YJ2CXbpNck8zE"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Rrk1MlT1APcW",
-      "mimeType" : "bCEntrfTh3nQ",
-      "size" : 1616054697,
+      "name" : "TD6yZsUdrm88Q",
+      "mimeType" : "nYLu7KydLp",
+      "size" : 1888729779,
       "license" : {
         "type" : "License",
-        "identifier" : "Xxw6BMAh43Ma",
+        "identifier" : "E9aRbpzjwfrSz4Grjw5",
         "labels" : {
-          "BrrEjHjqX66qHN" : "Szd6m4zhnm3zm01PQ"
+          "KOF5PAkbPSTzRMRIl" : "669ExutFykuAReovQ"
         },
-        "link" : "https://www.example.com/nCNRs4QQLdf8tK"
+        "link" : "https://www.example.com/tH1rGDg4PCQlaxoso"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nonaliquam",
-    "name" : "sTe8RMfB2JeGMKaMH",
+    "id" : "https://www.example.org/eligendiest",
+    "name" : "JFny5HrmK4W2Fir",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "tDejVSImC44Mb9n",
-      "id" : "XWf4ZA7gtjWi"
+      "source" : "4iYYuhifchXCiyM",
+      "id" : "vEB8B8leCS5fCtlZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "nIgeczIzhZTaK"
+      "applicationCode" : "Ssr2nCAJ0Jq0uNQC"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/blanditiissint" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/quosaepe" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,167 +1,167 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "JyftdbwSu4Evt",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "I9hviHk8iEZ",
   "resourceOwner" : {
-    "owner" : "JyftdbwSu4Evt",
-    "ownerAffiliation" : "https://www.example.org/asperioresquis"
+    "owner" : "I9hviHk8iEZ",
+    "ownerAffiliation" : "https://www.example.org/dictaut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/explicaboqui",
+    "id" : "https://www.example.org/animiaccusantium",
     "labels" : {
-      "v1qDSCmDw24zx0vC" : "ofFYLwaxVjj"
+      "X4sd1EbTi0E2U" : "CGlOP2A4WOARbsWk"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/placeatdolorum",
-  "doi" : "https://doi.org/10.1234/ea",
+  "handle" : "https://www.example.org/eaquequibusdam",
+  "doi" : "https://doi.org/10.1234/sed",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "beOCUWbNPedmX5w",
-      "author" : "4xwidbc7aIuxrIJ",
+      "text" : "rC6hEy0iGmu7GmGMZc",
+      "author" : "DY5NVrsqrz",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/molestiaset",
+  "link" : "https://www.example.org/possimusnihil",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "occIazSSAj1pU9",
+    "mainTitle" : "fDh2dfocxJJI",
     "alternativeTitles" : {
-      "ru" : "MJmA7NfvgwO3dLFfpJI"
+      "de" : "56HoDEZ19Ch4g2o"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "06kjed7KsRYQDgAWC",
-      "month" : "HcHZfwQNimQ",
-      "day" : "H9VnqHu11gl9S2xSs"
+      "year" : "HIFMZTyNZfyQJXPo",
+      "month" : "FR0PNoICc55r",
+      "day" : "s6li2mIE7eydiqCPVv4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sOK1dNTacL37T",
-        "name" : "EOu29nKCyvTq9pxu",
+        "id" : "https://www.example.com/HeNnBr1WU6F48jyk",
+        "name" : "8G2DG3vnlSgeLt",
         "nameType" : "Personal",
-        "orcId" : "8wJvQ04ACRMXpuAhq",
-        "arpId" : "OJAnb1pBXFV2C3p"
+        "orcId" : "1cOg1xfJkXavgvBe5",
+        "arpId" : "LL1gAe7VXNEcThmA8n"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/WgnwNh60dJt3kzBl8y",
+        "id" : "https://www.example.com/EgBDE7l7ZIf5",
         "labels" : {
-          "FXdBQ6TvlM3MjxL" : "gVtEI18iN02e2TE"
+          "NpUu6LB9rA1iS5DQU" : "TAWpXssGrGbi11evS8"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 7,
+      "role" : "Journalist",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Y98VFZn3WHgZfN0",
-        "name" : "2wb6grzgZ60wjizwMA2",
+        "id" : "https://www.example.com/ImpsHObBDHYPYkSO3T",
+        "name" : "AqEogET9y6d5sP",
         "nameType" : "Organizational",
-        "orcId" : "COpSM3mdJwyE0HQKV",
-        "arpId" : "wtcTEjmaFi32x"
+        "orcId" : "SMkcSUQutMcSB",
+        "arpId" : "hSRX3fqehnw0GQ7I8k"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7ChoAJdQ3qnjz9QE",
+        "id" : "https://www.example.com/DyuWv0ycqUhTfQus",
         "labels" : {
-          "cLYgYBrCxU8rUvr1S" : "Q3zveT7av9okhz571l4"
+          "oxjrJJOjr3qfWQbe0r" : "Xse9baNiTFHUf"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 1,
+      "role" : "InterviewSubject",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "RzQ5xwi2WsD",
-    "tags" : [ "ob7wQeX1pP6Cr" ],
-    "description" : "0TyNWC5rqXN0MGi",
+    "npiSubjectHeading" : "w9Wu7OT4uyH3wc",
+    "tags" : [ "aKo1Jh2r0hHfx7p" ],
+    "description" : "p3bEVw30K0D",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/M3N1EmhP6R"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7IIRF7sP5igq80hjW"
         },
-        "seriesNumber" : "N1jrtSukbZJ2",
+        "seriesNumber" : "5kUZ4GDXet0AhVb0",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/sGI0YkaRdSajrw8p"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Q093bD2scwx1s"
         },
-        "isbnList" : [ "9791920764653" ]
+        "isbnList" : [ "9781037910845" ]
       },
-      "doi" : "https://www.example.com/rlRfQpoaYa6eJkXIc",
+      "doi" : "https://www.example.com/cR8BwjEORgqWCAf",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Non-fiction Monograph",
+        "contentType" : "Textbook",
         "originalResearch" : false,
-        "peerReviewed" : false,
+        "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "F7A5feN6WwB1Q",
-            "end" : "sMl4MKcQjz6"
+            "begin" : "mzPQG2xoFTD",
+            "end" : "EC2eZbVf2UFfI"
           },
-          "pages" : "avck5HCnCo1zh81",
-          "illustrated" : false
+          "pages" : "EwoGMBW4tHDKcv",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/yfrvkkRVSHUxd4",
-    "abstract" : "Fm0X9eNcm3"
+    "metadataSource" : "https://www.example.com/5Yeb2II4p7ktqil",
+    "abstract" : "1eeFvuYs4SqsJpHpJR"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZdfqvaMxf0LrFm03N",
-      "mimeType" : "sZtrbBXhLs69tf0TRuB",
-      "size" : 78628992,
+      "name" : "Rrk1MlT1APcW",
+      "mimeType" : "bCEntrfTh3nQ",
+      "size" : 1616054697,
       "license" : {
         "type" : "License",
-        "identifier" : "JjHtzCzZ3sicNAhw",
+        "identifier" : "Xxw6BMAh43Ma",
         "labels" : {
-          "yQpaVukElk" : "SVAR7Pmmqs7nMT"
+          "BrrEjHjqX66qHN" : "Szd6m4zhnm3zm01PQ"
         },
-        "link" : "https://www.example.com/2P8QOsmIELc"
+        "link" : "https://www.example.com/nCNRs4QQLdf8tK"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consecteturnobis",
-    "name" : "Q0eBUV6JNl",
+    "id" : "https://www.example.org/nonaliquam",
+    "name" : "sTe8RMfB2JeGMKaMH",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "hgMNgl9vKwb491x",
-      "id" : "806YzEgoXqje4qC3"
+      "source" : "tDejVSImC44Mb9n",
+      "id" : "XWf4ZA7gtjWi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "ROkbtD22Fsl"
+      "applicationCode" : "nIgeczIzhZTaK"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliasaut" ],
+  "subjects" : [ "https://www.example.org/blanditiissint" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
-  "owner" : "kIQAH5a1slh0NBfR",
+  "owner" : "DEIRSphVUUb5hgMylb",
   "resourceOwner" : {
-    "owner" : "kIQAH5a1slh0NBfR",
-    "ownerAffiliation" : "https://www.example.org/consequaturquos"
+    "owner" : "DEIRSphVUUb5hgMylb",
+    "ownerAffiliation" : "https://www.example.org/quasvoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/suntperspiciatis",
+    "id" : "https://www.example.org/voluptatemqui",
     "labels" : {
-      "bfne2q63Sdk1U" : "kmH5O2IAZ4Dobrg"
+      "hO14VdyrTkYbFGjU" : "dYamend0BfUO1Wg"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ametvoluptatem",
-  "doi" : "https://doi.org/10.1234/numquam",
+  "handle" : "https://www.example.org/adsaepe",
+  "doi" : "https://doi.org/10.1234/sed",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,127 +27,127 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "LNCEqkGa3Y8DcWRKos",
-      "author" : "0hjH2mlLZWfjhDkEbB5",
+      "text" : "L6BPMMbWT9",
+      "author" : "XUWuiZQqRt",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloresvoluptates",
+  "link" : "https://www.example.org/estmollitia",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "g2Fo8VK6HN",
+    "mainTitle" : "dVx9TXeV5qe6J",
     "alternativeTitles" : {
-      "ru" : "JT91UVLaojHrbZ3Z1"
+      "nl" : "xuby5Bn55ep9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "9R5R8dXfHI",
-      "month" : "0MEIG9LZhUee",
-      "day" : "w2IFXYKY2hmIHmBwaIa"
+      "year" : "DEs4n5jAPH2QM10L6T",
+      "month" : "4uEXP1ihmciY",
+      "day" : "hXVjZqn0DS9Hz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/T7NKjWKZkz",
-        "name" : "8krkh8hF6QwqGPhlv",
+        "id" : "https://www.example.com/WZEg4dpYhrP7fTI5s",
+        "name" : "kZvHhI7R5OBG67",
         "nameType" : "Personal",
-        "orcId" : "iTYoSQFp1C",
-        "arpId" : "QjIqRF8qsYYRUw6"
+        "orcId" : "FRdgAKzvukzBpF9N",
+        "arpId" : "5f1v3ST9410F"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CXG0RGMkkva",
+        "id" : "https://www.example.com/1XphIuLRkN7d",
         "labels" : {
-          "ndVyOkoa2Isx5" : "3ypjrgO2HFn"
+          "PQMLbMOoaZcrmo" : "6ztJS7CV6BZb"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 0,
+      "role" : "Producer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/93C7xdbzWKlKu58C",
-        "name" : "Qfl6KtrxwSMi86vz",
+        "id" : "https://www.example.com/U9d9YJ7KGi",
+        "name" : "VvHjf0i5uufkXGHqBJ",
         "nameType" : "Personal",
-        "orcId" : "fPRxphz7gKM",
-        "arpId" : "8hF3QwuiugY4"
+        "orcId" : "27IgQZosFqgioMMi5qm",
+        "arpId" : "08Pess6KF5iZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RnXDXHBuiZeP",
+        "id" : "https://www.example.com/1Q60hQE3aLvZp",
         "labels" : {
-          "i94MoaRv4bzf" : "V7PzQO6O9nYpfr"
+          "tQUF85ApyE6oionTk" : "FdPVxAso8be"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 9,
+      "role" : "Other",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Woh9DPbkoiUM5V4R",
-    "tags" : [ "HliQ7YJ1tPBW2KB" ],
-    "description" : "WFY3QYsQ6fDv",
+    "npiSubjectHeading" : "z6zgbkXL3vUwev",
+    "tags" : [ "AmUcB6YvHR" ],
+    "description" : "wzwsB293gPhyhyKu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/iDyxlBHlj3Pb29dbe"
+        "partOf" : "https://www.example.com/9m7lKyrtey0qKw"
       },
-      "doi" : "https://www.example.com/qk162AJzWbH",
+      "doi" : "https://www.example.com/RZUXl8fn88ECMr0d",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "Academic Chapter",
-        "peerReviewed" : false,
+        "contentType" : "Non-fiction Chapter",
+        "peerReviewed" : true,
         "originalResearch" : true,
         "pages" : {
           "type" : "Range",
-          "begin" : "TMJZByjqwqYzuTjdI",
-          "end" : "heC0GmAtfVi"
+          "begin" : "Bt6Y5ltsvP",
+          "end" : "DHso5hJXGu51"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/cjynRqHJtLyalvct",
-    "abstract" : "YF8S7YYE989r2RtrkV"
+    "metadataSource" : "https://www.example.com/ILOFf9Q2eBvZ9ERnB",
+    "abstract" : "J40AVVmO3UbRS"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "5AK6eZxgHL",
-      "mimeType" : "tRowdG603tm3U",
-      "size" : 568577536,
+      "name" : "WD5AfNJl3PwX",
+      "mimeType" : "U2evU4NBMYURFAA",
+      "size" : 1941933304,
       "license" : {
         "type" : "License",
-        "identifier" : "3UoLwgiyTz",
+        "identifier" : "ewtid6HUz7KsT",
         "labels" : {
-          "o4Y8ZyGjtK" : "rlZZuHSMkcZF4gw"
+          "HEGVeOmoXFE" : "iLzEg0go5A2giqB"
         },
-        "link" : "https://www.example.com/qTamfqfYosdVjzYR"
+        "link" : "https://www.example.com/fUYmT5irCfd"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/oditrepellat",
-    "name" : "byAuFCrwJVUHA9zfm",
+    "id" : "https://www.example.org/veniamet",
+    "name" : "lYTKziHjgFiVPBErxr7",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "DKWu2XrhwAKZEL50j",
-      "id" : "UPXTRD9LKCWWAA"
+      "source" : "TzI8fplxhuoOEjGV9h",
+      "id" : "Elgqgln0xZ8i"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "vptqtSvhD0JQCn0cjS"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ofzxQfyuqbKV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -155,6 +155,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sequieligendi" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/eaquetemporibus" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "BSo89KcqVjfF3k69",
+  "status" : "PUBLISHED",
+  "owner" : "1yZ5ydzIh4dK",
   "resourceOwner" : {
-    "owner" : "BSo89KcqVjfF3k69",
-    "ownerAffiliation" : "https://www.example.org/distinctionostrum"
+    "owner" : "1yZ5ydzIh4dK",
+    "ownerAffiliation" : "https://www.example.org/voluptatibusfuga"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequaturnon",
+    "id" : "https://www.example.org/cumqueet",
     "labels" : {
-      "GTZoP1NuAKWRkJr" : "gLZqczjfQ3VA"
+      "UdDH70cuNGmqgf7Ck4" : "kKj5lNrdXC8w9K58i9X"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/rerumnesciunt",
-  "doi" : "https://doi.org/10.1234/facere",
+  "handle" : "https://www.example.org/minimaeos",
+  "doi" : "https://doi.org/10.1234/omnis",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,127 +27,127 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "zFfyOmB1j2",
-      "author" : "sfbp3KJc8Igw",
+      "text" : "GMHhlSFyUMwjH1rlnE",
+      "author" : "I0dmBio3QZ8Y8BslwR",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/nobismaiores",
+  "link" : "https://www.example.org/idfacere",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jEw8LDlNRko5eev",
+    "mainTitle" : "pzGP7WKwf5QD2Y",
     "alternativeTitles" : {
-      "nl" : "eZe7XbBmnUrhO"
+      "is" : "gS6FQibnfgdbbLE"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "d8yX48QFSBzF4zI1SGC",
-      "month" : "y6g6CNGRyGX6K22ikZN",
-      "day" : "1nFjCzmOLVNvqS"
+      "year" : "xBtky40RlXKyGA",
+      "month" : "7RVBh18RoMpB8",
+      "day" : "XQdMP4MNQMO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/4b4BA66HHDjxC",
-        "name" : "xy6ns5TdGJ2AROoVG",
-        "nameType" : "Personal",
-        "orcId" : "Rb4TVThgX9yJo2vFD",
-        "arpId" : "wbUM7olUIbhFy"
+        "id" : "https://www.example.com/s9FJiRxFkG",
+        "name" : "zpzisGMsOh6zz",
+        "nameType" : "Organizational",
+        "orcId" : "l5OWgj7vfpCbN",
+        "arpId" : "CaaHi62HSl4M9m"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/u5oTljioBt8Z",
+        "id" : "https://www.example.com/15lMJ23PcxftYELQ3",
         "labels" : {
-          "yHyyA9yOjKcdXrZwV" : "QD7XjH5RuieSqjaJ0rr"
+          "zk8338A7dTuR" : "miO6CrD7E3"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 7,
+      "role" : "Creator",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DbeycXOyt5NOMP",
-        "name" : "NzJkF2sOQnsaiS",
+        "id" : "https://www.example.com/LjLMKA8ZYAKQ",
+        "name" : "JApeR9opcVkyV7183",
         "nameType" : "Personal",
-        "orcId" : "VvXgawbxbpR3Zj",
-        "arpId" : "t06aXnAsVhomphp"
+        "orcId" : "anC6akr6e84NziIT",
+        "arpId" : "F47bD4OVNCkPz7R9hOm"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/P2gIB2KiXLikR",
+        "id" : "https://www.example.com/uRNYPlQbOfyVhKOS3v",
         "labels" : {
-          "NxTaJR8AmyB67kAJ" : "fKqvgZJvosIrXBZX"
+          "sslTCFIZdKTa" : "nmyAMNgksVXtQe3nT"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 2,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6a9LUsewtv",
-    "tags" : [ "klXhtlmqlVM" ],
-    "description" : "64ikO0Z6QHepf",
+    "npiSubjectHeading" : "VFJckl8jAcRW7Q801",
+    "tags" : [ "nCIXTsw0gHZVcCdQr" ],
+    "description" : "TFLpELKikZznfd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/uYBQBMOpGP0nM1x"
+        "partOf" : "https://www.example.com/D8mqm06WLELdPKUqghk"
       },
-      "doi" : "https://www.example.com/I1GiaJPnGSgu",
+      "doi" : "https://www.example.com/ttUcCM7VgSokbN7aXNO",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "Non-fiction Chapter",
-        "peerReviewed" : true,
+        "contentType" : "Textbook Chapter",
+        "peerReviewed" : false,
         "originalResearch" : true,
         "pages" : {
           "type" : "Range",
-          "begin" : "xVXCIixNKAreIc",
-          "end" : "LSoZvh3MxnZcsANmy"
+          "begin" : "FaaWROqjQ0xBHvSCCGG",
+          "end" : "XZmoeksNiGg"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/LcLf3U6HJQlEJ85Ok",
-    "abstract" : "yMDBujElvDf"
+    "metadataSource" : "https://www.example.com/OIHowj9BMBTS08uI7T",
+    "abstract" : "dqLFpl2eoEaPg"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "8cQLLlPy2WeOAC",
-      "mimeType" : "5yEx6kdQWEEUO",
-      "size" : 351897648,
+      "name" : "4mf5JFOb93sw0lHZqz",
+      "mimeType" : "fGzU3fTN9OPa5Hfmbr9",
+      "size" : 1458613597,
       "license" : {
         "type" : "License",
-        "identifier" : "sZ1IioQxOOWpazNRNI8",
+        "identifier" : "OH3MYiujWCJXoHzd",
         "labels" : {
-          "RFZmnJOoKtBWkzs" : "pgYsaSEO8V2Kk06"
+          "Y8iaonzm8mT1vE" : "FbA7NvRIAf9Ikoh8"
         },
-        "link" : "https://www.example.com/cfAVwEmsmJm22"
+        "link" : "https://www.example.com/FFfqHh8y6KeoJ1"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omniset",
-    "name" : "tOXAGAXFJ6Oai",
+    "id" : "https://www.example.org/reiciendisqui",
+    "name" : "JThOWS8YOf",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "dOoC2BbZdkNdC2OcY",
-      "id" : "ur0FwKVkNW6I1Nj"
+      "source" : "47AJOWSnjcutC",
+      "id" : "9WjdJFKmujBUd"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "qFhIBkAaegFSgsW"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "4EcfWmKZlwm"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -155,6 +155,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/exrepudiandae" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/debitisperferendis" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "1yZ5ydzIh4dK",
+  "status" : "DRAFT",
+  "owner" : "kIQAH5a1slh0NBfR",
   "resourceOwner" : {
-    "owner" : "1yZ5ydzIh4dK",
-    "ownerAffiliation" : "https://www.example.org/voluptatibusfuga"
+    "owner" : "kIQAH5a1slh0NBfR",
+    "ownerAffiliation" : "https://www.example.org/consequaturquos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cumqueet",
+    "id" : "https://www.example.org/suntperspiciatis",
     "labels" : {
-      "UdDH70cuNGmqgf7Ck4" : "kKj5lNrdXC8w9K58i9X"
+      "bfne2q63Sdk1U" : "kmH5O2IAZ4Dobrg"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/minimaeos",
-  "doi" : "https://doi.org/10.1234/omnis",
+  "handle" : "https://www.example.org/ametvoluptatem",
+  "doi" : "https://doi.org/10.1234/numquam",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,127 +27,127 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "GMHhlSFyUMwjH1rlnE",
-      "author" : "I0dmBio3QZ8Y8BslwR",
+      "text" : "LNCEqkGa3Y8DcWRKos",
+      "author" : "0hjH2mlLZWfjhDkEbB5",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/idfacere",
+  "link" : "https://www.example.org/doloresvoluptates",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pzGP7WKwf5QD2Y",
+    "mainTitle" : "g2Fo8VK6HN",
     "alternativeTitles" : {
-      "is" : "gS6FQibnfgdbbLE"
+      "ru" : "JT91UVLaojHrbZ3Z1"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "xBtky40RlXKyGA",
-      "month" : "7RVBh18RoMpB8",
-      "day" : "XQdMP4MNQMO"
+      "year" : "9R5R8dXfHI",
+      "month" : "0MEIG9LZhUee",
+      "day" : "w2IFXYKY2hmIHmBwaIa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/s9FJiRxFkG",
-        "name" : "zpzisGMsOh6zz",
-        "nameType" : "Organizational",
-        "orcId" : "l5OWgj7vfpCbN",
-        "arpId" : "CaaHi62HSl4M9m"
+        "id" : "https://www.example.com/T7NKjWKZkz",
+        "name" : "8krkh8hF6QwqGPhlv",
+        "nameType" : "Personal",
+        "orcId" : "iTYoSQFp1C",
+        "arpId" : "QjIqRF8qsYYRUw6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/15lMJ23PcxftYELQ3",
+        "id" : "https://www.example.com/CXG0RGMkkva",
         "labels" : {
-          "zk8338A7dTuR" : "miO6CrD7E3"
+          "ndVyOkoa2Isx5" : "3ypjrgO2HFn"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 9,
+      "role" : "Journalist",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/LjLMKA8ZYAKQ",
-        "name" : "JApeR9opcVkyV7183",
+        "id" : "https://www.example.com/93C7xdbzWKlKu58C",
+        "name" : "Qfl6KtrxwSMi86vz",
         "nameType" : "Personal",
-        "orcId" : "anC6akr6e84NziIT",
-        "arpId" : "F47bD4OVNCkPz7R9hOm"
+        "orcId" : "fPRxphz7gKM",
+        "arpId" : "8hF3QwuiugY4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uRNYPlQbOfyVhKOS3v",
+        "id" : "https://www.example.com/RnXDXHBuiZeP",
         "labels" : {
-          "sslTCFIZdKTa" : "nmyAMNgksVXtQe3nT"
+          "i94MoaRv4bzf" : "V7PzQO6O9nYpfr"
         }
       } ],
-      "role" : "ProgrammeParticipant",
+      "role" : "Sponsor",
       "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "VFJckl8jAcRW7Q801",
-    "tags" : [ "nCIXTsw0gHZVcCdQr" ],
-    "description" : "TFLpELKikZznfd",
+    "npiSubjectHeading" : "Woh9DPbkoiUM5V4R",
+    "tags" : [ "HliQ7YJ1tPBW2KB" ],
+    "description" : "WFY3QYsQ6fDv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/D8mqm06WLELdPKUqghk"
+        "partOf" : "https://www.example.com/iDyxlBHlj3Pb29dbe"
       },
-      "doi" : "https://www.example.com/ttUcCM7VgSokbN7aXNO",
+      "doi" : "https://www.example.com/qk162AJzWbH",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "Textbook Chapter",
+        "contentType" : "Academic Chapter",
         "peerReviewed" : false,
         "originalResearch" : true,
         "pages" : {
           "type" : "Range",
-          "begin" : "FaaWROqjQ0xBHvSCCGG",
-          "end" : "XZmoeksNiGg"
+          "begin" : "TMJZByjqwqYzuTjdI",
+          "end" : "heC0GmAtfVi"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/OIHowj9BMBTS08uI7T",
-    "abstract" : "dqLFpl2eoEaPg"
+    "metadataSource" : "https://www.example.com/cjynRqHJtLyalvct",
+    "abstract" : "YF8S7YYE989r2RtrkV"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "4mf5JFOb93sw0lHZqz",
-      "mimeType" : "fGzU3fTN9OPa5Hfmbr9",
-      "size" : 1458613597,
+      "name" : "5AK6eZxgHL",
+      "mimeType" : "tRowdG603tm3U",
+      "size" : 568577536,
       "license" : {
         "type" : "License",
-        "identifier" : "OH3MYiujWCJXoHzd",
+        "identifier" : "3UoLwgiyTz",
         "labels" : {
-          "Y8iaonzm8mT1vE" : "FbA7NvRIAf9Ikoh8"
+          "o4Y8ZyGjtK" : "rlZZuHSMkcZF4gw"
         },
-        "link" : "https://www.example.com/FFfqHh8y6KeoJ1"
+        "link" : "https://www.example.com/qTamfqfYosdVjzYR"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/reiciendisqui",
-    "name" : "JThOWS8YOf",
+    "id" : "https://www.example.org/oditrepellat",
+    "name" : "byAuFCrwJVUHA9zfm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "47AJOWSnjcutC",
-      "id" : "9WjdJFKmujBUd"
+      "source" : "DKWu2XrhwAKZEL50j",
+      "id" : "UPXTRD9LKCWWAA"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "4EcfWmKZlwm"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "vptqtSvhD0JQCn0cjS"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -155,6 +155,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/debitisperferendis" ],
+  "subjects" : [ "https://www.example.org/sequieligendi" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,119 +1,120 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "ATv7l24TwDKB4Z",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "gG9p5jW51yP",
   "resourceOwner" : {
-    "owner" : "ATv7l24TwDKB4Z",
-    "ownerAffiliation" : "https://www.example.org/providentmagni"
+    "owner" : "gG9p5jW51yP",
+    "ownerAffiliation" : "https://www.example.org/namitaque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiassimilique",
+    "id" : "https://www.example.org/sintmagnam",
     "labels" : {
-      "obaO59SAGV4A2eg2Pw1" : "lIbmQThGsz8km"
+      "lUeIMLApvRHCQTW9W" : "ymZXcm0ZPCJOu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suntcumque",
-  "doi" : "https://doi.org/10.1234/dicta",
+  "handle" : "https://www.example.org/ipsavoluptatibus",
+  "doi" : "https://doi.org/10.1234/modi",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "bxVsS9ltD7kPwXiJ4v",
-      "author" : "qQEjDNCvVWQlKfsoqLP",
+      "text" : "aDJUWxQBc2T",
+      "author" : "Q6YN5XpiSMYzzrV",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/ipsammolestiae",
+  "link" : "https://www.example.org/istecumque",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "muVXXH7PGou",
+    "mainTitle" : "C6xiBIPMPTmV0",
     "alternativeTitles" : {
-      "de" : "y9XUsLkgi8kwYw1FjKH"
+      "pt" : "ZqQvXCacYB1dqUVe"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "U0v3Gjf4fgdtRi1e",
-      "month" : "HsdZCMUqzo268",
-      "day" : "S1rKY9ruYvXX95U"
+      "year" : "qzkht16ZO9x4KO",
+      "month" : "kJu0NwjDCyWX",
+      "day" : "r9gI1K1q62Dyn"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UDM19Y9nQEbGrHt",
-        "name" : "MyE1ZK8498u1Dmexi",
+        "id" : "https://www.example.com/6VNLpCLl895h",
+        "name" : "tUJ3d77OaIU",
         "nameType" : "Organizational",
-        "orcId" : "szbZSioOleFTJEj0ZYC",
-        "arpId" : "iOa9Qs6BkMP9ZG50hs"
+        "orcId" : "OVKnjTZ5bk0s35T3GeS",
+        "arpId" : "inMZ91Pbvk4F"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5MH2HX8bDc4cA6U",
+        "id" : "https://www.example.com/zhMFlPUSDYJqH3KTrD4",
         "labels" : {
-          "paTFAaXu5BXtwbp" : "oyRHACRWfpGO52LD8"
+          "RQfMgdpHojmNb26YNSv" : "GfRfSo0fZc"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 2,
+      "role" : "DataCurator",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8IG5jTi9dOGwLLOQc",
-        "name" : "H7oQ2Y0kzSBWDsFC",
-        "nameType" : "Organizational",
-        "orcId" : "GysTiz6yN3YBj",
-        "arpId" : "jziZcADAL5KmQXOMT"
+        "id" : "https://www.example.com/E07fBSxMNLosXIOF",
+        "name" : "u1KLCRfnhWqUMOkto",
+        "nameType" : "Personal",
+        "orcId" : "wTXrX93MQB0l1Sk",
+        "arpId" : "xp89bug8zg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/klXgnLC71I",
+        "id" : "https://www.example.com/OqoKTSg7xJu6C9dg",
         "labels" : {
-          "z6ANO8MqQsYtWW" : "9Kdr5VW2yPmPZ"
+          "EFQ70BUuiHRm" : "iW5eYSfMiia"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 2,
+      "role" : "ProgrammeLeader",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "4TdZ8ZsBQ61nFtThl",
-    "tags" : [ "XNHBZ4dzcHsxrcixn" ],
-    "description" : "2Qeydbs7JX928NDZJj",
+    "npiSubjectHeading" : "1VbXgKQXsviZUD2",
+    "tags" : [ "JnAt6MINvkrzvx8Rw7" ],
+    "description" : "ugaVzpKVCX2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "oaxgWvYQxC8p47u",
+        "label" : "K0F6BkebUZp",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "dAdwURlhpSxXSlEWl",
-          "country" : "Nw0rDqgPrfy0wB"
+          "label" : "a7vT3QFtANP",
+          "country" : "wwUkbR0eydg2XI"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/9RbRuMKtlyxmOx8Wg",
+          "id" : "https://www.example.com/VemeC6mNnzjaOz4D",
           "labels" : {
-            "qxLglgVFxVb5W" : "foDLFEm7bgsjDOL"
+            "PUtP0L6gHBeNVOX" : "lAr1wjz3mgkPjXQe"
           }
         },
-        "product" : "https://www.example.com/d3UmxvbjqsMYpkIcX"
+        "product" : "https://www.example.com/3sx1zUBA1I146eTSYCK"
       },
-      "doi" : "https://www.example.com/f256kijfA0GPyP6l",
+      "doi" : "https://www.example.com/mRl3QTNscvb",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -122,45 +123,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Ktox5RT4MbpXPS",
-    "abstract" : "2EF3jCJ45lxWnh"
+    "metadataSource" : "https://www.example.com/2mqKWI4z7oUlRR",
+    "abstract" : "xfI3bYIzCES"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Jv7PHx46fUqs1BlP3vl",
-      "mimeType" : "X0AqlpbYmhept2tUt",
-      "size" : 1551848865,
+      "name" : "VbIAyWkBSZDCiC",
+      "mimeType" : "3HQP2YumD7CDY61JS",
+      "size" : 189116444,
       "license" : {
         "type" : "License",
-        "identifier" : "Dt4jegG95z",
+        "identifier" : "Z62m7VJNg9CY6Xr",
         "labels" : {
-          "vWSdIARhoHCge2LB" : "yereXz1ugUsd"
+          "6dyCrdF4IHGBWM" : "UvvFIMfeuC0gj"
         },
-        "link" : "https://www.example.com/3gMuDdUqWAU"
+        "link" : "https://www.example.com/Xa9Zuv2AejvidsSSmD"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/facilisvelit",
-    "name" : "FRldz9beZZlz6zz",
+    "id" : "https://www.example.org/veritatisaccusantium",
+    "name" : "EE4GZ3qwOUZNiG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "OYbD6FNhBjHVJHTXNTc",
-      "id" : "m5AZtuoAKR6ihVpFzX"
+      "source" : "QYPB5WtnvDNNzJjk",
+      "id" : "WjcSnZHJLdv1X81"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "yQfe518fxv"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "RuPke4EjJz"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ipsamqui" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/cumsit" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,104 +1,104 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "BbJkMglBdfWnny",
+  "status" : "NEW",
+  "owner" : "smX535KO7q",
   "resourceOwner" : {
-    "owner" : "BbJkMglBdfWnny",
-    "ownerAffiliation" : "https://www.example.org/pariatureaque"
+    "owner" : "smX535KO7q",
+    "ownerAffiliation" : "https://www.example.org/voluptatibusnihil"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rerumharum",
+    "id" : "https://www.example.org/inventorepariatur",
     "labels" : {
-      "V4311P9zBh7p5J" : "h0LL5jhkSTIed7"
+      "A8YCLIKsKBPzN" : "GZgcl4KdYwOjM2bcnbA"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/repudiandaesequi",
-  "doi" : "https://doi.org/10.1234/possimus",
+  "handle" : "https://www.example.org/providenteos",
+  "doi" : "https://doi.org/10.1234/vero",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "n2PGhpHwrIOR4hy",
-      "author" : "n1MHX8cAUSR7jm4",
+      "text" : "sSOhrGNKcVeN",
+      "author" : "Z0pNEgG3UPfmPN01o8",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/idvoluptate",
+  "link" : "https://www.example.org/enimaliquam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "amBzEwhFOCK8C67yl",
+    "mainTitle" : "6HnpffVp6QhJUl",
     "alternativeTitles" : {
-      "ru" : "khk9xUZA83IiCP2"
+      "is" : "Bq38qLA6e6PhcRRyc"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "wFb8bneddwQ",
-      "month" : "D5YLwQhNuMN1vu0IZe",
-      "day" : "wiHhSoB5Ds3ZB"
+      "year" : "z0WWPGCWIEJR",
+      "month" : "0rpqYLhf6s5SgIxlK0",
+      "day" : "u7YnuF0DcqqCNsluxI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Mo0E1LCE5Axh38F",
-        "name" : "5jfIiVwucDLHMCvW",
+        "id" : "https://www.example.com/X0SOwZ2QtXaKcN",
+        "name" : "9IS6m8pR9Q8vd",
         "nameType" : "Personal",
-        "orcId" : "tlExWrOsUb1ETwliO",
-        "arpId" : "2z7b50JTMjKWm"
+        "orcId" : "9jJjVVMBZKYaKlsq",
+        "arpId" : "zWN7lqxI1sx5gVUr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0VVo8lgjIj",
+        "id" : "https://www.example.com/7B77ml9S9aP",
         "labels" : {
-          "L8bsGgh4a7JUd2AFKa" : "FbJ2R3AKxZdnf2mEdL"
+          "berP60pxpAhqdaGGi5" : "qi1uzzISq35g5"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 2,
+      "role" : "RightsHolder",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xp9J17yCLk7jmf",
-        "name" : "CmzLZXc0ByZqDME9",
-        "nameType" : "Personal",
-        "orcId" : "Hw7HUsdzTDv",
-        "arpId" : "r9l2Y1hFOjD6Kl"
+        "id" : "https://www.example.com/3LxA31x43Dktzy",
+        "name" : "y00WOEfr5vMvnFTBQ",
+        "nameType" : "Organizational",
+        "orcId" : "gyLgUR5MnwakxwNhjt",
+        "arpId" : "fIen71k2SPMpl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3k1cWN4OPvDBmBiF",
+        "id" : "https://www.example.com/who3DrAcIvAnMKdF",
         "labels" : {
-          "rGKD5craj4MqDZT" : "uajDXhR7N8cJZ"
+          "ZnTbFRpCMKP" : "tvZHpVFnnCr"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 2,
+      "role" : "RelatedPerson",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1KIVMyxX1HREI",
-    "tags" : [ "joqfeiHg9X" ],
-    "description" : "1o02wNFaEp",
+    "npiSubjectHeading" : "kYxSAlkN3hzWhM3dy",
+    "tags" : [ "Axi9XVl3NOwor" ],
+    "description" : "Gcccjb0gbP1Znb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "1Nn6O25bR6CeYpvq",
+        "label" : "PrAi80NRKo",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "ICSEMW724fwQW",
-          "country" : "qtqAKDYFUHoxFzWUQU"
+          "label" : "P1bV4eyCgg",
+          "country" : "iOzAxtmDizK"
         },
         "time" : {
           "type" : "Instant",
@@ -106,14 +106,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/zWB77QNHR7pAkCG",
+          "id" : "https://www.example.com/q9smpXcD7M9zge",
           "labels" : {
-            "rIwN3LqeWGD" : "V4prACrQBkwL"
+            "0Vj3qZaaUtIoS" : "sCVheX5dFROL3nyJzjy"
           }
         },
-        "product" : "https://www.example.com/Y6uJfon4D9I13LmLx5"
+        "product" : "https://www.example.com/u1bL9kQ8XmtEhxP"
       },
-      "doi" : "https://www.example.com/kEba8tmsrTT50zZVaBm",
+      "doi" : "https://www.example.com/5vFgTdSboniES",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -122,45 +122,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/BEeYvcwwaxHugy3QHzp",
-    "abstract" : "jbdrOnxbKcTU4"
+    "metadataSource" : "https://www.example.com/YEj3kHYFp89u47H",
+    "abstract" : "8v9wvmqLZoD7Y"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "YnDYQlmwaPCy25",
-      "mimeType" : "CtmCv4mfSy7l1MclXw",
-      "size" : 1633699293,
+      "name" : "az7ccyNZ4x0cczc",
+      "mimeType" : "c9cKDmsRga0Z7itii9",
+      "size" : 1556300317,
       "license" : {
         "type" : "License",
-        "identifier" : "FztOUOJVfH4crQl3SjA",
+        "identifier" : "pfSP8ojqoXEtdk26ksT",
         "labels" : {
-          "J0ocapFsodFv0" : "G7wqng0t7KhQdcZNl"
+          "X2YXJiTGsWhV1" : "6iykO935iEA"
         },
-        "link" : "https://www.example.com/XP5mjwQoIXMYVkqkCbr"
+        "link" : "https://www.example.com/D56oCsCKw6Ueit"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloribussequi",
-    "name" : "vgMx8wsxX9ktIS",
+    "id" : "https://www.example.org/idnisi",
+    "name" : "0dkugLaJyZ3",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "OH5MfnC7FIrA0z",
-      "id" : "dMqUaRQX2SxzbVwbmX9"
+      "source" : "XDfRHhy95hKne0",
+      "id" : "aFEAMk1UuacA"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "FjWkzapzfpuNTb"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "vzhRinz6eQGj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/auteum" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/eiusquia" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -2,103 +2,103 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "smX535KO7q",
+  "owner" : "ATv7l24TwDKB4Z",
   "resourceOwner" : {
-    "owner" : "smX535KO7q",
-    "ownerAffiliation" : "https://www.example.org/voluptatibusnihil"
+    "owner" : "ATv7l24TwDKB4Z",
+    "ownerAffiliation" : "https://www.example.org/providentmagni"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/inventorepariatur",
+    "id" : "https://www.example.org/molestiassimilique",
     "labels" : {
-      "A8YCLIKsKBPzN" : "GZgcl4KdYwOjM2bcnbA"
+      "obaO59SAGV4A2eg2Pw1" : "lIbmQThGsz8km"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/providenteos",
-  "doi" : "https://doi.org/10.1234/vero",
+  "handle" : "https://www.example.org/suntcumque",
+  "doi" : "https://doi.org/10.1234/dicta",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "sSOhrGNKcVeN",
-      "author" : "Z0pNEgG3UPfmPN01o8",
+      "text" : "bxVsS9ltD7kPwXiJ4v",
+      "author" : "qQEjDNCvVWQlKfsoqLP",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/enimaliquam",
+  "link" : "https://www.example.org/ipsammolestiae",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6HnpffVp6QhJUl",
+    "mainTitle" : "muVXXH7PGou",
     "alternativeTitles" : {
-      "is" : "Bq38qLA6e6PhcRRyc"
+      "de" : "y9XUsLkgi8kwYw1FjKH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "z0WWPGCWIEJR",
-      "month" : "0rpqYLhf6s5SgIxlK0",
-      "day" : "u7YnuF0DcqqCNsluxI"
+      "year" : "U0v3Gjf4fgdtRi1e",
+      "month" : "HsdZCMUqzo268",
+      "day" : "S1rKY9ruYvXX95U"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/X0SOwZ2QtXaKcN",
-        "name" : "9IS6m8pR9Q8vd",
-        "nameType" : "Personal",
-        "orcId" : "9jJjVVMBZKYaKlsq",
-        "arpId" : "zWN7lqxI1sx5gVUr"
+        "id" : "https://www.example.com/UDM19Y9nQEbGrHt",
+        "name" : "MyE1ZK8498u1Dmexi",
+        "nameType" : "Organizational",
+        "orcId" : "szbZSioOleFTJEj0ZYC",
+        "arpId" : "iOa9Qs6BkMP9ZG50hs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7B77ml9S9aP",
+        "id" : "https://www.example.com/5MH2HX8bDc4cA6U",
         "labels" : {
-          "berP60pxpAhqdaGGi5" : "qi1uzzISq35g5"
+          "paTFAaXu5BXtwbp" : "oyRHACRWfpGO52LD8"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 6,
+      "role" : "Illustrator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3LxA31x43Dktzy",
-        "name" : "y00WOEfr5vMvnFTBQ",
+        "id" : "https://www.example.com/8IG5jTi9dOGwLLOQc",
+        "name" : "H7oQ2Y0kzSBWDsFC",
         "nameType" : "Organizational",
-        "orcId" : "gyLgUR5MnwakxwNhjt",
-        "arpId" : "fIen71k2SPMpl"
+        "orcId" : "GysTiz6yN3YBj",
+        "arpId" : "jziZcADAL5KmQXOMT"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/who3DrAcIvAnMKdF",
+        "id" : "https://www.example.com/klXgnLC71I",
         "labels" : {
-          "ZnTbFRpCMKP" : "tvZHpVFnnCr"
+          "z6ANO8MqQsYtWW" : "9Kdr5VW2yPmPZ"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 8,
+      "role" : "DataCollector",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "kYxSAlkN3hzWhM3dy",
-    "tags" : [ "Axi9XVl3NOwor" ],
-    "description" : "Gcccjb0gbP1Znb",
+    "npiSubjectHeading" : "4TdZ8ZsBQ61nFtThl",
+    "tags" : [ "XNHBZ4dzcHsxrcixn" ],
+    "description" : "2Qeydbs7JX928NDZJj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "PrAi80NRKo",
+        "label" : "oaxgWvYQxC8p47u",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "P1bV4eyCgg",
-          "country" : "iOzAxtmDizK"
+          "label" : "dAdwURlhpSxXSlEWl",
+          "country" : "Nw0rDqgPrfy0wB"
         },
         "time" : {
           "type" : "Instant",
@@ -106,14 +106,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/q9smpXcD7M9zge",
+          "id" : "https://www.example.com/9RbRuMKtlyxmOx8Wg",
           "labels" : {
-            "0Vj3qZaaUtIoS" : "sCVheX5dFROL3nyJzjy"
+            "qxLglgVFxVb5W" : "foDLFEm7bgsjDOL"
           }
         },
-        "product" : "https://www.example.com/u1bL9kQ8XmtEhxP"
+        "product" : "https://www.example.com/d3UmxvbjqsMYpkIcX"
       },
-      "doi" : "https://www.example.com/5vFgTdSboniES",
+      "doi" : "https://www.example.com/f256kijfA0GPyP6l",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -122,45 +122,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/YEj3kHYFp89u47H",
-    "abstract" : "8v9wvmqLZoD7Y"
+    "metadataSource" : "https://www.example.com/Ktox5RT4MbpXPS",
+    "abstract" : "2EF3jCJ45lxWnh"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "az7ccyNZ4x0cczc",
-      "mimeType" : "c9cKDmsRga0Z7itii9",
-      "size" : 1556300317,
+      "name" : "Jv7PHx46fUqs1BlP3vl",
+      "mimeType" : "X0AqlpbYmhept2tUt",
+      "size" : 1551848865,
       "license" : {
         "type" : "License",
-        "identifier" : "pfSP8ojqoXEtdk26ksT",
+        "identifier" : "Dt4jegG95z",
         "labels" : {
-          "X2YXJiTGsWhV1" : "6iykO935iEA"
+          "vWSdIARhoHCge2LB" : "yereXz1ugUsd"
         },
-        "link" : "https://www.example.com/D56oCsCKw6Ueit"
+        "link" : "https://www.example.com/3gMuDdUqWAU"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/idnisi",
-    "name" : "0dkugLaJyZ3",
+    "id" : "https://www.example.org/facilisvelit",
+    "name" : "FRldz9beZZlz6zz",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XDfRHhy95hKne0",
-      "id" : "aFEAMk1UuacA"
+      "source" : "OYbD6FNhBjHVJHTXNTc",
+      "id" : "m5AZtuoAKR6ihVpFzX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "vzhRinz6eQGj"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "yQfe518fxv"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eiusquia" ],
+  "subjects" : [ "https://www.example.org/ipsamqui" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,119 +1,120 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "pF9sQIKMjO",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "ob7dzWxzsspFYXGfPD",
   "resourceOwner" : {
-    "owner" : "pF9sQIKMjO",
-    "ownerAffiliation" : "https://www.example.org/voluptasrerum"
+    "owner" : "ob7dzWxzsspFYXGfPD",
+    "ownerAffiliation" : "https://www.example.org/quodoccaecati"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rationenisi",
+    "id" : "https://www.example.org/namhic",
     "labels" : {
-      "hqQfYxsFcsBK" : "seusxG9a7iLdLbJ"
+      "1VfLkofgndrUXBn" : "uIcFUXt2YWOmdGuUaq"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/natusillum",
-  "doi" : "https://doi.org/10.1234/in",
+  "handle" : "https://www.example.org/placeatconsequatur",
+  "doi" : "https://doi.org/10.1234/quo",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "X0GrZAOTFXQYL",
-      "author" : "1AS4wSUinccsc1Qc",
+      "text" : "1Nhs5CabBB7o62",
+      "author" : "CYaBla4GVsJ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/enimillum",
+  "link" : "https://www.example.org/estfugit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cSRGYdrVBHRu",
+    "mainTitle" : "sNQAUM1uI4Hdbx",
     "alternativeTitles" : {
-      "nl" : "rY3PS6UV0y"
+      "it" : "bNg7Q2B3PqjfajM3TZ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "n8Upq7E47QZvd",
-      "month" : "P0QLgQ8vdTaBr3cCCYL",
-      "day" : "bDFaM3l6QDhrGoUH"
+      "year" : "Sa6ypx2WMUYmquFbo",
+      "month" : "yWJzBFVwq8FRe",
+      "day" : "pYNPSTKoBTMLHKilfBc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8yAceFpVLjYaKb0oXfx",
-        "name" : "iVhYaApxTEFpI",
+        "id" : "https://www.example.com/DGvC4bdvmhCvqGQgH",
+        "name" : "6U3ym7sS2Cqp2SOI8V",
         "nameType" : "Organizational",
-        "orcId" : "aW1KI9K0NXls",
-        "arpId" : "StFAZUGkCZxM4G"
+        "orcId" : "5Hm3UZiX5Uu",
+        "arpId" : "2KLhfrQzSJuUZdj8"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yd2pw5pofuEqaIu4r",
+        "id" : "https://www.example.com/aFkPa0AGr49le2YL5Hl",
         "labels" : {
-          "2wNGJV5kQsf6edS5P9" : "S13TkCYjl4nnEv"
+          "qhdbVULZRyY" : "q1QlYsTXJYx2"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 7,
+      "role" : "AcademicCoordinator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8AEjCCg0UeZ7sA4CffA",
-        "name" : "USTKk6NIKxVfoRj",
+        "id" : "https://www.example.com/iAdf2oQZztpqTq26lH",
+        "name" : "blcFuSgTDlSc9SP",
         "nameType" : "Organizational",
-        "orcId" : "RuvY5ceMnGzMcvHfxqm",
-        "arpId" : "8BDmI9g0Re"
+        "orcId" : "TyWHWgSU9Byq0aFNRl0",
+        "arpId" : "XZVCloMuMd3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YDmGeZXN4K",
+        "id" : "https://www.example.com/9KdOXjCDr1Tz8WzL4lS",
         "labels" : {
-          "GCZRuTJ1srHnQl8u4O6" : "heTAGRdbo8MyJzsuDQr"
+          "NGbx5WjGwAw" : "aidS5N3b5s"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 1,
+      "role" : "Funder",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "MajikFAtDzuAtbyXXD",
-    "tags" : [ "NqPwrnttOA" ],
-    "description" : "JAX1XmpoGHpaFvIMq",
+    "npiSubjectHeading" : "y0SGtwRNHCPF8anJ7",
+    "tags" : [ "OE42CLGMZQ" ],
+    "description" : "dQ4ioYXKXqs6VAlE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "osehwQINRpBmA8IXgdm",
+        "label" : "M0SSZh9q6bPN",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "F5amr7tPJ5zKe",
-          "country" : "0w0G9ruvsJF"
+          "label" : "6Bh4FZ6mr2dLt3mw",
+          "country" : "vVRBcKjstgWC4sCO"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/6PHGsQyUODLzlx",
+          "id" : "https://www.example.com/ussyOAnwOd6",
           "labels" : {
-            "YRsTwlc6UHPp3N9" : "fsnGOLhr1qxe"
+            "VDgxZjCXQeTG" : "mLkIWl1PihgvmnL5P8"
           }
         },
-        "product" : "https://www.example.com/iGdJL6xKSaZ210H"
+        "product" : "https://www.example.com/CCLPXZT0wjq74"
       },
-      "doi" : "https://www.example.com/Wm4sMZwM5y5C",
+      "doi" : "https://www.example.com/Of8FGHxD4b1r",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -122,24 +123,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/wsw9GGh8D4M",
-    "abstract" : "zLpu3YJW9Zrbft1mS"
+    "metadataSource" : "https://www.example.com/0XroT7oHOmhlx",
+    "abstract" : "S837y61KSzu"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "qYKarESa7zJmrRKlf",
-      "mimeType" : "rjGoExWQPvHKdA",
-      "size" : 1256119483,
+      "name" : "ykS5GV9vgupk",
+      "mimeType" : "PYRvlA71BBU2",
+      "size" : 1143301598,
       "license" : {
         "type" : "License",
-        "identifier" : "cMZjx6GRqL9zdEL8YWT",
+        "identifier" : "74wH5LqaV9A",
         "labels" : {
-          "Cq4J8sdrpaDeh" : "ISl2oWQp2SMamlF"
+          "FTSOfgxqdBvo7KX" : "VlXrJoql11oPlF"
         },
-        "link" : "https://www.example.com/keiGHcODvNHxmp4PQ"
+        "link" : "https://www.example.com/whujXU15cj"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -148,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptaseos",
-    "name" : "uWUMS7jaVgHRaII",
+    "id" : "https://www.example.org/illoconsequatur",
+    "name" : "WRQsIgj1sNF9XG0no",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "1UzL1OU5w00",
-      "id" : "1wM4dtJ62aJ3"
+      "source" : "Ix6FqCbNlsLgQxenSG",
+      "id" : "dZAk7jI5gkXCmuPgt"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "16XsLFVZrNkUU6T"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "JrBKSr2dQvW3mrY"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/esseet" ],
+  "subjects" : [ "https://www.example.org/eosexcepturi" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,104 +1,104 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "z88hL3AnuX6bKtvalJ",
+  "status" : "DRAFT",
+  "owner" : "pF9sQIKMjO",
   "resourceOwner" : {
-    "owner" : "z88hL3AnuX6bKtvalJ",
-    "ownerAffiliation" : "https://www.example.org/enimvelit"
+    "owner" : "pF9sQIKMjO",
+    "ownerAffiliation" : "https://www.example.org/voluptasrerum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ullamnatus",
+    "id" : "https://www.example.org/rationenisi",
     "labels" : {
-      "ZXtgT51ugUMYHMtXi5B" : "9FqY1EGfhm"
+      "hqQfYxsFcsBK" : "seusxG9a7iLdLbJ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etdebitis",
-  "doi" : "https://doi.org/10.1234/quisquam",
+  "handle" : "https://www.example.org/natusillum",
+  "doi" : "https://doi.org/10.1234/in",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "yTyfBqok3WGpcLABA",
-      "author" : "BSv4DbfaUClFarA4",
+      "text" : "X0GrZAOTFXQYL",
+      "author" : "1AS4wSUinccsc1Qc",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/inpossimus",
+  "link" : "https://www.example.org/enimillum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vNbi7Uar7eVrkO",
+    "mainTitle" : "cSRGYdrVBHRu",
     "alternativeTitles" : {
-      "ca" : "pYYMiVF2guF13uoy9"
+      "nl" : "rY3PS6UV0y"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "lrF5RcGh8d5",
-      "month" : "uxuXktZG0ATHjOM6AT7",
-      "day" : "mVljSGL010w"
+      "year" : "n8Upq7E47QZvd",
+      "month" : "P0QLgQ8vdTaBr3cCCYL",
+      "day" : "bDFaM3l6QDhrGoUH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/YcOnQpzMKvrQsJ5d4",
-        "name" : "QzL6MN6HgiT",
+        "id" : "https://www.example.com/8yAceFpVLjYaKb0oXfx",
+        "name" : "iVhYaApxTEFpI",
         "nameType" : "Organizational",
-        "orcId" : "fkHoILKJ8TjMvmX0Uq",
-        "arpId" : "XGqLMBaKJ6"
+        "orcId" : "aW1KI9K0NXls",
+        "arpId" : "StFAZUGkCZxM4G"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zSPGN6NxUT55hY2fyG",
+        "id" : "https://www.example.com/yd2pw5pofuEqaIu4r",
         "labels" : {
-          "ZqG6OUkv0C8P3V" : "LPSsLJ3nfcllZOVmsMx"
+          "2wNGJV5kQsf6edS5P9" : "S13TkCYjl4nnEv"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 6,
+      "role" : "Researcher",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/1bZTeaJR9dCORR",
-        "name" : "HCgb70oQttjVmrYN",
+        "id" : "https://www.example.com/8AEjCCg0UeZ7sA4CffA",
+        "name" : "USTKk6NIKxVfoRj",
         "nameType" : "Organizational",
-        "orcId" : "2j5nmT62QXlP3dhC0Qq",
-        "arpId" : "Ohpo8nUbMmutdjtGc"
+        "orcId" : "RuvY5ceMnGzMcvHfxqm",
+        "arpId" : "8BDmI9g0Re"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ahIzSJ6YAiTdsT",
+        "id" : "https://www.example.com/YDmGeZXN4K",
         "labels" : {
-          "ajARJAh2EC" : "gw3d5SKiY3uuMbFP2jh"
+          "GCZRuTJ1srHnQl8u4O6" : "heTAGRdbo8MyJzsuDQr"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 6,
+      "role" : "RightsHolder",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9l7jGamfq5pSFTnLFLg",
-    "tags" : [ "8sUFCuQssQlO57ILh" ],
-    "description" : "aq445Ne1LtlG3eDf9hd",
+    "npiSubjectHeading" : "MajikFAtDzuAtbyXXD",
+    "tags" : [ "NqPwrnttOA" ],
+    "description" : "JAX1XmpoGHpaFvIMq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "F1CydoNzQ7",
+        "label" : "osehwQINRpBmA8IXgdm",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "xNqGqAxe06RI",
-          "country" : "6MeBaYU0oKjOJerJ"
+          "label" : "F5amr7tPJ5zKe",
+          "country" : "0w0G9ruvsJF"
         },
         "time" : {
           "type" : "Instant",
@@ -106,14 +106,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/cbz8bJYLDW",
+          "id" : "https://www.example.com/6PHGsQyUODLzlx",
           "labels" : {
-            "uCMyTpUoLhMgGLy" : "94lXAHh7nCxJh5TPRsJ"
+            "YRsTwlc6UHPp3N9" : "fsnGOLhr1qxe"
           }
         },
-        "product" : "https://www.example.com/GhEQnDd5osmLSO"
+        "product" : "https://www.example.com/iGdJL6xKSaZ210H"
       },
-      "doi" : "https://www.example.com/usYudC2qOlAlf2tzS",
+      "doi" : "https://www.example.com/Wm4sMZwM5y5C",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -122,45 +122,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/GPEVOyUlhbbVUsEU",
-    "abstract" : "zgTvyOtxCerbE"
+    "metadataSource" : "https://www.example.com/wsw9GGh8D4M",
+    "abstract" : "zLpu3YJW9Zrbft1mS"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "rHdalCsvsiek",
-      "mimeType" : "9Nau2y0C2oY",
-      "size" : 130488812,
+      "name" : "qYKarESa7zJmrRKlf",
+      "mimeType" : "rjGoExWQPvHKdA",
+      "size" : 1256119483,
       "license" : {
         "type" : "License",
-        "identifier" : "dI9lWg8xPY7MbT",
+        "identifier" : "cMZjx6GRqL9zdEL8YWT",
         "labels" : {
-          "K1xJY0dogZ95dgck2" : "1jxuVBmcLF"
+          "Cq4J8sdrpaDeh" : "ISl2oWQp2SMamlF"
         },
-        "link" : "https://www.example.com/2I8KD9YKhYRCzpuz"
+        "link" : "https://www.example.com/keiGHcODvNHxmp4PQ"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptasin",
-    "name" : "lnZyuJ7nqRiAqf",
+    "id" : "https://www.example.org/voluptaseos",
+    "name" : "uWUMS7jaVgHRaII",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "wAwuwT9YgUcPD1Kpc",
-      "id" : "uOaQdBYzJHJ"
+      "source" : "1UzL1OU5w00",
+      "id" : "1wM4dtJ62aJ3"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "ZeNBK5OoYs3IijcS"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "16XsLFVZrNkUU6T"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quasiharum" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/esseet" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,104 +1,104 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "ob7dzWxzsspFYXGfPD",
+  "status" : "PUBLISHED",
+  "owner" : "Q1hw4hbvUgkYRtivA",
   "resourceOwner" : {
-    "owner" : "ob7dzWxzsspFYXGfPD",
-    "ownerAffiliation" : "https://www.example.org/quodoccaecati"
+    "owner" : "Q1hw4hbvUgkYRtivA",
+    "ownerAffiliation" : "https://www.example.org/reprehenderitfugiat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/namhic",
+    "id" : "https://www.example.org/natusipsa",
     "labels" : {
-      "1VfLkofgndrUXBn" : "uIcFUXt2YWOmdGuUaq"
+      "LLz66cYYbDmtz1MyFZB" : "9g3NEevoOP4pp5K70M"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/placeatconsequatur",
-  "doi" : "https://doi.org/10.1234/quo",
+  "handle" : "https://www.example.org/quisaut",
+  "doi" : "https://doi.org/10.1234/illum",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "1Nhs5CabBB7o62",
-      "author" : "CYaBla4GVsJ",
+      "text" : "UQgi7jHn0J7QRYSCcf",
+      "author" : "8OYvyaCAzNx0GRz",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/estfugit",
+  "link" : "https://www.example.org/eiusnon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sNQAUM1uI4Hdbx",
+    "mainTitle" : "DZUrlUMuSDNk",
     "alternativeTitles" : {
-      "it" : "bNg7Q2B3PqjfajM3TZ"
+      "pl" : "bFJRqhTTxzskANzUrt"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Sa6ypx2WMUYmquFbo",
-      "month" : "yWJzBFVwq8FRe",
-      "day" : "pYNPSTKoBTMLHKilfBc"
+      "year" : "GDzhgRfqBFet1WGZfl",
+      "month" : "jy58OsRJ7eYgBo678tN",
+      "day" : "mRUB5530D8d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DGvC4bdvmhCvqGQgH",
-        "name" : "6U3ym7sS2Cqp2SOI8V",
-        "nameType" : "Organizational",
-        "orcId" : "5Hm3UZiX5Uu",
-        "arpId" : "2KLhfrQzSJuUZdj8"
+        "id" : "https://www.example.com/OUsC6rLH0h",
+        "name" : "pcDfP6zkRYYIRgxwf",
+        "nameType" : "Personal",
+        "orcId" : "VvXYydYn0Rt6ZmXIR",
+        "arpId" : "DVwM19Ne8W"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aFkPa0AGr49le2YL5Hl",
+        "id" : "https://www.example.com/vbqptdTuVWB1pdRj",
         "labels" : {
-          "qhdbVULZRyY" : "q1QlYsTXJYx2"
+          "xukDJ4mlHjZMxU" : "3c7i6I8Odxj4JwM8"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 2,
+      "role" : "DataManager",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iAdf2oQZztpqTq26lH",
-        "name" : "blcFuSgTDlSc9SP",
+        "id" : "https://www.example.com/frDCAKhf3RzCixA1U",
+        "name" : "4ty2hLAktfC940",
         "nameType" : "Organizational",
-        "orcId" : "TyWHWgSU9Byq0aFNRl0",
-        "arpId" : "XZVCloMuMd3"
+        "orcId" : "sPe7Qm4sVnHrLg6VvA1",
+        "arpId" : "AM1MFGOaksSUMoDDuoc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9KdOXjCDr1Tz8WzL4lS",
+        "id" : "https://www.example.com/3tYPTMXwQ4N8EACaU",
         "labels" : {
-          "NGbx5WjGwAw" : "aidS5N3b5s"
+          "VhFigwMfncvAuKkXsw8" : "1TKOueCsm5oNJ4FRm"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 0,
+      "role" : "Consultant",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "y0SGtwRNHCPF8anJ7",
-    "tags" : [ "OE42CLGMZQ" ],
-    "description" : "dQ4ioYXKXqs6VAlE",
+    "npiSubjectHeading" : "6ShGTSIw8zwkLkJe0H7",
+    "tags" : [ "AqcXWIEjKSi1vwrj" ],
+    "description" : "tuqqvl5pBnag",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "M0SSZh9q6bPN",
+        "label" : "dCDq8Tnp7MKi",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "6Bh4FZ6mr2dLt3mw",
-          "country" : "vVRBcKjstgWC4sCO"
+          "label" : "2MdocU8MWfmg",
+          "country" : "uPhn6vDym2TuS6Dso"
         },
         "time" : {
           "type" : "Period",
@@ -107,14 +107,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/ussyOAnwOd6",
+          "id" : "https://www.example.com/URMG8PCCB2sLz",
           "labels" : {
-            "VDgxZjCXQeTG" : "mLkIWl1PihgvmnL5P8"
+            "paDeX0Xy6Qwil1SP" : "04mD7NdELbWSjs7"
           }
         },
-        "product" : "https://www.example.com/CCLPXZT0wjq74"
+        "product" : "https://www.example.com/j9D1B6YWTwiWYIG"
       },
-      "doi" : "https://www.example.com/Of8FGHxD4b1r",
+      "doi" : "https://www.example.com/VTI2p7bI3t",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -123,24 +123,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0XroT7oHOmhlx",
-    "abstract" : "S837y61KSzu"
+    "metadataSource" : "https://www.example.com/v9XVttoX7DenXWBJ",
+    "abstract" : "lLw82d62i6GzgjPWG8"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ykS5GV9vgupk",
-      "mimeType" : "PYRvlA71BBU2",
-      "size" : 1143301598,
+      "name" : "S5iYPqNyTuEE",
+      "mimeType" : "wkTl9gc6vMCyzraeIT",
+      "size" : 1564005400,
       "license" : {
         "type" : "License",
-        "identifier" : "74wH5LqaV9A",
+        "identifier" : "0YBWAx3yhkqpIz8",
         "labels" : {
-          "FTSOfgxqdBvo7KX" : "VlXrJoql11oPlF"
+          "8Khyi123Zc" : "nkDVXBZSLp3UfWin"
         },
-        "link" : "https://www.example.com/whujXU15cj"
+        "link" : "https://www.example.com/SGrSTilPzj3L0jOet"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -149,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/illoconsequatur",
-    "name" : "WRQsIgj1sNF9XG0no",
+    "id" : "https://www.example.org/doloremautem",
+    "name" : "d9BZDOiLfF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Ix6FqCbNlsLgQxenSG",
-      "id" : "dZAk7jI5gkXCmuPgt"
+      "source" : "LjIvtWRxMd",
+      "id" : "c0qi5vjeXvvMT4aJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "JrBKSr2dQvW3mrY"
+      "applicationCode" : "6AtBhvWnCORfRbKh3"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eosexcepturi" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/sitcumque" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -2,149 +2,149 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "M6yRh1ZJtaw4tK8JV",
+  "owner" : "5IRPlt7w7PmqJVi",
   "resourceOwner" : {
-    "owner" : "M6yRh1ZJtaw4tK8JV",
-    "ownerAffiliation" : "https://www.example.org/repudiandaeinventore"
+    "owner" : "5IRPlt7w7PmqJVi",
+    "ownerAffiliation" : "https://www.example.org/sapientequam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/veniamquam",
+    "id" : "https://www.example.org/quisvoluptas",
     "labels" : {
-      "65ooqen8ZeSH7PNW" : "E6HWLJhGBkU0x2I"
+      "utsrbUsKRZivHQdM" : "fJiU5RuBQGyu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utaut",
-  "doi" : "https://doi.org/10.1234/nisi",
+  "handle" : "https://www.example.org/dolordolorem",
+  "doi" : "https://doi.org/10.1234/iste",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "4YRYuzDeDu6Fpz",
-      "author" : "xnuvgr6WcOMFR",
+      "text" : "sBkNJlUuXjLwGj",
+      "author" : "xBs1iqR14hJCdrgur",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/autrepudiandae",
+  "link" : "https://www.example.org/atqueut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Ra36KmFQMYVylhqKFaN",
+    "mainTitle" : "MUzhoxQoYxE0",
     "alternativeTitles" : {
-      "bg" : "ed6MDPPkLkWk0U"
+      "ru" : "6pDOobvK1t"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "3QAgfLIWNkJiJVcswD",
-      "month" : "v0V9cS0wAIYyfzL",
-      "day" : "Wa8sgKxWoFOwYt"
+      "year" : "oPPRFDTHk4O1XxS1",
+      "month" : "ZTyI3bQP7YtHTgZNjoN",
+      "day" : "UYIWzGBloGA6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TdRPDyYCx1UZmZgN",
-        "name" : "zvMO3mUNVKRlkJ",
+        "id" : "https://www.example.com/470QtUiXSgJ",
+        "name" : "N1jCPBpEOI9BpaIwm",
         "nameType" : "Organizational",
-        "orcId" : "SomzGd75GNWBS",
-        "arpId" : "i0oyfST7VB8aLT"
+        "orcId" : "2a9ebFDPRqFdQahFBh5",
+        "arpId" : "pmhlHtTfTC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0sHBtPyrfYFar5uWn",
+        "id" : "https://www.example.com/1GLHhqk4d730yvJD9cF",
         "labels" : {
-          "aB3fO3DL0yP0txxEoWE" : "IMqSnNAde2"
+          "eALTvIoJSoIjowlj" : "5dci5Poysrffh"
         }
       } ],
       "role" : "EditorialBoardMember",
-      "sequence" : 7,
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/LusC06eFSFh4hHDa7",
-        "name" : "TQG8ooEUzjQc5mHq",
-        "nameType" : "Organizational",
-        "orcId" : "pcsL3t2Cd8uc9Hx",
-        "arpId" : "AlG7tSq6hTuxZx2l"
+        "id" : "https://www.example.com/V31eaa36uwVZI",
+        "name" : "l3HmeC3Phbr",
+        "nameType" : "Personal",
+        "orcId" : "1CtzPLKT1adwLE5JKcz",
+        "arpId" : "l02JeECSU3pvfCuHs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/21UOlWvlriHVgy5hNHW",
+        "id" : "https://www.example.com/SBnkur2lDwcgvOY",
         "labels" : {
-          "o8hlIaffpF" : "e5cWpHThGlO0"
+          "QMTggw2T4tRZPxbspf" : "we2ohBPK5oDB9G"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 9,
+      "role" : "DataManager",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "HqxyfqEVAs1t3vCE",
-    "tags" : [ "4FwQ5Gmvlf" ],
-    "description" : "7U9ZLs71jzVg",
+    "npiSubjectHeading" : "bFamDuDWkbZ",
+    "tags" : [ "WTxzlXcoDCMT99elxwW" ],
+    "description" : "73BB5gwGPQIafuJvu0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hO2XiRYjul"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EQF7e1JBn7uYw2Oyb"
         },
-        "seriesNumber" : "jNnrAMWU0qd6cyVfJHv",
+        "seriesNumber" : "KGDFoLY5KwAx",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/44GJWieBKhF"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jz9bFYAmxy"
         },
-        "isbnList" : [ "9791990677112" ]
+        "isbnList" : [ "9780930331931" ]
       },
-      "doi" : "https://www.example.com/gXBlWdIS0N2ZxLTKj",
+      "doi" : "https://www.example.com/FsDELaKs6ZK",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "XuqzqfTPHH5Jksg",
-          "month" : "qeHbBjdybG6oA",
-          "day" : "3L5e0h9EuID"
+          "year" : "fEPITKbswgtQTYDEz3",
+          "month" : "binhKKkwXqZ0MIg8",
+          "day" : "SM7UE9PLHJe"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Vy8A99t7bD",
-            "end" : "IQQhQNXWbYYze"
+            "begin" : "nFJURhyo2xZR",
+            "end" : "Q2sfPpzVC3ywS"
           },
-          "pages" : "7XOUpdClVYy",
-          "illustrated" : true
+          "pages" : "JcNtJ4dwDfpdouvLl",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/x5mXmeoeHG8",
-    "abstract" : "1wuz84Jylle"
+    "metadataSource" : "https://www.example.com/BnTFzrFV2QGGX19T",
+    "abstract" : "NZFyhWg3qK"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "NuN4QPKFXQJ5h5TOB",
-      "mimeType" : "qfO9tu2vDYX2yoi",
-      "size" : 1571214287,
+      "name" : "gbpeWEG7ML5",
+      "mimeType" : "rcJNOCt7d9CQpNDCd",
+      "size" : 1034891414,
       "license" : {
         "type" : "License",
-        "identifier" : "aSapkif94PvlzfYbI0v",
+        "identifier" : "th0bBcRoM8g9UEs",
         "labels" : {
-          "loY09QMgqFk4Dto" : "d7h9e4YUp8q"
+          "zKIFIGvhDdBPy8U" : "FoWBuHzhIOe2CvzVl"
         },
-        "link" : "https://www.example.com/Uc08nfh6p6m"
+        "link" : "https://www.example.com/Zku5J5zABf4dRYJosFn"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dolorat",
-    "name" : "hzg8x7MpZqMg6SIOvW",
+    "id" : "https://www.example.org/expeditaaut",
+    "name" : "JxLKwXZ0fO5omXn",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "hM1W8IbgAjTm",
-      "id" : "kYAzackk2AoOVU6Nv"
+      "source" : "5m1W5o26eO3h6lTj",
+      "id" : "CplTI057ZUOkfXA2wK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "rD1tDbKoWtlvHHBUCr"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "c1s1SyBMBy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dignissimosad" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/suntitaque" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "5IRPlt7w7PmqJVi",
+  "owner" : "RxnEWNc2cMc91FQPY",
   "resourceOwner" : {
-    "owner" : "5IRPlt7w7PmqJVi",
-    "ownerAffiliation" : "https://www.example.org/sapientequam"
+    "owner" : "RxnEWNc2cMc91FQPY",
+    "ownerAffiliation" : "https://www.example.org/numquamquibusdam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quisvoluptas",
+    "id" : "https://www.example.org/laudantiumnihil",
     "labels" : {
-      "utsrbUsKRZivHQdM" : "fJiU5RuBQGyu"
+      "AcFuGJhCWROP" : "95sRfXyLTIxdyJWB"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolordolorem",
-  "doi" : "https://doi.org/10.1234/iste",
+  "handle" : "https://www.example.org/porrodoloribus",
+  "doi" : "https://doi.org/10.1234/ab",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,124 +27,124 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "sBkNJlUuXjLwGj",
-      "author" : "xBs1iqR14hJCdrgur",
+      "text" : "c0iFHN0UmWzR",
+      "author" : "t82JxgQHk1Uc",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/atqueut",
+  "link" : "https://www.example.org/iureaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MUzhoxQoYxE0",
+    "mainTitle" : "pSViWqgMKWNLVqoEsZN",
     "alternativeTitles" : {
-      "ru" : "6pDOobvK1t"
+      "zh" : "C8pCUix5SbvR"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "oPPRFDTHk4O1XxS1",
-      "month" : "ZTyI3bQP7YtHTgZNjoN",
-      "day" : "UYIWzGBloGA6"
+      "year" : "jTNKKOjP7s0",
+      "month" : "Mb8XOMXEsatEo",
+      "day" : "EM9UBxX3kPvTxr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/470QtUiXSgJ",
-        "name" : "N1jCPBpEOI9BpaIwm",
-        "nameType" : "Organizational",
-        "orcId" : "2a9ebFDPRqFdQahFBh5",
-        "arpId" : "pmhlHtTfTC"
+        "id" : "https://www.example.com/fxL8w24BDqxWQxa",
+        "name" : "juXcJeUEj4Sp2",
+        "nameType" : "Personal",
+        "orcId" : "VSnNo8mXMveMu3D",
+        "arpId" : "dZFAVqSBzSWH7fhoM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1GLHhqk4d730yvJD9cF",
+        "id" : "https://www.example.com/PXBxN6NoN6Wv3f6mJU",
         "labels" : {
-          "eALTvIoJSoIjowlj" : "5dci5Poysrffh"
+          "XT9ujd0wcvr1TDY1f" : "VvvvYep13vWZeQvw78"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 3,
+      "role" : "Supervisor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/V31eaa36uwVZI",
-        "name" : "l3HmeC3Phbr",
-        "nameType" : "Personal",
-        "orcId" : "1CtzPLKT1adwLE5JKcz",
-        "arpId" : "l02JeECSU3pvfCuHs"
+        "id" : "https://www.example.com/5yPgn909kMIpDgzn",
+        "name" : "eHZ5z0Br5DK",
+        "nameType" : "Organizational",
+        "orcId" : "BL971xB5KEf",
+        "arpId" : "dA5ufA8Mi7VOaJP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/SBnkur2lDwcgvOY",
+        "id" : "https://www.example.com/CL23zlW1Juu06ztz",
         "labels" : {
-          "QMTggw2T4tRZPxbspf" : "we2ohBPK5oDB9G"
+          "sJCVQ0tF2kktYu7J" : "IcNAIWX0HjhpWRCkGBR"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 7,
+      "role" : "Supervisor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "bFamDuDWkbZ",
-    "tags" : [ "WTxzlXcoDCMT99elxwW" ],
-    "description" : "73BB5gwGPQIafuJvu0",
+    "npiSubjectHeading" : "2DezdzpQCA3di",
+    "tags" : [ "IiYGeucMGGgERfxpI" ],
+    "description" : "dMT3HQZhga21By",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EQF7e1JBn7uYw2Oyb"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jOlwcTmchtoGqd"
         },
-        "seriesNumber" : "KGDFoLY5KwAx",
+        "seriesNumber" : "RIB3FtMG1tAB",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jz9bFYAmxy"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rkf4eBLcXqNN2QMuq8"
         },
-        "isbnList" : [ "9780930331931" ]
+        "isbnList" : [ "9780878205660" ]
       },
-      "doi" : "https://www.example.com/FsDELaKs6ZK",
+      "doi" : "https://www.example.com/BvzjS8v9ppEN",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "fEPITKbswgtQTYDEz3",
-          "month" : "binhKKkwXqZ0MIg8",
-          "day" : "SM7UE9PLHJe"
+          "year" : "jcY8aD7wgnV1z",
+          "month" : "Dl5Ppd5ETpob",
+          "day" : "LbvCHdMN7Etdv"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "nFJURhyo2xZR",
-            "end" : "Q2sfPpzVC3ywS"
+            "begin" : "O5qeo97rzybZ6tDY1",
+            "end" : "uoT1GJ9Vr6Na6b"
           },
-          "pages" : "JcNtJ4dwDfpdouvLl",
+          "pages" : "FItU9PWWAnNMP6kruV",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/BnTFzrFV2QGGX19T",
-    "abstract" : "NZFyhWg3qK"
+    "metadataSource" : "https://www.example.com/ZizeoqWLHcgI",
+    "abstract" : "1HHYAqTHGiv"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "gbpeWEG7ML5",
-      "mimeType" : "rcJNOCt7d9CQpNDCd",
-      "size" : 1034891414,
+      "name" : "mkmNyUN5eHC3",
+      "mimeType" : "L8gu0TX3OE",
+      "size" : 943879274,
       "license" : {
         "type" : "License",
-        "identifier" : "th0bBcRoM8g9UEs",
+        "identifier" : "Moi7lrPZcb6I8zN3w",
         "labels" : {
-          "zKIFIGvhDdBPy8U" : "FoWBuHzhIOe2CvzVl"
+          "SXdwWZ4VvZkMn" : "9ePvPDRG4yYRa77WJ8"
         },
-        "link" : "https://www.example.com/Zku5J5zABf4dRYJosFn"
+        "link" : "https://www.example.com/WvxRa73AMWCzkJx"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/expeditaaut",
-    "name" : "JxLKwXZ0fO5omXn",
+    "id" : "https://www.example.org/beataeomnis",
+    "name" : "DBATdPkE7nU4m",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "5m1W5o26eO3h6lTj",
-      "id" : "CplTI057ZUOkfXA2wK"
+      "source" : "ea1PMVysMN6hPNf",
+      "id" : "z6dZDlSBhauk6Cp4a"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "c1s1SyBMBy"
+      "applicationCode" : "f7oYiVHoeNOrAUP7mLM"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/suntitaque" ],
+  "subjects" : [ "https://www.example.org/sapientedolorem" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,150 +1,150 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "RxnEWNc2cMc91FQPY",
+  "status" : "PUBLISHED",
+  "owner" : "rTcaAaNP14BXi0",
   "resourceOwner" : {
-    "owner" : "RxnEWNc2cMc91FQPY",
-    "ownerAffiliation" : "https://www.example.org/numquamquibusdam"
+    "owner" : "rTcaAaNP14BXi0",
+    "ownerAffiliation" : "https://www.example.org/ideos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laudantiumnihil",
+    "id" : "https://www.example.org/sedarchitecto",
     "labels" : {
-      "AcFuGJhCWROP" : "95sRfXyLTIxdyJWB"
+      "EaEzDZLqQSl0OveB2" : "3X28GRMqXKwUWv"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/porrodoloribus",
-  "doi" : "https://doi.org/10.1234/ab",
+  "handle" : "https://www.example.org/deseruntaperiam",
+  "doi" : "https://doi.org/10.1234/voluptatem",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "c0iFHN0UmWzR",
-      "author" : "t82JxgQHk1Uc",
+      "text" : "4NwdpWzgLbPWo",
+      "author" : "zz71Ij1sI0M",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/iureaut",
+  "link" : "https://www.example.org/dolorumenim",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pSViWqgMKWNLVqoEsZN",
+    "mainTitle" : "hyAdbZLO0Yp",
     "alternativeTitles" : {
-      "zh" : "C8pCUix5SbvR"
+      "cs" : "jSmpsilK0s"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "jTNKKOjP7s0",
-      "month" : "Mb8XOMXEsatEo",
-      "day" : "EM9UBxX3kPvTxr"
+      "year" : "tN5hO3DFHJ9Sa7MeBp",
+      "month" : "JIoZb2X0h5QBqJ",
+      "day" : "UerZUdHLJNM7SRyz4OX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fxL8w24BDqxWQxa",
-        "name" : "juXcJeUEj4Sp2",
+        "id" : "https://www.example.com/oNE94oH2y8NO",
+        "name" : "A2zqb5I7uFUE",
         "nameType" : "Personal",
-        "orcId" : "VSnNo8mXMveMu3D",
-        "arpId" : "dZFAVqSBzSWH7fhoM"
+        "orcId" : "ICg0eJGIzH",
+        "arpId" : "WKbLtoEUXV0K3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PXBxN6NoN6Wv3f6mJU",
+        "id" : "https://www.example.com/SNGGZZslzDd",
         "labels" : {
-          "XT9ujd0wcvr1TDY1f" : "VvvvYep13vWZeQvw78"
+          "zdn1ZEB711Lxw7B1" : "5YZtUGEI2Ma"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 9,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5yPgn909kMIpDgzn",
-        "name" : "eHZ5z0Br5DK",
+        "id" : "https://www.example.com/8tb0LZ9Gzuqa",
+        "name" : "FVx00iHocNRifXqcEn",
         "nameType" : "Organizational",
-        "orcId" : "BL971xB5KEf",
-        "arpId" : "dA5ufA8Mi7VOaJP"
+        "orcId" : "q4CmIoxBrLvKaefG",
+        "arpId" : "aPSHwHiFeW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CL23zlW1Juu06ztz",
+        "id" : "https://www.example.com/VOUZRfReYn",
         "labels" : {
-          "sJCVQ0tF2kktYu7J" : "IcNAIWX0HjhpWRCkGBR"
+          "rNyS7TTz8gwRv44CmIN" : "WnuHO4bDZySkUCXq"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 6,
+      "role" : "CuratorOrganizer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "2DezdzpQCA3di",
-    "tags" : [ "IiYGeucMGGgERfxpI" ],
-    "description" : "dMT3HQZhga21By",
+    "npiSubjectHeading" : "Giy4HGez3mu1t",
+    "tags" : [ "1QeL6yPxTRclHRJYkM" ],
+    "description" : "b5XkKXxo3jI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jOlwcTmchtoGqd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1Y4WOQXqE5ge"
         },
-        "seriesNumber" : "RIB3FtMG1tAB",
+        "seriesNumber" : "uBU2OjHmRf04hHix",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rkf4eBLcXqNN2QMuq8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gJpKUOQNspbxNozGVC"
         },
-        "isbnList" : [ "9780878205660" ]
+        "isbnList" : [ "9791042830748" ]
       },
-      "doi" : "https://www.example.com/BvzjS8v9ppEN",
+      "doi" : "https://www.example.com/ZYGQgGNrUKCw",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "jcY8aD7wgnV1z",
-          "month" : "Dl5Ppd5ETpob",
-          "day" : "LbvCHdMN7Etdv"
+          "year" : "TV5eBCy3w7jEVTd7IV",
+          "month" : "uZFxTcCIs0I",
+          "day" : "aM79241rb2mWbCy5NT"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "O5qeo97rzybZ6tDY1",
-            "end" : "uoT1GJ9Vr6Na6b"
+            "begin" : "5k1GIINCVmDGB",
+            "end" : "DdCwctts6ey8EHvXvwN"
           },
-          "pages" : "FItU9PWWAnNMP6kruV",
-          "illustrated" : false
+          "pages" : "N3ZOYciyOGQ5eP",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/ZizeoqWLHcgI",
-    "abstract" : "1HHYAqTHGiv"
+    "metadataSource" : "https://www.example.com/tRmoyj7gsK",
+    "abstract" : "oWh2rIVjl4"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "mkmNyUN5eHC3",
-      "mimeType" : "L8gu0TX3OE",
-      "size" : 943879274,
+      "name" : "ZeySYcjovkPq8",
+      "mimeType" : "Ol2NXvx07kX",
+      "size" : 1394051332,
       "license" : {
         "type" : "License",
-        "identifier" : "Moi7lrPZcb6I8zN3w",
+        "identifier" : "dccd0xZwftTy8",
         "labels" : {
-          "SXdwWZ4VvZkMn" : "9ePvPDRG4yYRa77WJ8"
+          "eQZCIvUlg2bV3" : "QJAJGHOK9SM0jL"
         },
-        "link" : "https://www.example.com/WvxRa73AMWCzkJx"
+        "link" : "https://www.example.com/kbMz8j6w94"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/beataeomnis",
-    "name" : "DBATdPkE7nU4m",
+    "id" : "https://www.example.org/sitdoloribus",
+    "name" : "NXtV9IFMELBr",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ea1PMVysMN6hPNf",
-      "id" : "z6dZDlSBhauk6Cp4a"
+      "source" : "8C6Gcr3SWmjl9coO",
+      "id" : "vObARjBLwNJZlL5cX9M"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "f7oYiVHoeNOrAUP7mLM"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "d2Maj7C9E8GPiRSfN9"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sapientedolorem" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/utautem" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "YwfI0JVy9YW",
+  "status" : "DRAFT",
+  "owner" : "9pyyMjQrNw5lOSs",
   "resourceOwner" : {
-    "owner" : "YwfI0JVy9YW",
-    "ownerAffiliation" : "https://www.example.org/modiminus"
+    "owner" : "9pyyMjQrNw5lOSs",
+    "ownerAffiliation" : "https://www.example.org/harumalias"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/facereaut",
+    "id" : "https://www.example.org/autat",
     "labels" : {
-      "4tfA5yy7aa8QjO" : "9vsjziwLyT"
+      "5GmJemdf7SznVlPeI" : "McRNiKXVunzeYT"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/fugiatest",
-  "doi" : "https://doi.org/10.1234/ut",
+  "handle" : "https://www.example.org/omnisincidunt",
+  "doi" : "https://doi.org/10.1234/qui",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,145 +27,145 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "PxItL6Zi95",
-      "author" : "Msh6JTYJud",
+      "text" : "UfAdA8egqMZMv5",
+      "author" : "ff1MRl53KUk3pY",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/consecteturvoluptatibus",
+  "link" : "https://www.example.org/corporisullam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mZ6pIspVyuVrms",
+    "mainTitle" : "zdJCo8F1emcF",
     "alternativeTitles" : {
-      "de" : "GRReZCd5XzPV1Uhsse"
+      "cs" : "0CM5WUzlfbxB8"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "2IJhwlWDwF",
-      "month" : "xxfUDlhwbC023dGHKD",
-      "day" : "aajh3R6XbNTBTyl3v"
+      "year" : "E0Gxp8ziNyqlE8I3f9",
+      "month" : "GIYmxXId7cN4j4pFa",
+      "day" : "9mXQz3KGcJ7m32HM1jV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/zDHdZstcGP",
-        "name" : "gDndu8cXyk",
-        "nameType" : "Organizational",
-        "orcId" : "gXaPFVpFiR78gMQ9",
-        "arpId" : "3aD9qv3x6n6RoWZ"
+        "id" : "https://www.example.com/N0hmwB6pxCILe",
+        "name" : "CaMYIJhSyI",
+        "nameType" : "Personal",
+        "orcId" : "uuFgzDVvC1efxl8LnMt",
+        "arpId" : "Cpv4Gh0V70gmstHJ58"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4tZ8jBO5PE8nnC5GCH",
+        "id" : "https://www.example.com/2zEX0elRsX",
         "labels" : {
-          "lXFUy0F5kCKVag" : "9FpcnXm4IOfzQ4RmCB"
+          "P3FHUWHXMP" : "JZQaPtCZ9Cz"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 3,
+      "role" : "WorkPackageLeader",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/u5zeijRCtAj",
-        "name" : "3cgHNlRmLOgyX",
-        "nameType" : "Organizational",
-        "orcId" : "Rvu8AxAM2eUL5iv",
-        "arpId" : "I8DGMnWB9KNrn3"
+        "id" : "https://www.example.com/jcEw1Ijf1wSr",
+        "name" : "HDf4AzFyepDhjCVf2",
+        "nameType" : "Personal",
+        "orcId" : "Wp4Qb0Ixsg4Q6ADm",
+        "arpId" : "QQo2CQjUMo45j85"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/pL0qvLE7o9jCxONCU",
+        "id" : "https://www.example.com/ZxpdgabcwPZc",
         "labels" : {
-          "b1cahR2aeDkqIFJRh" : "au7cYX1l0wqH6j7U5KT"
+          "q2ZWLESrq5nG" : "7UkpnkdJ9e2M1MbiUA"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 6,
+      "role" : "Funder",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "PaLMrnHJdyjX3VReII",
-    "tags" : [ "aZmI86HTTf" ],
-    "description" : "SN4T8tJgaoQquRj",
+    "npiSubjectHeading" : "tqgDQ0Zt6pH2kEeP",
+    "tags" : [ "jqpMOVpH9tPf3WS" ],
+    "description" : "yGcSbUbndGV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7gcT7CxHXHgK"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/QzQtlPcyhVg74O1Wp"
         },
-        "seriesNumber" : "dVYLcvZhJ3CFID8",
+        "seriesNumber" : "70Tbbn6vPnGGW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mwUUAGCH9b2k5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/D5zCDCVDtdiB9dXHv"
         },
-        "isbnList" : [ "9790484140101" ]
+        "isbnList" : [ "9780956868152" ]
       },
-      "doi" : "https://www.example.com/INtNI12Sv19",
+      "doi" : "https://www.example.com/pn28RMj68kWE6VC4Dm",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "yCeUPgXIormYS",
-          "month" : "jtQwIeGlyzh",
-          "day" : "jcvAV1nnsEcc15"
+          "year" : "DgMdoIUyZ0mtYKNI1P4",
+          "month" : "QvQ7CRwaxEKVms",
+          "day" : "md2PsTMV5Lw"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "K2ywWv0iWzJ4u",
-            "end" : "EuL5qJK7fpS7j8cDO7a"
+            "begin" : "w9PPYTY2dRoT",
+            "end" : "wtjhLGjyS5"
           },
-          "pages" : "gDKsYTeAXBPQZV0XY",
+          "pages" : "ZORRkSXsl8p",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/9zaauZr9AJYMF",
-    "abstract" : "61ozCnLmemUqvY7"
+    "metadataSource" : "https://www.example.com/j029MGXhgcLABbi",
+    "abstract" : "4qAYVsEq26"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ge6RpAxlQzZILxiAA",
-      "mimeType" : "fIIxVi0QL4Oq",
-      "size" : 361254288,
+      "name" : "WCx9Q4Q1csNWYm8gk7",
+      "mimeType" : "rDRcxLWyJPqkLPKo5",
+      "size" : 1595060391,
       "license" : {
         "type" : "License",
-        "identifier" : "cO4jaOJbXz8",
+        "identifier" : "oucv08Qm2U1Gu",
         "labels" : {
-          "i6UI4ZaxhtHp3" : "6IKWLNu3dSV6xZ8FmZh"
+          "fPC15JZLHn9sjGPNxcT" : "xnQcS6yqBydelEEpg4e"
         },
-        "link" : "https://www.example.com/uPPgKMJSlKL0"
+        "link" : "https://www.example.com/5nmQw9XyxpLXy"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estet",
-    "name" : "hNilz2vO0t1",
+    "id" : "https://www.example.org/fugafacere",
+    "name" : "VMAhPSrzvbPd9i84LhU",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZTLyaR5g0b",
-      "id" : "6seekxhcNwhzHXZC7hr"
+      "source" : "3iYoPAqKyJCrEZ9xY0U",
+      "id" : "2ygN4aJog38thfIz6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "ndzBi4RPS1s"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "udmX1eL27rHfSq7i"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velrerum" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/cumquedolores" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "Rrc9kB7HZTXKntIQUtO",
+  "status" : "DRAFT",
+  "owner" : "QBLScZiakxM19BYPTd",
   "resourceOwner" : {
-    "owner" : "Rrc9kB7HZTXKntIQUtO",
-    "ownerAffiliation" : "https://www.example.org/totaminventore"
+    "owner" : "QBLScZiakxM19BYPTd",
+    "ownerAffiliation" : "https://www.example.org/quifacere"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/hicanimi",
+    "id" : "https://www.example.org/utexercitationem",
     "labels" : {
-      "QjSXK3aO8W4sV" : "klkdUUEJxMGWWRXiVc"
+      "TG7iVBjPCoEvUS" : "XYj7AAJuhm1IuLla9c3"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ipsamet",
-  "doi" : "https://doi.org/10.1234/nesciunt",
+  "handle" : "https://www.example.org/quimolestiae",
+  "doi" : "https://doi.org/10.1234/et",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,145 +27,145 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Jsha8BKqK8bmznxMF",
-      "author" : "8bzi3bd7NqadHRNqGj",
+      "text" : "9qESpdBrqvUuHXZQN",
+      "author" : "X7OjRSjwbJXm",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/odioeius",
+  "link" : "https://www.example.org/quialaboriosam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Bz4LqPUQp2P4ZhG",
+    "mainTitle" : "m8gZ7NwziJ",
     "alternativeTitles" : {
-      "es" : "y0jH7qBYHVKgqT"
+      "fi" : "9wtmkRPYwXHO53xfmA"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "WLPi84DBo1N1rZ10i",
-      "month" : "7mVuBZAtRKM940xQjIQ",
-      "day" : "4rCzXChyQDkwy"
+      "year" : "M0q3EanqfioFG",
+      "month" : "17Qwt5DuKofQRr",
+      "day" : "EISfP7PF1elBRp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/t7PYgzL7jIuXkY",
-        "name" : "kA6rCmfb9ZbXIH",
+        "id" : "https://www.example.com/iLh7tI62a7GFHsW5I",
+        "name" : "hzXOt5dFeJZt28",
         "nameType" : "Organizational",
-        "orcId" : "w1OvctjnHHz",
-        "arpId" : "dsBbA1Qzdi8QU"
+        "orcId" : "BDVAq6PNuFRJEO8DWD",
+        "arpId" : "c9b455wOLu4P3KB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uA7D8gzkwi",
+        "id" : "https://www.example.com/8vKYo0quGgrP",
         "labels" : {
-          "XEf7Wr8zURkbiYlDk" : "oK1bLPHaS8Oa9wKiEH"
+          "o58b4jZHTo7rO" : "3lZjT5DEsUhW8xyFsi"
         }
       } ],
-      "role" : "DataCollector",
+      "role" : "HostingInstitution",
       "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xWjukVAbGFxkLQDJItm",
-        "name" : "1P1F8XfEl1PDwFxQ",
+        "id" : "https://www.example.com/X3CMDr7BTZR",
+        "name" : "vM92TfhtVe1QtPg",
         "nameType" : "Organizational",
-        "orcId" : "n2v76g4GsvblX",
-        "arpId" : "g0VJTNlWekKcbd"
+        "orcId" : "azwZHXaRnB9jVU",
+        "arpId" : "6t7uSM4oBBw5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Vfrr89JCXkkfmCk1",
+        "id" : "https://www.example.com/CUzts8gSpCTi0xnbx",
         "labels" : {
-          "snIHMwebbat2EPhj" : "q1oqcg8HWw"
+          "mX5xUCfyzFalO3oX73" : "C0ArajFKop"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 4,
+      "role" : "InterviewSubject",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "JwdMzglKgnDxy7RB20",
-    "tags" : [ "erFE0cCnEJ" ],
-    "description" : "yhPXILWV0niGms",
+    "npiSubjectHeading" : "NGQ5zviftd7",
+    "tags" : [ "YGQsC3A8xLK5C6lQZaK" ],
+    "description" : "T3Y6z0REG8rQleYA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/k665jFkB4Yh5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cgbD36g5xV"
         },
-        "seriesNumber" : "zCfmIm40tH7iy0",
+        "seriesNumber" : "wWcShuYS1mexH",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/E7S08shAlYucqIQanM"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OuoyFCsW8d3U"
         },
-        "isbnList" : [ "9781560514145" ]
+        "isbnList" : [ "9791857374208" ]
       },
-      "doi" : "https://www.example.com/c6uxmPFdVxTyebM5lZ",
+      "doi" : "https://www.example.com/OrAtuuScepHj93d",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "CoCgS3UL0ik",
-          "month" : "S4YYXsot9xMH3t3c",
-          "day" : "Ie47TkrVOEOR4DK"
+          "year" : "U0AbwufeZnLrc9uo",
+          "month" : "i5UFLsASCB93WijG",
+          "day" : "fsWx0F33ux"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "df0lnaJUE2Oh91cCKp",
-            "end" : "yPrlfgOyk8EXl"
+            "begin" : "bM0HvanJChvX7",
+            "end" : "RcSjIjnXe6FXo"
           },
-          "pages" : "Q54reY7XdIxSa",
+          "pages" : "SpNm7nFWl4ef",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/op8NOd7kIg6zS5og",
-    "abstract" : "FRSGzqN5WHkHraH"
+    "metadataSource" : "https://www.example.com/upKuOpU0VaKEPAT",
+    "abstract" : "cBRQ9kHFcv"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "5CFCdlsHQK6",
-      "mimeType" : "5Jb3IDHyahf19",
-      "size" : 908749699,
+      "name" : "otzObNyVnbG3",
+      "mimeType" : "RLtPYhL6KI",
+      "size" : 86973134,
       "license" : {
         "type" : "License",
-        "identifier" : "5tl3er4h5F7tYHj58",
+        "identifier" : "SQW2dNP1fB8W1",
         "labels" : {
-          "Rj2d84bbF193AGJZgm" : "DweHkxhSCSxtPFHOZ"
+          "CudzLzxgPaT4d0Qi" : "FH19Yz8nigIJ"
         },
-        "link" : "https://www.example.com/wUMhsmiVLfUu5z"
+        "link" : "https://www.example.com/0eXrXsQEpyfclcyWCw"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/reiciendishic",
-    "name" : "5WfhSa9phmnnOXopsv",
+    "id" : "https://www.example.org/evenietconsectetur",
+    "name" : "auMz7ZuktGiPE",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FIIyc3BLAOz",
-      "id" : "UmAuTsLSsjYZ1V9"
+      "source" : "kPTRB1dam12HALI",
+      "id" : "Us5EzC0P709faE"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Ys9eb8k9ltN3X"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "ILkTSy9UtW5"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cumqueaut" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/aquia" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,171 +1,171 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "QBLScZiakxM19BYPTd",
+  "status" : "PUBLISHED",
+  "owner" : "YwfI0JVy9YW",
   "resourceOwner" : {
-    "owner" : "QBLScZiakxM19BYPTd",
-    "ownerAffiliation" : "https://www.example.org/quifacere"
+    "owner" : "YwfI0JVy9YW",
+    "ownerAffiliation" : "https://www.example.org/modiminus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/utexercitationem",
+    "id" : "https://www.example.org/facereaut",
     "labels" : {
-      "TG7iVBjPCoEvUS" : "XYj7AAJuhm1IuLla9c3"
+      "4tfA5yy7aa8QjO" : "9vsjziwLyT"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quimolestiae",
-  "doi" : "https://doi.org/10.1234/et",
+  "handle" : "https://www.example.org/fugiatest",
+  "doi" : "https://doi.org/10.1234/ut",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "9qESpdBrqvUuHXZQN",
-      "author" : "X7OjRSjwbJXm",
+      "text" : "PxItL6Zi95",
+      "author" : "Msh6JTYJud",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quialaboriosam",
+  "link" : "https://www.example.org/consecteturvoluptatibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "m8gZ7NwziJ",
+    "mainTitle" : "mZ6pIspVyuVrms",
     "alternativeTitles" : {
-      "fi" : "9wtmkRPYwXHO53xfmA"
+      "de" : "GRReZCd5XzPV1Uhsse"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "M0q3EanqfioFG",
-      "month" : "17Qwt5DuKofQRr",
-      "day" : "EISfP7PF1elBRp"
+      "year" : "2IJhwlWDwF",
+      "month" : "xxfUDlhwbC023dGHKD",
+      "day" : "aajh3R6XbNTBTyl3v"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iLh7tI62a7GFHsW5I",
-        "name" : "hzXOt5dFeJZt28",
+        "id" : "https://www.example.com/zDHdZstcGP",
+        "name" : "gDndu8cXyk",
         "nameType" : "Organizational",
-        "orcId" : "BDVAq6PNuFRJEO8DWD",
-        "arpId" : "c9b455wOLu4P3KB"
+        "orcId" : "gXaPFVpFiR78gMQ9",
+        "arpId" : "3aD9qv3x6n6RoWZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/8vKYo0quGgrP",
+        "id" : "https://www.example.com/4tZ8jBO5PE8nnC5GCH",
         "labels" : {
-          "o58b4jZHTo7rO" : "3lZjT5DEsUhW8xyFsi"
+          "lXFUy0F5kCKVag" : "9FpcnXm4IOfzQ4RmCB"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 8,
+      "role" : "RelatedPerson",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/X3CMDr7BTZR",
-        "name" : "vM92TfhtVe1QtPg",
+        "id" : "https://www.example.com/u5zeijRCtAj",
+        "name" : "3cgHNlRmLOgyX",
         "nameType" : "Organizational",
-        "orcId" : "azwZHXaRnB9jVU",
-        "arpId" : "6t7uSM4oBBw5"
+        "orcId" : "Rvu8AxAM2eUL5iv",
+        "arpId" : "I8DGMnWB9KNrn3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CUzts8gSpCTi0xnbx",
+        "id" : "https://www.example.com/pL0qvLE7o9jCxONCU",
         "labels" : {
-          "mX5xUCfyzFalO3oX73" : "C0ArajFKop"
+          "b1cahR2aeDkqIFJRh" : "au7cYX1l0wqH6j7U5KT"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 5,
+      "role" : "ProjectLeader",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NGQ5zviftd7",
-    "tags" : [ "YGQsC3A8xLK5C6lQZaK" ],
-    "description" : "T3Y6z0REG8rQleYA",
+    "npiSubjectHeading" : "PaLMrnHJdyjX3VReII",
+    "tags" : [ "aZmI86HTTf" ],
+    "description" : "SN4T8tJgaoQquRj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cgbD36g5xV"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7gcT7CxHXHgK"
         },
-        "seriesNumber" : "wWcShuYS1mexH",
+        "seriesNumber" : "dVYLcvZhJ3CFID8",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OuoyFCsW8d3U"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mwUUAGCH9b2k5"
         },
-        "isbnList" : [ "9791857374208" ]
+        "isbnList" : [ "9790484140101" ]
       },
-      "doi" : "https://www.example.com/OrAtuuScepHj93d",
+      "doi" : "https://www.example.com/INtNI12Sv19",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "U0AbwufeZnLrc9uo",
-          "month" : "i5UFLsASCB93WijG",
-          "day" : "fsWx0F33ux"
+          "year" : "yCeUPgXIormYS",
+          "month" : "jtQwIeGlyzh",
+          "day" : "jcvAV1nnsEcc15"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "bM0HvanJChvX7",
-            "end" : "RcSjIjnXe6FXo"
+            "begin" : "K2ywWv0iWzJ4u",
+            "end" : "EuL5qJK7fpS7j8cDO7a"
           },
-          "pages" : "SpNm7nFWl4ef",
-          "illustrated" : true
+          "pages" : "gDKsYTeAXBPQZV0XY",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/upKuOpU0VaKEPAT",
-    "abstract" : "cBRQ9kHFcv"
+    "metadataSource" : "https://www.example.com/9zaauZr9AJYMF",
+    "abstract" : "61ozCnLmemUqvY7"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "otzObNyVnbG3",
-      "mimeType" : "RLtPYhL6KI",
-      "size" : 86973134,
+      "name" : "ge6RpAxlQzZILxiAA",
+      "mimeType" : "fIIxVi0QL4Oq",
+      "size" : 361254288,
       "license" : {
         "type" : "License",
-        "identifier" : "SQW2dNP1fB8W1",
+        "identifier" : "cO4jaOJbXz8",
         "labels" : {
-          "CudzLzxgPaT4d0Qi" : "FH19Yz8nigIJ"
+          "i6UI4ZaxhtHp3" : "6IKWLNu3dSV6xZ8FmZh"
         },
-        "link" : "https://www.example.com/0eXrXsQEpyfclcyWCw"
+        "link" : "https://www.example.com/uPPgKMJSlKL0"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/evenietconsectetur",
-    "name" : "auMz7ZuktGiPE",
+    "id" : "https://www.example.org/estet",
+    "name" : "hNilz2vO0t1",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "kPTRB1dam12HALI",
-      "id" : "Us5EzC0P709faE"
+      "source" : "ZTLyaR5g0b",
+      "id" : "6seekxhcNwhzHXZC7hr"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "ILkTSy9UtW5"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ndzBi4RPS1s"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aquia" ],
+  "subjects" : [ "https://www.example.org/velrerum" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,171 +1,171 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "F3b2mpEjTJ",
+  "status" : "PUBLISHED",
+  "owner" : "NUHKIDILmbM",
   "resourceOwner" : {
-    "owner" : "F3b2mpEjTJ",
-    "ownerAffiliation" : "https://www.example.org/rerumdolor"
+    "owner" : "NUHKIDILmbM",
+    "ownerAffiliation" : "https://www.example.org/esserepellendus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemqui",
+    "id" : "https://www.example.org/etneque",
     "labels" : {
-      "JufePd7yZU1Z" : "zNA6N8fyBlr"
+      "hCDizTGDOzbORaBGIS" : "Smb7qhWD3cvPCQi"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/adnatus",
-  "doi" : "https://doi.org/10.1234/rerum",
+  "handle" : "https://www.example.org/autemipsum",
+  "doi" : "https://doi.org/10.1234/et",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "gRxyhzQHm4",
-      "author" : "hqKyQKhjOC7RYqTC",
+      "text" : "p5iCDKifX4Ii1mNybg",
+      "author" : "Pe72eKGFMHvzZ4Nvh6q",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/etamet",
+  "link" : "https://www.example.org/eosullam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RGdoUkL8cgwFoyS5",
+    "mainTitle" : "CILO9ekYQC8P8x1hP8",
     "alternativeTitles" : {
-      "de" : "kSCsTPq8J5ND2H"
+      "ru" : "vFpf0jEb3tpmCHDqmp"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "6hzMGXzs9W1AjQotggv",
-      "month" : "AVoXXDkIm3xWYCR",
-      "day" : "9s9HR9xfUU1x"
+      "year" : "sL0nn7fXaUSWw1lPaXp",
+      "month" : "s94m1w7KhSvibDPVLS",
+      "day" : "TQ880vrlSa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/2pXhThLAfmRy05UNCgt",
-        "name" : "XOM18ooXrYF",
-        "nameType" : "Personal",
-        "orcId" : "qN4k6HkOqaLBrcw",
-        "arpId" : "bvjAJI0dLc"
+        "id" : "https://www.example.com/Ir2k1VZBHB6aM",
+        "name" : "FlknPuO6iwweabG6uqT",
+        "nameType" : "Organizational",
+        "orcId" : "sfGeT2B4EEQ9",
+        "arpId" : "b4VKXN1dJK9d3vgSW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wS0LoXd8bNTquCSA",
+        "id" : "https://www.example.com/yuqPR4ziwzl7HtyYZ",
         "labels" : {
-          "eYFTPOznCTi7" : "1HfNqcW4oa7VWXi7N3"
+          "DLMsa4eOYTPtbm0SQ" : "rS8WMEhISY6eC"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 5,
+      "role" : "DataCurator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0rMOn7OZWVzP",
-        "name" : "wmB8XEwzc5piZ1",
+        "id" : "https://www.example.com/5aorR3mHxjOoXxXmiMi",
+        "name" : "sV21af3W7TvnT2D9",
         "nameType" : "Organizational",
-        "orcId" : "xH2nVDvPhld",
-        "arpId" : "ym1bPN2CTx"
+        "orcId" : "D14LKw5k9wh",
+        "arpId" : "dwqXdAkJBjH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mY09JUVrwVHGb",
+        "id" : "https://www.example.com/QVtUSv9J51FDBUxA",
         "labels" : {
-          "WCEhipjmKcKqP9B7tzO" : "x7aruU2lH1tAX"
+          "eTITdg5Slbtk16" : "mqZJw51IIaWE81"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 4,
+      "role" : "Advisor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "99wX1279A00DA",
-    "tags" : [ "WVxbCfPRi2QaN99Gup" ],
-    "description" : "LBQbBR4iQPLTIqX8S",
+    "npiSubjectHeading" : "tXYnr1XvAQFFHIC",
+    "tags" : [ "pXisraesl0UxgKX" ],
+    "description" : "Nv3oUncRas",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PSby8BLR4tWab418aG"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HEp6isCmn6Fe5EQ"
         },
-        "seriesNumber" : "MuFOloI0h5Br4hSvOc",
+        "seriesNumber" : "i5d1vI0I1CSuz7kTaU",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dyohZz5WWF7VsBm6vtE"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XKwokdJH2E2U"
         },
-        "isbnList" : [ "9790767441970" ]
+        "isbnList" : [ "9780854694129" ]
       },
-      "doi" : "https://www.example.com/G3saczzkduJb4RN",
+      "doi" : "https://www.example.com/J9a4AkhDlM",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "q5NUjZ8OBhS61xmYV79",
-          "month" : "6Jso5rKZps",
-          "day" : "IfTEUcmPMq"
+          "year" : "yG4OXi8VEGqCkJ",
+          "month" : "Ve19N11E79sswKvc",
+          "day" : "jDAjh2iyQkc9Dj7nzLT"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "sIEiyaznljiuT3",
-            "end" : "GmgNImw2NEbNAm"
+            "begin" : "I4qVXSSLjy2O02M4I",
+            "end" : "kABWL9tJyxYrv4zKaot"
           },
-          "pages" : "zOVF60henRG",
+          "pages" : "Pg8iCzJ7l3xIqgD",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/qnpkzATWA5ob",
-    "abstract" : "IJQzthmkfkM3eu"
+    "metadataSource" : "https://www.example.com/z3jVHaec9nk",
+    "abstract" : "HWCnaJ0IRhyM"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "j8nVIpB0GGgmLNk",
-      "mimeType" : "YWZuRwKVIj",
-      "size" : 1413029568,
+      "name" : "CcFI44gzL9g4lwCyo",
+      "mimeType" : "tPM69NXhs5vgtide3e",
+      "size" : 2009838917,
       "license" : {
         "type" : "License",
-        "identifier" : "Zi6gWqCb2t",
+        "identifier" : "EvCUG8rU4WLpl",
         "labels" : {
-          "GAz3KZOrnZtAm" : "pi5rkCE9ttGufTYC"
+          "AdMh9VxICKev" : "nlWFLJpI5khFZfMUMv"
         },
-        "link" : "https://www.example.com/LYIxgcVCXb2t"
+        "link" : "https://www.example.com/viMnvTdfElWAH"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/inciduntenim",
-    "name" : "M0h4SFHLEW",
+    "id" : "https://www.example.org/doloremofficia",
+    "name" : "fOTUpQ4vHH",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Kuv1ZFzny2Q",
-      "id" : "2bBf3Gt7HMkB7sgcKJ"
+      "source" : "gbZuShDRdghScX",
+      "id" : "fgRDD5DgnN6lLQx2s"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Afip7UmF6LuWN32TC"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "lvET3G8qaQs6"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatemdistinctio" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/voluptasaccusantium" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,150 +1,150 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "NUHKIDILmbM",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "fD91Uymtu5WpMinD6",
   "resourceOwner" : {
-    "owner" : "NUHKIDILmbM",
-    "ownerAffiliation" : "https://www.example.org/esserepellendus"
+    "owner" : "fD91Uymtu5WpMinD6",
+    "ownerAffiliation" : "https://www.example.org/sintrecusandae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etneque",
+    "id" : "https://www.example.org/repudiandaecupiditate",
     "labels" : {
-      "hCDizTGDOzbORaBGIS" : "Smb7qhWD3cvPCQi"
+      "5HwEOiC3P6" : "8LlMRvmbI0zssO7UN"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/autemipsum",
-  "doi" : "https://doi.org/10.1234/et",
+  "handle" : "https://www.example.org/expeditavoluptatem",
+  "doi" : "https://doi.org/10.1234/quia",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "p5iCDKifX4Ii1mNybg",
-      "author" : "Pe72eKGFMHvzZ4Nvh6q",
+      "text" : "R9XefUiikvaiXd",
+      "author" : "0KDjT21riOPWC",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/eosullam",
+  "link" : "https://www.example.org/perferendisnon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "CILO9ekYQC8P8x1hP8",
+    "mainTitle" : "bWGDwc0XWGBEfEx71mp",
     "alternativeTitles" : {
-      "ru" : "vFpf0jEb3tpmCHDqmp"
+      "ca" : "8oKFegz592IcT"
     },
     "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "sL0nn7fXaUSWw1lPaXp",
-      "month" : "s94m1w7KhSvibDPVLS",
-      "day" : "TQ880vrlSa"
+      "year" : "KY4veKhhGlfm",
+      "month" : "ELKRMyNGMh",
+      "day" : "E27THxNRIIn93QdS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Ir2k1VZBHB6aM",
-        "name" : "FlknPuO6iwweabG6uqT",
-        "nameType" : "Organizational",
-        "orcId" : "sfGeT2B4EEQ9",
-        "arpId" : "b4VKXN1dJK9d3vgSW"
+        "id" : "https://www.example.com/zcIngamJJXfQHJ",
+        "name" : "JQc9xUsQdNzgKtTzt",
+        "nameType" : "Personal",
+        "orcId" : "bmWQxs0PFb",
+        "arpId" : "gE8Fh8egRCrdQR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yuqPR4ziwzl7HtyYZ",
+        "id" : "https://www.example.com/xYd1aslvMEARrX2L48",
         "labels" : {
-          "DLMsa4eOYTPtbm0SQ" : "rS8WMEhISY6eC"
+          "8gYI4pEVRiyJwsNvWA" : "mLqUTEhQk0rtZM"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 2,
+      "role" : "RegistrationAgency",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5aorR3mHxjOoXxXmiMi",
-        "name" : "sV21af3W7TvnT2D9",
+        "id" : "https://www.example.com/5OTDMMOkZnZT8",
+        "name" : "nVziuTkNzlZtPwb",
         "nameType" : "Organizational",
-        "orcId" : "D14LKw5k9wh",
-        "arpId" : "dwqXdAkJBjH"
+        "orcId" : "gYZWNU2zcDqdrT",
+        "arpId" : "wS6CwoKl4Njy09g"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QVtUSv9J51FDBUxA",
+        "id" : "https://www.example.com/P2eTx5LBucvPlz323",
         "labels" : {
-          "eTITdg5Slbtk16" : "mqZJw51IIaWE81"
+          "E270zAWz5tzA7sG5" : "iQ2eze894TCbsd5"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 9,
+      "role" : "RelatedPerson",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "tXYnr1XvAQFFHIC",
-    "tags" : [ "pXisraesl0UxgKX" ],
-    "description" : "Nv3oUncRas",
+    "npiSubjectHeading" : "NphQ8yPwaDxVCEiOR5t",
+    "tags" : [ "aHRfRJoOTGT3HPDAv" ],
+    "description" : "AzAQjAq0AnL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HEp6isCmn6Fe5EQ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/m7nvJXWaG0n5ta"
         },
-        "seriesNumber" : "i5d1vI0I1CSuz7kTaU",
+        "seriesNumber" : "WZSj5N1kfQ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XKwokdJH2E2U"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2jL5OXr975Km0hPtEAk"
         },
-        "isbnList" : [ "9780854694129" ]
+        "isbnList" : [ "9790951628163" ]
       },
-      "doi" : "https://www.example.com/J9a4AkhDlM",
+      "doi" : "https://www.example.com/L6kSnEvzqBN6",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "yG4OXi8VEGqCkJ",
-          "month" : "Ve19N11E79sswKvc",
-          "day" : "jDAjh2iyQkc9Dj7nzLT"
+          "year" : "PRT35fM0iPD",
+          "month" : "uApFEU9s4ixy5",
+          "day" : "ZAPyVRCZ0wejxNG"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "I4qVXSSLjy2O02M4I",
-            "end" : "kABWL9tJyxYrv4zKaot"
+            "begin" : "lGkWfFW9BGimgM9v5",
+            "end" : "6meQBerhrG8"
           },
-          "pages" : "Pg8iCzJ7l3xIqgD",
+          "pages" : "gPq5dreGOJiT6",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/z3jVHaec9nk",
-    "abstract" : "HWCnaJ0IRhyM"
+    "metadataSource" : "https://www.example.com/0XlBrLQ0xU0D",
+    "abstract" : "e3hNx41rLm"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "CcFI44gzL9g4lwCyo",
-      "mimeType" : "tPM69NXhs5vgtide3e",
-      "size" : 2009838917,
+      "name" : "JRvJrrvLWfJFMskygbR",
+      "mimeType" : "pm0xuJTinFMzNW",
+      "size" : 2058605585,
       "license" : {
         "type" : "License",
-        "identifier" : "EvCUG8rU4WLpl",
+        "identifier" : "uh5RkrBiR05mRTWo1ls",
         "labels" : {
-          "AdMh9VxICKev" : "nlWFLJpI5khFZfMUMv"
+          "j38FmZ414EPOYbkdq7" : "0Tw0wtkZAbUHqN0"
         },
-        "link" : "https://www.example.com/viMnvTdfElWAH"
+        "link" : "https://www.example.com/9rFtUUxUTmibAc"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloremofficia",
-    "name" : "fOTUpQ4vHH",
+    "id" : "https://www.example.org/architectoquis",
+    "name" : "1RXgUIXgx7SpxnLMkG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "gbZuShDRdghScX",
-      "id" : "fgRDD5DgnN6lLQx2s"
+      "source" : "LNVhDjiXXUrsFqDK",
+      "id" : "OeCUOsEqWAYcQAQxDbm"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "lvET3G8qaQs6"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "pXxlz5ZwBeOo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptasaccusantium" ],
+  "subjects" : [ "https://www.example.org/pariatursimilique" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
-  "owner" : "fD91Uymtu5WpMinD6",
+  "owner" : "QbCYQiy9k3GqI",
   "resourceOwner" : {
-    "owner" : "fD91Uymtu5WpMinD6",
-    "ownerAffiliation" : "https://www.example.org/sintrecusandae"
+    "owner" : "QbCYQiy9k3GqI",
+    "ownerAffiliation" : "https://www.example.org/delenitiet"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repudiandaecupiditate",
+    "id" : "https://www.example.org/delenitireiciendis",
     "labels" : {
-      "5HwEOiC3P6" : "8LlMRvmbI0zssO7UN"
+      "nfEicnGe3h" : "0P3L3tMMZVXA"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/expeditavoluptatem",
-  "doi" : "https://doi.org/10.1234/quia",
+  "handle" : "https://www.example.org/recusandaetempora",
+  "doi" : "https://doi.org/10.1234/minus",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,145 +27,145 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "R9XefUiikvaiXd",
-      "author" : "0KDjT21riOPWC",
+      "text" : "jzMsksReFgdljBasIl",
+      "author" : "zPuAHxlvyViZ8FCQtI",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/perferendisnon",
+  "link" : "https://www.example.org/distinctioreprehenderit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bWGDwc0XWGBEfEx71mp",
+    "mainTitle" : "LllQcsKIrn993p",
     "alternativeTitles" : {
-      "ca" : "8oKFegz592IcT"
+      "sv" : "wMJtcfSaU5nj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "KY4veKhhGlfm",
-      "month" : "ELKRMyNGMh",
-      "day" : "E27THxNRIIn93QdS"
+      "year" : "wcfRCTVtLa1",
+      "month" : "3l4VGSu3ZhVyfMBikFa",
+      "day" : "q4jsGTFQD6bjT4q"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/zcIngamJJXfQHJ",
-        "name" : "JQc9xUsQdNzgKtTzt",
+        "id" : "https://www.example.com/uImpbjIWYulFpvnVdWB",
+        "name" : "YK02jVuKvOSDYeZoB1",
         "nameType" : "Personal",
-        "orcId" : "bmWQxs0PFb",
-        "arpId" : "gE8Fh8egRCrdQR"
+        "orcId" : "mXthU7uS6EN8XkNAU8",
+        "arpId" : "mGDPPTpcqyaE03Ke1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xYd1aslvMEARrX2L48",
+        "id" : "https://www.example.com/3i9ZKE3PYxwLj9",
         "labels" : {
-          "8gYI4pEVRiyJwsNvWA" : "mLqUTEhQk0rtZM"
+          "mKDkALHeVe" : "9wpYL7jt8tJtsBC0LB"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 6,
+      "role" : "ProjectMember",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5OTDMMOkZnZT8",
-        "name" : "nVziuTkNzlZtPwb",
-        "nameType" : "Organizational",
-        "orcId" : "gYZWNU2zcDqdrT",
-        "arpId" : "wS6CwoKl4Njy09g"
+        "id" : "https://www.example.com/0DLvs3GbRTF95j",
+        "name" : "iS4DlipR0krPElGQR5w",
+        "nameType" : "Personal",
+        "orcId" : "JV1iTG823FVoNXOB0T",
+        "arpId" : "MjyFv2QTGRXeg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/P2eTx5LBucvPlz323",
+        "id" : "https://www.example.com/1oQTIpecK5lUknOJw",
         "labels" : {
-          "E270zAWz5tzA7sG5" : "iQ2eze894TCbsd5"
+          "i1iDTpLNiC3eUAl7RK" : "Pduf6KfjHt25yy"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 4,
+      "role" : "HostingInstitution",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NphQ8yPwaDxVCEiOR5t",
-    "tags" : [ "aHRfRJoOTGT3HPDAv" ],
-    "description" : "AzAQjAq0AnL",
+    "npiSubjectHeading" : "DIXGBdL3kgPVqaD",
+    "tags" : [ "SsI2e9auV9hzCG" ],
+    "description" : "x13vcYxPWcD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/m7nvJXWaG0n5ta"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2yBb07Y2vV"
         },
-        "seriesNumber" : "WZSj5N1kfQ",
+        "seriesNumber" : "W6bMh4Geazq",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2jL5OXr975Km0hPtEAk"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kkZkQNeEswrpQLdyq"
         },
-        "isbnList" : [ "9790951628163" ]
+        "isbnList" : [ "9790047033918" ]
       },
-      "doi" : "https://www.example.com/L6kSnEvzqBN6",
+      "doi" : "https://www.example.com/VcPi3Xx7WAmZFXR6mT",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "PRT35fM0iPD",
-          "month" : "uApFEU9s4ixy5",
-          "day" : "ZAPyVRCZ0wejxNG"
+          "year" : "nr3zgYdeyGKpZ8K4H",
+          "month" : "ktI4afbs9IO",
+          "day" : "ILHyXu9bCtV3V10m"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "lGkWfFW9BGimgM9v5",
-            "end" : "6meQBerhrG8"
+            "begin" : "nMekDLE0sVuVMEwY",
+            "end" : "qHI8lUfIOG"
           },
-          "pages" : "gPq5dreGOJiT6",
+          "pages" : "EMHNnURq2yI",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0XlBrLQ0xU0D",
-    "abstract" : "e3hNx41rLm"
+    "metadataSource" : "https://www.example.com/z7wOr8pN7Osv8vV98k",
+    "abstract" : "jv7v3jh65BBePBey"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "JRvJrrvLWfJFMskygbR",
-      "mimeType" : "pm0xuJTinFMzNW",
-      "size" : 2058605585,
+      "name" : "wCpeudNYOpH",
+      "mimeType" : "Zz2GFnrukVPT8NE3",
+      "size" : 2023965529,
       "license" : {
         "type" : "License",
-        "identifier" : "uh5RkrBiR05mRTWo1ls",
+        "identifier" : "tPICCdBAVjA",
         "labels" : {
-          "j38FmZ414EPOYbkdq7" : "0Tw0wtkZAbUHqN0"
+          "4JhSpsvriF" : "IgHw5wQEKfB5rSAMK5"
         },
-        "link" : "https://www.example.com/9rFtUUxUTmibAc"
+        "link" : "https://www.example.com/DvyJ2nFfkf"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/architectoquis",
-    "name" : "1RXgUIXgx7SpxnLMkG",
+    "id" : "https://www.example.org/laborumdelectus",
+    "name" : "uRQ2J9CZ9IZsfhkLKb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "LNVhDjiXXUrsFqDK",
-      "id" : "OeCUOsEqWAYcQAQxDbm"
+      "source" : "vS0J4yqZr4slVmEdBj",
+      "id" : "pgk00aZFJxkjQ57ALvB"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "pXxlz5ZwBeOo"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "3CvmFwcmfIuExpYs"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/pariatursimilique" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/dolorenemo" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "hNZzKJUS5ZPk3e",
+  "status" : "NEW",
+  "owner" : "1QMXSgDWK4IWKa",
   "resourceOwner" : {
-    "owner" : "hNZzKJUS5ZPk3e",
-    "ownerAffiliation" : "https://www.example.org/quaeratcupiditate"
+    "owner" : "1QMXSgDWK4IWKa",
+    "ownerAffiliation" : "https://www.example.org/sedqui"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/saepereiciendis",
+    "id" : "https://www.example.org/dolorumfugiat",
     "labels" : {
-      "XgB7kp2BVV" : "7HgGcueQwlo"
+      "abmPaONuTLMnopUSXj" : "clZrLcsG7hUbM3W"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quaeratvelit",
-  "doi" : "https://doi.org/10.1234/voluptatibus",
+  "handle" : "https://www.example.org/doloribusitaque",
+  "doi" : "https://doi.org/10.1234/ad",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "8nirjCgLh34eSVGZRc",
-      "author" : "1mUqP9x5yFSEuwbjTu",
+      "text" : "epxpT0uuri1lTVSaTzy",
+      "author" : "hUV3nnIy2YWFnxfj",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/eaquequia",
+  "link" : "https://www.example.org/delenitidicta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GkiBRy2Fi102",
+    "mainTitle" : "e04sZEfkiYhBSKSTZ",
     "alternativeTitles" : {
-      "zh" : "wjgFAdgAYvFFaY"
+      "ru" : "Tl35L17MYovTf7gi6"
     },
     "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "o2JRR6mOkV36KXhQy",
-      "month" : "Soi93BMMtnHyW5nEY",
-      "day" : "9WA680ZqvZMPhQ7d"
+      "year" : "Cw77YnIIxCggaFxD",
+      "month" : "2QWgKjGHgfjKf1DX86A",
+      "day" : "fZqJWMY5eOS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AlBkes4pAtTe7S",
-        "name" : "4IrT9LjlM9xg",
+        "id" : "https://www.example.com/yvFpuQhV8WFUKN",
+        "name" : "flrd3k1Vp5WR4",
         "nameType" : "Personal",
-        "orcId" : "EyQxGj59TQf",
-        "arpId" : "NNldNPkAt4"
+        "orcId" : "tIvLYISOYx",
+        "arpId" : "V6WtvFC48W0INySrSKe"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/58cIJwREJ4lIta",
+        "id" : "https://www.example.com/Bgo0nxakoUe98",
         "labels" : {
-          "ExBhfX38mcMt" : "VTkVKStuOE8x"
+          "Se0ku3Q2eKgzBC" : "hTtnG0AIn6B632"
         }
       } ],
-      "role" : "ProjectMember",
+      "role" : "Sponsor",
       "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wkYBjinyAWu",
-        "name" : "pZmuZGzZ6SRhwCsSFme",
+        "id" : "https://www.example.com/j2GEuzklnuGv",
+        "name" : "Dp7WfAiBvgSQmeldNA",
         "nameType" : "Personal",
-        "orcId" : "ppaiS8JhPCw1VE",
-        "arpId" : "Dp1mM39dTikRtFVEf"
+        "orcId" : "GvyLeFpHBb",
+        "arpId" : "kqGErHx3QM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FqbF3PJjvUegS6pgMp7",
+        "id" : "https://www.example.com/W34c0clE1wHebY46F",
         "labels" : {
-          "MBVLGxGx4Rd99XOqs" : "JXqVpkAnJcT1jEr9hw2"
+          "wcByoUuLuPcY" : "WsOP2lZDuNirJTxq"
         }
       } ],
       "role" : "Editor",
-      "sequence" : 1,
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "GyryZPt9CeUHMQ",
-    "tags" : [ "c19qJ8CuZjpralKK" ],
-    "description" : "fW72Uj1zgZ",
+    "npiSubjectHeading" : "WNl2tG4ZYZtIOo",
+    "tags" : [ "voDiPf0d9MJ" ],
+    "description" : "rLvgc7Fp708fGn7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PcgbOjOneGr3XWPHO"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9sGssNII5pYI8qRmwu"
       },
-      "doi" : "https://www.example.com/mrQdyurc8z1tW",
+      "doi" : "https://www.example.com/rZkSow8aZEO6",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "p1MiHj03K8",
-        "issue" : "H3X5jPz9VM6Vbe",
-        "articleNumber" : "4qaNxocfy9dS",
+        "volume" : "QpU8toDB98Fn5Re0",
+        "issue" : "CA6Y8bB8y3hlxl",
+        "articleNumber" : "DmHBWM89ey2hsq1n",
         "pages" : {
           "type" : "Range",
-          "begin" : "3LYyPXrPP2KrM",
-          "end" : "GDFkkEvKtO"
+          "begin" : "ixAghdiFHkPa7WKD1f",
+          "end" : "H0YAoOYYrVSMVU"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/j5IqcKFMcB",
-    "abstract" : "AkMDWAevRXeq"
+    "metadataSource" : "https://www.example.com/UKdmPvjRq2EQQ7",
+    "abstract" : "dLU1sOkHvfmn5M"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "2LujiM5gua",
-      "mimeType" : "xF9C0ZCeIQj2V",
-      "size" : 485333305,
+      "name" : "xQW7WR8qST1bU3sqk86",
+      "mimeType" : "DnEDiWu5iBe1d6",
+      "size" : 1915281206,
       "license" : {
         "type" : "License",
-        "identifier" : "cnseLZaK5myZ",
+        "identifier" : "vyUliArRSZxjk2sYoL",
         "labels" : {
-          "7FPSRA4MA4NF1mVdZCI" : "VQdJpVU4YL6Sb9gWnxp"
+          "daXp0KHPT5ZkHp" : "19Y94XyRQVCUF0cY"
         },
-        "link" : "https://www.example.com/d7a0Wt0YFn6ZFqf"
+        "link" : "https://www.example.com/tDBHagmo1fpBNJrAK"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequatursaepe",
-    "name" : "7iLUJd9Z8qO",
+    "id" : "https://www.example.org/beataereprehenderit",
+    "name" : "MzBB5pIQIUI97XSx",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "PTI9YgDNWyme",
-      "id" : "By6l5ZsxQ3bXva75"
+      "source" : "1NY1Eb8pNUyT3Gw",
+      "id" : "prW1SSZ6YfKnI510Ce6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "gFiUY3UlFF77kSgd"
+      "applicationCode" : "gj7A8WLGWzZoErJGHE"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/estrerum" ],
+  "subjects" : [ "https://www.example.org/utsed" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "FCdEdBWKJf4iDtqTHDi",
+  "status" : "DRAFT",
+  "owner" : "Y1dTAIj8oUDl",
   "resourceOwner" : {
-    "owner" : "FCdEdBWKJf4iDtqTHDi",
-    "ownerAffiliation" : "https://www.example.org/quidemquam"
+    "owner" : "Y1dTAIj8oUDl",
+    "ownerAffiliation" : "https://www.example.org/veritatisrem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/corruptifuga",
+    "id" : "https://www.example.org/autemfugit",
     "labels" : {
-      "K6UWBAUrk1ENouLIML" : "i4yA3L1w9jpFkrrp"
+      "MUs2vfZfWhvU" : "T7Ttbt5aKXfWrga"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/iurevoluptatem",
-  "doi" : "https://doi.org/10.1234/cum",
+  "handle" : "https://www.example.org/commodierror",
+  "doi" : "https://doi.org/10.1234/impedit",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,128 +27,128 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "ZulxILT71yGZXd",
-      "author" : "4UtAIKaMrURTFwSq",
+      "text" : "OTjPbyyRS4w",
+      "author" : "oFjq7DVtBYv6p",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quiaut",
+  "link" : "https://www.example.org/teneturab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "54NhjdDpGe1r",
+    "mainTitle" : "6IZ6I3Xx5wSfzQzd",
     "alternativeTitles" : {
-      "pt" : "rSDf92G7Cky49"
+      "hu" : "LZAYkLosfADpNo5v"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4E5kVZsrVHuDfxBlEa",
-      "month" : "tFIrzWdrj8as",
-      "day" : "4qdM2pR7cQqPuz"
+      "year" : "32j53fMxFZS6Xck",
+      "month" : "FbUpvMHAuncZZxNRI",
+      "day" : "jrYL6hosIj4HUaO1A"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HRI9kHu0p59Xd",
-        "name" : "10wgmyxKD4ymth2",
-        "nameType" : "Personal",
-        "orcId" : "vyCYELKq2yPSdprd",
-        "arpId" : "4zBvgL87UbI7gOx"
+        "id" : "https://www.example.com/6sL1GDOOjnrRSWl2",
+        "name" : "OeqxfCKk9Ny1pOKLb4",
+        "nameType" : "Organizational",
+        "orcId" : "10OBDTdBEom4sc2",
+        "arpId" : "LeXLVnGirEHQ6MB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/J83I8NJhELSNK",
+        "id" : "https://www.example.com/a5yMLTLrM7MIPqFtD",
         "labels" : {
-          "ggDn3ok2ojTg6FiJvl" : "5wzX5kS2c9SDUyArzb"
+          "T83GS6KYRTlcfVMJ" : "WTaWlp6yyDPPBL"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 9,
+      "role" : "DataCollector",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Zh8Tza1stJ3sqy",
-        "name" : "DVVde5MNhLdc2J",
+        "id" : "https://www.example.com/FSmB154vXB3h3wfkKbr",
+        "name" : "kOmY0aAqauy5",
         "nameType" : "Personal",
-        "orcId" : "BpqKchl90neF5vLRrBC",
-        "arpId" : "SjVmlzhAb5GFo"
+        "orcId" : "utfHsAuelzjvBQE2",
+        "arpId" : "jBpBDdir0ouK5b"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VkGLZidKraZ3iwZglrX",
+        "id" : "https://www.example.com/nSzaBd5Yq3rjuxr9Vm",
         "labels" : {
-          "5ugieWitSsN8" : "ZL4jAv2Vj53med9nvx4"
+          "qL8byow8Zzfh0l" : "nCtVjFgRSj"
         }
       } ],
-      "role" : "Other",
+      "role" : "Illustrator",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "IRiF40bA3Q9D4d",
-    "tags" : [ "pOeMs70vrK" ],
-    "description" : "BkN1c1OLYg",
+    "npiSubjectHeading" : "Wq4iFR8Inyack5C",
+    "tags" : [ "9vD0V9usyNggp" ],
+    "description" : "zIycvE9uNVXsI0iD8tL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BJdhukm9Rl8SranLsf"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2a6IhlJ5Uw"
       },
-      "doi" : "https://www.example.com/MkXPcWgtDPi4",
+      "doi" : "https://www.example.com/20L4nq6rbkDrxhUYG",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "VF7rbnuzBxNLrSrq",
-        "issue" : "21qAoQKgwxtNL4cSue",
-        "articleNumber" : "dUtGyrGVYW39wEhb",
+        "volume" : "Boi3KoeXUdF3a0",
+        "issue" : "zwyl2zz8e6MJ0lXm",
+        "articleNumber" : "piqMkdxOo3CnbpY",
         "pages" : {
           "type" : "Range",
-          "begin" : "e3irEz7KapmJM8Y5qQc",
-          "end" : "kEs9yLWlQ49"
+          "begin" : "W9c777Bsdo8",
+          "end" : "gNVc7ALMQXz7"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Hg1HlWKmLGoFdUNpPQV",
-    "abstract" : "S86VoUlfow7zZFQINf"
+    "metadataSource" : "https://www.example.com/1jMYIjcpVRD8vwo",
+    "abstract" : "u9zD4CZgn0kPekEdu2"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "pfysJXZCHzM99O",
-      "mimeType" : "NZiE9irz1dUbUE6C2t",
-      "size" : 1849232484,
+      "name" : "fQ6VLdnvTJVOeC",
+      "mimeType" : "103o6bEaAejjByuT",
+      "size" : 1284092764,
       "license" : {
         "type" : "License",
-        "identifier" : "bUkAUklRvRz2fMjTWH",
+        "identifier" : "hu6OcHmy07gXMrT4bsr",
         "labels" : {
-          "5Eg1XpmnLrlRZcG1d" : "zEJD9x0ZY2PejfA"
+          "A97MTohgOYgE" : "XPJCUDztanRyIqDnkaQ"
         },
-        "link" : "https://www.example.com/FxxOHhrzB6iNUzgOcX"
+        "link" : "https://www.example.com/uFLjiF9oUB3"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utsit",
-    "name" : "1qPcaw3ENEKe",
+    "id" : "https://www.example.org/laudantiumvel",
+    "name" : "M1L5jhE8eg2IuVb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "IAnu3yTZVbciSU",
-      "id" : "lfRvM3Z39jO"
+      "source" : "WizlPv0h3DRO2wQa6",
+      "id" : "QjVLzDQQ7KmvCP"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "pEHQxKFMGcY7GtKvo2"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "hLFw4DAwPDCZ3eTEy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/optiohic" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/etquasi" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "Y1dTAIj8oUDl",
+  "status" : "PUBLISHED",
+  "owner" : "zQKrAbd09TppL",
   "resourceOwner" : {
-    "owner" : "Y1dTAIj8oUDl",
-    "ownerAffiliation" : "https://www.example.org/veritatisrem"
+    "owner" : "zQKrAbd09TppL",
+    "ownerAffiliation" : "https://www.example.org/officiissit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemfugit",
+    "id" : "https://www.example.org/solutaconsequuntur",
     "labels" : {
-      "MUs2vfZfWhvU" : "T7Ttbt5aKXfWrga"
+      "MB1WRHXHHeriX" : "87vT9SkuFo51LbVvkAe"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/commodierror",
-  "doi" : "https://doi.org/10.1234/impedit",
+  "handle" : "https://www.example.org/faceredeserunt",
+  "doi" : "https://doi.org/10.1234/et",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,107 +27,107 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "OTjPbyyRS4w",
-      "author" : "oFjq7DVtBYv6p",
+      "text" : "5daLshXpVkKZmKtdcK8",
+      "author" : "jUvIWCsaNsC",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/teneturab",
+  "link" : "https://www.example.org/sitnihil",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6IZ6I3Xx5wSfzQzd",
+    "mainTitle" : "mIZqD0ay7CaSX",
     "alternativeTitles" : {
-      "hu" : "LZAYkLosfADpNo5v"
+      "nl" : "9ZRb95woFMfVzG"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "32j53fMxFZS6Xck",
-      "month" : "FbUpvMHAuncZZxNRI",
-      "day" : "jrYL6hosIj4HUaO1A"
+      "year" : "9sFnE5VrS5pkUfvcy",
+      "month" : "CVZtK723CNAv",
+      "day" : "xFu0nxpOsfsYS8YKiyb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/6sL1GDOOjnrRSWl2",
-        "name" : "OeqxfCKk9Ny1pOKLb4",
+        "id" : "https://www.example.com/FvD3FkHyq0jzukE8",
+        "name" : "5qsUu75RSMxWBJCFPc6",
         "nameType" : "Organizational",
-        "orcId" : "10OBDTdBEom4sc2",
-        "arpId" : "LeXLVnGirEHQ6MB"
+        "orcId" : "YFcVEcmSDH",
+        "arpId" : "TwOGMJNdOA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/a5yMLTLrM7MIPqFtD",
+        "id" : "https://www.example.com/N1I0X0puHt7ytEICV",
         "labels" : {
-          "T83GS6KYRTlcfVMJ" : "WTaWlp6yyDPPBL"
+          "9LSyxTpNIlOtzce6Vu" : "0jJQWubchi2nLukYq"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 3,
+      "role" : "RightsHolder",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FSmB154vXB3h3wfkKbr",
-        "name" : "kOmY0aAqauy5",
-        "nameType" : "Personal",
-        "orcId" : "utfHsAuelzjvBQE2",
-        "arpId" : "jBpBDdir0ouK5b"
+        "id" : "https://www.example.com/oUeW1hNew5krCFE",
+        "name" : "xdLn06hkoD",
+        "nameType" : "Organizational",
+        "orcId" : "b9o9BN7lEfglBF4z",
+        "arpId" : "Gc8rDEo457peT5dfKgh"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/nSzaBd5Yq3rjuxr9Vm",
+        "id" : "https://www.example.com/2Hgj2Vwbn6UHR",
         "labels" : {
-          "qL8byow8Zzfh0l" : "nCtVjFgRSj"
+          "T2d5C9n2bm5uX" : "esDYZRa76RRBpVIxqA"
         }
       } ],
-      "role" : "Illustrator",
+      "role" : "Journalist",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Wq4iFR8Inyack5C",
-    "tags" : [ "9vD0V9usyNggp" ],
-    "description" : "zIycvE9uNVXsI0iD8tL",
+    "npiSubjectHeading" : "2oSA2OyZNYK8Hy",
+    "tags" : [ "6qBtBYwqO1wbfJ" ],
+    "description" : "odGm1Se7scjJb81",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2a6IhlJ5Uw"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CDeEr4TbmFBG"
       },
-      "doi" : "https://www.example.com/20L4nq6rbkDrxhUYG",
+      "doi" : "https://www.example.com/weYYwTE1lMZzkkjEQF",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "Boi3KoeXUdF3a0",
-        "issue" : "zwyl2zz8e6MJ0lXm",
-        "articleNumber" : "piqMkdxOo3CnbpY",
+        "volume" : "rtsyi5nWyLDoD2DYE",
+        "issue" : "UYTpIwTsqrmKRlmkyQ",
+        "articleNumber" : "5DedSOwdUpLw",
         "pages" : {
           "type" : "Range",
-          "begin" : "W9c777Bsdo8",
-          "end" : "gNVc7ALMQXz7"
+          "begin" : "Kp6V7GG7WUgG7T9PB",
+          "end" : "45sSOM4ocEeytqNDsE"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/1jMYIjcpVRD8vwo",
-    "abstract" : "u9zD4CZgn0kPekEdu2"
+    "metadataSource" : "https://www.example.com/9HzxkL7NKwG83LkI5jC",
+    "abstract" : "9ExfmLxBA2kh1H0B"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "fQ6VLdnvTJVOeC",
-      "mimeType" : "103o6bEaAejjByuT",
-      "size" : 1284092764,
+      "name" : "yGmuVcfbNB74D2m",
+      "mimeType" : "vhkBXrjgSaILEkA05",
+      "size" : 84492173,
       "license" : {
         "type" : "License",
-        "identifier" : "hu6OcHmy07gXMrT4bsr",
+        "identifier" : "ywsWquiBpUl",
         "labels" : {
-          "A97MTohgOYgE" : "XPJCUDztanRyIqDnkaQ"
+          "GkvePrNCx0naWrSoSl" : "gInSj0pImGKmOD"
         },
-        "link" : "https://www.example.com/uFLjiF9oUB3"
+        "link" : "https://www.example.com/dW4JTpWXKh"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laudantiumvel",
-    "name" : "M1L5jhE8eg2IuVb",
+    "id" : "https://www.example.org/voluptatemet",
+    "name" : "p8C3ugLlooQJm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "WizlPv0h3DRO2wQa6",
-      "id" : "QjVLzDQQ7KmvCP"
+      "source" : "ZJn3NZLpoI2NdQoe",
+      "id" : "kRALgqbmykAYl"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "hLFw4DAwPDCZ3eTEy"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "B3u1axrsvpiS"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etquasi" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/veroaut" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "1QMXSgDWK4IWKa",
+  "status" : "DRAFT",
+  "owner" : "lHXif17Sdw3OAq",
   "resourceOwner" : {
-    "owner" : "1QMXSgDWK4IWKa",
-    "ownerAffiliation" : "https://www.example.org/sedqui"
+    "owner" : "lHXif17Sdw3OAq",
+    "ownerAffiliation" : "https://www.example.org/quiinventore"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorumfugiat",
+    "id" : "https://www.example.org/laborumvoluptates",
     "labels" : {
-      "abmPaONuTLMnopUSXj" : "clZrLcsG7hUbM3W"
+      "wb8BtJa3cgYD1YX" : "yfuKBholOZwmr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/doloribusitaque",
-  "doi" : "https://doi.org/10.1234/ad",
+  "handle" : "https://www.example.org/eaquos",
+  "doi" : "https://doi.org/10.1234/dolorem",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,128 +27,128 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "epxpT0uuri1lTVSaTzy",
-      "author" : "hUV3nnIy2YWFnxfj",
+      "text" : "M2xaytlDrHRsxw13FKW",
+      "author" : "YwmJZ33H0S2bqF1By",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/delenitidicta",
+  "link" : "https://www.example.org/doloribusrepellat",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "e04sZEfkiYhBSKSTZ",
+    "mainTitle" : "AOXTTaXScL4XZy0z8W",
     "alternativeTitles" : {
-      "ru" : "Tl35L17MYovTf7gi6"
+      "bg" : "wL4Za3qF8MYR"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Cw77YnIIxCggaFxD",
-      "month" : "2QWgKjGHgfjKf1DX86A",
-      "day" : "fZqJWMY5eOS"
+      "year" : "c1R3Ba7hogmPryz4",
+      "month" : "ynlRfY8EubmsRaOm5Z",
+      "day" : "1YZoZX99Xfu74vy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/yvFpuQhV8WFUKN",
-        "name" : "flrd3k1Vp5WR4",
-        "nameType" : "Personal",
-        "orcId" : "tIvLYISOYx",
-        "arpId" : "V6WtvFC48W0INySrSKe"
+        "id" : "https://www.example.com/O1LyWY9SUjQw",
+        "name" : "DlgxbeH2bl",
+        "nameType" : "Organizational",
+        "orcId" : "1wS0N6ENqG4LAy",
+        "arpId" : "FEA26pKTWYTscc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Bgo0nxakoUe98",
+        "id" : "https://www.example.com/ngegksN93GAp",
         "labels" : {
-          "Se0ku3Q2eKgzBC" : "hTtnG0AIn6B632"
+          "4sbZTfpCB8EqPSOoE" : "YjXAsp8hXdDnv0"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 7,
+      "role" : "Editor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/j2GEuzklnuGv",
-        "name" : "Dp7WfAiBvgSQmeldNA",
+        "id" : "https://www.example.com/9Dj1K6PYTiM",
+        "name" : "bIUqw0SwpM",
         "nameType" : "Personal",
-        "orcId" : "GvyLeFpHBb",
-        "arpId" : "kqGErHx3QM"
+        "orcId" : "09g04EFbLpdVBGEeK",
+        "arpId" : "1iSseFq7Wi"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/W34c0clE1wHebY46F",
+        "id" : "https://www.example.com/rTweldJOZ04i",
         "labels" : {
-          "wcByoUuLuPcY" : "WsOP2lZDuNirJTxq"
+          "VzcuBANIsI" : "88Wub7qeUTfez"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 9,
+      "role" : "CuratorOrganizer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "WNl2tG4ZYZtIOo",
-    "tags" : [ "voDiPf0d9MJ" ],
-    "description" : "rLvgc7Fp708fGn7",
+    "npiSubjectHeading" : "QLUKOGNriON7Z",
+    "tags" : [ "KACe39clSO8zKL" ],
+    "description" : "h6N0gt9hHHXrCUem",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9sGssNII5pYI8qRmwu"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hKt73juBJVAZfDg"
       },
-      "doi" : "https://www.example.com/rZkSow8aZEO6",
+      "doi" : "https://www.example.com/RJaBJu6glxl4oH61",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "QpU8toDB98Fn5Re0",
-        "issue" : "CA6Y8bB8y3hlxl",
-        "articleNumber" : "DmHBWM89ey2hsq1n",
+        "volume" : "hgWXwFdy6yQ",
+        "issue" : "XMWVxOdJlRYV",
+        "articleNumber" : "aDj1d8PVZoU",
         "pages" : {
           "type" : "Range",
-          "begin" : "ixAghdiFHkPa7WKD1f",
-          "end" : "H0YAoOYYrVSMVU"
+          "begin" : "FnFAEIJaXqj",
+          "end" : "hicxyRVrbMLj"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/UKdmPvjRq2EQQ7",
-    "abstract" : "dLU1sOkHvfmn5M"
+    "metadataSource" : "https://www.example.com/HKH6Gl0TrZ9OTd",
+    "abstract" : "gitdJaFVH50igvMpa"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "xQW7WR8qST1bU3sqk86",
-      "mimeType" : "DnEDiWu5iBe1d6",
-      "size" : 1915281206,
+      "name" : "iMIzw8dzsXQvU4SP",
+      "mimeType" : "ogL9hJ9DQdsi7UvwB1",
+      "size" : 453692604,
       "license" : {
         "type" : "License",
-        "identifier" : "vyUliArRSZxjk2sYoL",
+        "identifier" : "qXHrfJJALm49E2IJSHs",
         "labels" : {
-          "daXp0KHPT5ZkHp" : "19Y94XyRQVCUF0cY"
+          "5WFEBmc8y37tUQbc" : "hr7k7CZXXX7"
         },
-        "link" : "https://www.example.com/tDBHagmo1fpBNJrAK"
+        "link" : "https://www.example.com/zieOUE8QQthP8AJ7fu"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/beataereprehenderit",
-    "name" : "MzBB5pIQIUI97XSx",
+    "id" : "https://www.example.org/consecteturrecusandae",
+    "name" : "CaHSj3GTL0pbQA2tP9",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "1NY1Eb8pNUyT3Gw",
-      "id" : "prW1SSZ6YfKnI510Ce6"
+      "source" : "8CNWisD6ThT",
+      "id" : "m04wLArcwb9S"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "gj7A8WLGWzZoErJGHE"
+      "applicationCode" : "JK19qZ3vBKL4n"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/utsed" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/inciduntsint" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "zQKrAbd09TppL",
+  "status" : "DRAFT",
+  "owner" : "hNZzKJUS5ZPk3e",
   "resourceOwner" : {
-    "owner" : "zQKrAbd09TppL",
-    "ownerAffiliation" : "https://www.example.org/officiissit"
+    "owner" : "hNZzKJUS5ZPk3e",
+    "ownerAffiliation" : "https://www.example.org/quaeratcupiditate"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/solutaconsequuntur",
+    "id" : "https://www.example.org/saepereiciendis",
     "labels" : {
-      "MB1WRHXHHeriX" : "87vT9SkuFo51LbVvkAe"
+      "XgB7kp2BVV" : "7HgGcueQwlo"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/faceredeserunt",
-  "doi" : "https://doi.org/10.1234/et",
+  "handle" : "https://www.example.org/quaeratvelit",
+  "doi" : "https://doi.org/10.1234/voluptatibus",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "5daLshXpVkKZmKtdcK8",
-      "author" : "jUvIWCsaNsC",
+      "text" : "8nirjCgLh34eSVGZRc",
+      "author" : "1mUqP9x5yFSEuwbjTu",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/sitnihil",
+  "link" : "https://www.example.org/eaquequia",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mIZqD0ay7CaSX",
+    "mainTitle" : "GkiBRy2Fi102",
     "alternativeTitles" : {
-      "nl" : "9ZRb95woFMfVzG"
+      "zh" : "wjgFAdgAYvFFaY"
     },
-    "language" : "http://lexvo.org/id/iso639-3/hun",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "9sFnE5VrS5pkUfvcy",
-      "month" : "CVZtK723CNAv",
-      "day" : "xFu0nxpOsfsYS8YKiyb"
+      "year" : "o2JRR6mOkV36KXhQy",
+      "month" : "Soi93BMMtnHyW5nEY",
+      "day" : "9WA680ZqvZMPhQ7d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FvD3FkHyq0jzukE8",
-        "name" : "5qsUu75RSMxWBJCFPc6",
-        "nameType" : "Organizational",
-        "orcId" : "YFcVEcmSDH",
-        "arpId" : "TwOGMJNdOA"
+        "id" : "https://www.example.com/AlBkes4pAtTe7S",
+        "name" : "4IrT9LjlM9xg",
+        "nameType" : "Personal",
+        "orcId" : "EyQxGj59TQf",
+        "arpId" : "NNldNPkAt4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/N1I0X0puHt7ytEICV",
+        "id" : "https://www.example.com/58cIJwREJ4lIta",
         "labels" : {
-          "9LSyxTpNIlOtzce6Vu" : "0jJQWubchi2nLukYq"
+          "ExBhfX38mcMt" : "VTkVKStuOE8x"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 0,
+      "role" : "ProjectMember",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oUeW1hNew5krCFE",
-        "name" : "xdLn06hkoD",
-        "nameType" : "Organizational",
-        "orcId" : "b9o9BN7lEfglBF4z",
-        "arpId" : "Gc8rDEo457peT5dfKgh"
+        "id" : "https://www.example.com/wkYBjinyAWu",
+        "name" : "pZmuZGzZ6SRhwCsSFme",
+        "nameType" : "Personal",
+        "orcId" : "ppaiS8JhPCw1VE",
+        "arpId" : "Dp1mM39dTikRtFVEf"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/2Hgj2Vwbn6UHR",
+        "id" : "https://www.example.com/FqbF3PJjvUegS6pgMp7",
         "labels" : {
-          "T2d5C9n2bm5uX" : "esDYZRa76RRBpVIxqA"
+          "MBVLGxGx4Rd99XOqs" : "JXqVpkAnJcT1jEr9hw2"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 4,
+      "role" : "Editor",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "2oSA2OyZNYK8Hy",
-    "tags" : [ "6qBtBYwqO1wbfJ" ],
-    "description" : "odGm1Se7scjJb81",
+    "npiSubjectHeading" : "GyryZPt9CeUHMQ",
+    "tags" : [ "c19qJ8CuZjpralKK" ],
+    "description" : "fW72Uj1zgZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CDeEr4TbmFBG"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PcgbOjOneGr3XWPHO"
       },
-      "doi" : "https://www.example.com/weYYwTE1lMZzkkjEQF",
+      "doi" : "https://www.example.com/mrQdyurc8z1tW",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "rtsyi5nWyLDoD2DYE",
-        "issue" : "UYTpIwTsqrmKRlmkyQ",
-        "articleNumber" : "5DedSOwdUpLw",
+        "volume" : "p1MiHj03K8",
+        "issue" : "H3X5jPz9VM6Vbe",
+        "articleNumber" : "4qaNxocfy9dS",
         "pages" : {
           "type" : "Range",
-          "begin" : "Kp6V7GG7WUgG7T9PB",
-          "end" : "45sSOM4ocEeytqNDsE"
+          "begin" : "3LYyPXrPP2KrM",
+          "end" : "GDFkkEvKtO"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/9HzxkL7NKwG83LkI5jC",
-    "abstract" : "9ExfmLxBA2kh1H0B"
+    "metadataSource" : "https://www.example.com/j5IqcKFMcB",
+    "abstract" : "AkMDWAevRXeq"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yGmuVcfbNB74D2m",
-      "mimeType" : "vhkBXrjgSaILEkA05",
-      "size" : 84492173,
+      "name" : "2LujiM5gua",
+      "mimeType" : "xF9C0ZCeIQj2V",
+      "size" : 485333305,
       "license" : {
         "type" : "License",
-        "identifier" : "ywsWquiBpUl",
+        "identifier" : "cnseLZaK5myZ",
         "labels" : {
-          "GkvePrNCx0naWrSoSl" : "gInSj0pImGKmOD"
+          "7FPSRA4MA4NF1mVdZCI" : "VQdJpVU4YL6Sb9gWnxp"
         },
-        "link" : "https://www.example.com/dW4JTpWXKh"
+        "link" : "https://www.example.com/d7a0Wt0YFn6ZFqf"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemet",
-    "name" : "p8C3ugLlooQJm",
+    "id" : "https://www.example.org/consequatursaepe",
+    "name" : "7iLUJd9Z8qO",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZJn3NZLpoI2NdQoe",
-      "id" : "kRALgqbmykAYl"
+      "source" : "PTI9YgDNWyme",
+      "id" : "By6l5ZsxQ3bXva75"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "B3u1axrsvpiS"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "gFiUY3UlFF77kSgd"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veroaut" ],
+  "subjects" : [ "https://www.example.org/estrerum" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "b4EnQ5Rw7dVY68NSt1m",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "oF8w9EuqPnQ1TUZj61T",
   "resourceOwner" : {
-    "owner" : "b4EnQ5Rw7dVY68NSt1m",
-    "ownerAffiliation" : "https://www.example.org/utdeleniti"
+    "owner" : "oF8w9EuqPnQ1TUZj61T",
+    "ownerAffiliation" : "https://www.example.org/esseex"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nobisquod",
+    "id" : "https://www.example.org/abblanditiis",
     "labels" : {
-      "TcLAmOMWRRfycRUMmi" : "Zjj778x01S7"
+      "cpYoMRA1pOrZUzF0mD" : "cERDwdprVGbL"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/temporenisi",
-  "doi" : "https://doi.org/10.1234/quo",
+  "handle" : "https://www.example.org/maximesed",
+  "doi" : "https://doi.org/10.1234/ratione",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,130 +27,130 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "G5nl3XSn6hM73djS",
-      "author" : "HHZibtc8uhav1omNsmb",
+      "text" : "VDhdEDRoHfs88",
+      "author" : "yFadgSqIidI",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/harumut",
+  "link" : "https://www.example.org/architectodicta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WSTAptmUVyImG238",
+    "mainTitle" : "cj1vK2k1Pc9g29ysQS",
     "alternativeTitles" : {
-      "da" : "DllyKkXtbnih"
+      "ca" : "c9pyaVOwqWrjQsv"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4mksLlvzfNkR4MS",
-      "month" : "tKZGR7yxDcFXThRwcMM",
-      "day" : "uRhS3kgtf1xx0J"
+      "year" : "vG9uF378V6cEnf",
+      "month" : "JTQs4CHPnu",
+      "day" : "48idTsb36mUsGsnhhj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Sk0aTXtl8TKXhqAYH",
-        "name" : "cQPl1RxVqQ2",
+        "id" : "https://www.example.com/aOOIhpavslkiRuF",
+        "name" : "FhnGLcJUyjs7hxHm",
         "nameType" : "Organizational",
-        "orcId" : "dlTIK5xooidwK0BlSXD",
-        "arpId" : "rao8SoSTwJyXXqtN1"
+        "orcId" : "Ig0UKwQmFt",
+        "arpId" : "VWeTWCbOMrxE1mY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/R7i17pP6S7uA",
+        "id" : "https://www.example.com/ZZQwYZODMDl",
         "labels" : {
-          "A81QyKeA1H1QsJir" : "umr7FUiD3Gu70AQyG"
+          "V0ES2kU6bdbqB" : "nUY6mEFMwAB91Sbg"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 3,
+      "role" : "RegistrationAgency",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KKg5oaEYuQYOH",
-        "name" : "jgwD8X9cxFk8vg4nx",
-        "nameType" : "Organizational",
-        "orcId" : "at4fPyImtIvMRe",
-        "arpId" : "3KkaZTr95l"
+        "id" : "https://www.example.com/aFzfA7tah9666M",
+        "name" : "4QJHCMVbv0T0FB",
+        "nameType" : "Personal",
+        "orcId" : "HKd1bGXjPhHO2WljkOI",
+        "arpId" : "lRcoVj9zovewdLADWWY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/isohyPYQOn69IX77",
+        "id" : "https://www.example.com/507khpCiq6CqV5M2",
         "labels" : {
-          "JKvmHYuLG9vcZF" : "IlihMIYb12"
+          "PpmtLLAlLHDVcD" : "Rnt6L2bPILyZFJwy3"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 3,
+      "role" : "RelatedPerson",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "mJ1a6jKIs4aU",
-    "tags" : [ "O7Nk0m9QdwF" ],
-    "description" : "EMT3iQeLyX7P9PWAJ",
+    "npiSubjectHeading" : "BEFvudO2KIitf2ZF",
+    "tags" : [ "sGTbtoME5S8JoHDgN" ],
+    "description" : "zGKotIaasD6KFgme7HZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JpjorHgzmpZla5"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aVGlPXPAk8VnWNbWzqP"
       },
-      "doi" : "https://www.example.com/5UpWUWP9QiZWYP",
+      "doi" : "https://www.example.com/rMkamqSdYA",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "HJTfG5pn6Zr4n",
-        "issue" : "ik2miTdvXP7enh",
-        "articleNumber" : "BIR7myopGThUspdtBN7",
-        "contentType" : "Case report",
+        "volume" : "C1diGziGpG",
+        "issue" : "4y2MUAl7zEgbR",
+        "articleNumber" : "Vz5HlRgIpKoBQt2S",
+        "contentType" : "Popular science article",
         "peerReviewed" : false,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "UuqZHBhKb37",
-          "end" : "D7o5Cd1pd4AsXlJ9N4"
+          "begin" : "xvFdl5iRSyaYGjA0Y",
+          "end" : "Jyv6dNhw43Z3"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/fzd3EOlklaedT",
-    "abstract" : "pu3EVMKUMZq"
+    "metadataSource" : "https://www.example.com/XeGZFxfyUB3",
+    "abstract" : "JS4jl7gNwO6Dd"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "9cApVzzWHQXuxEN",
-      "mimeType" : "XFY9H3PEZAT",
-      "size" : 1460867371,
+      "name" : "sajFolvzWP",
+      "mimeType" : "ril7dMn29SthJq3EKs",
+      "size" : 1000307275,
       "license" : {
         "type" : "License",
-        "identifier" : "Lln9GwLJZ6BclVZ",
+        "identifier" : "0EJJtm8TDL0",
         "labels" : {
-          "v0yJ8KCsZdf" : "kHBvFFDKaX3snQNI"
+          "Wrm9aaRrqh" : "7ZqKunB7OfZ4"
         },
-        "link" : "https://www.example.com/0Xbuu3YTPYetyqWj"
+        "link" : "https://www.example.com/h3uc7Ws0oo2"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+      "embargoDate" : "1980-06-16T17:47:07Z"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloremtotam",
-    "name" : "ZWh9EmKNvRfP5",
+    "id" : "https://www.example.org/eumeligendi",
+    "name" : "9dP4DpCMePyIl1sDv",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "l5wgdvS59nJNRMpEGg",
-      "id" : "VHceg0KF4rKQjWUe"
+      "source" : "kIjo7iC8NgMQkh2s7m",
+      "id" : "kNbSxfihiZAZU6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "lU8tlt276cgLNh4"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "3LSz7gMouc8bOJDu"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,6 +158,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delectusreprehenderit" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/perferendiset" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "Q5kgs0kuj6yxAOVXuRY",
+  "status" : "DRAFT",
+  "owner" : "a4hwsEDOoYt8",
   "resourceOwner" : {
-    "owner" : "Q5kgs0kuj6yxAOVXuRY",
-    "ownerAffiliation" : "https://www.example.org/quibusdamnobis"
+    "owner" : "a4hwsEDOoYt8",
+    "ownerAffiliation" : "https://www.example.org/quiaconsequatur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nullaadipisci",
+    "id" : "https://www.example.org/essequaerat",
     "labels" : {
-      "7w3ahnolGbaU" : "eq83bzldJdWM6nPh"
+      "gGBUceNEJ4e6" : "WmwzUUGfDSoC8A4W"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ettenetur",
-  "doi" : "https://doi.org/10.1234/sint",
+  "handle" : "https://www.example.org/rerumsit",
+  "doi" : "https://doi.org/10.1234/quia",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,109 +27,109 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "YYcM1wrBYVwA1cuDr1",
-      "author" : "J1QCOlCfiR2",
+      "text" : "rtOsDHUWST2RN",
+      "author" : "GltuXlgfkKHq77N54Bd",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/omnissunt",
+  "link" : "https://www.example.org/liberocum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yqRFqahLIsjef",
+    "mainTitle" : "Xxobq0v8BMrCrzAip",
     "alternativeTitles" : {
-      "nl" : "JTQnXImTrnI"
+      "nl" : "PyESzvUVKBp4A1Q7bo"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "B3y62wB61kYacSGGm",
-      "month" : "lk0Os9jpLoz9b8Nro",
-      "day" : "6QZXxX45ZM5X5g3Y"
+      "year" : "tlPP9IzhX9d3HSg",
+      "month" : "uHSuygWNaTXDtNY0g",
+      "day" : "Iu0QCSTAi41NGNpRI3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/StduCxoY4YOBOtEhLF",
-        "name" : "evnjmQlvONhfdtqu",
+        "id" : "https://www.example.com/Xyi53PxwYs2JMW0qGp",
+        "name" : "P2uaWxzy7Urh8daf",
         "nameType" : "Organizational",
-        "orcId" : "2Yi0cuYOlZTM",
-        "arpId" : "tilQUebyUNwM"
+        "orcId" : "YFbjUyDgKLfDMxk9",
+        "arpId" : "9S1Oh4tuc2vMEzw9YdK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/EDhpG1bazeX",
+        "id" : "https://www.example.com/xGvuCGE5Hb52c",
         "labels" : {
-          "ZKr0VvXqjgnrGR8Daj" : "HTSP3LJM27SvoKo9"
+          "1KOE4DEWVqoJpw3x0" : "woiIvtv6JI"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 7,
+      "role" : "ProjectLeader",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/10FzEssQ7Em",
-        "name" : "jh8bTKDH2enQR",
+        "id" : "https://www.example.com/W9BQ4EByDFXEBo",
+        "name" : "kuf0bIqUMQg",
         "nameType" : "Organizational",
-        "orcId" : "UmQb5SwNq5knH7p",
-        "arpId" : "FXDl5rH1LZ"
+        "orcId" : "Xk32I334RK2vKtIO60V",
+        "arpId" : "YsgebNMeww7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dsEv8tlcMScfipeN",
+        "id" : "https://www.example.com/LaLqdZCpg5RLosLDtPW",
         "labels" : {
-          "UNidhl9C8rhTN" : "2fygRvH71Ris"
+          "EW9M996ACiWCFLKp6w" : "h4AiOLWsZ3o"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 5,
+      "role" : "Funder",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "P0YJBKg2SM",
-    "tags" : [ "JN6SJZIlx0n92wJ" ],
-    "description" : "P2ajOpjpcFf",
+    "npiSubjectHeading" : "ZTOp2I34VPM2al1",
+    "tags" : [ "Hvo3551CcPtPJDtkSZ" ],
+    "description" : "1is417DmbHyVJOlvfh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9kCDN5ODNesrBFc"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PZbmjbbJ80dLil8"
       },
-      "doi" : "https://www.example.com/V3Vu9q9L8ErHNjLEWD",
+      "doi" : "https://www.example.com/IuOvR7VwjcXYKAQR5F2",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "lv5HSpgSVMk",
-        "issue" : "UDzJCgOX08nohn",
-        "articleNumber" : "vSgXYC7yvHopO7Km",
-        "contentType" : "Study protocol",
-        "peerReviewed" : false,
+        "volume" : "NwiZok3jEhjID",
+        "issue" : "gWNyJVKAC2WiAXSKgm",
+        "articleNumber" : "svqfPTX8qB",
+        "contentType" : "Case report",
+        "peerReviewed" : true,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "Usx8kbEIXmi9hEg",
-          "end" : "QnzhyTHMW4UWv7j"
+          "begin" : "gaRqElK1Oh0hpdH5",
+          "end" : "nPdAcR8Knepm8i0Dw"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/o5EK51p0ENNoAut",
-    "abstract" : "hZtYuEizgF94C"
+    "metadataSource" : "https://www.example.com/y9JY13aOUn",
+    "abstract" : "vPHyor1TbvGS6q2W"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "hd6e5woX5czLR",
-      "mimeType" : "bvn1UX3IYkIgqbTQcKv",
-      "size" : 1136988881,
+      "name" : "muA2VyBP3hCDC4FGg",
+      "mimeType" : "cRFdRraiKq",
+      "size" : 1343324320,
       "license" : {
         "type" : "License",
-        "identifier" : "oVN0yOziq7ksC0xY3k",
+        "identifier" : "lOnwKO0EFLijaB",
         "labels" : {
-          "a8mMJjGP0JcIts" : "inzB8wUDDSoWVCMyPAe"
+          "YPdbkQEXfiwxtU" : "l7TLg6lpNYthAQ"
         },
-        "link" : "https://www.example.com/VxzbCX8Id7NBUVzaK"
+        "link" : "https://www.example.com/9jyQurzwh7i0"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -138,19 +138,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/inciduntquisquam",
-    "name" : "9YblzZtkgrLQJsVHv51",
+    "id" : "https://www.example.org/excepturiperspiciatis",
+    "name" : "IoTwYQPygWoQ5",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SrLMgs3S1Ya",
-      "id" : "HhFlxkJPZ3R8a7y"
+      "source" : "CQJZ3zTWJfN6UltxX",
+      "id" : "KnuiEotPygVZjl"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "BwakMTmm11Ig7yiSM"
+      "applicationCode" : "MmB84QKyI18V"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,6 +158,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/idquis" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/quaminventore" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "a4hwsEDOoYt8",
+  "status" : "PUBLISHED",
+  "owner" : "axmiGtUL3Bp",
   "resourceOwner" : {
-    "owner" : "a4hwsEDOoYt8",
-    "ownerAffiliation" : "https://www.example.org/quiaconsequatur"
+    "owner" : "axmiGtUL3Bp",
+    "ownerAffiliation" : "https://www.example.org/atperferendis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/essequaerat",
+    "id" : "https://www.example.org/dolorummollitia",
     "labels" : {
-      "gGBUceNEJ4e6" : "WmwzUUGfDSoC8A4W"
+      "wZkEH0nFmwC" : "KoOFRbafq3h4"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/rerumsit",
-  "doi" : "https://doi.org/10.1234/quia",
+  "handle" : "https://www.example.org/esteos",
+  "doi" : "https://doi.org/10.1234/iusto",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,130 +27,130 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "rtOsDHUWST2RN",
-      "author" : "GltuXlgfkKHq77N54Bd",
+      "text" : "A35KKsR8VIe7tCaF",
+      "author" : "tTZY6CI4AAqW9",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/liberocum",
+  "link" : "https://www.example.org/sequieum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Xxobq0v8BMrCrzAip",
+    "mainTitle" : "4EFrQWaUvGbD0T8",
     "alternativeTitles" : {
-      "nl" : "PyESzvUVKBp4A1Q7bo"
+      "is" : "owvnWpk8t17Hra"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tlPP9IzhX9d3HSg",
-      "month" : "uHSuygWNaTXDtNY0g",
-      "day" : "Iu0QCSTAi41NGNpRI3"
+      "year" : "FmMYeCc1tQx",
+      "month" : "5csk8wjOWqjj",
+      "day" : "WLnjFLW5QTfINn1MExF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Xyi53PxwYs2JMW0qGp",
-        "name" : "P2uaWxzy7Urh8daf",
+        "id" : "https://www.example.com/q3NntBYNScXjr3kteC",
+        "name" : "6Hyn54wOxXBFWrvI",
         "nameType" : "Organizational",
-        "orcId" : "YFbjUyDgKLfDMxk9",
-        "arpId" : "9S1Oh4tuc2vMEzw9YdK"
+        "orcId" : "5PibXKT1NwItzOK",
+        "arpId" : "traRQXvyGAgdKz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xGvuCGE5Hb52c",
+        "id" : "https://www.example.com/PrMjkr9IVAcuoU",
         "labels" : {
-          "1KOE4DEWVqoJpw3x0" : "woiIvtv6JI"
+          "dOEH5HAz7hrpfbvNQN" : "6QublO2h0R"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 5,
+      "role" : "Creator",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/W9BQ4EByDFXEBo",
-        "name" : "kuf0bIqUMQg",
+        "id" : "https://www.example.com/tcLQVZKKQHIK8oIKld",
+        "name" : "3SqHLNnngCqlSociqbN",
         "nameType" : "Organizational",
-        "orcId" : "Xk32I334RK2vKtIO60V",
-        "arpId" : "YsgebNMeww7"
+        "orcId" : "3tC3v1SpeiJfTz9",
+        "arpId" : "oJoAE4OuvKQ7GrX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LaLqdZCpg5RLosLDtPW",
+        "id" : "https://www.example.com/Xc1NuR5reHo1M",
         "labels" : {
-          "EW9M996ACiWCFLKp6w" : "h4AiOLWsZ3o"
+          "i8GL4w4wur" : "GyZFTsd7d5ntaX"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 8,
+      "role" : "InterviewSubject",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ZTOp2I34VPM2al1",
-    "tags" : [ "Hvo3551CcPtPJDtkSZ" ],
-    "description" : "1is417DmbHyVJOlvfh",
+    "npiSubjectHeading" : "2kdQsq8GNL",
+    "tags" : [ "I4Bv3WNnqVTh" ],
+    "description" : "JU4pz5rgSZOCHtbW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PZbmjbbJ80dLil8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gHVgiW8cTnthHi"
       },
-      "doi" : "https://www.example.com/IuOvR7VwjcXYKAQR5F2",
+      "doi" : "https://www.example.com/QQfPmuEy34",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "NwiZok3jEhjID",
-        "issue" : "gWNyJVKAC2WiAXSKgm",
-        "articleNumber" : "svqfPTX8qB",
-        "contentType" : "Case report",
+        "volume" : "QP7Z1SoSHCh6ZzQm",
+        "issue" : "3Kz657NnguFacuQtR",
+        "articleNumber" : "8U7uhROkBv4O",
+        "contentType" : "Popular science article",
         "peerReviewed" : true,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "gaRqElK1Oh0hpdH5",
-          "end" : "nPdAcR8Knepm8i0Dw"
+          "begin" : "RXjEcFRnfh",
+          "end" : "XxLL5Wkw5GZN"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/y9JY13aOUn",
-    "abstract" : "vPHyor1TbvGS6q2W"
+    "metadataSource" : "https://www.example.com/AHsNUftITU6",
+    "abstract" : "O6saWnY2K2T"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "muA2VyBP3hCDC4FGg",
-      "mimeType" : "cRFdRraiKq",
-      "size" : 1343324320,
+      "name" : "tYqjMWklrMp8NzEq",
+      "mimeType" : "yyKxPDyGCbj1zAp",
+      "size" : 239115863,
       "license" : {
         "type" : "License",
-        "identifier" : "lOnwKO0EFLijaB",
+        "identifier" : "0nOjsFJl7JV",
         "labels" : {
-          "YPdbkQEXfiwxtU" : "l7TLg6lpNYthAQ"
+          "JBZPUAQxeJwlSphjAhR" : "CZqOWc3pC2aa"
         },
-        "link" : "https://www.example.com/9jyQurzwh7i0"
+        "link" : "https://www.example.com/9XldqmF9ckVkA44"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/excepturiperspiciatis",
-    "name" : "IoTwYQPygWoQ5",
+    "id" : "https://www.example.org/ipsaofficia",
+    "name" : "xizjYBDA7rV2ugU",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "CQJZ3zTWJfN6UltxX",
-      "id" : "KnuiEotPygVZjl"
+      "source" : "SRdMI7R6K5qJU0V",
+      "id" : "lZxawA5OyzE"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "MmB84QKyI18V"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "rJh35uVdjwf5"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,6 +158,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quaminventore" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/quiasint" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "7YTPXuUOQtzo",
+  "status" : "DRAFT",
+  "owner" : "b4EnQ5Rw7dVY68NSt1m",
   "resourceOwner" : {
-    "owner" : "7YTPXuUOQtzo",
-    "ownerAffiliation" : "https://www.example.org/deseruntporro"
+    "owner" : "b4EnQ5Rw7dVY68NSt1m",
+    "ownerAffiliation" : "https://www.example.org/utdeleniti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/officiaut",
+    "id" : "https://www.example.org/nobisquod",
     "labels" : {
-      "R17BDocDbm" : "igWnbC9nLSZ8"
+      "TcLAmOMWRRfycRUMmi" : "Zjj778x01S7"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/rerumnihil",
-  "doi" : "https://doi.org/10.1234/necessitatibus",
+  "handle" : "https://www.example.org/temporenisi",
+  "doi" : "https://doi.org/10.1234/quo",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,109 +27,109 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "uZo4zkfs7v",
-      "author" : "QCg6xQLsT1NKP",
+      "text" : "G5nl3XSn6hM73djS",
+      "author" : "HHZibtc8uhav1omNsmb",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/erroret",
+  "link" : "https://www.example.org/harumut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7FljzBjuTaWqsG5q",
+    "mainTitle" : "WSTAptmUVyImG238",
     "alternativeTitles" : {
-      "de" : "xgOeMvBQZUz"
+      "da" : "DllyKkXtbnih"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "cje9qxA5fFKMROApx6b",
-      "month" : "AKD9NDnNfjyD",
-      "day" : "1XaB9LFl8pUw31"
+      "year" : "4mksLlvzfNkR4MS",
+      "month" : "tKZGR7yxDcFXThRwcMM",
+      "day" : "uRhS3kgtf1xx0J"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Xdaab3IMUJNFut3",
-        "name" : "H9Ryp0We9mSQx2Hm",
-        "nameType" : "Personal",
-        "orcId" : "BHpZNy91YY",
-        "arpId" : "7fPFLoR99wRP"
+        "id" : "https://www.example.com/Sk0aTXtl8TKXhqAYH",
+        "name" : "cQPl1RxVqQ2",
+        "nameType" : "Organizational",
+        "orcId" : "dlTIK5xooidwK0BlSXD",
+        "arpId" : "rao8SoSTwJyXXqtN1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FHUcnGsTSDb",
+        "id" : "https://www.example.com/R7i17pP6S7uA",
         "labels" : {
-          "HOYHRx7PpnR4S" : "ya54jb9mgJpF"
+          "A81QyKeA1H1QsJir" : "umr7FUiD3Gu70AQyG"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 1,
+      "role" : "Supervisor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/88KNLz4BJV",
-        "name" : "YfR28WB4tjhvM",
-        "nameType" : "Personal",
-        "orcId" : "IVmrGM1iDF",
-        "arpId" : "wzQr2M6oJww"
+        "id" : "https://www.example.com/KKg5oaEYuQYOH",
+        "name" : "jgwD8X9cxFk8vg4nx",
+        "nameType" : "Organizational",
+        "orcId" : "at4fPyImtIvMRe",
+        "arpId" : "3KkaZTr95l"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UkLH6WMFeIUiisbCeY",
+        "id" : "https://www.example.com/isohyPYQOn69IX77",
         "labels" : {
-          "460anXTlBkJyvqQRTOn" : "N4uKjIgjYRJKrXAaia"
+          "JKvmHYuLG9vcZF" : "IlihMIYb12"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 7,
+      "role" : "ResearchGroup",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "li21bjAQsnagC6lhNgb",
-    "tags" : [ "7ZHyfF0PH6AbG7T" ],
-    "description" : "6w5mkwQs8ic2n",
+    "npiSubjectHeading" : "mJ1a6jKIs4aU",
+    "tags" : [ "O7Nk0m9QdwF" ],
+    "description" : "EMT3iQeLyX7P9PWAJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YNSWgugYLf3U6ZQ89"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JpjorHgzmpZla5"
       },
-      "doi" : "https://www.example.com/bRiv5hVIGMOVP",
+      "doi" : "https://www.example.com/5UpWUWP9QiZWYP",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "ofvgTQBUv4Z",
-        "issue" : "aSekRiWe66eVXg1M",
-        "articleNumber" : "zdmXWPbRiA",
-        "contentType" : "Professional article",
+        "volume" : "HJTfG5pn6Zr4n",
+        "issue" : "ik2miTdvXP7enh",
+        "articleNumber" : "BIR7myopGThUspdtBN7",
+        "contentType" : "Case report",
         "peerReviewed" : false,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "d8lLlbT6YyBkzm2Oqq",
-          "end" : "6nnXwxcY98c"
+          "begin" : "UuqZHBhKb37",
+          "end" : "D7o5Cd1pd4AsXlJ9N4"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/gqdPssOAyUs",
-    "abstract" : "X2DSD9KgFrOMWFGHE5"
+    "metadataSource" : "https://www.example.com/fzd3EOlklaedT",
+    "abstract" : "pu3EVMKUMZq"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "kM0m1OHk16",
-      "mimeType" : "17e8GfEvx9ltJjWm",
-      "size" : 1999564737,
+      "name" : "9cApVzzWHQXuxEN",
+      "mimeType" : "XFY9H3PEZAT",
+      "size" : 1460867371,
       "license" : {
         "type" : "License",
-        "identifier" : "43qbdgg7ACh",
+        "identifier" : "Lln9GwLJZ6BclVZ",
         "labels" : {
-          "XAN0at7BJkqr5U" : "KlMcMtqtx8"
+          "v0yJ8KCsZdf" : "kHBvFFDKaX3snQNI"
         },
-        "link" : "https://www.example.com/PS1CKBo6oK2JSeN"
+        "link" : "https://www.example.com/0Xbuu3YTPYetyqWj"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -138,19 +138,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/liberonemo",
-    "name" : "WpbCmNOZGljDFXuU",
+    "id" : "https://www.example.org/doloremtotam",
+    "name" : "ZWh9EmKNvRfP5",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Rw4rR4Vzkd",
-      "id" : "uBJLSAw3DVcAf5NYPo"
+      "source" : "l5wgdvS59nJNRMpEGg",
+      "id" : "VHceg0KF4rKQjWUe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "mVPscbdsYblKwAL6M"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "lU8tlt276cgLNh4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,6 +158,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/rerumex" ],
+  "subjects" : [ "https://www.example.org/delectusreprehenderit" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,156 +1,156 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "axmiGtUL3Bp",
+  "status" : "NEW",
+  "owner" : "7YTPXuUOQtzo",
   "resourceOwner" : {
-    "owner" : "axmiGtUL3Bp",
-    "ownerAffiliation" : "https://www.example.org/atperferendis"
+    "owner" : "7YTPXuUOQtzo",
+    "ownerAffiliation" : "https://www.example.org/deseruntporro"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorummollitia",
+    "id" : "https://www.example.org/officiaut",
     "labels" : {
-      "wZkEH0nFmwC" : "KoOFRbafq3h4"
+      "R17BDocDbm" : "igWnbC9nLSZ8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/esteos",
-  "doi" : "https://doi.org/10.1234/iusto",
+  "handle" : "https://www.example.org/rerumnihil",
+  "doi" : "https://doi.org/10.1234/necessitatibus",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "A35KKsR8VIe7tCaF",
-      "author" : "tTZY6CI4AAqW9",
+      "text" : "uZo4zkfs7v",
+      "author" : "QCg6xQLsT1NKP",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/sequieum",
+  "link" : "https://www.example.org/erroret",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4EFrQWaUvGbD0T8",
+    "mainTitle" : "7FljzBjuTaWqsG5q",
     "alternativeTitles" : {
-      "is" : "owvnWpk8t17Hra"
+      "de" : "xgOeMvBQZUz"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FmMYeCc1tQx",
-      "month" : "5csk8wjOWqjj",
-      "day" : "WLnjFLW5QTfINn1MExF"
+      "year" : "cje9qxA5fFKMROApx6b",
+      "month" : "AKD9NDnNfjyD",
+      "day" : "1XaB9LFl8pUw31"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/q3NntBYNScXjr3kteC",
-        "name" : "6Hyn54wOxXBFWrvI",
-        "nameType" : "Organizational",
-        "orcId" : "5PibXKT1NwItzOK",
-        "arpId" : "traRQXvyGAgdKz"
+        "id" : "https://www.example.com/Xdaab3IMUJNFut3",
+        "name" : "H9Ryp0We9mSQx2Hm",
+        "nameType" : "Personal",
+        "orcId" : "BHpZNy91YY",
+        "arpId" : "7fPFLoR99wRP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PrMjkr9IVAcuoU",
+        "id" : "https://www.example.com/FHUcnGsTSDb",
         "labels" : {
-          "dOEH5HAz7hrpfbvNQN" : "6QublO2h0R"
+          "HOYHRx7PpnR4S" : "ya54jb9mgJpF"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 0,
+      "role" : "DataCurator",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/tcLQVZKKQHIK8oIKld",
-        "name" : "3SqHLNnngCqlSociqbN",
-        "nameType" : "Organizational",
-        "orcId" : "3tC3v1SpeiJfTz9",
-        "arpId" : "oJoAE4OuvKQ7GrX"
+        "id" : "https://www.example.com/88KNLz4BJV",
+        "name" : "YfR28WB4tjhvM",
+        "nameType" : "Personal",
+        "orcId" : "IVmrGM1iDF",
+        "arpId" : "wzQr2M6oJww"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Xc1NuR5reHo1M",
+        "id" : "https://www.example.com/UkLH6WMFeIUiisbCeY",
         "labels" : {
-          "i8GL4w4wur" : "GyZFTsd7d5ntaX"
+          "460anXTlBkJyvqQRTOn" : "N4uKjIgjYRJKrXAaia"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 3,
+      "role" : "HostingInstitution",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "2kdQsq8GNL",
-    "tags" : [ "I4Bv3WNnqVTh" ],
-    "description" : "JU4pz5rgSZOCHtbW",
+    "npiSubjectHeading" : "li21bjAQsnagC6lhNgb",
+    "tags" : [ "7ZHyfF0PH6AbG7T" ],
+    "description" : "6w5mkwQs8ic2n",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gHVgiW8cTnthHi"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YNSWgugYLf3U6ZQ89"
       },
-      "doi" : "https://www.example.com/QQfPmuEy34",
+      "doi" : "https://www.example.com/bRiv5hVIGMOVP",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "QP7Z1SoSHCh6ZzQm",
-        "issue" : "3Kz657NnguFacuQtR",
-        "articleNumber" : "8U7uhROkBv4O",
-        "contentType" : "Popular science article",
-        "peerReviewed" : true,
+        "volume" : "ofvgTQBUv4Z",
+        "issue" : "aSekRiWe66eVXg1M",
+        "articleNumber" : "zdmXWPbRiA",
+        "contentType" : "Professional article",
+        "peerReviewed" : false,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "RXjEcFRnfh",
-          "end" : "XxLL5Wkw5GZN"
+          "begin" : "d8lLlbT6YyBkzm2Oqq",
+          "end" : "6nnXwxcY98c"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/AHsNUftITU6",
-    "abstract" : "O6saWnY2K2T"
+    "metadataSource" : "https://www.example.com/gqdPssOAyUs",
+    "abstract" : "X2DSD9KgFrOMWFGHE5"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "tYqjMWklrMp8NzEq",
-      "mimeType" : "yyKxPDyGCbj1zAp",
-      "size" : 239115863,
+      "name" : "kM0m1OHk16",
+      "mimeType" : "17e8GfEvx9ltJjWm",
+      "size" : 1999564737,
       "license" : {
         "type" : "License",
-        "identifier" : "0nOjsFJl7JV",
+        "identifier" : "43qbdgg7ACh",
         "labels" : {
-          "JBZPUAQxeJwlSphjAhR" : "CZqOWc3pC2aa"
+          "XAN0at7BJkqr5U" : "KlMcMtqtx8"
         },
-        "link" : "https://www.example.com/9XldqmF9ckVkA44"
+        "link" : "https://www.example.com/PS1CKBo6oK2JSeN"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ipsaofficia",
-    "name" : "xizjYBDA7rV2ugU",
+    "id" : "https://www.example.org/liberonemo",
+    "name" : "WpbCmNOZGljDFXuU",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SRdMI7R6K5qJU0V",
-      "id" : "lZxawA5OyzE"
+      "source" : "Rw4rR4Vzkd",
+      "id" : "uBJLSAw3DVcAf5NYPo"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "rJh35uVdjwf5"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "mVPscbdsYblKwAL6M"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,6 +158,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiasint" ],
+  "subjects" : [ "https://www.example.org/rerumex" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,134 +1,134 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "nwe2340ljAWdjSSF",
+  "status" : "NEW",
+  "owner" : "DpDvm4MjMtmW57clGMI",
   "resourceOwner" : {
-    "owner" : "nwe2340ljAWdjSSF",
-    "ownerAffiliation" : "https://www.example.org/estet"
+    "owner" : "DpDvm4MjMtmW57clGMI",
+    "ownerAffiliation" : "https://www.example.org/hicaut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorut",
+    "id" : "https://www.example.org/aliasnumquam",
     "labels" : {
-      "4Fitdt4YfeD" : "6yStVcI5kYVDK2wnCyf"
+      "sJhYIbU1AvK4G9" : "CK6l2uAfy6y9kCw"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/autexpedita",
-  "doi" : "https://doi.org/10.1234/omnis",
+  "handle" : "https://www.example.org/quasveritatis",
+  "doi" : "https://doi.org/10.1234/nesciunt",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "UEHEKXUP94Gw7R61m",
-      "author" : "BXaGMa2Wmp",
+      "text" : "tTNszR2Yxbq6",
+      "author" : "h7AiFlzV2I",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/eligendiconsequatur",
+  "link" : "https://www.example.org/quisnon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mC8iRbdqhvzMebw5",
+    "mainTitle" : "BjVcsTgCSSnnbntkHUA",
     "alternativeTitles" : {
-      "pt" : "WGrlts6D2jOuSDtI"
+      "bg" : "eivMrK8Xxs"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tBbAeSs3biz9uA",
-      "month" : "qPXgGcU7ZYOA0Df3",
-      "day" : "sQ6UXdl9bvG"
+      "year" : "JnrPk8PkQCpdeGLI",
+      "month" : "trVjUoOhrsNlb1dR",
+      "day" : "EDQ2mpDUHP5DR1Q3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DkfBI5DKG3wVHEVOg6g",
-        "name" : "xU03OY04pFmOTv",
+        "id" : "https://www.example.com/mKECwjmxJ5Mkse",
+        "name" : "Alr5qjmX9uWcgf",
         "nameType" : "Organizational",
-        "orcId" : "FoPcg2NZ7gP0Q96kGH8",
-        "arpId" : "aMRwe67NKKCvq"
+        "orcId" : "WOAW8ctoChCg",
+        "arpId" : "ibHpla8YdlByi"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uV2RQpv2OR39M",
+        "id" : "https://www.example.com/XrpMjIQFJfY",
         "labels" : {
-          "ezbpD0ZlhtC" : "RSZzXMAMlDQw19b"
+          "yMnmLz7USXowtzw2XbG" : "e9e4xH9mXea2uOmbm"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 8,
+      "role" : "RegistrationAgency",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/RRXHtfW1DuRYC",
-        "name" : "pIjHBFGxBe",
-        "nameType" : "Personal",
-        "orcId" : "nan0S77UholXZ",
-        "arpId" : "pmuWig8EZ2n0ImHeF"
+        "id" : "https://www.example.com/GmCbuxYAZUmfFr0Zx",
+        "name" : "GleEuYLqoXd7WKo",
+        "nameType" : "Organizational",
+        "orcId" : "6lmRjGfDnm7qq",
+        "arpId" : "5R1hK6KYPWZGDY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lYmZ1UiZYgzX6X",
+        "id" : "https://www.example.com/HcVqglTML3SwsRjkpf",
         "labels" : {
-          "1YwHZatD7m" : "ISsD6rjS5KSQ"
+          "w7JGx10rbOe8ZvfaHg" : "NPpxaXvNyXuQ"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 6,
+      "role" : "RegistrationAgency",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "RAyVuccDhQlgY",
-    "tags" : [ "OGXW8OSMs6QXSuTzWO" ],
-    "description" : "gLNtTblIsqBh",
+    "npiSubjectHeading" : "sovNS0TCaQgZ",
+    "tags" : [ "JcffleZqXi0vuKhD" ],
+    "description" : "GBIyJZJbcPNvePWeP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Lv56PmQZ6BqXCgn"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5hZ4ezDdDrMNDrblMs7"
       },
-      "doi" : "https://www.example.com/pTH85rrp4R8A",
+      "doi" : "https://www.example.com/GT143r67rPaGFvNo7T4",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "61pD80cAjLXsrtoHk",
-        "issue" : "Wa2k8jPo3dNiIb3lf",
-        "articleNumber" : "mlzyrlkuvXzlF",
+        "volume" : "h7dwo2OSC6qGqYA6a",
+        "issue" : "pqu7EGzGyQj3JjrV",
+        "articleNumber" : "NHdE8EDDwzKSBL",
         "pages" : {
           "type" : "Range",
-          "begin" : "ishr6ZKE9EJ",
-          "end" : "P8jnzCxM6lGbId5YV2c"
+          "begin" : "8EmEU4Yz1BW",
+          "end" : "LdkDsHUGna"
         },
-        "corrigendumFor" : "https://www.example.com/eW73nMX0lYpb",
+        "corrigendumFor" : "https://www.example.com/DsubAfLjdgu",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/vy4Hzn26fdo2vaciF",
-    "abstract" : "mWFfRmKYoKTqqs"
+    "metadataSource" : "https://www.example.com/pQTmJYtwKsTn4h",
+    "abstract" : "9zrCBvb5A0I0C"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "qifW8RbXZC8VHbTZ9Z",
-      "mimeType" : "WKlmRgCt2IDnEWFHgh",
-      "size" : 650481143,
+      "name" : "pwKeKkUIhaomdan",
+      "mimeType" : "KjGvuFnTr9JxQLkG",
+      "size" : 182835341,
       "license" : {
         "type" : "License",
-        "identifier" : "HINdpDENNmbvsy",
+        "identifier" : "61vNwfOKFKLn7dH3Zn",
         "labels" : {
-          "PERkwSYXQGvatQz2y" : "ixJ00zVyCFMauUGGC"
+          "fcF0eGEVTv" : "cDrPLNd1ei4Jhmk8Kb"
         },
-        "link" : "https://www.example.com/psaWMHkbTIAyRUEOA9"
+        "link" : "https://www.example.com/id3i6UQczJ8x8L"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -137,19 +137,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etnihil",
-    "name" : "B9r7qUFfYBkIny",
+    "id" : "https://www.example.org/sapientemolestiae",
+    "name" : "n1LS5pRh5hODAQvV9AC",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "BUrE8uOVauGEh8",
-      "id" : "Rn9Fwxj72V1wh"
+      "source" : "c2rYC7Luq5A",
+      "id" : "tQQxeDkXIB0ecnQ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "nvs9VMQMFroUH"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "JfjDMv5bW3BqhuuWR4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -157,6 +157,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autemvoluptatibus" ],
+  "subjects" : [ "https://www.example.org/cupiditateillo" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,155 +1,155 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "2T9WksQT8i8j1",
+  "status" : "PUBLISHED",
+  "owner" : "nwe2340ljAWdjSSF",
   "resourceOwner" : {
-    "owner" : "2T9WksQT8i8j1",
-    "ownerAffiliation" : "https://www.example.org/abab"
+    "owner" : "nwe2340ljAWdjSSF",
+    "ownerAffiliation" : "https://www.example.org/estet"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etet",
+    "id" : "https://www.example.org/dolorut",
     "labels" : {
-      "B24S4CSMP7r8rWH" : "jKFHCcPSaGH"
+      "4Fitdt4YfeD" : "6yStVcI5kYVDK2wnCyf"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suntquaerat",
-  "doi" : "https://doi.org/10.1234/possimus",
+  "handle" : "https://www.example.org/autexpedita",
+  "doi" : "https://doi.org/10.1234/omnis",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "vYkRcLezoG",
-      "author" : "VV08qNi1wMJSwfOGq9z",
+      "text" : "UEHEKXUP94Gw7R61m",
+      "author" : "BXaGMa2Wmp",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/repudiandaefacilis",
+  "link" : "https://www.example.org/eligendiconsequatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "A32RpvpWWpTRud46qt",
+    "mainTitle" : "mC8iRbdqhvzMebw5",
     "alternativeTitles" : {
-      "cs" : "RaWo957wsn4"
+      "pt" : "WGrlts6D2jOuSDtI"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "CcfMUPlvawCJ0h66z",
-      "month" : "izPSr8S3DR0GrsNk",
-      "day" : "rGoclXXdr58WS1"
+      "year" : "tBbAeSs3biz9uA",
+      "month" : "qPXgGcU7ZYOA0Df3",
+      "day" : "sQ6UXdl9bvG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HxUGYaxJFpmvQ",
-        "name" : "HC3pRN963ru9wmUVMlM",
-        "nameType" : "Personal",
-        "orcId" : "CjTtx9CBuzWCncA",
-        "arpId" : "6hrXauguU2"
+        "id" : "https://www.example.com/DkfBI5DKG3wVHEVOg6g",
+        "name" : "xU03OY04pFmOTv",
+        "nameType" : "Organizational",
+        "orcId" : "FoPcg2NZ7gP0Q96kGH8",
+        "arpId" : "aMRwe67NKKCvq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lZLtLbswfwnQ63SjOO",
+        "id" : "https://www.example.com/uV2RQpv2OR39M",
         "labels" : {
-          "vg3Dsqvy3oAJQu1IVw" : "kYUhHaITeuMOjT3U"
+          "ezbpD0ZlhtC" : "RSZzXMAMlDQw19b"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 5,
+      "role" : "Other",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/j0St1CJ6kc",
-        "name" : "PDCtfYUBtf",
-        "nameType" : "Organizational",
-        "orcId" : "GHSTH1BBI0",
-        "arpId" : "cw74mDRUWlTgYv"
+        "id" : "https://www.example.com/RRXHtfW1DuRYC",
+        "name" : "pIjHBFGxBe",
+        "nameType" : "Personal",
+        "orcId" : "nan0S77UholXZ",
+        "arpId" : "pmuWig8EZ2n0ImHeF"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/s078gOSiEH4v3Hrd",
+        "id" : "https://www.example.com/lYmZ1UiZYgzX6X",
         "labels" : {
-          "i9B7fAKS9yL" : "aLFGs125Zks4"
+          "1YwHZatD7m" : "ISsD6rjS5KSQ"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 2,
+      "role" : "CuratorOrganizer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "v8F92757MbsY",
-    "tags" : [ "IYSVP3DygaBp74OWj4F" ],
-    "description" : "x0L7Zyc8uu0",
+    "npiSubjectHeading" : "RAyVuccDhQlgY",
+    "tags" : [ "OGXW8OSMs6QXSuTzWO" ],
+    "description" : "gLNtTblIsqBh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/as37JwRo3yha4"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Lv56PmQZ6BqXCgn"
       },
-      "doi" : "https://www.example.com/2inMObDS6D94",
+      "doi" : "https://www.example.com/pTH85rrp4R8A",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "v4rI94cvCICbVj",
-        "issue" : "8VQJVe3sT7fB",
-        "articleNumber" : "NJ5YlEpBFdD",
+        "volume" : "61pD80cAjLXsrtoHk",
+        "issue" : "Wa2k8jPo3dNiIb3lf",
+        "articleNumber" : "mlzyrlkuvXzlF",
         "pages" : {
           "type" : "Range",
-          "begin" : "01bn4uuvbt",
-          "end" : "EuzRuzVgLYpVqr"
+          "begin" : "ishr6ZKE9EJ",
+          "end" : "P8jnzCxM6lGbId5YV2c"
         },
-        "corrigendumFor" : "https://www.example.com/DPYnLXon79dn",
+        "corrigendumFor" : "https://www.example.com/eW73nMX0lYpb",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/4JJdVEwPsRC",
-    "abstract" : "bkSDRbBHEbCELZHBN7c"
+    "metadataSource" : "https://www.example.com/vy4Hzn26fdo2vaciF",
+    "abstract" : "mWFfRmKYoKTqqs"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "EWemlhAVpCY5wR",
-      "mimeType" : "3VVea3TsP7sNcf4VrgN",
-      "size" : 1751763270,
+      "name" : "qifW8RbXZC8VHbTZ9Z",
+      "mimeType" : "WKlmRgCt2IDnEWFHgh",
+      "size" : 650481143,
       "license" : {
         "type" : "License",
-        "identifier" : "Op2Yf4RouUxTRTFXc",
+        "identifier" : "HINdpDENNmbvsy",
         "labels" : {
-          "zWM7euUKcGyvVPdCq" : "r2vCCLJcuePRmXh"
+          "PERkwSYXQGvatQz2y" : "ixJ00zVyCFMauUGGC"
         },
-        "link" : "https://www.example.com/d6RlAK5nRrkx4Gyf"
+        "link" : "https://www.example.com/psaWMHkbTIAyRUEOA9"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/accusantiumet",
-    "name" : "PG8Yuqe42r1hACu",
+    "id" : "https://www.example.org/etnihil",
+    "name" : "B9r7qUFfYBkIny",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "WqkzhMyr4EL65",
-      "id" : "iVj8m0MoZtW"
+      "source" : "BUrE8uOVauGEh8",
+      "id" : "Rn9Fwxj72V1wh"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "kC9bSgbRJmoH"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "nvs9VMQMFroUH"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -157,6 +157,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quaequibusdam" ],
+  "subjects" : [ "https://www.example.org/autemvoluptatibus" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "DpDvm4MjMtmW57clGMI",
+  "status" : "PUBLISHED",
+  "owner" : "ttDdWNRMftrOjbar2G",
   "resourceOwner" : {
-    "owner" : "DpDvm4MjMtmW57clGMI",
-    "ownerAffiliation" : "https://www.example.org/hicaut"
+    "owner" : "ttDdWNRMftrOjbar2G",
+    "ownerAffiliation" : "https://www.example.org/inciduntmagni"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aliasnumquam",
+    "id" : "https://www.example.org/providentconsequuntur",
     "labels" : {
-      "sJhYIbU1AvK4G9" : "CK6l2uAfy6y9kCw"
+      "FnQqOFEBd6FuRhA12" : "M32WjcXCmAeFMHXF"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quasveritatis",
-  "doi" : "https://doi.org/10.1234/nesciunt",
+  "handle" : "https://www.example.org/utut",
+  "doi" : "https://doi.org/10.1234/libero",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,108 +27,108 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "tTNszR2Yxbq6",
-      "author" : "h7AiFlzV2I",
+      "text" : "J0NEaDdbSMV",
+      "author" : "vIOtBi8dJr0",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quisnon",
+  "link" : "https://www.example.org/reiciendisquia",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BjVcsTgCSSnnbntkHUA",
+    "mainTitle" : "tM0vm9VyX94E7pgVeB",
     "alternativeTitles" : {
-      "bg" : "eivMrK8Xxs"
+      "nl" : "pwtTSdFwp2plG1Gw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "JnrPk8PkQCpdeGLI",
-      "month" : "trVjUoOhrsNlb1dR",
-      "day" : "EDQ2mpDUHP5DR1Q3"
+      "year" : "iVRoRUs8KPKOu",
+      "month" : "YHA69nijplbs",
+      "day" : "Qf53D1oXk5yGW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/mKECwjmxJ5Mkse",
-        "name" : "Alr5qjmX9uWcgf",
+        "id" : "https://www.example.com/GFrJuWE1zpGO",
+        "name" : "ulPzJZ3Bg1aF4gfOsM",
         "nameType" : "Organizational",
-        "orcId" : "WOAW8ctoChCg",
-        "arpId" : "ibHpla8YdlByi"
+        "orcId" : "X2fHqMqvdGXD72DCqk6",
+        "arpId" : "nE8s5zogwlFN06oD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XrpMjIQFJfY",
+        "id" : "https://www.example.com/xlPsB3hOwPr4TWQ",
         "labels" : {
-          "yMnmLz7USXowtzw2XbG" : "e9e4xH9mXea2uOmbm"
+          "78hK418W4OslT0exC" : "oFenJ2i1wXoea3"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 1,
+      "role" : "ProgrammeLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/GmCbuxYAZUmfFr0Zx",
-        "name" : "GleEuYLqoXd7WKo",
-        "nameType" : "Organizational",
-        "orcId" : "6lmRjGfDnm7qq",
-        "arpId" : "5R1hK6KYPWZGDY"
+        "id" : "https://www.example.com/ncl87IMVBgOREJpQ",
+        "name" : "IlIUmnJYxBAoLvmsyP",
+        "nameType" : "Personal",
+        "orcId" : "goirELhK6bTldfJYP",
+        "arpId" : "ZDxpk2at2Eg1Ak"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/HcVqglTML3SwsRjkpf",
+        "id" : "https://www.example.com/zUWqs52pjgPDdFlhr8",
         "labels" : {
-          "w7JGx10rbOe8ZvfaHg" : "NPpxaXvNyXuQ"
+          "6aoMRYJUXH7SGu1p" : "YSJDgvzb81F3bVlrH"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 2,
+      "role" : "RightsHolder",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "sovNS0TCaQgZ",
-    "tags" : [ "JcffleZqXi0vuKhD" ],
-    "description" : "GBIyJZJbcPNvePWeP",
+    "npiSubjectHeading" : "kyuM81bwJ4hC67AGW",
+    "tags" : [ "2YodLl2AoWUvh7UeoE" ],
+    "description" : "G7Q7WiffbJsx9c0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5hZ4ezDdDrMNDrblMs7"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8X0NOZyg52"
       },
-      "doi" : "https://www.example.com/GT143r67rPaGFvNo7T4",
+      "doi" : "https://www.example.com/T2ZtsvmIB8",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "h7dwo2OSC6qGqYA6a",
-        "issue" : "pqu7EGzGyQj3JjrV",
-        "articleNumber" : "NHdE8EDDwzKSBL",
+        "volume" : "H2xWO8ahPil",
+        "issue" : "SRHJmE6MLv0v",
+        "articleNumber" : "YQvHRSnekbYqFHNb7Tl",
         "pages" : {
           "type" : "Range",
-          "begin" : "8EmEU4Yz1BW",
-          "end" : "LdkDsHUGna"
+          "begin" : "uKK2omqLphJKJd6sRH",
+          "end" : "M6obMszzaQ"
         },
-        "corrigendumFor" : "https://www.example.com/DsubAfLjdgu",
+        "corrigendumFor" : "https://www.example.com/9bTMn64cApevx8ho5GX",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/pQTmJYtwKsTn4h",
-    "abstract" : "9zrCBvb5A0I0C"
+    "metadataSource" : "https://www.example.com/380BudEYX1",
+    "abstract" : "t454KbGVPaUyp5vy9"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "pwKeKkUIhaomdan",
-      "mimeType" : "KjGvuFnTr9JxQLkG",
-      "size" : 182835341,
+      "name" : "ewIXNZxHAHf",
+      "mimeType" : "MBC7YGtPcEHd5H3BPDv",
+      "size" : 2100043990,
       "license" : {
         "type" : "License",
-        "identifier" : "61vNwfOKFKLn7dH3Zn",
+        "identifier" : "MtACuEOo8SP1RO3",
         "labels" : {
-          "fcF0eGEVTv" : "cDrPLNd1ei4Jhmk8Kb"
+          "DANwgbZmJmF9iI3j" : "hH7FGa90t7rRCQ"
         },
-        "link" : "https://www.example.com/id3i6UQczJ8x8L"
+        "link" : "https://www.example.com/HzEMBHCZpl"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -137,19 +137,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sapientemolestiae",
-    "name" : "n1LS5pRh5hODAQvV9AC",
+    "id" : "https://www.example.org/vitaeet",
+    "name" : "ktx5IcwpiD",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "c2rYC7Luq5A",
-      "id" : "tQQxeDkXIB0ecnQ"
+      "source" : "9MksK0aX6wsWGYUt",
+      "id" : "ursl16dmvkV"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "JfjDMv5bW3BqhuuWR4"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "PdwKMM21GahVKRg"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -157,6 +157,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cupiditateillo" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/voluptatemqui" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "Rlyg0YwtuHkxGdgX9",
+  "status" : "NEW",
+  "owner" : "dP1hBxqyZ0N7HJ3v",
   "resourceOwner" : {
-    "owner" : "Rlyg0YwtuHkxGdgX9",
-    "ownerAffiliation" : "https://www.example.org/eiusenim"
+    "owner" : "dP1hBxqyZ0N7HJ3v",
+    "ownerAffiliation" : "https://www.example.org/etiste"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dignissimosad",
+    "id" : "https://www.example.org/repellattenetur",
     "labels" : {
-      "haQsVLTb6Mf" : "2UyVGoPVu3"
+      "dcW0x4LYh5HmwGFAs" : "ZCxuuwHIjDvwKck"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/praesentiumnisi",
-  "doi" : "https://doi.org/10.1234/neque",
+  "handle" : "https://www.example.org/quaeratlaboriosam",
+  "doi" : "https://doi.org/10.1234/aut",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,129 +27,129 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "0KYnWXbVYqd8Mn",
-      "author" : "qENkVoVIwP0o",
+      "text" : "xiCpfbysVn8De6",
+      "author" : "i2dnJFh2MTjBJ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloremaxime",
+  "link" : "https://www.example.org/quiofficiis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "d7C6x50StRAzV5BtS",
+    "mainTitle" : "RCh831CjDTdl",
     "alternativeTitles" : {
-      "fi" : "YpEJb9ToB0luo02h1l"
+      "en" : "kvKm0ad2QWbDplYn"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "uRr7SJpFwDrFOH8W",
-      "month" : "okNchJjaOdbzVGu",
-      "day" : "2mGlPj8tv8uXaty"
+      "year" : "ObVYBZOj5O6",
+      "month" : "FrBHzjMnc5b",
+      "day" : "toS3ebt3ojU9TvLyKUT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MmSWrQyqhs3ElDOC",
-        "name" : "9RaHqgxYQssHM",
-        "nameType" : "Personal",
-        "orcId" : "8eYF1U34BCzVH",
-        "arpId" : "miHfB1pIeGq5X"
+        "id" : "https://www.example.com/BpBpOYnhxcynXM2s",
+        "name" : "ssJzfIECXfYPKl4",
+        "nameType" : "Organizational",
+        "orcId" : "ZimZPhJ6DY",
+        "arpId" : "Kl5YbbTuiR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/AP25Sg6ZZ9tLMX3KB",
+        "id" : "https://www.example.com/tajInIRwaD8rVxp4l0",
         "labels" : {
-          "QpUrT2WXbCeNJ" : "mEfGLfGWVjmociDuEyi"
+          "mXe8m6CzeL4bo" : "SSKU2vatOh8"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 0,
+      "role" : "Distributor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Wr82Bu8hKrIcY3Wvl",
-        "name" : "qnTNYs8TnA",
-        "nameType" : "Organizational",
-        "orcId" : "4uz8Bex1ySYY4Y7B",
-        "arpId" : "13lEu80jHz7yMvr"
+        "id" : "https://www.example.com/OyMBCS5mNVXdibOf",
+        "name" : "g8xSfn08Yb06d2zJ",
+        "nameType" : "Personal",
+        "orcId" : "Rqr2B33YMSGQvcUaCzv",
+        "arpId" : "LXzSAmnSHXjh4t5D2"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Y0n6OuxHbdpMfASF",
+        "id" : "https://www.example.com/v7wdAhnxlAWRDu",
         "labels" : {
-          "XAi4YYzz6r0AJ" : "naen0DWJpX3IK6xL"
+          "JQsCBgDlAZ" : "qnasiXWzjMF"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 6,
+      "role" : "WorkPackageLeader",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Ts5Jjo6JOFsOmDRurWr",
-    "tags" : [ "ImbwKsT6SN5BL64cBj" ],
-    "description" : "JGbBNceITA",
+    "npiSubjectHeading" : "ehFuyVyuU6v",
+    "tags" : [ "nj0C2TqXjusM44" ],
+    "description" : "m3I6sROBrCjpc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JqRAF6EHkR0cqNYbAG"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iDQ1TPVnB6Hfei"
       },
-      "doi" : "https://www.example.com/AQdP9Al5KZcPJJD0Y",
+      "doi" : "https://www.example.com/xH3wYkN40lKHxx1sw",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "vpPiSmPk08h5acK",
-        "issue" : "EqxQwWqRoy0Sruy",
-        "articleNumber" : "yj7h8yk3NM",
+        "volume" : "nrulIJctPD0juPoFQ",
+        "issue" : "Ey1FRZck5YDOS6",
+        "articleNumber" : "dOTex2e57ZACB",
         "pages" : {
           "type" : "Range",
-          "begin" : "9bP3dPePN4ckL",
-          "end" : "Ux2qOhm98N"
+          "begin" : "0oAxZhF3iZyVOx",
+          "end" : "uKb6hTtun1M"
         },
-        "corrigendumFor" : "https://www.example.com/1syJb9LXOviTf",
+        "corrigendumFor" : "https://www.example.com/5Qzk9whxOmebi",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/e7JyTNA44esBaapJRTZ",
-    "abstract" : "E6dowjn2RmUUAr9km"
+    "metadataSource" : "https://www.example.com/Kz93t5ZiOW64vKo",
+    "abstract" : "4G9jHEAqwwsck"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "saNhltfItPnB4L",
-      "mimeType" : "kdOtGdlPMolR",
-      "size" : 440514848,
+      "name" : "wtqiLidOvRxukG9",
+      "mimeType" : "duNmJqGqX7295nXK",
+      "size" : 136400639,
       "license" : {
         "type" : "License",
-        "identifier" : "8zMoB3bOZWRe",
+        "identifier" : "WHg83wPd9WxVyMC6",
         "labels" : {
-          "2c21ZfvMoKxGxEpmku" : "x65GIsCCGeOqS"
+          "FP9Y7S5WZ41cXA" : "R2Ev5mXXuoq"
         },
-        "link" : "https://www.example.com/B0L2RDyimEA8x4f"
+        "link" : "https://www.example.com/X7aEDhZd9KAl9ti52u"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eaquia",
-    "name" : "5Y4V1cuMuRAMKjp",
+    "id" : "https://www.example.org/eaodit",
+    "name" : "bPVvfEaYYktNA6M",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "oOuIKWj9tAWb",
-      "id" : "2SOERJY1LBjOQOdq6"
+      "source" : "AvgTWDNVEDwph",
+      "id" : "K76TYG9mSZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "vTb1AjeFb16wgMGRW6"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "9hl3Ywyw2x5"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -157,6 +157,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/perferendiseos" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/solutaquibusdam" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,134 +1,134 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "dP1hBxqyZ0N7HJ3v",
+  "status" : "DRAFT",
+  "owner" : "2T9WksQT8i8j1",
   "resourceOwner" : {
-    "owner" : "dP1hBxqyZ0N7HJ3v",
-    "ownerAffiliation" : "https://www.example.org/etiste"
+    "owner" : "2T9WksQT8i8j1",
+    "ownerAffiliation" : "https://www.example.org/abab"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repellattenetur",
+    "id" : "https://www.example.org/etet",
     "labels" : {
-      "dcW0x4LYh5HmwGFAs" : "ZCxuuwHIjDvwKck"
+      "B24S4CSMP7r8rWH" : "jKFHCcPSaGH"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quaeratlaboriosam",
-  "doi" : "https://doi.org/10.1234/aut",
+  "handle" : "https://www.example.org/suntquaerat",
+  "doi" : "https://doi.org/10.1234/possimus",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "xiCpfbysVn8De6",
-      "author" : "i2dnJFh2MTjBJ",
+      "text" : "vYkRcLezoG",
+      "author" : "VV08qNi1wMJSwfOGq9z",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quiofficiis",
+  "link" : "https://www.example.org/repudiandaefacilis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RCh831CjDTdl",
+    "mainTitle" : "A32RpvpWWpTRud46qt",
     "alternativeTitles" : {
-      "en" : "kvKm0ad2QWbDplYn"
+      "cs" : "RaWo957wsn4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ObVYBZOj5O6",
-      "month" : "FrBHzjMnc5b",
-      "day" : "toS3ebt3ojU9TvLyKUT"
+      "year" : "CcfMUPlvawCJ0h66z",
+      "month" : "izPSr8S3DR0GrsNk",
+      "day" : "rGoclXXdr58WS1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BpBpOYnhxcynXM2s",
-        "name" : "ssJzfIECXfYPKl4",
-        "nameType" : "Organizational",
-        "orcId" : "ZimZPhJ6DY",
-        "arpId" : "Kl5YbbTuiR"
+        "id" : "https://www.example.com/HxUGYaxJFpmvQ",
+        "name" : "HC3pRN963ru9wmUVMlM",
+        "nameType" : "Personal",
+        "orcId" : "CjTtx9CBuzWCncA",
+        "arpId" : "6hrXauguU2"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tajInIRwaD8rVxp4l0",
+        "id" : "https://www.example.com/lZLtLbswfwnQ63SjOO",
         "labels" : {
-          "mXe8m6CzeL4bo" : "SSKU2vatOh8"
+          "vg3Dsqvy3oAJQu1IVw" : "kYUhHaITeuMOjT3U"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 7,
+      "role" : "RegistrationAgency",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OyMBCS5mNVXdibOf",
-        "name" : "g8xSfn08Yb06d2zJ",
-        "nameType" : "Personal",
-        "orcId" : "Rqr2B33YMSGQvcUaCzv",
-        "arpId" : "LXzSAmnSHXjh4t5D2"
+        "id" : "https://www.example.com/j0St1CJ6kc",
+        "name" : "PDCtfYUBtf",
+        "nameType" : "Organizational",
+        "orcId" : "GHSTH1BBI0",
+        "arpId" : "cw74mDRUWlTgYv"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/v7wdAhnxlAWRDu",
+        "id" : "https://www.example.com/s078gOSiEH4v3Hrd",
         "labels" : {
-          "JQsCBgDlAZ" : "qnasiXWzjMF"
+          "i9B7fAKS9yL" : "aLFGs125Zks4"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 7,
+      "role" : "Other",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ehFuyVyuU6v",
-    "tags" : [ "nj0C2TqXjusM44" ],
-    "description" : "m3I6sROBrCjpc",
+    "npiSubjectHeading" : "v8F92757MbsY",
+    "tags" : [ "IYSVP3DygaBp74OWj4F" ],
+    "description" : "x0L7Zyc8uu0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iDQ1TPVnB6Hfei"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/as37JwRo3yha4"
       },
-      "doi" : "https://www.example.com/xH3wYkN40lKHxx1sw",
+      "doi" : "https://www.example.com/2inMObDS6D94",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "nrulIJctPD0juPoFQ",
-        "issue" : "Ey1FRZck5YDOS6",
-        "articleNumber" : "dOTex2e57ZACB",
+        "volume" : "v4rI94cvCICbVj",
+        "issue" : "8VQJVe3sT7fB",
+        "articleNumber" : "NJ5YlEpBFdD",
         "pages" : {
           "type" : "Range",
-          "begin" : "0oAxZhF3iZyVOx",
-          "end" : "uKb6hTtun1M"
+          "begin" : "01bn4uuvbt",
+          "end" : "EuzRuzVgLYpVqr"
         },
-        "corrigendumFor" : "https://www.example.com/5Qzk9whxOmebi",
+        "corrigendumFor" : "https://www.example.com/DPYnLXon79dn",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Kz93t5ZiOW64vKo",
-    "abstract" : "4G9jHEAqwwsck"
+    "metadataSource" : "https://www.example.com/4JJdVEwPsRC",
+    "abstract" : "bkSDRbBHEbCELZHBN7c"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wtqiLidOvRxukG9",
-      "mimeType" : "duNmJqGqX7295nXK",
-      "size" : 136400639,
+      "name" : "EWemlhAVpCY5wR",
+      "mimeType" : "3VVea3TsP7sNcf4VrgN",
+      "size" : 1751763270,
       "license" : {
         "type" : "License",
-        "identifier" : "WHg83wPd9WxVyMC6",
+        "identifier" : "Op2Yf4RouUxTRTFXc",
         "labels" : {
-          "FP9Y7S5WZ41cXA" : "R2Ev5mXXuoq"
+          "zWM7euUKcGyvVPdCq" : "r2vCCLJcuePRmXh"
         },
-        "link" : "https://www.example.com/X7aEDhZd9KAl9ti52u"
+        "link" : "https://www.example.com/d6RlAK5nRrkx4Gyf"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -137,19 +137,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eaodit",
-    "name" : "bPVvfEaYYktNA6M",
+    "id" : "https://www.example.org/accusantiumet",
+    "name" : "PG8Yuqe42r1hACu",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "AvgTWDNVEDwph",
-      "id" : "K76TYG9mSZ"
+      "source" : "WqkzhMyr4EL65",
+      "id" : "iVj8m0MoZtW"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "9hl3Ywyw2x5"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "kC9bSgbRJmoH"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -157,6 +157,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/solutaquibusdam" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/quaequibusdam" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "H0tkIkKk6WVh1n87xqu",
+  "status" : "NEW",
+  "owner" : "DTEVBYf8gCNyjd9gtIv",
   "resourceOwner" : {
-    "owner" : "H0tkIkKk6WVh1n87xqu",
-    "ownerAffiliation" : "https://www.example.org/deseruntnatus"
+    "owner" : "DTEVBYf8gCNyjd9gtIv",
+    "ownerAffiliation" : "https://www.example.org/voluptatibussit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/enimvoluptas",
+    "id" : "https://www.example.org/quaeratnihil",
     "labels" : {
-      "QNSt2abQP6FohyzWR" : "IGc4MGo7A8BusDeiI7u"
+      "p1JDa6jFW0HIUw" : "3zX9dwPc4yELv"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnisvelit",
-  "doi" : "https://doi.org/10.1234/tenetur",
+  "handle" : "https://www.example.org/dolorvitae",
+  "doi" : "https://doi.org/10.1234/velit",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,128 +27,128 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "YmvEXqvVCo5b8iauj7",
-      "author" : "mLWwIuBXRylyDUMi9TH",
+      "text" : "6bJlUC0cK4Tgjs",
+      "author" : "ThPsM5QBoarBhNiiNCP",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/dignissimosofficiis",
+  "link" : "https://www.example.org/undeconsectetur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "X2Xgjzk0emaU",
+    "mainTitle" : "3zFh9PTY4ttFR0zO",
     "alternativeTitles" : {
-      "sv" : "VFrG1JClmdL0D0VVB"
+      "nl" : "FTCMtj6Shw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "QyQ8nu3QKsDT",
-      "month" : "3Nq4Nwh9x6cbXKbO",
-      "day" : "jkGgRhpLsOXK"
+      "year" : "rTGxqDxAPRpaZ",
+      "month" : "FapF6cuInJO8Rx",
+      "day" : "SxAzCQkcoq9zxNHB9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aYZqMarM7RM4fRf",
-        "name" : "zb87Nw637a2pu",
-        "nameType" : "Personal",
-        "orcId" : "1tztG4izeGgUc",
-        "arpId" : "JRQ40YCReZK"
+        "id" : "https://www.example.com/VowDqyqOWCG7C1lBUV",
+        "name" : "CKNp4TFMHQHdMP",
+        "nameType" : "Organizational",
+        "orcId" : "ttYukPjeg276u7OjEJ",
+        "arpId" : "ASmnL5ZO0S"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/55ucom4S0s",
+        "id" : "https://www.example.com/0ujxaOaDZOR9ZQ",
         "labels" : {
-          "ZUaev79lhi59F7Kr" : "zYGZgAtxZQ7U8Tzn"
+          "KzJKuz8K8WHcZ" : "TevxlxxxtKxdTofls"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 8,
+      "role" : "Journalist",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MD3l031vUpiZ6PRSpQ",
-        "name" : "jEABaZnuV5WSgl",
+        "id" : "https://www.example.com/AOt9dOTSVkrVvfl",
+        "name" : "d36cPzlL1eo3uHxGksz",
         "nameType" : "Organizational",
-        "orcId" : "TiOHdWWVEd9CyDyU5",
-        "arpId" : "JSXEJb2rq6Eun"
+        "orcId" : "yrlsVymC7XOqHuFx1",
+        "arpId" : "0479Ti4ILv2ibDs2u"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bgzgYDbu4zUmZMy7Ai",
+        "id" : "https://www.example.com/wpKkndE7HKWzxQTv",
         "labels" : {
-          "EQNdS5Wb39Ryw" : "B44vu4nChn0AHaNfYWs"
+          "65KTEhMd8jhcLt" : "3bYX80vlWQ31YuZgYi"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 6,
+      "role" : "HostingInstitution",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "jLL7EmNAOWLkCUG7E9",
-    "tags" : [ "Fs4vW5c2KiyOTDn" ],
-    "description" : "9VWvZiE3OwGJuVL",
+    "npiSubjectHeading" : "6WXLftGQgDVC",
+    "tags" : [ "VNvStAGXAKvK0" ],
+    "description" : "NPRNJOKXRODiaQOqUN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/NmXNbTxlP9J"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/lVZXf4S6aYMnY"
       },
-      "doi" : "https://www.example.com/PfVj84xma6XOckXO",
+      "doi" : "https://www.example.com/hUoFIs4z2NLKtnod",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "zyIQ5xqXNMALIxn",
-        "issue" : "6MGNslJrbOpv",
-        "articleNumber" : "wWoi4lexBJ25EXs",
+        "volume" : "WS3QyO6F1Rkx",
+        "issue" : "wKJOZLfbb9KnUYLZBg",
+        "articleNumber" : "R34sPL5r9x3",
         "pages" : {
           "type" : "Range",
-          "begin" : "4YV1qsnLLcS",
-          "end" : "iVsIYffhpGOrUnMZZ"
+          "begin" : "lfyTAnPBQgy7Nr",
+          "end" : "tAobsBtA3hyJqtzd"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/80pFiLtOL14bIP",
-    "abstract" : "x7ieVNQOBlNnKzAnTu"
+    "metadataSource" : "https://www.example.com/U8CRBHgV2aCsFsh",
+    "abstract" : "23fZJqw5wfeuWPMtw"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "xVcN1Vh7vKlk3Cy19Ez",
-      "mimeType" : "tNLvGc0809su",
-      "size" : 1268726519,
+      "name" : "B2tDVdgKBRbzLL1yt",
+      "mimeType" : "F9vYmGWDVA9Om",
+      "size" : 703986053,
       "license" : {
         "type" : "License",
-        "identifier" : "2uuPtok2c51PL1",
+        "identifier" : "pbFnUCCCqJUsWEJP",
         "labels" : {
-          "2QBcWpd3c2L12t" : "ripn2d6hqlL"
+          "enAr0rXNh2P453rqYD4" : "s0fGtJLG4ejhYZSYGKA"
         },
-        "link" : "https://www.example.com/TcjKOjh9EDezjIn"
+        "link" : "https://www.example.com/C56YItpx3oNmKrWB"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utratione",
-    "name" : "MOjysGVKSFqpbB2Lwy8",
+    "id" : "https://www.example.org/suscipitsaepe",
+    "name" : "msU3t7QCWRVBZJ6xXy",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "NuuyzNKCPvMUbf0hRvr",
-      "id" : "iuzC07LENL"
+      "source" : "LIoCXZFnkG7",
+      "id" : "fjSP6pxcEByXjBLcgm9"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "pWIpAFVFyE7hDoUJ"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "RqQCAIdgreQ5"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fugitqui" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/doloret" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "SmtHuWYixfC",
+  "status" : "DRAFT",
+  "owner" : "ON8GT8sSrtNiZ",
   "resourceOwner" : {
-    "owner" : "SmtHuWYixfC",
-    "ownerAffiliation" : "https://www.example.org/porroprovident"
+    "owner" : "ON8GT8sSrtNiZ",
+    "ownerAffiliation" : "https://www.example.org/saepeconsequatur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aliquiddeleniti",
+    "id" : "https://www.example.org/eumqui",
     "labels" : {
-      "G0ScMgQznPaDLuhDF" : "qbT5B85zKMDXfh"
+      "DqnM16dH1cv" : "4XwiG320YyPnzfmFq8C"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eaqueexplicabo",
-  "doi" : "https://doi.org/10.1234/esse",
+  "handle" : "https://www.example.org/dignissimosvoluptates",
+  "doi" : "https://doi.org/10.1234/quidem",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "qUdRjt0fwu1szCFuJ",
-      "author" : "I8aKzmOgGIzML",
+      "text" : "8T7WNFQDIxWolG4G2Uo",
+      "author" : "00qvR67uNkgIDflEstZ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloremqueaperiam",
+  "link" : "https://www.example.org/sapientevoluptatem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "etH4ICiqKPdjAZr",
+    "mainTitle" : "XJPfW9qZjYNNBr9",
     "alternativeTitles" : {
-      "ru" : "4rP0rg2oSNr"
+      "nn" : "nPdcx5ttU7fcMYo"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4GNCQEPklTUw",
-      "month" : "U9CYQQOXt8k",
-      "day" : "yHJnRs5KMhqWd"
+      "year" : "RPrLmxp64byCQkn",
+      "month" : "YS6U5sj3wa4tc",
+      "day" : "RgNOIuzjz6tsx11"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KDfQ9ZPXqHY",
-        "name" : "zB0q3YPMkEj",
+        "id" : "https://www.example.com/QwVkBYyxK8nBThRstwU",
+        "name" : "aFqhRHRWZDvCgQyRd",
         "nameType" : "Organizational",
-        "orcId" : "4IBbtIbPYFJ",
-        "arpId" : "DlfEFPSeZqqLbbU1Yn"
+        "orcId" : "LLh3WY0gpI3Kk",
+        "arpId" : "T0CvTulHC3EmU9hyMvq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OY8batDu5ndLhUrsk6",
+        "id" : "https://www.example.com/H4lO5v8jxAXoER2TxCu",
         "labels" : {
-          "wAeWWzvElhzbM" : "4f1ZfWBnrS16nAkCk"
+          "Tbe0FTBb8SWmnp" : "18h4SfKBeyrqinZD"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 8,
+      "role" : "ProjectLeader",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/6896kEQPrJCTBGhz7eM",
-        "name" : "aogT4PbObNxw0hxHlU",
+        "id" : "https://www.example.com/f6B73K9ICpgV",
+        "name" : "hodEZKffNbKm0uenIF",
         "nameType" : "Personal",
-        "orcId" : "GFNcPSvnHOES2YzLjR",
-        "arpId" : "HcnjnhRoDo"
+        "orcId" : "sjTvyNwtRYK",
+        "arpId" : "xRMte5RDjDtw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/F5NVPJuULG9rQRcCQC",
+        "id" : "https://www.example.com/xU7wQ8Ufzm",
         "labels" : {
-          "378APD56O51MYgk0Yu1" : "7EUotHpK1Jq"
+          "riIfaoEJXImvCYx" : "mXCd3fxdnwfzg"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 4,
+      "role" : "DataCollector",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "xUmgNjGsHWIqs5GO",
-    "tags" : [ "HytkBzsBOFZAZ8" ],
-    "description" : "vs8BbUjfPs22Xdm1",
+    "npiSubjectHeading" : "EjbNXrLPPr6v",
+    "tags" : [ "otvITIOO20d9a" ],
+    "description" : "MM9IlmLsAjRCjmH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4bd4Fdf42ub0W"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4Z1PBVxuVvCDkT0WaYq"
       },
-      "doi" : "https://www.example.com/bIEUQfEFREkfC",
+      "doi" : "https://www.example.com/ywDpx96QPXINDHU8PK",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "1S9a2QswkdjmdkOnDzA",
-        "issue" : "WY4g5zyRrelN",
-        "articleNumber" : "dV4KlwYUoYiRxRr",
+        "volume" : "x7cfxp1ZvBi5hfeH5",
+        "issue" : "Wq1eiD9n4JUBmlp",
+        "articleNumber" : "wJTNSqAHJr",
         "pages" : {
           "type" : "Range",
-          "begin" : "HBxcaIA8JDj",
-          "end" : "B7UYzN0ouyxxV"
+          "begin" : "daoGlbS3F54x8XxNw",
+          "end" : "bNjaEvms357VNRhG"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/qkXiVcNoRdlQ9K23x0N",
-    "abstract" : "ZXv3XepHIRn7"
+    "metadataSource" : "https://www.example.com/GBQzKFOHmtpI2l",
+    "abstract" : "6f2MTljRXVqhowgbIB"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "K1qhj7UgA7jNLtzp0qR",
-      "mimeType" : "etl5sSw10urGo3",
-      "size" : 1744337781,
+      "name" : "NlYJ7rNk4nPbgypX",
+      "mimeType" : "WyCtqIOVgR3ks57g",
+      "size" : 1079440290,
       "license" : {
         "type" : "License",
-        "identifier" : "AeP6s30uivioWSc0H9",
+        "identifier" : "933Oca6kw65",
         "labels" : {
-          "1ftc1EVRUG" : "5KPRGv1E4WnXCx7niX"
+          "S5JjCx4zZZfI" : "S28W0Pbm1jh9As"
         },
-        "link" : "https://www.example.com/0bQybvSjJQNJVlKJ"
+        "link" : "https://www.example.com/kzRRmFAUxgC8IVJ"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laborumet",
-    "name" : "aX5ggQNxCzx",
+    "id" : "https://www.example.org/voluptatesiusto",
+    "name" : "noU75rI7sI1pHJ4y7",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "WWREtcUk606BDwUGJQ",
-      "id" : "PAXcuQlyIRsc"
+      "source" : "jvvReFTVEb5",
+      "id" : "67BOpjnW91cuSacag"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "qIDgihovLvoQIBhgQW"
+      "applicationCode" : "qxM2xq21ltbGPVg"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veroqui" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/autcumque" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "dj23oLnitiwYvnLBV",
+  "status" : "PUBLISHED",
+  "owner" : "SmtHuWYixfC",
   "resourceOwner" : {
-    "owner" : "dj23oLnitiwYvnLBV",
-    "ownerAffiliation" : "https://www.example.org/quaetenetur"
+    "owner" : "SmtHuWYixfC",
+    "ownerAffiliation" : "https://www.example.org/porroprovident"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nobislaboriosam",
+    "id" : "https://www.example.org/aliquiddeleniti",
     "labels" : {
-      "b1bSbL76LKzrQR6rT" : "i9g6O8y1nCM97WvTaiC"
+      "G0ScMgQznPaDLuhDF" : "qbT5B85zKMDXfh"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/siteligendi",
-  "doi" : "https://doi.org/10.1234/impedit",
+  "handle" : "https://www.example.org/eaqueexplicabo",
+  "doi" : "https://doi.org/10.1234/esse",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,107 +27,107 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "KUX1iHbelmPkX8V",
-      "author" : "H8MHfN0DxVs1w2dgFG",
+      "text" : "qUdRjt0fwu1szCFuJ",
+      "author" : "I8aKzmOgGIzML",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/adet",
+  "link" : "https://www.example.org/doloremqueaperiam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1MMvms0Wxt",
+    "mainTitle" : "etH4ICiqKPdjAZr",
     "alternativeTitles" : {
-      "sv" : "1pekK5rjyJI6GCGp"
+      "ru" : "4rP0rg2oSNr"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AEfRR3HtbNJtYBm6e",
-      "month" : "nJNXrVoJA2",
-      "day" : "tY2W9Rfy468J"
+      "year" : "4GNCQEPklTUw",
+      "month" : "U9CYQQOXt8k",
+      "day" : "yHJnRs5KMhqWd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wDxZOylop1desSvE",
-        "name" : "oJOyAR8neZIia",
-        "nameType" : "Personal",
-        "orcId" : "5MGbG6kg6tQUCy3o",
-        "arpId" : "oFbC4srSRTdx4AHNx"
+        "id" : "https://www.example.com/KDfQ9ZPXqHY",
+        "name" : "zB0q3YPMkEj",
+        "nameType" : "Organizational",
+        "orcId" : "4IBbtIbPYFJ",
+        "arpId" : "DlfEFPSeZqqLbbU1Yn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/o3plWGRcJg0DOsZghC",
+        "id" : "https://www.example.com/OY8batDu5ndLhUrsk6",
         "labels" : {
-          "nFNqcW7IO1o" : "qunEHcKJffoD"
+          "wAeWWzvElhzbM" : "4f1ZfWBnrS16nAkCk"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 9,
+      "role" : "Designer",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/f8ECwDhx2nRNeL",
-        "name" : "GKdWIUelLkDQ5",
+        "id" : "https://www.example.com/6896kEQPrJCTBGhz7eM",
+        "name" : "aogT4PbObNxw0hxHlU",
         "nameType" : "Personal",
-        "orcId" : "OFoazW0vljU",
-        "arpId" : "7GWznjr3D6lJuDWj7X"
+        "orcId" : "GFNcPSvnHOES2YzLjR",
+        "arpId" : "HcnjnhRoDo"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dqdDwaiqHlqSizAxvVY",
+        "id" : "https://www.example.com/F5NVPJuULG9rQRcCQC",
         "labels" : {
-          "QvbH8C5d1WzJwqSIO" : "ivHRceRCeTu4iHGgfo"
+          "378APD56O51MYgk0Yu1" : "7EUotHpK1Jq"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 1,
+      "role" : "Designer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "W5X81HuLYD3X019Egb",
-    "tags" : [ "emrZmdZo8D23kyy" ],
-    "description" : "e7o566onqfEDeUXu",
+    "npiSubjectHeading" : "xUmgNjGsHWIqs5GO",
+    "tags" : [ "HytkBzsBOFZAZ8" ],
+    "description" : "vs8BbUjfPs22Xdm1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xne4kksud7Df4Z"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4bd4Fdf42ub0W"
       },
-      "doi" : "https://www.example.com/HpaireabR9whxJ9Dxz",
+      "doi" : "https://www.example.com/bIEUQfEFREkfC",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "niKThwHDDzwZv",
-        "issue" : "7FS0aLqNJr5U",
-        "articleNumber" : "emurFuFdnldfTsU2Qce",
+        "volume" : "1S9a2QswkdjmdkOnDzA",
+        "issue" : "WY4g5zyRrelN",
+        "articleNumber" : "dV4KlwYUoYiRxRr",
         "pages" : {
           "type" : "Range",
-          "begin" : "XqBxdYDlqNNzcxjTiwd",
-          "end" : "BuZ3xM7UbmmGoMjv"
+          "begin" : "HBxcaIA8JDj",
+          "end" : "B7UYzN0ouyxxV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/KFzxT0mbrYJF9RVuuHk",
-    "abstract" : "t2BGh6GTkTYie8jFs"
+    "metadataSource" : "https://www.example.com/qkXiVcNoRdlQ9K23x0N",
+    "abstract" : "ZXv3XepHIRn7"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "cUSSMihst6lg",
-      "mimeType" : "qKPLWi6BeAsQY6",
-      "size" : 2090434302,
+      "name" : "K1qhj7UgA7jNLtzp0qR",
+      "mimeType" : "etl5sSw10urGo3",
+      "size" : 1744337781,
       "license" : {
         "type" : "License",
-        "identifier" : "pSdaQrpYfPSbWN",
+        "identifier" : "AeP6s30uivioWSc0H9",
         "labels" : {
-          "3AcQDlaKHNghuDV4" : "RjUc2IdEqsv"
+          "1ftc1EVRUG" : "5KPRGv1E4WnXCx7niX"
         },
-        "link" : "https://www.example.com/CZRO0AsxJk"
+        "link" : "https://www.example.com/0bQybvSjJQNJVlKJ"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laudantiumsed",
-    "name" : "zz0Uu2xI24BJwLgL6R",
+    "id" : "https://www.example.org/laborumet",
+    "name" : "aX5ggQNxCzx",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "UQGYYK3Isg1b0PgxWnI",
-      "id" : "IVJPHxjZ13fKo9m5jT"
+      "source" : "WWREtcUk606BDwUGJQ",
+      "id" : "PAXcuQlyIRsc"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "JfwdHafPl3mZcyN"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "qIDgihovLvoQIBhgQW"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/maioressaepe" ],
+  "subjects" : [ "https://www.example.org/veroqui" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -2,132 +2,132 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "DTEVBYf8gCNyjd9gtIv",
+  "owner" : "dj23oLnitiwYvnLBV",
   "resourceOwner" : {
-    "owner" : "DTEVBYf8gCNyjd9gtIv",
-    "ownerAffiliation" : "https://www.example.org/voluptatibussit"
+    "owner" : "dj23oLnitiwYvnLBV",
+    "ownerAffiliation" : "https://www.example.org/quaetenetur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quaeratnihil",
+    "id" : "https://www.example.org/nobislaboriosam",
     "labels" : {
-      "p1JDa6jFW0HIUw" : "3zX9dwPc4yELv"
+      "b1bSbL76LKzrQR6rT" : "i9g6O8y1nCM97WvTaiC"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolorvitae",
-  "doi" : "https://doi.org/10.1234/velit",
+  "handle" : "https://www.example.org/siteligendi",
+  "doi" : "https://doi.org/10.1234/impedit",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "6bJlUC0cK4Tgjs",
-      "author" : "ThPsM5QBoarBhNiiNCP",
+      "text" : "KUX1iHbelmPkX8V",
+      "author" : "H8MHfN0DxVs1w2dgFG",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/undeconsectetur",
+  "link" : "https://www.example.org/adet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3zFh9PTY4ttFR0zO",
+    "mainTitle" : "1MMvms0Wxt",
     "alternativeTitles" : {
-      "nl" : "FTCMtj6Shw"
+      "sv" : "1pekK5rjyJI6GCGp"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "rTGxqDxAPRpaZ",
-      "month" : "FapF6cuInJO8Rx",
-      "day" : "SxAzCQkcoq9zxNHB9"
+      "year" : "AEfRR3HtbNJtYBm6e",
+      "month" : "nJNXrVoJA2",
+      "day" : "tY2W9Rfy468J"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VowDqyqOWCG7C1lBUV",
-        "name" : "CKNp4TFMHQHdMP",
-        "nameType" : "Organizational",
-        "orcId" : "ttYukPjeg276u7OjEJ",
-        "arpId" : "ASmnL5ZO0S"
+        "id" : "https://www.example.com/wDxZOylop1desSvE",
+        "name" : "oJOyAR8neZIia",
+        "nameType" : "Personal",
+        "orcId" : "5MGbG6kg6tQUCy3o",
+        "arpId" : "oFbC4srSRTdx4AHNx"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0ujxaOaDZOR9ZQ",
+        "id" : "https://www.example.com/o3plWGRcJg0DOsZghC",
         "labels" : {
-          "KzJKuz8K8WHcZ" : "TevxlxxxtKxdTofls"
+          "nFNqcW7IO1o" : "qunEHcKJffoD"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 1,
+      "role" : "Funder",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AOt9dOTSVkrVvfl",
-        "name" : "d36cPzlL1eo3uHxGksz",
-        "nameType" : "Organizational",
-        "orcId" : "yrlsVymC7XOqHuFx1",
-        "arpId" : "0479Ti4ILv2ibDs2u"
+        "id" : "https://www.example.com/f8ECwDhx2nRNeL",
+        "name" : "GKdWIUelLkDQ5",
+        "nameType" : "Personal",
+        "orcId" : "OFoazW0vljU",
+        "arpId" : "7GWznjr3D6lJuDWj7X"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wpKkndE7HKWzxQTv",
+        "id" : "https://www.example.com/dqdDwaiqHlqSizAxvVY",
         "labels" : {
-          "65KTEhMd8jhcLt" : "3bYX80vlWQ31YuZgYi"
+          "QvbH8C5d1WzJwqSIO" : "ivHRceRCeTu4iHGgfo"
         }
       } ],
-      "role" : "HostingInstitution",
+      "role" : "CuratorOrganizer",
       "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6WXLftGQgDVC",
-    "tags" : [ "VNvStAGXAKvK0" ],
-    "description" : "NPRNJOKXRODiaQOqUN",
+    "npiSubjectHeading" : "W5X81HuLYD3X019Egb",
+    "tags" : [ "emrZmdZo8D23kyy" ],
+    "description" : "e7o566onqfEDeUXu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/lVZXf4S6aYMnY"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xne4kksud7Df4Z"
       },
-      "doi" : "https://www.example.com/hUoFIs4z2NLKtnod",
+      "doi" : "https://www.example.com/HpaireabR9whxJ9Dxz",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "WS3QyO6F1Rkx",
-        "issue" : "wKJOZLfbb9KnUYLZBg",
-        "articleNumber" : "R34sPL5r9x3",
+        "volume" : "niKThwHDDzwZv",
+        "issue" : "7FS0aLqNJr5U",
+        "articleNumber" : "emurFuFdnldfTsU2Qce",
         "pages" : {
           "type" : "Range",
-          "begin" : "lfyTAnPBQgy7Nr",
-          "end" : "tAobsBtA3hyJqtzd"
+          "begin" : "XqBxdYDlqNNzcxjTiwd",
+          "end" : "BuZ3xM7UbmmGoMjv"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/U8CRBHgV2aCsFsh",
-    "abstract" : "23fZJqw5wfeuWPMtw"
+    "metadataSource" : "https://www.example.com/KFzxT0mbrYJF9RVuuHk",
+    "abstract" : "t2BGh6GTkTYie8jFs"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "B2tDVdgKBRbzLL1yt",
-      "mimeType" : "F9vYmGWDVA9Om",
-      "size" : 703986053,
+      "name" : "cUSSMihst6lg",
+      "mimeType" : "qKPLWi6BeAsQY6",
+      "size" : 2090434302,
       "license" : {
         "type" : "License",
-        "identifier" : "pbFnUCCCqJUsWEJP",
+        "identifier" : "pSdaQrpYfPSbWN",
         "labels" : {
-          "enAr0rXNh2P453rqYD4" : "s0fGtJLG4ejhYZSYGKA"
+          "3AcQDlaKHNghuDV4" : "RjUc2IdEqsv"
         },
-        "link" : "https://www.example.com/C56YItpx3oNmKrWB"
+        "link" : "https://www.example.com/CZRO0AsxJk"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/suscipitsaepe",
-    "name" : "msU3t7QCWRVBZJ6xXy",
+    "id" : "https://www.example.org/laudantiumsed",
+    "name" : "zz0Uu2xI24BJwLgL6R",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "LIoCXZFnkG7",
-      "id" : "fjSP6pxcEByXjBLcgm9"
+      "source" : "UQGYYK3Isg1b0PgxWnI",
+      "id" : "IVJPHxjZ13fKo9m5jT"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "RqQCAIdgreQ5"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "JfwdHafPl3mZcyN"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloret" ],
+  "subjects" : [ "https://www.example.org/maioressaepe" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "CGRfjYH7tKVO214K",
+  "status" : "PUBLISHED",
+  "owner" : "H0tkIkKk6WVh1n87xqu",
   "resourceOwner" : {
-    "owner" : "CGRfjYH7tKVO214K",
-    "ownerAffiliation" : "https://www.example.org/officiapossimus"
+    "owner" : "H0tkIkKk6WVh1n87xqu",
+    "ownerAffiliation" : "https://www.example.org/deseruntnatus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/easapiente",
+    "id" : "https://www.example.org/enimvoluptas",
     "labels" : {
-      "s1Pzu4LqMO" : "6pd84kumFPFBy1"
+      "QNSt2abQP6FohyzWR" : "IGc4MGo7A8BusDeiI7u"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/beataeamet",
-  "doi" : "https://doi.org/10.1234/voluptas",
+  "handle" : "https://www.example.org/omnisvelit",
+  "doi" : "https://doi.org/10.1234/tenetur",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "w2xQkUhJO6Wp0md",
-      "author" : "Wf3sdUCmck5twkdm",
+      "text" : "YmvEXqvVCo5b8iauj7",
+      "author" : "mLWwIuBXRylyDUMi9TH",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/optionobis",
+  "link" : "https://www.example.org/dignissimosofficiis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Wq5Lhdh9yweTr",
+    "mainTitle" : "X2Xgjzk0emaU",
     "alternativeTitles" : {
-      "el" : "nw96FBPFSwKF0pb41r"
+      "sv" : "VFrG1JClmdL0D0VVB"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "hp7Nff8zL1eNcZ8d",
-      "month" : "O81D5jxApR3uoMJ",
-      "day" : "EUF2nQpkbpf6"
+      "year" : "QyQ8nu3QKsDT",
+      "month" : "3Nq4Nwh9x6cbXKbO",
+      "day" : "jkGgRhpLsOXK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/awLlYbh1B5iYxdk",
-        "name" : "SOaWZNL7ML",
+        "id" : "https://www.example.com/aYZqMarM7RM4fRf",
+        "name" : "zb87Nw637a2pu",
         "nameType" : "Personal",
-        "orcId" : "tDbW8HYa8XZSy0fcWi",
-        "arpId" : "3t340RLPJL"
+        "orcId" : "1tztG4izeGgUc",
+        "arpId" : "JRQ40YCReZK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/IEUyfzz78kcXDhxNK6",
+        "id" : "https://www.example.com/55ucom4S0s",
         "labels" : {
-          "8vMvMkbxUgoF" : "O8PMZnqzYhCNk"
+          "ZUaev79lhi59F7Kr" : "zYGZgAtxZQ7U8Tzn"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 1,
+      "role" : "ProgrammeLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FjldAtwVqDPnreAtgki",
-        "name" : "ssFXfw5nluwBECX",
+        "id" : "https://www.example.com/MD3l031vUpiZ6PRSpQ",
+        "name" : "jEABaZnuV5WSgl",
         "nameType" : "Organizational",
-        "orcId" : "kG4dSGksaxSDsgt",
-        "arpId" : "RQEhddutFH9nxI4"
+        "orcId" : "TiOHdWWVEd9CyDyU5",
+        "arpId" : "JSXEJb2rq6Eun"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6CpqMSKlrC",
+        "id" : "https://www.example.com/bgzgYDbu4zUmZMy7Ai",
         "labels" : {
-          "ZOvmIvjvLIHL" : "VFIRuFhfvLdYTvk1o"
+          "EQNdS5Wb39Ryw" : "B44vu4nChn0AHaNfYWs"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 7,
+      "role" : "Other",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Xvytmwk8WVLwcS6V",
-    "tags" : [ "Z0qStNXmKf4M" ],
-    "description" : "HLGkvVAtemITv7",
+    "npiSubjectHeading" : "jLL7EmNAOWLkCUG7E9",
+    "tags" : [ "Fs4vW5c2KiyOTDn" ],
+    "description" : "9VWvZiE3OwGJuVL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8jbK1gUMLWQH33mC0"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/NmXNbTxlP9J"
       },
-      "doi" : "https://www.example.com/9Z83LEzUDK",
+      "doi" : "https://www.example.com/PfVj84xma6XOckXO",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "0ZdGpDPYE6972OW4",
-        "issue" : "wzzfJ2nIajhuhPXY8HZ",
-        "articleNumber" : "ge4pjJqBqKr7Xkhljjy",
+        "volume" : "zyIQ5xqXNMALIxn",
+        "issue" : "6MGNslJrbOpv",
+        "articleNumber" : "wWoi4lexBJ25EXs",
         "pages" : {
           "type" : "Range",
-          "begin" : "Nwq6kllEmLhkKR",
-          "end" : "0OQ6lWaNhwOw7"
+          "begin" : "4YV1qsnLLcS",
+          "end" : "iVsIYffhpGOrUnMZZ"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/vVuRL5Ecqr",
-    "abstract" : "fyFtWjf5W6jS56MJTo"
+    "metadataSource" : "https://www.example.com/80pFiLtOL14bIP",
+    "abstract" : "x7ieVNQOBlNnKzAnTu"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wKnWcxat5RwcFMs",
-      "mimeType" : "nGkDKj27Gq3RPXDX",
-      "size" : 1158027524,
+      "name" : "xVcN1Vh7vKlk3Cy19Ez",
+      "mimeType" : "tNLvGc0809su",
+      "size" : 1268726519,
       "license" : {
         "type" : "License",
-        "identifier" : "a9AwCyt0h87OjnCG",
+        "identifier" : "2uuPtok2c51PL1",
         "labels" : {
-          "FlSv9243qJPAXsMKE1" : "pECqSydEh6"
+          "2QBcWpd3c2L12t" : "ripn2d6hqlL"
         },
-        "link" : "https://www.example.com/2Kcm8VWpmDpafHRm"
+        "link" : "https://www.example.com/TcjKOjh9EDezjIn"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/velitmodi",
-    "name" : "ggwzrfhydA5ozvAW",
+    "id" : "https://www.example.org/utratione",
+    "name" : "MOjysGVKSFqpbB2Lwy8",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Bqeukysvnd2yKHS",
-      "id" : "FGl4i5JTlCc28xgB"
+      "source" : "NuuyzNKCPvMUbf0hRvr",
+      "id" : "iuzC07LENL"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "KfPB8PMHBON3i"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "pWIpAFVFyE7hDoUJ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatevoluptatibus" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/fugitqui" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "CuAe5XhVDm35hG",
+  "status" : "DRAFT",
+  "owner" : "q6StP2zApclCFx",
   "resourceOwner" : {
-    "owner" : "CuAe5XhVDm35hG",
-    "ownerAffiliation" : "https://www.example.org/nostrumiusto"
+    "owner" : "q6StP2zApclCFx",
+    "ownerAffiliation" : "https://www.example.org/quiblanditiis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/errorlaudantium",
+    "id" : "https://www.example.org/veritatissunt",
     "labels" : {
-      "ZleyMijAPGkzAt" : "nA7XMy2YP5"
+      "ofBvEgEwz05MZe" : "GtusL2s8RL2BsKPVYRW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quibusdamnumquam",
-  "doi" : "https://doi.org/10.1234/ut",
+  "handle" : "https://www.example.org/cupiditatepraesentium",
+  "doi" : "https://doi.org/10.1234/est",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "PVS9G1mKkrBnI2m",
-      "author" : "l9NWICNSbKsRXY3",
+      "text" : "Wnbwt12zIs",
+      "author" : "DHoPRRXJvsC1W",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/numquameum",
+  "link" : "https://www.example.org/molestiasqui",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9Es8lLMovhjxGt",
+    "mainTitle" : "T6BCQXCh8jypp2N",
     "alternativeTitles" : {
-      "nl" : "CzWsKMLKrB9Xt"
+      "af" : "yYxhzAvSY8k"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Taj8PPq7mU",
-      "month" : "Q753ooM3DQghKMC3eg",
-      "day" : "BXv76oeKbNVHJDrLrJc"
+      "year" : "C77FRaSKoMXJ",
+      "month" : "rl0Edl3CG4nytvK",
+      "day" : "Xv810GPZzlqgU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/yGyuCFhaRAIb",
-        "name" : "G3bgL0QaJYJ8N",
-        "nameType" : "Personal",
-        "orcId" : "bHs0GRIdYKi",
-        "arpId" : "stYf4jiFwBgp7J"
+        "id" : "https://www.example.com/hkvSVfwDbAht3zAJvcz",
+        "name" : "YpaMate7LHFqV",
+        "nameType" : "Organizational",
+        "orcId" : "CeUXhWMn7Q5yX10",
+        "arpId" : "U9eTL2KMY8n73UP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hFTWSXNhDtjlR7zkbhe",
+        "id" : "https://www.example.com/mBpThY9TQnqLOc",
         "labels" : {
-          "AMzLWtLUyZpcNtpiD" : "uMZPqzpXCGRqDWx"
+          "G7l5ubEuKlUJYrSNL5" : "kp8a7SEhDVAhdkR"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 7,
+      "role" : "DataCurator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sAMODIr2NkgnzSHyeH",
-        "name" : "6T8TA7NtX5tWHDPHyfZ",
-        "nameType" : "Personal",
-        "orcId" : "4L2gwXtCx9O2lel0",
-        "arpId" : "0fibwci1XRsm"
+        "id" : "https://www.example.com/rnRb0PnTC5iWsbQPPqq",
+        "name" : "oBbLff2BYBHxoH",
+        "nameType" : "Organizational",
+        "orcId" : "D5w1fP2ep22XSbBvM",
+        "arpId" : "0MOQYj51kjsZMrGFTht"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/TJEeaBO3z1jF44gYDmU",
+        "id" : "https://www.example.com/Y19hg7pfSJJ3zAhGS6",
         "labels" : {
-          "nzDgn86rMTJ8Rq2" : "CUpDiApl4XBMS"
+          "k0zKYh6U3N" : "O2iXQcohCbEZQT0Z"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 3,
+      "role" : "DataManager",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "kxb64DW31dNaeT",
-    "tags" : [ "Z0EKpqScxi7a9j4" ],
-    "description" : "bwyWYnuYGUgZRgKb5",
+    "npiSubjectHeading" : "A0AdEs9nqLT1n",
+    "tags" : [ "9sSuaP0Uaw" ],
+    "description" : "qfocYPmObparHN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/I2lbTwDapxRpLbb"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Z0EBNL9H8Tp9"
       },
-      "doi" : "https://www.example.com/Jjsh18nSuj",
+      "doi" : "https://www.example.com/01GSOO8FPyUxnk",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "q96UPtU2DB4YWI9OY3X",
-        "issue" : "NaTpyEwc3VgVqQ9CDMh",
-        "articleNumber" : "8jGQPXgCvIJwR",
+        "volume" : "LGtHLSXfG9P",
+        "issue" : "Ut3UaqeDMcP",
+        "articleNumber" : "AwtQH0iBpS",
         "pages" : {
           "type" : "Range",
-          "begin" : "8fUvuGD4yFz9E8DqZR",
-          "end" : "gZD8EnaZXQdHLzX30"
+          "begin" : "bNd8QiRHXkNX",
+          "end" : "JmTpX7uVNmPKnIrV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/csspst2ObszmZ9Cc",
-    "abstract" : "pK8vGGZoYUMUZ3iNw"
+    "metadataSource" : "https://www.example.com/RxwdtTgDOtB1m7UyS",
+    "abstract" : "a6bAochwdC5Z8Odu"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "amdmcNymEgFXtnNP41",
-      "mimeType" : "EorySnPs9O3SNKb",
-      "size" : 1543405756,
+      "name" : "Wogr7jh3t4xuWi",
+      "mimeType" : "05ReMl5LcP7yvEy",
+      "size" : 1576032597,
       "license" : {
         "type" : "License",
-        "identifier" : "kwOy2fkItXE",
+        "identifier" : "RoSjA2zFzluJ",
         "labels" : {
-          "3GVWmSRbeXA3Rx" : "FYL2O2Gl8XJGGglA"
+          "CwFbI1Nx5N4ex" : "4W1QAV84uO9xpxZVNyI"
         },
-        "link" : "https://www.example.com/FhouL4OrAD"
+        "link" : "https://www.example.com/MqLA8a6FNfmkbAcmOf"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/isteassumenda",
-    "name" : "Sx2ZATUs679V",
+    "id" : "https://www.example.org/etmagni",
+    "name" : "uUQ2cai1LrTuCvNl",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ieVGkDSqFwAQO1czqPl",
-      "id" : "fp7tj7K8uROLfri"
+      "source" : "T8QOlNNlQq6et3",
+      "id" : "OuUHAelUj59lou3tN"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "TORpJtmpAnFb20S"
+      "applicationCode" : "umf2MA2hoFHh"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatumminima" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/similiquenihil" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "Gc1MUx36CYuQN9Z",
+  "status" : "DRAFT",
+  "owner" : "wNuAFYahcDA9WTD7J8M",
   "resourceOwner" : {
-    "owner" : "Gc1MUx36CYuQN9Z",
-    "ownerAffiliation" : "https://www.example.org/quiasunt"
+    "owner" : "wNuAFYahcDA9WTD7J8M",
+    "ownerAffiliation" : "https://www.example.org/suscipitlaboriosam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiconsequatur",
+    "id" : "https://www.example.org/facilisdeserunt",
     "labels" : {
-      "wOKYEif5WE5R0l0A" : "1ooFaBnbxTMqzAWQx"
+      "WOWyE6dqYdBsn" : "1gIVchDBvhe"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sapientecorrupti",
-  "doi" : "https://doi.org/10.1234/maiores",
+  "handle" : "https://www.example.org/sintiure",
+  "doi" : "https://doi.org/10.1234/ex",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "nv92Qc67GJM9PTg",
-      "author" : "CWp5UiGd8IPC0QyF",
+      "text" : "7sHJJxD0A8",
+      "author" : "xOyXWz9zcG",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/placeatexcepturi",
+  "link" : "https://www.example.org/doloreet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "muDFCuQTjlmohn",
+    "mainTitle" : "9BtkCSn5PDHxAOMG",
     "alternativeTitles" : {
-      "sv" : "BUMwRG8zef6cI6jRfg"
+      "es" : "IzCOhEy3Ewt1hQ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "LxSGQ3tsKyQqUYEL0R",
-      "month" : "6F5JTxpuIFg",
-      "day" : "ht6qPFYesoSkHj"
+      "year" : "NAhSxnb2feTFkn15",
+      "month" : "lz3Ozcs44yOiHVQ87L",
+      "day" : "AuBlp3vocYTsX0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/PuSmv5PcVOs3Qv8EZ",
-        "name" : "gpC3U9AfX3vLZy",
+        "id" : "https://www.example.com/kyzrZ51fftjusWwD1P",
+        "name" : "zz5qJwxWyM6HmQXxel",
         "nameType" : "Organizational",
-        "orcId" : "kuDztawJ3eLaOz7bjS",
-        "arpId" : "xchTrzaVGg"
+        "orcId" : "Ge2KDCAYJDonkZE4Ps",
+        "arpId" : "MSPTU09g8Cnaz0"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4uyfo9bfTAqFKW9p",
+        "id" : "https://www.example.com/D5D4N6jKgDvZ2",
         "labels" : {
-          "UUbE8ZIu1ey0y" : "UJbNukUA4Pk5Eka2iDB"
+          "ymBI2HORBOHxH3OOT" : "9obFabVHSzy6I"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 5,
+      "role" : "Advisor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HdFyuyspUIugQCiJ",
-        "name" : "AoKgFWN84I8",
+        "id" : "https://www.example.com/FhkZpA7k4h9PE38U7v",
+        "name" : "lms7CdeOl8ywlgm",
         "nameType" : "Personal",
-        "orcId" : "7mS2SZ4pIahwS",
-        "arpId" : "3LCIYyMhwq4hnVS4G7"
+        "orcId" : "NNKJwYUZ6vGlwk",
+        "arpId" : "N2dP1ctzsYoB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Qw9VKOQVzVAN",
+        "id" : "https://www.example.com/uQ7fFizJpZf5WU1Na",
         "labels" : {
-          "RSeXQnHF4WrEt29IDL" : "d3fKGSQXJvD"
+          "5sfRVcxJxQj" : "FZbpI6iNd232"
         }
       } ],
-      "role" : "ProjectManager",
+      "role" : "Other",
       "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "i52CkpaTkeQ7oAuMcQ",
-    "tags" : [ "xCi5MHpn0IZQM6" ],
-    "description" : "lAhswMVpjYR4U",
+    "npiSubjectHeading" : "QassqXq8LW",
+    "tags" : [ "CQD6RXe24VjwN5FDh09" ],
+    "description" : "hcvG9kQHI7nus",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zxGnUfGyAM08d"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XxngwlEHCUjv6CNf"
       },
-      "doi" : "https://www.example.com/YHz5vAvdsWslHkN24id",
+      "doi" : "https://www.example.com/9PKttIlcRG4A",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "gIG1plCqks0xSim",
-        "issue" : "YakQdNrQ4Zp7f1BBCDv",
-        "articleNumber" : "e6jOxg6Y7jrGzTMTv",
+        "volume" : "9ULp9pThnlU",
+        "issue" : "bUX91kocQq5xfuiK3",
+        "articleNumber" : "q6idS3ytq6MPK4m39r3",
         "pages" : {
           "type" : "Range",
-          "begin" : "1Pq6niGwKbp",
-          "end" : "1gr1l1LoSTUg3Mrfx1"
+          "begin" : "ttjXw954TPeMfML",
+          "end" : "0F7JrsIrzqFZ5BjuW"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/lD3N7KHVzZg",
-    "abstract" : "c1FFCeaf2lnBxg8y"
+    "metadataSource" : "https://www.example.com/AEJUlSGGHibu2hq4QmX",
+    "abstract" : "bJMWXlYMnBvg36"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "psAMihAjVDE",
-      "mimeType" : "0RP4CWcDO23aJ",
-      "size" : 2066917401,
+      "name" : "1MocFufjJnlwD",
+      "mimeType" : "w8TMVhvnX5PbqvSG7K",
+      "size" : 924388934,
       "license" : {
         "type" : "License",
-        "identifier" : "R0a9cbKLskBQluzHmm",
+        "identifier" : "GhpScPbCE8sZ0R",
         "labels" : {
-          "Z3HoWj3KuP4IXA" : "mQz0lnn2Li"
+          "pgOKCSnNrrymnpnmk" : "GiXi0z6uZSDo"
         },
-        "link" : "https://www.example.com/D8vYjA3mft"
+        "link" : "https://www.example.com/EnhB2yjKJFk3gFJ0"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiaesse",
-    "name" : "Dm6PGlHKH7",
+    "id" : "https://www.example.org/noniste",
+    "name" : "HiZ789OGZC",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "arZSr7bgsmCQq81fSf",
-      "id" : "d6y06gIhZXdeX"
+      "source" : "wqVgU3Y6U40JtCU",
+      "id" : "E5DE4CLwr6iInE7"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "SIxdj210ASkR"
+      "applicationCode" : "d0OHFPq9gujLCpq3tr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/errorunde" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/molestiaeratione" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "pnXtigBj8Ri6",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "Gc1MUx36CYuQN9Z",
   "resourceOwner" : {
-    "owner" : "pnXtigBj8Ri6",
-    "ownerAffiliation" : "https://www.example.org/esttemporibus"
+    "owner" : "Gc1MUx36CYuQN9Z",
+    "ownerAffiliation" : "https://www.example.org/quiasunt"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aperiamtemporibus",
+    "id" : "https://www.example.org/quiconsequatur",
     "labels" : {
-      "RfufvWHvsPdcbPn" : "wYDqIpot6YwtWesD"
+      "wOKYEif5WE5R0l0A" : "1ooFaBnbxTMqzAWQx"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiqui",
-  "doi" : "https://doi.org/10.1234/facere",
+  "handle" : "https://www.example.org/sapientecorrupti",
+  "doi" : "https://doi.org/10.1234/maiores",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "EMa57SDJUL",
-      "author" : "5NJOekXTKDQIUjXnDdY",
+      "text" : "nv92Qc67GJM9PTg",
+      "author" : "CWp5UiGd8IPC0QyF",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/veniamreiciendis",
+  "link" : "https://www.example.org/placeatexcepturi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SeeiJnoKqu",
+    "mainTitle" : "muDFCuQTjlmohn",
     "alternativeTitles" : {
-      "bg" : "5MPLwE8ZEGjWTj"
+      "sv" : "BUMwRG8zef6cI6jRfg"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "eASSeaj79wNA",
-      "month" : "WPON7nqbG1snE6",
-      "day" : "WoCynWsaLz"
+      "year" : "LxSGQ3tsKyQqUYEL0R",
+      "month" : "6F5JTxpuIFg",
+      "day" : "ht6qPFYesoSkHj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jtCSqTKh6BPTqM",
-        "name" : "ydk8I3xZOJtFlympeX",
+        "id" : "https://www.example.com/PuSmv5PcVOs3Qv8EZ",
+        "name" : "gpC3U9AfX3vLZy",
         "nameType" : "Organizational",
-        "orcId" : "JbdvuYERKokLU0yLBc",
-        "arpId" : "XvbWGT262g3B0XrMlcY"
+        "orcId" : "kuDztawJ3eLaOz7bjS",
+        "arpId" : "xchTrzaVGg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wXp4LOREajbJaRQ",
+        "id" : "https://www.example.com/4uyfo9bfTAqFKW9p",
         "labels" : {
-          "rNL0XTJuF7JAGG" : "rcfC8i7Bp5uz"
+          "UUbE8ZIu1ey0y" : "UJbNukUA4Pk5Eka2iDB"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 9,
+      "role" : "Researcher",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KdPuKOPNMoC",
-        "name" : "b3DxanqwK0",
-        "nameType" : "Organizational",
-        "orcId" : "15FGzSLqladiyo",
-        "arpId" : "CDYwQWhEXdwlY0wd"
+        "id" : "https://www.example.com/HdFyuyspUIugQCiJ",
+        "name" : "AoKgFWN84I8",
+        "nameType" : "Personal",
+        "orcId" : "7mS2SZ4pIahwS",
+        "arpId" : "3LCIYyMhwq4hnVS4G7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qR5hq1bbCJWABY6WlH",
+        "id" : "https://www.example.com/Qw9VKOQVzVAN",
         "labels" : {
-          "bfl66EiS3m6RPN8" : "7zAQvY5esmzvF"
+          "RSeXQnHF4WrEt29IDL" : "d3fKGSQXJvD"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 3,
+      "role" : "ProjectManager",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6zSfnG9MzoSfn28dfIF",
-    "tags" : [ "sPejiRNZ6EJ2" ],
-    "description" : "IApZu35YCVS",
+    "npiSubjectHeading" : "i52CkpaTkeQ7oAuMcQ",
+    "tags" : [ "xCi5MHpn0IZQM6" ],
+    "description" : "lAhswMVpjYR4U",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BZLRnMke5yhi7j2vz"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zxGnUfGyAM08d"
       },
-      "doi" : "https://www.example.com/0pTib7dMks6P91azKO",
+      "doi" : "https://www.example.com/YHz5vAvdsWslHkN24id",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "C3qWHkwT01",
-        "issue" : "rBZMhUQpSX9LsGUCTZG",
-        "articleNumber" : "h4UXZNSeewf",
+        "volume" : "gIG1plCqks0xSim",
+        "issue" : "YakQdNrQ4Zp7f1BBCDv",
+        "articleNumber" : "e6jOxg6Y7jrGzTMTv",
         "pages" : {
           "type" : "Range",
-          "begin" : "W505NmXm3a",
-          "end" : "LnxXI9TztHz35IUy9zT"
+          "begin" : "1Pq6niGwKbp",
+          "end" : "1gr1l1LoSTUg3Mrfx1"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/qwqZqjAoXh95W8TAi",
-    "abstract" : "5jUOkWOjy7qvAp35"
+    "metadataSource" : "https://www.example.com/lD3N7KHVzZg",
+    "abstract" : "c1FFCeaf2lnBxg8y"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Upa5NGUXHXEhtn",
-      "mimeType" : "bXho6MAyjOVkT",
-      "size" : 1087438778,
+      "name" : "psAMihAjVDE",
+      "mimeType" : "0RP4CWcDO23aJ",
+      "size" : 2066917401,
       "license" : {
         "type" : "License",
-        "identifier" : "siGxJ5zut7BvGVs",
+        "identifier" : "R0a9cbKLskBQluzHmm",
         "labels" : {
-          "fe59sqWrWjI" : "7Q1if3kv8xnOEY9"
+          "Z3HoWj3KuP4IXA" : "mQz0lnn2Li"
         },
-        "link" : "https://www.example.com/wmRTYaV7vVJpW2"
+        "link" : "https://www.example.com/D8vYjA3mft"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/asperioresinventore",
-    "name" : "dcHxGFGzZbiPOvH",
+    "id" : "https://www.example.org/quiaesse",
+    "name" : "Dm6PGlHKH7",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "eokrJbZPm3LJ",
-      "id" : "JC1zv9t1mYcw"
+      "source" : "arZSr7bgsmCQq81fSf",
+      "id" : "d6y06gIhZXdeX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "6rIuiNrEAr77y"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "SIxdj210ASkR"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiofficiis" ],
+  "subjects" : [ "https://www.example.org/errorunde" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "q6StP2zApclCFx",
+  "status" : "PUBLISHED",
+  "owner" : "pnXtigBj8Ri6",
   "resourceOwner" : {
-    "owner" : "q6StP2zApclCFx",
-    "ownerAffiliation" : "https://www.example.org/quiblanditiis"
+    "owner" : "pnXtigBj8Ri6",
+    "ownerAffiliation" : "https://www.example.org/esttemporibus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/veritatissunt",
+    "id" : "https://www.example.org/aperiamtemporibus",
     "labels" : {
-      "ofBvEgEwz05MZe" : "GtusL2s8RL2BsKPVYRW"
+      "RfufvWHvsPdcbPn" : "wYDqIpot6YwtWesD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/cupiditatepraesentium",
-  "doi" : "https://doi.org/10.1234/est",
+  "handle" : "https://www.example.org/quiqui",
+  "doi" : "https://doi.org/10.1234/facere",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Wnbwt12zIs",
-      "author" : "DHoPRRXJvsC1W",
+      "text" : "EMa57SDJUL",
+      "author" : "5NJOekXTKDQIUjXnDdY",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/molestiasqui",
+  "link" : "https://www.example.org/veniamreiciendis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "T6BCQXCh8jypp2N",
+    "mainTitle" : "SeeiJnoKqu",
     "alternativeTitles" : {
-      "af" : "yYxhzAvSY8k"
+      "bg" : "5MPLwE8ZEGjWTj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "C77FRaSKoMXJ",
-      "month" : "rl0Edl3CG4nytvK",
-      "day" : "Xv810GPZzlqgU"
+      "year" : "eASSeaj79wNA",
+      "month" : "WPON7nqbG1snE6",
+      "day" : "WoCynWsaLz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hkvSVfwDbAht3zAJvcz",
-        "name" : "YpaMate7LHFqV",
+        "id" : "https://www.example.com/jtCSqTKh6BPTqM",
+        "name" : "ydk8I3xZOJtFlympeX",
         "nameType" : "Organizational",
-        "orcId" : "CeUXhWMn7Q5yX10",
-        "arpId" : "U9eTL2KMY8n73UP"
+        "orcId" : "JbdvuYERKokLU0yLBc",
+        "arpId" : "XvbWGT262g3B0XrMlcY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mBpThY9TQnqLOc",
+        "id" : "https://www.example.com/wXp4LOREajbJaRQ",
         "labels" : {
-          "G7l5ubEuKlUJYrSNL5" : "kp8a7SEhDVAhdkR"
+          "rNL0XTJuF7JAGG" : "rcfC8i7Bp5uz"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 3,
+      "role" : "ResearchGroup",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rnRb0PnTC5iWsbQPPqq",
-        "name" : "oBbLff2BYBHxoH",
+        "id" : "https://www.example.com/KdPuKOPNMoC",
+        "name" : "b3DxanqwK0",
         "nameType" : "Organizational",
-        "orcId" : "D5w1fP2ep22XSbBvM",
-        "arpId" : "0MOQYj51kjsZMrGFTht"
+        "orcId" : "15FGzSLqladiyo",
+        "arpId" : "CDYwQWhEXdwlY0wd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Y19hg7pfSJJ3zAhGS6",
+        "id" : "https://www.example.com/qR5hq1bbCJWABY6WlH",
         "labels" : {
-          "k0zKYh6U3N" : "O2iXQcohCbEZQT0Z"
+          "bfl66EiS3m6RPN8" : "7zAQvY5esmzvF"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 5,
+      "role" : "WorkPackageLeader",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "A0AdEs9nqLT1n",
-    "tags" : [ "9sSuaP0Uaw" ],
-    "description" : "qfocYPmObparHN",
+    "npiSubjectHeading" : "6zSfnG9MzoSfn28dfIF",
+    "tags" : [ "sPejiRNZ6EJ2" ],
+    "description" : "IApZu35YCVS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Z0EBNL9H8Tp9"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BZLRnMke5yhi7j2vz"
       },
-      "doi" : "https://www.example.com/01GSOO8FPyUxnk",
+      "doi" : "https://www.example.com/0pTib7dMks6P91azKO",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "LGtHLSXfG9P",
-        "issue" : "Ut3UaqeDMcP",
-        "articleNumber" : "AwtQH0iBpS",
+        "volume" : "C3qWHkwT01",
+        "issue" : "rBZMhUQpSX9LsGUCTZG",
+        "articleNumber" : "h4UXZNSeewf",
         "pages" : {
           "type" : "Range",
-          "begin" : "bNd8QiRHXkNX",
-          "end" : "JmTpX7uVNmPKnIrV"
+          "begin" : "W505NmXm3a",
+          "end" : "LnxXI9TztHz35IUy9zT"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/RxwdtTgDOtB1m7UyS",
-    "abstract" : "a6bAochwdC5Z8Odu"
+    "metadataSource" : "https://www.example.com/qwqZqjAoXh95W8TAi",
+    "abstract" : "5jUOkWOjy7qvAp35"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Wogr7jh3t4xuWi",
-      "mimeType" : "05ReMl5LcP7yvEy",
-      "size" : 1576032597,
+      "name" : "Upa5NGUXHXEhtn",
+      "mimeType" : "bXho6MAyjOVkT",
+      "size" : 1087438778,
       "license" : {
         "type" : "License",
-        "identifier" : "RoSjA2zFzluJ",
+        "identifier" : "siGxJ5zut7BvGVs",
         "labels" : {
-          "CwFbI1Nx5N4ex" : "4W1QAV84uO9xpxZVNyI"
+          "fe59sqWrWjI" : "7Q1if3kv8xnOEY9"
         },
-        "link" : "https://www.example.com/MqLA8a6FNfmkbAcmOf"
+        "link" : "https://www.example.com/wmRTYaV7vVJpW2"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etmagni",
-    "name" : "uUQ2cai1LrTuCvNl",
+    "id" : "https://www.example.org/asperioresinventore",
+    "name" : "dcHxGFGzZbiPOvH",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "T8QOlNNlQq6et3",
-      "id" : "OuUHAelUj59lou3tN"
+      "source" : "eokrJbZPm3LJ",
+      "id" : "JC1zv9t1mYcw"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "umf2MA2hoFHh"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "6rIuiNrEAr77y"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/similiquenihil" ],
+  "subjects" : [ "https://www.example.org/quiofficiis" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "trbPWafNOiP5nW0sT6",
+  "status" : "PUBLISHED",
+  "owner" : "CuAe5XhVDm35hG",
   "resourceOwner" : {
-    "owner" : "trbPWafNOiP5nW0sT6",
-    "ownerAffiliation" : "https://www.example.org/quamquisquam"
+    "owner" : "CuAe5XhVDm35hG",
+    "ownerAffiliation" : "https://www.example.org/nostrumiusto"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/magnamofficia",
+    "id" : "https://www.example.org/errorlaudantium",
     "labels" : {
-      "wzYAOmzlQr8QjfmU" : "0Rc6u2lwAPMfi"
+      "ZleyMijAPGkzAt" : "nA7XMy2YP5"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etvoluptas",
-  "doi" : "https://doi.org/10.1234/eius",
+  "handle" : "https://www.example.org/quibusdamnumquam",
+  "doi" : "https://doi.org/10.1234/ut",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "4z2ez415d5ik0iQHdfy",
-      "author" : "3ipzwOL4ccxO",
+      "text" : "PVS9G1mKkrBnI2m",
+      "author" : "l9NWICNSbKsRXY3",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloremqueeligendi",
+  "link" : "https://www.example.org/numquameum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fl3umscSOeKc3ouOV",
+    "mainTitle" : "9Es8lLMovhjxGt",
     "alternativeTitles" : {
-      "se" : "2TI8V4losaHD960u"
+      "nl" : "CzWsKMLKrB9Xt"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "B4qMqvSzAVAOMRewRfJ",
-      "month" : "4qOqoL6MA2V7LqYiFw",
-      "day" : "mn0wtXMGyser0uTlDT"
+      "year" : "Taj8PPq7mU",
+      "month" : "Q753ooM3DQghKMC3eg",
+      "day" : "BXv76oeKbNVHJDrLrJc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/C26CL7nSHG0D",
-        "name" : "Psayw5gg5RnCJ",
+        "id" : "https://www.example.com/yGyuCFhaRAIb",
+        "name" : "G3bgL0QaJYJ8N",
         "nameType" : "Personal",
-        "orcId" : "w3MOfVmt4geqLvJ9G0R",
-        "arpId" : "AU8RbRoHaIh1en"
+        "orcId" : "bHs0GRIdYKi",
+        "arpId" : "stYf4jiFwBgp7J"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9A8kc4exTfl0Eh9b2O",
+        "id" : "https://www.example.com/hFTWSXNhDtjlR7zkbhe",
         "labels" : {
-          "exmAbszsHKl4M" : "nVlS7etHmtxK40pu"
+          "AMzLWtLUyZpcNtpiD" : "uMZPqzpXCGRqDWx"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 6,
+      "role" : "ProjectMember",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Lcr3KGxWYgT",
-        "name" : "rVJ76mAdExyC7Kj",
+        "id" : "https://www.example.com/sAMODIr2NkgnzSHyeH",
+        "name" : "6T8TA7NtX5tWHDPHyfZ",
         "nameType" : "Personal",
-        "orcId" : "IS3sFFYEuQmo8f5F3k",
-        "arpId" : "DNQUOSXmJA8IteBCh"
+        "orcId" : "4L2gwXtCx9O2lel0",
+        "arpId" : "0fibwci1XRsm"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yfNFzGDPs73dBkP",
+        "id" : "https://www.example.com/TJEeaBO3z1jF44gYDmU",
         "labels" : {
-          "gRdNbbJFrpA8Qu" : "VO7mnqRP5lvfy"
+          "nzDgn86rMTJ8Rq2" : "CUpDiApl4XBMS"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 2,
+      "role" : "Consultant",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "8gtD8yUB0BnX",
-    "tags" : [ "oLWJhd3SbK2PB2mYp" ],
-    "description" : "ageiyZp71weZ2zCPe",
+    "npiSubjectHeading" : "kxb64DW31dNaeT",
+    "tags" : [ "Z0EKpqScxi7a9j4" ],
+    "description" : "bwyWYnuYGUgZRgKb5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hkVU5slCuZ"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/I2lbTwDapxRpLbb"
       },
-      "doi" : "https://www.example.com/K2xzl8ASuXKHK",
+      "doi" : "https://www.example.com/Jjsh18nSuj",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "CHrl1ao7jVhFWf",
-        "issue" : "rYkhi6SLMIU",
-        "articleNumber" : "2wlQ4u14RFdo9",
+        "volume" : "q96UPtU2DB4YWI9OY3X",
+        "issue" : "NaTpyEwc3VgVqQ9CDMh",
+        "articleNumber" : "8jGQPXgCvIJwR",
         "pages" : {
           "type" : "Range",
-          "begin" : "bb3n6Un50chW1F9uksD",
-          "end" : "7j1lcFsYWo3Mm"
+          "begin" : "8fUvuGD4yFz9E8DqZR",
+          "end" : "gZD8EnaZXQdHLzX30"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/rQeAbecc73XP3",
-    "abstract" : "EhCdNS3kQ66"
+    "metadataSource" : "https://www.example.com/csspst2ObszmZ9Cc",
+    "abstract" : "pK8vGGZoYUMUZ3iNw"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "T78ObF8yeyUZ",
-      "mimeType" : "9fQjY8P90xaZHKb",
-      "size" : 1878752065,
+      "name" : "amdmcNymEgFXtnNP41",
+      "mimeType" : "EorySnPs9O3SNKb",
+      "size" : 1543405756,
       "license" : {
         "type" : "License",
-        "identifier" : "TQZiBi2ZzfOM",
+        "identifier" : "kwOy2fkItXE",
         "labels" : {
-          "79Y6phQ02awVko1H7" : "BXAcrbnhngvujSyM"
+          "3GVWmSRbeXA3Rx" : "FYL2O2Gl8XJGGglA"
         },
-        "link" : "https://www.example.com/n0ahIXR43RwjJ"
+        "link" : "https://www.example.com/FhouL4OrAD"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemreiciendis",
-    "name" : "MYVMBjXRp9ToWkG",
+    "id" : "https://www.example.org/isteassumenda",
+    "name" : "Sx2ZATUs679V",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ptLoX5xjsx3vlNxMkp",
-      "id" : "NS5iUcSAFK4Nxw"
+      "source" : "ieVGkDSqFwAQO1czqPl",
+      "id" : "fp7tj7K8uROLfri"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Ju4qlXkQnahLWf5Bz8S"
+      "applicationCode" : "TORpJtmpAnFb20S"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliquamunde" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/voluptatumminima" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "8xr6GTGQJUeZK78Nz4",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "hviTRqLxBcpi",
   "resourceOwner" : {
-    "owner" : "8xr6GTGQJUeZK78Nz4",
-    "ownerAffiliation" : "https://www.example.org/exercitationemesse"
+    "owner" : "hviTRqLxBcpi",
+    "ownerAffiliation" : "https://www.example.org/eumnon"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiaeautem",
+    "id" : "https://www.example.org/autamet",
     "labels" : {
-      "sAxpDwVq54k4NCoi" : "xEVy3Lgft8"
+      "A3eI0pMazOjhK" : "BvjTPxLSEDbXZAurrz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utodio",
-  "doi" : "https://doi.org/10.1234/quaerat",
+  "handle" : "https://www.example.org/accusamuseum",
+  "doi" : "https://doi.org/10.1234/unde",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,107 +27,107 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "wpGcBbPlOk5SwQ",
-      "author" : "7yLfq87sFDrAO",
+      "text" : "DHoK3R8903KDmyz",
+      "author" : "PvRaokYUr1dVg",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/oditad",
+  "link" : "https://www.example.org/nesciuntest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XLbAITSBeAYc",
+    "mainTitle" : "MudXwgexFfrklK",
     "alternativeTitles" : {
-      "fi" : "ii0NiLi2jZ0OI0wVxS"
+      "zh" : "4h03aHqxSiZkGUbF"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "kUCzWuiW3kln4X",
-      "month" : "agct4UOuIwG57XSqZ3",
-      "day" : "dydvpf8ugHSw977"
+      "year" : "E8vgPMo2BOkndCbABtc",
+      "month" : "MoYXWWGQbQ0JR",
+      "day" : "LhQUePnjBBXhiW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/QUe23A9TUtNSC6HO",
-        "name" : "7tunyjRp28s",
+        "id" : "https://www.example.com/IYuLnrj8aRgyK",
+        "name" : "TtZ8dy7TIAMR",
         "nameType" : "Personal",
-        "orcId" : "fBhMMdBJa78W",
-        "arpId" : "AxIrz2tOv0yo0z4Xbbt"
+        "orcId" : "UdaKIQTCJYX",
+        "arpId" : "bMMGDspyQRM12EB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/izrY910GL6xJw",
+        "id" : "https://www.example.com/nZC2CS3eObN",
         "labels" : {
-          "O6ruHlTgxW" : "EmRWh3jgpbyuLDc"
+          "pfCzYzB5jue" : "bLR3IjWgRUkAYUePp7H"
         }
       } ],
-      "role" : "Supervisor",
+      "role" : "Designer",
       "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Zs9Xd4rqnNDqw7WgJA",
-        "name" : "4KdwLA9Y0othfLpRa6J",
-        "nameType" : "Personal",
-        "orcId" : "LtsQz4yMlp",
-        "arpId" : "ICpdfhlwbmNED0T3Fb5"
+        "id" : "https://www.example.com/oBGeM8li8Y",
+        "name" : "7Gn0AFuLWEL",
+        "nameType" : "Organizational",
+        "orcId" : "LseLSV9GEqK",
+        "arpId" : "QXYdiQJVSqahvE5jd4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/G0tsdRpJbFQqQk5D",
+        "id" : "https://www.example.com/RR5wtYD5w8fu4",
         "labels" : {
-          "uG9UJyt0un" : "FFlyXoOSB2w"
+          "H3X87aSYYA9hVCk" : "rh3GNkN3C2euspUB2F"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 9,
+      "role" : "RegistrationAgency",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "uZ02TNl2S2ICpKV",
-    "tags" : [ "jEsp7bcbPviKF" ],
-    "description" : "YaoomQE26Piea80W0fA",
+    "npiSubjectHeading" : "91lOKtPV0DegChX8NGA",
+    "tags" : [ "LIdivnKQ8uoYxLWtd3I" ],
+    "description" : "sUdr59fJKkWCmN4CA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/R0PFphFnHU"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/RORi6ireTa3OqyVklK"
       },
-      "doi" : "https://www.example.com/9j3Lh38YtoAI",
+      "doi" : "https://www.example.com/PlaHSDIJTK0VplLgVI",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "zhYJLvEnt3s",
-        "issue" : "IJzDJe9lBfVT12TVG",
-        "articleNumber" : "E2eVLJBZMiQ6UIeY",
+        "volume" : "PZXH45o3A7H7hG0DTu",
+        "issue" : "eICUCbVbeL",
+        "articleNumber" : "WOXF2H1O3S1",
         "pages" : {
           "type" : "Range",
-          "begin" : "2KE7m6uTETn2",
-          "end" : "I1gETUfhI6xgQd1wohM"
+          "begin" : "fsTPwKP4wsyF",
+          "end" : "JVl6KJ4rdz3NLo"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/h8BH5JpsIFxyKD",
-    "abstract" : "WpgwF2aOHTjTvA2"
+    "metadataSource" : "https://www.example.com/Zd3vMHaxtuYqhIt0",
+    "abstract" : "T0JVq0m6GXFpg0q"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "HVPyeEZ4wnqP9xt5k",
-      "mimeType" : "ySTRuW7TBEUwa1BP",
-      "size" : 1686431076,
+      "name" : "3qZ7DoZ8ycCWjADIdYX",
+      "mimeType" : "khYzUMkPHR",
+      "size" : 1204857731,
       "license" : {
         "type" : "License",
-        "identifier" : "m3sGfbgVUwVQBL",
+        "identifier" : "RgwOyLpWKeMkJHTN",
         "labels" : {
-          "9mk6w1D7QMuqz56" : "fZtVteJXNRiLuXqXi"
+          "WQisFZONUw2KFe" : "a8fSwaI95XQ7sGzGYeE"
         },
-        "link" : "https://www.example.com/ASovQtGX9V7S"
+        "link" : "https://www.example.com/qylvxgdFbjvEf8hDzxl"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etmollitia",
-    "name" : "U0wNXQvF6ogEuYyQz",
+    "id" : "https://www.example.org/consequaturqui",
+    "name" : "96GeMjUPyk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "7yeOHLh1UYlx",
-      "id" : "pdIV6iADmzVIOIIYh7G"
+      "source" : "YLOKe3BEoO",
+      "id" : "RHCD44EURC1C"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zdqq21sJlGr"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "5JG95xUJTc67wxG"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eaqueexpedita" ],
+  "subjects" : [ "https://www.example.org/voluptateminventore" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "dgB9Vcx9zHtiOggb",
+  "status" : "PUBLISHED",
+  "owner" : "8xr6GTGQJUeZK78Nz4",
   "resourceOwner" : {
-    "owner" : "dgB9Vcx9zHtiOggb",
-    "ownerAffiliation" : "https://www.example.org/nonquia"
+    "owner" : "8xr6GTGQJUeZK78Nz4",
+    "ownerAffiliation" : "https://www.example.org/exercitationemesse"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nonconsequatur",
+    "id" : "https://www.example.org/molestiaeautem",
     "labels" : {
-      "3qAsjpE17dPD8Mt8DPp" : "ViKJX5x1fiJ"
+      "sAxpDwVq54k4NCoi" : "xEVy3Lgft8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/estsunt",
-  "doi" : "https://doi.org/10.1234/tempore",
+  "handle" : "https://www.example.org/utodio",
+  "doi" : "https://doi.org/10.1234/quaerat",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "IB5VRndFIle",
-      "author" : "mHUXPT71qqhOmPKCR",
+      "text" : "wpGcBbPlOk5SwQ",
+      "author" : "7yLfq87sFDrAO",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/utid",
+  "link" : "https://www.example.org/oditad",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NRGf1dUaIcr9PtAmX4D",
+    "mainTitle" : "XLbAITSBeAYc",
     "alternativeTitles" : {
-      "hu" : "VRkQHl7J9QfsSK"
+      "fi" : "ii0NiLi2jZ0OI0wVxS"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AqtiZvhKQq",
-      "month" : "BqjAP836TW6M4Cqz",
-      "day" : "RnAIHnVxViAidy"
+      "year" : "kUCzWuiW3kln4X",
+      "month" : "agct4UOuIwG57XSqZ3",
+      "day" : "dydvpf8ugHSw977"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AZInblDF8TCX4sXKu",
-        "name" : "Mylg1R8qLb6",
+        "id" : "https://www.example.com/QUe23A9TUtNSC6HO",
+        "name" : "7tunyjRp28s",
         "nameType" : "Personal",
-        "orcId" : "YF5Qgr6E1i",
-        "arpId" : "HlVF9uqT6HCtOV"
+        "orcId" : "fBhMMdBJa78W",
+        "arpId" : "AxIrz2tOv0yo0z4Xbbt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5X0IPWwovof6",
+        "id" : "https://www.example.com/izrY910GL6xJw",
         "labels" : {
-          "o5JDn1vVoIxmeh6Ii1" : "MwtD6hqwW77Yn"
+          "O6ruHlTgxW" : "EmRWh3jgpbyuLDc"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 5,
+      "role" : "Supervisor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iaXpXjT8NMAG2",
-        "name" : "fYrq6Veksdf",
-        "nameType" : "Organizational",
-        "orcId" : "k8FvvXyNBQjS",
-        "arpId" : "gm73jHDH16"
+        "id" : "https://www.example.com/Zs9Xd4rqnNDqw7WgJA",
+        "name" : "4KdwLA9Y0othfLpRa6J",
+        "nameType" : "Personal",
+        "orcId" : "LtsQz4yMlp",
+        "arpId" : "ICpdfhlwbmNED0T3Fb5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ijxQEZWw7SBuoLP",
+        "id" : "https://www.example.com/G0tsdRpJbFQqQk5D",
         "labels" : {
-          "46KACWsSm3ska1eaC" : "inAokJz4FBPVY"
+          "uG9UJyt0un" : "FFlyXoOSB2w"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 2,
+      "role" : "EditorialBoardMember",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "xuQLfPryErWXebCnzBk",
-    "tags" : [ "YvnT1qn8DuugoZ" ],
-    "description" : "x5kn0qR074",
+    "npiSubjectHeading" : "uZ02TNl2S2ICpKV",
+    "tags" : [ "jEsp7bcbPviKF" ],
+    "description" : "YaoomQE26Piea80W0fA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2HLJdJCDoiUN7dw8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/R0PFphFnHU"
       },
-      "doi" : "https://www.example.com/9W18dzEFXqvSR6",
+      "doi" : "https://www.example.com/9j3Lh38YtoAI",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "Ogp0jGwsnaWduDle",
-        "issue" : "hGaYaJaowUIltSj",
-        "articleNumber" : "AHLMIXzGz8Iz5O8M3",
+        "volume" : "zhYJLvEnt3s",
+        "issue" : "IJzDJe9lBfVT12TVG",
+        "articleNumber" : "E2eVLJBZMiQ6UIeY",
         "pages" : {
           "type" : "Range",
-          "begin" : "yqFJLAzD8gpw93Yl2S",
-          "end" : "DHLqBeHoP7opcZOB"
+          "begin" : "2KE7m6uTETn2",
+          "end" : "I1gETUfhI6xgQd1wohM"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/GTKE2WCiDtAbp6q5B",
-    "abstract" : "j07VklZMHHSotzk2b"
+    "metadataSource" : "https://www.example.com/h8BH5JpsIFxyKD",
+    "abstract" : "WpgwF2aOHTjTvA2"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "08iwuervVjhxYr",
-      "mimeType" : "3gfXxIvASvXnMZTbnp",
-      "size" : 2021918591,
+      "name" : "HVPyeEZ4wnqP9xt5k",
+      "mimeType" : "ySTRuW7TBEUwa1BP",
+      "size" : 1686431076,
       "license" : {
         "type" : "License",
-        "identifier" : "tMGLV8lET9u6O8",
+        "identifier" : "m3sGfbgVUwVQBL",
         "labels" : {
-          "ru1NvIzzrilo256CtK7" : "AJVKjZUhIwER5D"
+          "9mk6w1D7QMuqz56" : "fZtVteJXNRiLuXqXi"
         },
-        "link" : "https://www.example.com/3wHnUD2bJbk06"
+        "link" : "https://www.example.com/ASovQtGX9V7S"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/porroquo",
-    "name" : "CdzU7U7x3J0k2kDjK",
+    "id" : "https://www.example.org/etmollitia",
+    "name" : "U0wNXQvF6ogEuYyQz",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "LxvPkwuG63cl4",
-      "id" : "DEuqYLGsaID48u"
+      "source" : "7yeOHLh1UYlx",
+      "id" : "pdIV6iADmzVIOIIYh7G"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "UYQEAQgWTuqMGA7"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "zdqq21sJlGr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/teneturaut" ],
+  "subjects" : [ "https://www.example.org/eaqueexpedita" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "I9OC2hr2YrN",
+  "status" : "DRAFT",
+  "owner" : "dgB9Vcx9zHtiOggb",
   "resourceOwner" : {
-    "owner" : "I9OC2hr2YrN",
-    "ownerAffiliation" : "https://www.example.org/etreprehenderit"
+    "owner" : "dgB9Vcx9zHtiOggb",
+    "ownerAffiliation" : "https://www.example.org/nonquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sintconsequatur",
+    "id" : "https://www.example.org/nonconsequatur",
     "labels" : {
-      "uUfm1RRVdlOieQX" : "Pxoo0vLQ0VmaW"
+      "3qAsjpE17dPD8Mt8DPp" : "ViKJX5x1fiJ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/facereeum",
-  "doi" : "https://doi.org/10.1234/ut",
+  "handle" : "https://www.example.org/estsunt",
+  "doi" : "https://doi.org/10.1234/tempore",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "eewBtSgA8Ug8Q",
-      "author" : "6zHXrjWPbd4floO2w",
+      "text" : "IB5VRndFIle",
+      "author" : "mHUXPT71qqhOmPKCR",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloremsit",
+  "link" : "https://www.example.org/utid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kMZmLI2s0J8XjJLXUND",
+    "mainTitle" : "NRGf1dUaIcr9PtAmX4D",
     "alternativeTitles" : {
-      "ca" : "9tMjF6KXeCGt9"
+      "hu" : "VRkQHl7J9QfsSK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/hun",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "b6WuhfkGylio",
-      "month" : "F4a3SLFrDapaQ203xg",
-      "day" : "C55soYFJRTHJtG7"
+      "year" : "AqtiZvhKQq",
+      "month" : "BqjAP836TW6M4Cqz",
+      "day" : "RnAIHnVxViAidy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/b9xEMb9YWS",
-        "name" : "d6B3o4uxreRo2bzmk",
+        "id" : "https://www.example.com/AZInblDF8TCX4sXKu",
+        "name" : "Mylg1R8qLb6",
         "nameType" : "Personal",
-        "orcId" : "3JS8jNIeAXBE7CeN5eS",
-        "arpId" : "AvUVxnWn8Q7xD"
+        "orcId" : "YF5Qgr6E1i",
+        "arpId" : "HlVF9uqT6HCtOV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Ik81LH5SvfgmC",
+        "id" : "https://www.example.com/5X0IPWwovof6",
         "labels" : {
-          "6pgz61nn3Ud" : "N4S3CzCAaR5Iqxy13E7"
+          "o5JDn1vVoIxmeh6Ii1" : "MwtD6hqwW77Yn"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 3,
+      "role" : "Other",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dGpUG6OLiuJd",
-        "name" : "a6R4JRrZNph8YPpoZvD",
-        "nameType" : "Personal",
-        "orcId" : "VB8ynKnhsQxlOiTRuB",
-        "arpId" : "XRFHc00CU755IgdK"
+        "id" : "https://www.example.com/iaXpXjT8NMAG2",
+        "name" : "fYrq6Veksdf",
+        "nameType" : "Organizational",
+        "orcId" : "k8FvvXyNBQjS",
+        "arpId" : "gm73jHDH16"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/p91IBIz7DtV8aUoO",
+        "id" : "https://www.example.com/ijxQEZWw7SBuoLP",
         "labels" : {
-          "4kVPNNoS00BGoCk1Ca" : "twCFbOLQT6ga9nm"
+          "46KACWsSm3ska1eaC" : "inAokJz4FBPVY"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 6,
+      "role" : "Consultant",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "GlP7PqJfDbcsC2keu",
-    "tags" : [ "vMkQiFxaf7c02m" ],
-    "description" : "eJuIQG6UNqg",
+    "npiSubjectHeading" : "xuQLfPryErWXebCnzBk",
+    "tags" : [ "YvnT1qn8DuugoZ" ],
+    "description" : "x5kn0qR074",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zcy9yKZCZE3zW"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2HLJdJCDoiUN7dw8"
       },
-      "doi" : "https://www.example.com/UdBIR6rENggMxZM",
+      "doi" : "https://www.example.com/9W18dzEFXqvSR6",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "LBtBJroAcxE2WcN",
-        "issue" : "DbHS8dPj5RrjgoPzzFY",
-        "articleNumber" : "cp61EWtSyXngv",
+        "volume" : "Ogp0jGwsnaWduDle",
+        "issue" : "hGaYaJaowUIltSj",
+        "articleNumber" : "AHLMIXzGz8Iz5O8M3",
         "pages" : {
           "type" : "Range",
-          "begin" : "5kqLJP0NGRxPVmp",
-          "end" : "e07jcNLcfDDoszeduV"
+          "begin" : "yqFJLAzD8gpw93Yl2S",
+          "end" : "DHLqBeHoP7opcZOB"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/1fjPsfgVgdBXNaybD",
-    "abstract" : "L8iYm3eVZZzzqlzO"
+    "metadataSource" : "https://www.example.com/GTKE2WCiDtAbp6q5B",
+    "abstract" : "j07VklZMHHSotzk2b"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "TPoojxP0ekAE7oo8Dp",
-      "mimeType" : "3eF1TCIC8EsnpA",
-      "size" : 1444863785,
+      "name" : "08iwuervVjhxYr",
+      "mimeType" : "3gfXxIvASvXnMZTbnp",
+      "size" : 2021918591,
       "license" : {
         "type" : "License",
-        "identifier" : "cocdpoBj9gniQ",
+        "identifier" : "tMGLV8lET9u6O8",
         "labels" : {
-          "mPSC60Cgfq4Cnc08C" : "VT17nNe5HeTEZi"
+          "ru1NvIzzrilo256CtK7" : "AJVKjZUhIwER5D"
         },
-        "link" : "https://www.example.com/GRXOnNGSxP"
+        "link" : "https://www.example.com/3wHnUD2bJbk06"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/corruptilabore",
-    "name" : "Hu087hwGpwwb",
+    "id" : "https://www.example.org/porroquo",
+    "name" : "CdzU7U7x3J0k2kDjK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "9C350Jn4p3teVfUaC9O",
-      "id" : "Aw20kfdONtdqUM5"
+      "source" : "LxvPkwuG63cl4",
+      "id" : "DEuqYLGsaID48u"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "5e4gjcAZSdac3Y"
+      "applicationCode" : "UYQEAQgWTuqMGA7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/reiciendisab" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/teneturaut" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "OktOOOF6uGpB1p9zF",
+  "status" : "NEW",
+  "owner" : "I9OC2hr2YrN",
   "resourceOwner" : {
-    "owner" : "OktOOOF6uGpB1p9zF",
-    "ownerAffiliation" : "https://www.example.org/doloresea"
+    "owner" : "I9OC2hr2YrN",
+    "ownerAffiliation" : "https://www.example.org/etreprehenderit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nisimolestias",
+    "id" : "https://www.example.org/sintconsequatur",
     "labels" : {
-      "wYuImGAlbswnYy3crGW" : "OIv13JxEOVSSOFe"
+      "uUfm1RRVdlOieQX" : "Pxoo0vLQ0VmaW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ipsumeaque",
-  "doi" : "https://doi.org/10.1234/eos",
+  "handle" : "https://www.example.org/facereeum",
+  "doi" : "https://doi.org/10.1234/ut",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "JH4yNnqh93E",
-      "author" : "5WdQt6tA7KOLKk6",
+      "text" : "eewBtSgA8Ug8Q",
+      "author" : "6zHXrjWPbd4floO2w",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/similiquefugit",
+  "link" : "https://www.example.org/doloremsit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Ik1qGVJYCHMIB3jts",
+    "mainTitle" : "kMZmLI2s0J8XjJLXUND",
     "alternativeTitles" : {
-      "de" : "wh2W7dsDTEa"
+      "ca" : "9tMjF6KXeCGt9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "lujotLNVsP38Sd9Ag",
-      "month" : "PusLEh6NdAH",
-      "day" : "PoqYKL8FaxCuNSD"
+      "year" : "b6WuhfkGylio",
+      "month" : "F4a3SLFrDapaQ203xg",
+      "day" : "C55soYFJRTHJtG7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SgPqiG93oJyum0aNL",
-        "name" : "F2BBW9VPViRgR0",
+        "id" : "https://www.example.com/b9xEMb9YWS",
+        "name" : "d6B3o4uxreRo2bzmk",
         "nameType" : "Personal",
-        "orcId" : "uT3kWJZwahaIgE",
-        "arpId" : "1xvv7Yew0cIZ6gRuYz6"
+        "orcId" : "3JS8jNIeAXBE7CeN5eS",
+        "arpId" : "AvUVxnWn8Q7xD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/l603HaAGE1bEVlW",
+        "id" : "https://www.example.com/Ik81LH5SvfgmC",
         "labels" : {
-          "STdrjWVXsB1" : "ldwAXrX8iEulN"
+          "6pgz61nn3Ud" : "N4S3CzCAaR5Iqxy13E7"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 7,
+      "role" : "Researcher",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fbzCqAUo4i9l5",
-        "name" : "lGMifssGzkv5",
-        "nameType" : "Organizational",
-        "orcId" : "KJ08yMoWRuH4b",
-        "arpId" : "06Mmpgx3LrNIy43jT"
+        "id" : "https://www.example.com/dGpUG6OLiuJd",
+        "name" : "a6R4JRrZNph8YPpoZvD",
+        "nameType" : "Personal",
+        "orcId" : "VB8ynKnhsQxlOiTRuB",
+        "arpId" : "XRFHc00CU755IgdK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Yg203OUxaj3",
+        "id" : "https://www.example.com/p91IBIz7DtV8aUoO",
         "labels" : {
-          "tw6mmln9W3c4q6EuW" : "7lTFOBD5gph7"
+          "4kVPNNoS00BGoCk1Ca" : "twCFbOLQT6ga9nm"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 9,
+      "role" : "ProgrammeLeader",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NcbnTHj7tMHwc",
-    "tags" : [ "1N3olKRl5IKg" ],
-    "description" : "AbfcI8dYQtjHDPj",
+    "npiSubjectHeading" : "GlP7PqJfDbcsC2keu",
+    "tags" : [ "vMkQiFxaf7c02m" ],
+    "description" : "eJuIQG6UNqg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GHWNorDTDrrGTkfSmA"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zcy9yKZCZE3zW"
       },
-      "doi" : "https://www.example.com/6fDTczmHQgQ9",
+      "doi" : "https://www.example.com/UdBIR6rENggMxZM",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "alh3ry2QaK2tUHWY2lq",
-        "issue" : "NEBO3Deh9qb3b",
-        "articleNumber" : "1iWBH7zqbJaSgnKv",
+        "volume" : "LBtBJroAcxE2WcN",
+        "issue" : "DbHS8dPj5RrjgoPzzFY",
+        "articleNumber" : "cp61EWtSyXngv",
         "pages" : {
           "type" : "Range",
-          "begin" : "YctbmtjfdJ",
-          "end" : "6BO4GmaROpEKUD2Lcw"
+          "begin" : "5kqLJP0NGRxPVmp",
+          "end" : "e07jcNLcfDDoszeduV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/wsDsA1oKbgCaVyo",
-    "abstract" : "h8U0EzPXBA9Mv1xJ"
+    "metadataSource" : "https://www.example.com/1fjPsfgVgdBXNaybD",
+    "abstract" : "L8iYm3eVZZzzqlzO"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yR93mEEAUAhy",
-      "mimeType" : "1lranjEHiToj",
-      "size" : 1455004653,
+      "name" : "TPoojxP0ekAE7oo8Dp",
+      "mimeType" : "3eF1TCIC8EsnpA",
+      "size" : 1444863785,
       "license" : {
         "type" : "License",
-        "identifier" : "w0A4bbeldE",
+        "identifier" : "cocdpoBj9gniQ",
         "labels" : {
-          "zRf3ew1NiANYtpySdjn" : "K3OmqrLCSoNsavuu"
+          "mPSC60Cgfq4Cnc08C" : "VT17nNe5HeTEZi"
         },
-        "link" : "https://www.example.com/sX1uQIgbhV7"
+        "link" : "https://www.example.com/GRXOnNGSxP"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nihilcum",
-    "name" : "6qNonXPKJQDZdYAKJ",
+    "id" : "https://www.example.org/corruptilabore",
+    "name" : "Hu087hwGpwwb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "NHrHMZsMTkiaM2OwQ",
-      "id" : "PZIG7xeQafQFyitAa8"
+      "source" : "9C350Jn4p3teVfUaC9O",
+      "id" : "Aw20kfdONtdqUM5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "owWO1PpHDN"
+      "applicationCode" : "5e4gjcAZSdac3Y"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autnobis" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/reiciendisab" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "hviTRqLxBcpi",
+  "status" : "PUBLISHED",
+  "owner" : "IAECkZQgFS",
   "resourceOwner" : {
-    "owner" : "hviTRqLxBcpi",
-    "ownerAffiliation" : "https://www.example.org/eumnon"
+    "owner" : "IAECkZQgFS",
+    "ownerAffiliation" : "https://www.example.org/magnamassumenda"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autamet",
+    "id" : "https://www.example.org/numquamsed",
     "labels" : {
-      "A3eI0pMazOjhK" : "BvjTPxLSEDbXZAurrz"
+      "xUptuCHrtVw" : "hacQwkIq9pO8xPYzUtn"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/accusamuseum",
-  "doi" : "https://doi.org/10.1234/unde",
+  "handle" : "https://www.example.org/atquelibero",
+  "doi" : "https://doi.org/10.1234/sit",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "DHoK3R8903KDmyz",
-      "author" : "PvRaokYUr1dVg",
+      "text" : "5gMLq9SLvi",
+      "author" : "JjNR3SKMXBoXw1xZhh",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/nesciuntest",
+  "link" : "https://www.example.org/sequidolor",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MudXwgexFfrklK",
+    "mainTitle" : "SxLGT9hupwE3imVb",
     "alternativeTitles" : {
-      "zh" : "4h03aHqxSiZkGUbF"
+      "ru" : "ZD8tQy2cWDeMKzitVq"
     },
     "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "E8vgPMo2BOkndCbABtc",
-      "month" : "MoYXWWGQbQ0JR",
-      "day" : "LhQUePnjBBXhiW"
+      "year" : "eg50iimzVzwAs7",
+      "month" : "8muNazRe7LDw",
+      "day" : "9rqLTMR1wvUq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IYuLnrj8aRgyK",
-        "name" : "TtZ8dy7TIAMR",
+        "id" : "https://www.example.com/AbLgGoZXuFsLmW8j",
+        "name" : "CSyryP6wzvR3C8",
         "nameType" : "Personal",
-        "orcId" : "UdaKIQTCJYX",
-        "arpId" : "bMMGDspyQRM12EB"
+        "orcId" : "I6RZDrzcGB3",
+        "arpId" : "p2iI4MMII9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/nZC2CS3eObN",
+        "id" : "https://www.example.com/kjdLtwIN36",
         "labels" : {
-          "pfCzYzB5jue" : "bLR3IjWgRUkAYUePp7H"
+          "JVR8JiuLtClGYVxhR" : "OmYrWe9X1tvSOYd"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 0,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oBGeM8li8Y",
-        "name" : "7Gn0AFuLWEL",
+        "id" : "https://www.example.com/HO1QRPpY4Jjw",
+        "name" : "V5YScETuyii2ti",
         "nameType" : "Organizational",
-        "orcId" : "LseLSV9GEqK",
-        "arpId" : "QXYdiQJVSqahvE5jd4"
+        "orcId" : "nxbDpGX938Z4Ao",
+        "arpId" : "dmauqZhESjW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RR5wtYD5w8fu4",
+        "id" : "https://www.example.com/9QYwI2V2vqeDms",
         "labels" : {
-          "H3X87aSYYA9hVCk" : "rh3GNkN3C2euspUB2F"
+          "3175kvh6R2pMQQEIbY" : "Z9Zj9diAv5LP"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 0,
+      "role" : "Producer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "91lOKtPV0DegChX8NGA",
-    "tags" : [ "LIdivnKQ8uoYxLWtd3I" ],
-    "description" : "sUdr59fJKkWCmN4CA",
+    "npiSubjectHeading" : "UkQF03vMWxG6dOJ4",
+    "tags" : [ "GO5iHM9XkiT0urGz" ],
+    "description" : "TxLObDpZwPgJuCvXo3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/RORi6ireTa3OqyVklK"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b8FLenrVrEWAHA"
       },
-      "doi" : "https://www.example.com/PlaHSDIJTK0VplLgVI",
+      "doi" : "https://www.example.com/paVy4Br6x6odCs",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "PZXH45o3A7H7hG0DTu",
-        "issue" : "eICUCbVbeL",
-        "articleNumber" : "WOXF2H1O3S1",
+        "volume" : "bwqnzVTkA8ZCl3o",
+        "issue" : "SvFB3C3FprxJRzNKs8G",
+        "articleNumber" : "RwJo56Kxdho",
         "pages" : {
           "type" : "Range",
-          "begin" : "fsTPwKP4wsyF",
-          "end" : "JVl6KJ4rdz3NLo"
+          "begin" : "RwLC9gF4pLy72vIPqde",
+          "end" : "jTZyk7bgk3AHJAW8"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Zd3vMHaxtuYqhIt0",
-    "abstract" : "T0JVq0m6GXFpg0q"
+    "metadataSource" : "https://www.example.com/rUiMohLgKDgK7",
+    "abstract" : "WJZPkf81uGhx"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "3qZ7DoZ8ycCWjADIdYX",
-      "mimeType" : "khYzUMkPHR",
-      "size" : 1204857731,
+      "name" : "Jq8NjUF2BoPxyZp",
+      "mimeType" : "9AjoQd5JcHxhPfs4",
+      "size" : 1898920638,
       "license" : {
         "type" : "License",
-        "identifier" : "RgwOyLpWKeMkJHTN",
+        "identifier" : "TX0AsmX4NOwhn9Qc",
         "labels" : {
-          "WQisFZONUw2KFe" : "a8fSwaI95XQ7sGzGYeE"
+          "iUGivtXGgPOZ" : "lpttk58rnDZ5ZHr"
         },
-        "link" : "https://www.example.com/qylvxgdFbjvEf8hDzxl"
+        "link" : "https://www.example.com/gFnSJLyearo"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequaturqui",
-    "name" : "96GeMjUPyk",
+    "id" : "https://www.example.org/quonostrum",
+    "name" : "p5g64aJvzP7RiSQmNU",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "YLOKe3BEoO",
-      "id" : "RHCD44EURC1C"
+      "source" : "xKiaUixYbs98F",
+      "id" : "JeID8DmcGVpyH"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "5JG95xUJTc67wxG"
+      "applicationCode" : "qfyBi6duQROaNmQ7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptateminventore" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/atquereprehenderit" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -2,153 +2,153 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
-  "owner" : "l4HrIBkczV",
+  "owner" : "mr6qm3M7jaMmOPeS",
   "resourceOwner" : {
-    "owner" : "l4HrIBkczV",
-    "ownerAffiliation" : "https://www.example.org/consequatureos"
+    "owner" : "mr6qm3M7jaMmOPeS",
+    "ownerAffiliation" : "https://www.example.org/eiusreprehenderit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiautem",
+    "id" : "https://www.example.org/utrerum",
     "labels" : {
-      "pUzErsdZ1uD" : "5kXbkduWixf0y86ww"
+      "GnXEsEMBzf4k1u" : "IFlrp18yafC"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/praesentiumaliquam",
-  "doi" : "https://doi.org/10.1234/deleniti",
+  "handle" : "https://www.example.org/etquis",
+  "doi" : "https://doi.org/10.1234/a",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "z2Bj7FD9VwyE7FG",
-      "author" : "UFYUdHVqnyqFgPUzK",
+      "text" : "d6RJ9f7twdTdoP9",
+      "author" : "5r5YThKXvNeopxe6H",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/optiodolores",
+  "link" : "https://www.example.org/consequatura",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uEwU7aZubNpDNaCYp",
+    "mainTitle" : "bFY3eQoNPzYalpudL1",
     "alternativeTitles" : {
-      "en" : "9Djx075abrqy"
+      "en" : "Qr3wAQJO2Gaj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "5nkVyp3rM2",
-      "month" : "SvWbnP6EB0bYmasy",
-      "day" : "rrtBK1P66o4R2wjxoJP"
+      "year" : "rbBooQojFzAGCK6nFc",
+      "month" : "0yxOERzKMH8S",
+      "day" : "g09LGIgbwAhSLXwP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/R89QNfn6DVX",
-        "name" : "s3uqiC9kpm0VqYh0tP2",
-        "nameType" : "Organizational",
-        "orcId" : "eQnWikDsXu8AyCL2Fo",
-        "arpId" : "baSj2Kv4SBIurbay7y"
+        "id" : "https://www.example.com/ZgeGXvsd1MgXWDh8FP",
+        "name" : "iNlrDn4KaMbg",
+        "nameType" : "Personal",
+        "orcId" : "Tu2z6FjivcGpvn5",
+        "arpId" : "GC209BJ7Wxj6x7Zf9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xJTseWydXslu",
+        "id" : "https://www.example.com/mTJRDPwHpBC1g6e0wh",
         "labels" : {
-          "aErrUm8v8U9OfrgNpm" : "XulrS9f1DsDniv5BhKE"
+          "DOxa3Bf2U2ixhEWy" : "bQJjMzkpnw31aygG4"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 5,
+      "role" : "Producer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/w9FgnPJzPCR4tDqBgj",
-        "name" : "sPm4j4Ql8gnVsJ0",
-        "nameType" : "Organizational",
-        "orcId" : "ALKRNywAI7U",
-        "arpId" : "JolavU2pOkiUYEPn"
+        "id" : "https://www.example.com/3tcRIByq3Bg",
+        "name" : "5cFSlCvm9Zt",
+        "nameType" : "Personal",
+        "orcId" : "jLxeS0L01a9mVsS",
+        "arpId" : "N8RmamE1OA7Pnz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OWdW4NMcLEqW",
+        "id" : "https://www.example.com/Z0nWW3vbwZ",
         "labels" : {
-          "zHsOoFJHO5L" : "gCg1w5QBuUU"
+          "2bUVECxJ6yRQ" : "e4NoULSaKJ8L7E91VFD"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 3,
+      "role" : "RegistrationAuthority",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YEsDQBnD798XJqfn",
-    "tags" : [ "gjnneIvLOHMZr0" ],
-    "description" : "ITpIu3dHgh5CM8Xh8g",
+    "npiSubjectHeading" : "cMahnx7xOrno",
+    "tags" : [ "kRAbuE0s73gv9iZ" ],
+    "description" : "wl1HImvuflT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aBmBwxca697vS9U"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xFbsY8ET5W8F"
       },
-      "doi" : "https://www.example.com/Eh5oBk1Wkp",
+      "doi" : "https://www.example.com/046SmNsnT1D",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "7cLwhklemG2stctoKi",
-        "issue" : "mACVtt9a172i1LAU261",
-        "articleNumber" : "nZ4qvPEMT00Pxw",
+        "volume" : "Es7ThH5ifIG",
+        "issue" : "7xI6CGpNFOFFGw",
+        "articleNumber" : "G6hDw0yohCwyPaW",
         "pages" : {
           "type" : "Range",
-          "begin" : "PIsGGWNCT2MB",
-          "end" : "YKfu0ZnXaahw7"
+          "begin" : "cMbB5wfFBywvML",
+          "end" : "V4m4WfWydbE6aRZMWfk"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/uXuLlvWNojce86ou7ks",
-    "abstract" : "2biGOPtTze"
+    "metadataSource" : "https://www.example.com/k75iSxhTORwsqDvDi",
+    "abstract" : "ustq6qnNcEV"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "O3ZgUPwHs2XFY29",
-      "mimeType" : "kRuH2RbRTyHlBeLaD",
-      "size" : 1854101787,
+      "name" : "c8tgJEth1t9EpQqaIWF",
+      "mimeType" : "PxnqqxxCMyJSF",
+      "size" : 510755112,
       "license" : {
         "type" : "License",
-        "identifier" : "cHbwEQXGtKwA6o",
+        "identifier" : "SthSoSwslcsLP",
         "labels" : {
-          "B3CtAj6LIWlgv81vi3u" : "T6Dzt3dYPfZd0rbSEQx"
+          "2KAniFgR6iJWJ" : "6qHL1fWaYdzW"
         },
-        "link" : "https://www.example.com/S6j7QUtq4bWYxmdfcXL"
+        "link" : "https://www.example.com/5ZVYjuWpfx"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/totamest",
-    "name" : "hE2Bre6W6ikgh6",
+    "id" : "https://www.example.org/siterror",
+    "name" : "K9HMI5c0Pk5T1oRpg3h",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "NWNfUFLvSooEBnr",
-      "id" : "N1yC0FMUD6kRuCpNS40"
+      "source" : "GRQD7ZoFeqC",
+      "id" : "9ZKMNCqALIms"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "c6qO19PwNOYNJ3t"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ikwXGrFCcmEs6ArMYhO"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/itaqueimpedit" ],
+  "subjects" : [ "https://www.example.org/accusantiumdoloremque" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "JYUF0dbyIqI4s3",
+  "status" : "PUBLISHED",
+  "owner" : "ZJPnPo9Q5qO6s14z",
   "resourceOwner" : {
-    "owner" : "JYUF0dbyIqI4s3",
-    "ownerAffiliation" : "https://www.example.org/voluptatemdeleniti"
+    "owner" : "ZJPnPo9Q5qO6s14z",
+    "ownerAffiliation" : "https://www.example.org/quiaillo"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/inventorecumque",
+    "id" : "https://www.example.org/consequatursapiente",
     "labels" : {
-      "19XFx6sSuY" : "8df88uArEUOK"
+      "UdXAAR1D51pTRvtavDA" : "XPJW4dV6ZT01I"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etquibusdam",
-  "doi" : "https://doi.org/10.1234/eum",
+  "handle" : "https://www.example.org/voluptatemminima",
+  "doi" : "https://doi.org/10.1234/et",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "AMmZzmcPEFAnWTJrISp",
-      "author" : "iukLByvLfs",
+      "text" : "DltD6M7DQuZ8B",
+      "author" : "TaRejlEhTUgI0",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/sitharum",
+  "link" : "https://www.example.org/suntid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QOeYdRQrUN2xuSFF",
+    "mainTitle" : "6bJsxACw7ZG",
     "alternativeTitles" : {
-      "nb" : "LZ5uCEG69T3K"
+      "es" : "sNF9ynBOSdVZZJMga"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "w8eRl4oxFh",
-      "month" : "YWsmr91k6P4vMCQJaW",
-      "day" : "xCLoK3fvHQ"
+      "year" : "mCxEsUxue6h",
+      "month" : "XbY8ZhGFbrr",
+      "day" : "5dKVod4zU5E"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/YQg2qICoNGptEr2",
-        "name" : "i5B0S1WDWDnE12cs7",
+        "id" : "https://www.example.com/Gtk2J2dOG40ImshjlP",
+        "name" : "DqFmeCSzxbyCpI7",
         "nameType" : "Organizational",
-        "orcId" : "JaPcz0RAZch",
-        "arpId" : "wJFKhkV7radPO6Bg"
+        "orcId" : "4BUXqSM8xgmOhSD",
+        "arpId" : "TZhw4wucU3Dp2191Rtl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ZoshNeuVVN9chXo3",
+        "id" : "https://www.example.com/dCn1bpN675P",
         "labels" : {
-          "X1GELv2ZyJtZanX4n3" : "SUnJmBICvw"
+          "xmQKFwmRrjoPEOS2L" : "WtQuzoDPoQ1vH"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 3,
+      "role" : "Producer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HH5VwNf9QDJ7CkSNc",
-        "name" : "scV8zUCoCrvti",
-        "nameType" : "Organizational",
-        "orcId" : "wNQlwSGAX4UuiJF",
-        "arpId" : "nrP4dEKxESymiHV"
+        "id" : "https://www.example.com/5ykQZdPiKfbYX",
+        "name" : "e6uMTb7D2M4fWis",
+        "nameType" : "Personal",
+        "orcId" : "KqY41Ob3oPL7j9UY",
+        "arpId" : "SCBmO80mNZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bvVMcJmVPbHrMJf9OM",
+        "id" : "https://www.example.com/bnI1L98sfC3LT1",
         "labels" : {
-          "hXjkv1OkuyDOv" : "ZiQiSMibS7UI7oY"
+          "Dl7rAV5IlLZ8Z3mr" : "dk475GxzDGDgtnP69"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 1,
+      "role" : "AcademicCoordinator",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "nDaUCFFaU6FCTCBd",
-    "tags" : [ "fVg7gfutqLl9" ],
-    "description" : "oh7MNlbv1sAvj4",
+    "npiSubjectHeading" : "Nt0GsAPVve0xtZ",
+    "tags" : [ "KZXGgTTZawRS3" ],
+    "description" : "mmz0ltyGFRJshQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FS98kOkmXHxVhz66S"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xMLROYYznnJYXNu6i0H"
       },
-      "doi" : "https://www.example.com/s4AF4ZWFFIx4j8jGl",
+      "doi" : "https://www.example.com/ehjKpN3Ttph6ov",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "47VYWJf8J5ZvU4Pv2PC",
-        "issue" : "adAX0TjQWjFJeuwXWc",
-        "articleNumber" : "GnpHZy1SzNO93",
+        "volume" : "3gsMAduXRKZz",
+        "issue" : "hgxnhnVDMWNMV",
+        "articleNumber" : "tNMMla3DXaNsgp",
         "pages" : {
           "type" : "Range",
-          "begin" : "SgRT5E0nmXsQgiOI",
-          "end" : "FKlT2TrvxYm9AD"
+          "begin" : "EixSBX0WD8",
+          "end" : "Iyeg02wRhfvkPV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/HxEmac5R4T",
-    "abstract" : "jMUzGnTrvo4fZTEk6NK"
+    "metadataSource" : "https://www.example.com/DLoUTSAWTvj",
+    "abstract" : "iEKp55FOI83ceeZ"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "SlS0e1qKxK1RzQH",
-      "mimeType" : "ajXPRAYnv4q",
-      "size" : 763040560,
+      "name" : "mFFasZtbJy3YZR155",
+      "mimeType" : "H0oHnMQo3r1qUSnZrd",
+      "size" : 2111164059,
       "license" : {
         "type" : "License",
-        "identifier" : "T9FRpLobdxFCO",
+        "identifier" : "r4zsqUvJXu",
         "labels" : {
-          "cCzIGwEcOMHNYLGtt" : "85KGqHvn6n3wLMu2d"
+          "azEscRed8N7Gt8Un1I" : "P9znsqWDtzA"
         },
-        "link" : "https://www.example.com/q8crAuqfeL4"
+        "link" : "https://www.example.com/tjR2VqxvQD"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aliquidipsa",
-    "name" : "FVklbcGoI5hUBaI8R",
+    "id" : "https://www.example.org/ipsamullam",
+    "name" : "owXyxiCTArVgWn",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Ivi0MkBnrJA",
-      "id" : "GBUfqwjitcpFZ"
+      "source" : "kf2TPK9sNpoo7BWOQ",
+      "id" : "eZdZSEB75d"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "phFK3HwqwOStm"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "eUNIxiIOvj6mEsV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatemnisi" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/utquas" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "ZJPnPo9Q5qO6s14z",
+  "status" : "DRAFT",
+  "owner" : "UKu7lEvA0B",
   "resourceOwner" : {
-    "owner" : "ZJPnPo9Q5qO6s14z",
-    "ownerAffiliation" : "https://www.example.org/quiaillo"
+    "owner" : "UKu7lEvA0B",
+    "ownerAffiliation" : "https://www.example.org/atquequis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequatursapiente",
+    "id" : "https://www.example.org/etquis",
     "labels" : {
-      "UdXAAR1D51pTRvtavDA" : "XPJW4dV6ZT01I"
+      "5BsJFmjnn3lMwtrLJ" : "Va19mEeKRNpVd"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/voluptatemminima",
-  "doi" : "https://doi.org/10.1234/et",
+  "handle" : "https://www.example.org/omnispariatur",
+  "doi" : "https://doi.org/10.1234/quia",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "DltD6M7DQuZ8B",
-      "author" : "TaRejlEhTUgI0",
+      "text" : "N77siGFK5Ax0F",
+      "author" : "Y0xY3sKMk3vjsJ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/suntid",
+  "link" : "https://www.example.org/vitaeesse",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6bJsxACw7ZG",
+    "mainTitle" : "JK40AHVGQ043X9oeW",
     "alternativeTitles" : {
-      "es" : "sNF9ynBOSdVZZJMga"
+      "it" : "u5GvBVThbxfSTPVjs"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "mCxEsUxue6h",
-      "month" : "XbY8ZhGFbrr",
-      "day" : "5dKVod4zU5E"
+      "year" : "Cn3327lxfWprQoS",
+      "month" : "zj8ZrbSdOGxFW",
+      "day" : "h74CX5tT1W7Fk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Gtk2J2dOG40ImshjlP",
-        "name" : "DqFmeCSzxbyCpI7",
+        "id" : "https://www.example.com/2Xx1GIIa584BV",
+        "name" : "s3PU6a7MIvTlRkYy",
         "nameType" : "Organizational",
-        "orcId" : "4BUXqSM8xgmOhSD",
-        "arpId" : "TZhw4wucU3Dp2191Rtl"
+        "orcId" : "zlHa9hTBEHyaKM",
+        "arpId" : "Al7qW1fG5k5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dCn1bpN675P",
+        "id" : "https://www.example.com/YwKN4dXKgjDSjjUQ",
         "labels" : {
-          "xmQKFwmRrjoPEOS2L" : "WtQuzoDPoQ1vH"
+          "ErtHDojz0uuREG9eFSz" : "rzhXnz73jtBRffBoSsl"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 5,
+      "role" : "HostingInstitution",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5ykQZdPiKfbYX",
-        "name" : "e6uMTb7D2M4fWis",
-        "nameType" : "Personal",
-        "orcId" : "KqY41Ob3oPL7j9UY",
-        "arpId" : "SCBmO80mNZ"
+        "id" : "https://www.example.com/wRUaTch6e9SiT1MO",
+        "name" : "YKDfJell3PvHmiBQjSn",
+        "nameType" : "Organizational",
+        "orcId" : "kKNrfVXJ0ydlrt0SO0M",
+        "arpId" : "OeSCmWFcTWa"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bnI1L98sfC3LT1",
+        "id" : "https://www.example.com/qVWts7MQyKE3oei",
         "labels" : {
-          "Dl7rAV5IlLZ8Z3mr" : "dk475GxzDGDgtnP69"
+          "oYl9xsEvsiZhNOB7" : "JttRZiQ5JTUDDpHylez"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 6,
+      "role" : "Producer",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Nt0GsAPVve0xtZ",
-    "tags" : [ "KZXGgTTZawRS3" ],
-    "description" : "mmz0ltyGFRJshQ",
+    "npiSubjectHeading" : "kVESms8UklAyo",
+    "tags" : [ "HvPHfEZZt4mM56t7n1W" ],
+    "description" : "7AjW0oHeWYWKDGEN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xMLROYYznnJYXNu6i0H"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YYInUATqrdUD"
       },
-      "doi" : "https://www.example.com/ehjKpN3Ttph6ov",
+      "doi" : "https://www.example.com/PZnzNkqAABtxHcaqOn",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "3gsMAduXRKZz",
-        "issue" : "hgxnhnVDMWNMV",
-        "articleNumber" : "tNMMla3DXaNsgp",
+        "volume" : "8YLVO6ohXJfdBwi",
+        "issue" : "49dD6kMAAA",
+        "articleNumber" : "OZfO9EjS9ttq1v4nRu",
         "pages" : {
           "type" : "Range",
-          "begin" : "EixSBX0WD8",
-          "end" : "Iyeg02wRhfvkPV"
+          "begin" : "c2NJPICNcQhxnowDeO",
+          "end" : "qez89PV9gINkjue"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/DLoUTSAWTvj",
-    "abstract" : "iEKp55FOI83ceeZ"
+    "metadataSource" : "https://www.example.com/GphHHMRQgDSz",
+    "abstract" : "eX4jOmNdDU7Usmhmqm"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "mFFasZtbJy3YZR155",
-      "mimeType" : "H0oHnMQo3r1qUSnZrd",
-      "size" : 2111164059,
+      "name" : "iku855BhWkk",
+      "mimeType" : "Jf0IkigQa6DKl",
+      "size" : 658791884,
       "license" : {
         "type" : "License",
-        "identifier" : "r4zsqUvJXu",
+        "identifier" : "3KHabcUtxC",
         "labels" : {
-          "azEscRed8N7Gt8Un1I" : "P9znsqWDtzA"
+          "q5Ss9GAPipJZBVqr2" : "gnfTXs8ReQfg7yY5dm0"
         },
-        "link" : "https://www.example.com/tjR2VqxvQD"
+        "link" : "https://www.example.com/t5w3nhfrG5jWd"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ipsamullam",
-    "name" : "owXyxiCTArVgWn",
+    "id" : "https://www.example.org/omnisomnis",
+    "name" : "i0K6P1aCHWxfHF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "kf2TPK9sNpoo7BWOQ",
-      "id" : "eZdZSEB75d"
+      "source" : "HaVAs6nVRXAZC6",
+      "id" : "WZyTXYloEruV"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "eUNIxiIOvj6mEsV"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "NiZ6dYVJ24upXL8MU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/utquas" ],
+  "subjects" : [ "https://www.example.org/quibusdamatque" ],
   "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -2,132 +2,132 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
-  "owner" : "mr6qm3M7jaMmOPeS",
+  "owner" : "YTJcmKhWip2rzb5ZrY9",
   "resourceOwner" : {
-    "owner" : "mr6qm3M7jaMmOPeS",
-    "ownerAffiliation" : "https://www.example.org/eiusreprehenderit"
+    "owner" : "YTJcmKhWip2rzb5ZrY9",
+    "ownerAffiliation" : "https://www.example.org/distinctiosuscipit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/utrerum",
+    "id" : "https://www.example.org/eteius",
     "labels" : {
-      "GnXEsEMBzf4k1u" : "IFlrp18yafC"
+      "Q8Mob0dcSrAriKaXJ8" : "VrRxKmliRmKInO1c"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etquis",
-  "doi" : "https://doi.org/10.1234/a",
+  "handle" : "https://www.example.org/omnissint",
+  "doi" : "https://doi.org/10.1234/tenetur",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "d6RJ9f7twdTdoP9",
-      "author" : "5r5YThKXvNeopxe6H",
+      "text" : "XwrxLhVfpP1K",
+      "author" : "YsOsMXOWldY",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/consequatura",
+  "link" : "https://www.example.org/aliasaliquam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bFY3eQoNPzYalpudL1",
+    "mainTitle" : "SwPtrb9frUh7iy2A",
     "alternativeTitles" : {
-      "en" : "Qr3wAQJO2Gaj"
+      "es" : "Ggcuyrd6GPbCWaiIMa"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "rbBooQojFzAGCK6nFc",
-      "month" : "0yxOERzKMH8S",
-      "day" : "g09LGIgbwAhSLXwP"
+      "year" : "IDYFTkZVQPofpe",
+      "month" : "iwlozG559SMM6kMcZ",
+      "day" : "EC2HDuNQCJ1D"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZgeGXvsd1MgXWDh8FP",
-        "name" : "iNlrDn4KaMbg",
+        "id" : "https://www.example.com/ZOjheBJTs7Gbj1i1yi",
+        "name" : "ACirwevnaJcJ",
         "nameType" : "Personal",
-        "orcId" : "Tu2z6FjivcGpvn5",
-        "arpId" : "GC209BJ7Wxj6x7Zf9"
+        "orcId" : "IARKGILR6q",
+        "arpId" : "ncHEyHZcyTpd2NIbdW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mTJRDPwHpBC1g6e0wh",
+        "id" : "https://www.example.com/qqJD56FnA5j",
         "labels" : {
-          "DOxa3Bf2U2ixhEWy" : "bQJjMzkpnw31aygG4"
+          "0GcV96i2gxw4taFersv" : "XZnrOdjOEY6P7kt"
         }
       } ],
-      "role" : "Producer",
+      "role" : "Journalist",
       "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3tcRIByq3Bg",
-        "name" : "5cFSlCvm9Zt",
-        "nameType" : "Personal",
-        "orcId" : "jLxeS0L01a9mVsS",
-        "arpId" : "N8RmamE1OA7Pnz"
+        "id" : "https://www.example.com/cc1FtJaMmcHMBszR5",
+        "name" : "EwWxwjS8jqvX1kv",
+        "nameType" : "Organizational",
+        "orcId" : "KFKC4LR0G4aPeqV3P",
+        "arpId" : "iZgTMAePkZGzkn4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Z0nWW3vbwZ",
+        "id" : "https://www.example.com/pSW3ySGjhXUPtK7i3",
         "labels" : {
-          "2bUVECxJ6yRQ" : "e4NoULSaKJ8L7E91VFD"
+          "ZYTgvjABtppjxaRy" : "aKSr51vPkNjAMAPoY"
         }
       } ],
-      "role" : "RegistrationAuthority",
+      "role" : "RightsHolder",
       "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cMahnx7xOrno",
-    "tags" : [ "kRAbuE0s73gv9iZ" ],
-    "description" : "wl1HImvuflT",
+    "npiSubjectHeading" : "i8tUyjkWZIWtA96v6",
+    "tags" : [ "U9LfCcbSxc" ],
+    "description" : "nmnhZ1jNJ7V",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xFbsY8ET5W8F"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8yxrnI9WooiIUbLYy"
       },
-      "doi" : "https://www.example.com/046SmNsnT1D",
+      "doi" : "https://www.example.com/YJuX9HHKf4JeZTXgU",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "Es7ThH5ifIG",
-        "issue" : "7xI6CGpNFOFFGw",
-        "articleNumber" : "G6hDw0yohCwyPaW",
+        "volume" : "Bz4btXJ4gJZJJS4",
+        "issue" : "yMzcjhouLe7sm",
+        "articleNumber" : "sPGXmnj71SLE",
         "pages" : {
           "type" : "Range",
-          "begin" : "cMbB5wfFBywvML",
-          "end" : "V4m4WfWydbE6aRZMWfk"
+          "begin" : "idKfoClVQdxi",
+          "end" : "SZWwloSDOUklOLD"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/k75iSxhTORwsqDvDi",
-    "abstract" : "ustq6qnNcEV"
+    "metadataSource" : "https://www.example.com/u8RhFV04cgjwtcRrD",
+    "abstract" : "qs4Y9NaUSS4t"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "c8tgJEth1t9EpQqaIWF",
-      "mimeType" : "PxnqqxxCMyJSF",
-      "size" : 510755112,
+      "name" : "ZjKTUCxBFfcHXoPe",
+      "mimeType" : "p3s5Nlp2683Qn0J0jft",
+      "size" : 2096686906,
       "license" : {
         "type" : "License",
-        "identifier" : "SthSoSwslcsLP",
+        "identifier" : "Un8ELCkcagpa",
         "labels" : {
-          "2KAniFgR6iJWJ" : "6qHL1fWaYdzW"
+          "tZCyTzfluWq" : "tA47xSKIMd8xj"
         },
-        "link" : "https://www.example.com/5ZVYjuWpfx"
+        "link" : "https://www.example.com/mGS5oadFPxFMpPgXvX"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/siterror",
-    "name" : "K9HMI5c0Pk5T1oRpg3h",
+    "id" : "https://www.example.org/cumquevelit",
+    "name" : "0TB6vYZKnnWZ63k3",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "GRQD7ZoFeqC",
-      "id" : "9ZKMNCqALIms"
+      "source" : "pxgviJYhaYrG5Z",
+      "id" : "Xit7FfszX9"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "ikwXGrFCcmEs6ArMYhO"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "2Ciy9krb61ND28I4d"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/accusantiumdoloremque" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/numquamaut" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,133 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "UKu7lEvA0B",
+  "status" : "PUBLISHED",
+  "owner" : "l4HrIBkczV",
   "resourceOwner" : {
-    "owner" : "UKu7lEvA0B",
-    "ownerAffiliation" : "https://www.example.org/atquequis"
+    "owner" : "l4HrIBkczV",
+    "ownerAffiliation" : "https://www.example.org/consequatureos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etquis",
+    "id" : "https://www.example.org/quiautem",
     "labels" : {
-      "5BsJFmjnn3lMwtrLJ" : "Va19mEeKRNpVd"
+      "pUzErsdZ1uD" : "5kXbkduWixf0y86ww"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnispariatur",
-  "doi" : "https://doi.org/10.1234/quia",
+  "handle" : "https://www.example.org/praesentiumaliquam",
+  "doi" : "https://doi.org/10.1234/deleniti",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "N77siGFK5Ax0F",
-      "author" : "Y0xY3sKMk3vjsJ",
+      "text" : "z2Bj7FD9VwyE7FG",
+      "author" : "UFYUdHVqnyqFgPUzK",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/vitaeesse",
+  "link" : "https://www.example.org/optiodolores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JK40AHVGQ043X9oeW",
+    "mainTitle" : "uEwU7aZubNpDNaCYp",
     "alternativeTitles" : {
-      "it" : "u5GvBVThbxfSTPVjs"
+      "en" : "9Djx075abrqy"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Cn3327lxfWprQoS",
-      "month" : "zj8ZrbSdOGxFW",
-      "day" : "h74CX5tT1W7Fk"
+      "year" : "5nkVyp3rM2",
+      "month" : "SvWbnP6EB0bYmasy",
+      "day" : "rrtBK1P66o4R2wjxoJP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/2Xx1GIIa584BV",
-        "name" : "s3PU6a7MIvTlRkYy",
+        "id" : "https://www.example.com/R89QNfn6DVX",
+        "name" : "s3uqiC9kpm0VqYh0tP2",
         "nameType" : "Organizational",
-        "orcId" : "zlHa9hTBEHyaKM",
-        "arpId" : "Al7qW1fG5k5"
+        "orcId" : "eQnWikDsXu8AyCL2Fo",
+        "arpId" : "baSj2Kv4SBIurbay7y"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YwKN4dXKgjDSjjUQ",
+        "id" : "https://www.example.com/xJTseWydXslu",
         "labels" : {
-          "ErtHDojz0uuREG9eFSz" : "rzhXnz73jtBRffBoSsl"
+          "aErrUm8v8U9OfrgNpm" : "XulrS9f1DsDniv5BhKE"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 9,
+      "role" : "ProjectMember",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wRUaTch6e9SiT1MO",
-        "name" : "YKDfJell3PvHmiBQjSn",
+        "id" : "https://www.example.com/w9FgnPJzPCR4tDqBgj",
+        "name" : "sPm4j4Ql8gnVsJ0",
         "nameType" : "Organizational",
-        "orcId" : "kKNrfVXJ0ydlrt0SO0M",
-        "arpId" : "OeSCmWFcTWa"
+        "orcId" : "ALKRNywAI7U",
+        "arpId" : "JolavU2pOkiUYEPn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qVWts7MQyKE3oei",
+        "id" : "https://www.example.com/OWdW4NMcLEqW",
         "labels" : {
-          "oYl9xsEvsiZhNOB7" : "JttRZiQ5JTUDDpHylez"
+          "zHsOoFJHO5L" : "gCg1w5QBuUU"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 1,
+      "role" : "RegistrationAgency",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "kVESms8UklAyo",
-    "tags" : [ "HvPHfEZZt4mM56t7n1W" ],
-    "description" : "7AjW0oHeWYWKDGEN",
+    "npiSubjectHeading" : "YEsDQBnD798XJqfn",
+    "tags" : [ "gjnneIvLOHMZr0" ],
+    "description" : "ITpIu3dHgh5CM8Xh8g",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YYInUATqrdUD"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aBmBwxca697vS9U"
       },
-      "doi" : "https://www.example.com/PZnzNkqAABtxHcaqOn",
+      "doi" : "https://www.example.com/Eh5oBk1Wkp",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "8YLVO6ohXJfdBwi",
-        "issue" : "49dD6kMAAA",
-        "articleNumber" : "OZfO9EjS9ttq1v4nRu",
+        "volume" : "7cLwhklemG2stctoKi",
+        "issue" : "mACVtt9a172i1LAU261",
+        "articleNumber" : "nZ4qvPEMT00Pxw",
         "pages" : {
           "type" : "Range",
-          "begin" : "c2NJPICNcQhxnowDeO",
-          "end" : "qez89PV9gINkjue"
+          "begin" : "PIsGGWNCT2MB",
+          "end" : "YKfu0ZnXaahw7"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/GphHHMRQgDSz",
-    "abstract" : "eX4jOmNdDU7Usmhmqm"
+    "metadataSource" : "https://www.example.com/uXuLlvWNojce86ou7ks",
+    "abstract" : "2biGOPtTze"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "iku855BhWkk",
-      "mimeType" : "Jf0IkigQa6DKl",
-      "size" : 658791884,
+      "name" : "O3ZgUPwHs2XFY29",
+      "mimeType" : "kRuH2RbRTyHlBeLaD",
+      "size" : 1854101787,
       "license" : {
         "type" : "License",
-        "identifier" : "3KHabcUtxC",
+        "identifier" : "cHbwEQXGtKwA6o",
         "labels" : {
-          "q5Ss9GAPipJZBVqr2" : "gnfTXs8ReQfg7yY5dm0"
+          "B3CtAj6LIWlgv81vi3u" : "T6Dzt3dYPfZd0rbSEQx"
         },
-        "link" : "https://www.example.com/t5w3nhfrG5jWd"
+        "link" : "https://www.example.com/S6j7QUtq4bWYxmdfcXL"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omnisomnis",
-    "name" : "i0K6P1aCHWxfHF",
+    "id" : "https://www.example.org/totamest",
+    "name" : "hE2Bre6W6ikgh6",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "HaVAs6nVRXAZC6",
-      "id" : "WZyTXYloEruV"
+      "source" : "NWNfUFLvSooEBnr",
+      "id" : "N1yC0FMUD6kRuCpNS40"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "NiZ6dYVJ24upXL8MU"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "c6qO19PwNOYNJ3t"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quibusdamatque" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/itaqueimpedit" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "Eb3W6fYm8m66pNIJ",
+  "status" : "NEW",
+  "owner" : "YqCi7y7TNWlCJps",
   "resourceOwner" : {
-    "owner" : "Eb3W6fYm8m66pNIJ",
-    "ownerAffiliation" : "https://www.example.org/utsaepe"
+    "owner" : "YqCi7y7TNWlCJps",
+    "ownerAffiliation" : "https://www.example.org/cumarchitecto"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatelaborum",
+    "id" : "https://www.example.org/etplaceat",
     "labels" : {
-      "lXdsqPHiALgyDx" : "6yOEvkfKcY3heYhH5"
+      "9LAx1FD4qJq5uPzG6" : "WqigJzLlDy2vaic7M1"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/aliquamdolorem",
-  "doi" : "https://doi.org/10.1234/facilis",
+  "handle" : "https://www.example.org/maximeexpedita",
+  "doi" : "https://doi.org/10.1234/provident",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "8Rxy7qnbRNyQB90",
-      "author" : "R3iEwSBOD3aenxHvYsr",
+      "text" : "6QlY88X9AvKk",
+      "author" : "b7u6vj1yF6",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quiadolorem",
+  "link" : "https://www.example.org/fugamagni",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QIAEEWVNDR",
+    "mainTitle" : "Xm8Nz1O01wax",
     "alternativeTitles" : {
-      "nb" : "SjvTnNPVTzETY"
+      "en" : "TAwqCcI1eTVVc"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TPOJaclESLa1sYz63d",
-      "month" : "YAWz2rporTtDzkT",
-      "day" : "qiZjka05Wq"
+      "year" : "ROj0yTJAxNf0hTU",
+      "month" : "9wJBv593lGm",
+      "day" : "3QQdUly29j00sdRSq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lRy9iRVJEHTbKLzmR7",
-        "name" : "Oh0RxCgpUsY",
-        "nameType" : "Organizational",
-        "orcId" : "sVUx0izBuQXOUi0",
-        "arpId" : "OGZnJqIJc3kXc1td"
+        "id" : "https://www.example.com/5ToMdBpVRVo7pp0n",
+        "name" : "fiqeQcncoFbZN7ysGU",
+        "nameType" : "Personal",
+        "orcId" : "DSie4Dt0j6cvkYUT4Je",
+        "arpId" : "jGeXJ6KIeVCk7h4a"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/JTfZHsL7J0ggkRnJT",
+        "id" : "https://www.example.com/ZW2nLVmCiezWKpl",
         "labels" : {
-          "R6M0iPyXlenjwI7ot0" : "hayfxFTac3"
+          "NslwnrBYTi" : "g2stDK0ZSEojG"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 7,
+      "role" : "Illustrator",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rkZwMwoZjcdgHFKq92l",
-        "name" : "1XSJXX3bbLPv1fkx",
-        "nameType" : "Organizational",
-        "orcId" : "GzNHOqppSit7",
-        "arpId" : "WtfDU9RVTEyRN"
+        "id" : "https://www.example.com/xAaKNS2CkQipvkTIOz2",
+        "name" : "njhGSfG7z8Zxj",
+        "nameType" : "Personal",
+        "orcId" : "Ls8u5GGHQtw1GIOV",
+        "arpId" : "oDhQJrV7xVmNhH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1Djj5Atarh",
+        "id" : "https://www.example.com/Aj96f05DHeYu",
         "labels" : {
-          "HZjQH94mNxKlcGQofe6" : "3FwU1eaLcr"
+          "8K0KLCklENA" : "I5N90b8LY9mIg"
         }
       } ],
       "role" : "WorkPackageLeader",
-      "sequence" : 6,
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "3xmB9l5dm7gKTFBNy",
-    "tags" : [ "UYfrLSYvpNf8" ],
-    "description" : "ZR2hB2hwPc",
+    "npiSubjectHeading" : "vCG9KB7nNbG8nI",
+    "tags" : [ "XfswQX7IRfiKgVLC" ],
+    "description" : "gKsCYMTnwuDz6RV6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eRd7yZDnY2j"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9LfOZPaW8f"
       },
-      "doi" : "https://www.example.com/tGUq1g30gcpBBMHRB",
+      "doi" : "https://www.example.com/qcELn4yC623P",
       "publicationInstance" : {
         "type" : "JournalShortCommunication",
-        "volume" : "WGNdcptlEKuTWCeFq",
-        "issue" : "UWuPbtImglGCMb5",
-        "articleNumber" : "peSKT1jZKmfvXjqXR2",
+        "volume" : "h2zDshNehJGJTBmzv",
+        "issue" : "VwZDN7ZREJZd",
+        "articleNumber" : "ILdXMTOZJvQ",
         "pages" : {
           "type" : "Range",
-          "begin" : "4TI6SNpI3I",
-          "end" : "FJXfAhsiWdIA"
+          "begin" : "Zq8Bzt0JdIS69Me",
+          "end" : "Hd4Sp04HRXnJDOq2Lu"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Wkt8R2aWKd4u",
-    "abstract" : "iXWozLgzaUUvSs2s2"
+    "metadataSource" : "https://www.example.com/F5dyEwQkTlUl5q",
+    "abstract" : "GLHPRhRhr2J21liT4"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "cu1ERBetFTl",
-      "mimeType" : "riZHPRhj0RKpG0T4c",
-      "size" : 1144134008,
+      "name" : "HGMB5doH0P0sBe",
+      "mimeType" : "wTiwm0YkBfi7uUyn",
+      "size" : 262541493,
       "license" : {
         "type" : "License",
-        "identifier" : "U2qddbo7ngZ17A",
+        "identifier" : "5bP5uB4CTXszdpR",
         "labels" : {
-          "v2cBKQQjsjR0Df" : "QmVXxo3nMjAcZa8bQ0"
+          "vIzYYpy6pSKn9EP" : "fKxH6apxamYPNI9Ud"
         },
-        "link" : "https://www.example.com/DNgKIW3zrKMikQU4"
+        "link" : "https://www.example.com/Eavb53s1A4f4jj3g"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatempariatur",
-    "name" : "zNkndJdTmp6bsosd9",
+    "id" : "https://www.example.org/quiad",
+    "name" : "lKOZIHKLrxn",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "o9j5xePEZzWMQzU2t",
-      "id" : "qI1JYZx3Rl"
+      "source" : "SSnvwWxasnBdfIQ",
+      "id" : "txE6WxoYniASJPJaR"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "SAHmGwJ6gRlhYM"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "7vFs1goNAu6rTx"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/molestiaea" ],
+  "subjects" : [ "https://www.example.org/evenietmagni" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "YqCi7y7TNWlCJps",
+  "status" : "PUBLISHED",
+  "owner" : "DXO7pREkDx4Ho2",
   "resourceOwner" : {
-    "owner" : "YqCi7y7TNWlCJps",
-    "ownerAffiliation" : "https://www.example.org/cumarchitecto"
+    "owner" : "DXO7pREkDx4Ho2",
+    "ownerAffiliation" : "https://www.example.org/cumquedolores"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etplaceat",
+    "id" : "https://www.example.org/blanditiisomnis",
     "labels" : {
-      "9LAx1FD4qJq5uPzG6" : "WqigJzLlDy2vaic7M1"
+      "zzAcVBt2IMOavqJA" : "C4tjqxpqhMcxhGkdND2"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/maximeexpedita",
-  "doi" : "https://doi.org/10.1234/provident",
+  "handle" : "https://www.example.org/beataevel",
+  "doi" : "https://doi.org/10.1234/vel",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "6QlY88X9AvKk",
-      "author" : "b7u6vj1yF6",
+      "text" : "l81GhAmk6CjPJyWu",
+      "author" : "Po0LeR2G8nv",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/fugamagni",
+  "link" : "https://www.example.org/voluptasea",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Xm8Nz1O01wax",
+    "mainTitle" : "enZzG0Co4yPMN4AJ74b",
     "alternativeTitles" : {
-      "en" : "TAwqCcI1eTVVc"
+      "it" : "D2ahVvmk7Kg"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ROj0yTJAxNf0hTU",
-      "month" : "9wJBv593lGm",
-      "day" : "3QQdUly29j00sdRSq"
+      "year" : "nf6SJja4P0",
+      "month" : "ZdsE743u3EVyPhqrQ",
+      "day" : "0tscoJ77jTdXbZ8D"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5ToMdBpVRVo7pp0n",
-        "name" : "fiqeQcncoFbZN7ysGU",
+        "id" : "https://www.example.com/1OxT3o7fpY1",
+        "name" : "mUeQI1P9cQKou8l",
         "nameType" : "Personal",
-        "orcId" : "DSie4Dt0j6cvkYUT4Je",
-        "arpId" : "jGeXJ6KIeVCk7h4a"
+        "orcId" : "ZW2jZYCAfgmZxB",
+        "arpId" : "mHIzwcQVePbQNJZZ0L"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ZW2nLVmCiezWKpl",
+        "id" : "https://www.example.com/z2egC3chxP39JQ7vT8I",
         "labels" : {
-          "NslwnrBYTi" : "g2stDK0ZSEojG"
+          "mcOHksmsxcPIdNy1" : "asTpJmihwxwfhQ"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 1,
+      "role" : "ProjectManager",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xAaKNS2CkQipvkTIOz2",
-        "name" : "njhGSfG7z8Zxj",
-        "nameType" : "Personal",
-        "orcId" : "Ls8u5GGHQtw1GIOV",
-        "arpId" : "oDhQJrV7xVmNhH"
+        "id" : "https://www.example.com/trrom92n28fNI2FHF",
+        "name" : "x5hEfsJwwevBfDHz",
+        "nameType" : "Organizational",
+        "orcId" : "u0OL4KZLn3FJx",
+        "arpId" : "HvQ7d3p2Xm1yBKutzYH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Aj96f05DHeYu",
+        "id" : "https://www.example.com/K40Sm6s3UzOa6XlRl9",
         "labels" : {
-          "8K0KLCklENA" : "I5N90b8LY9mIg"
+          "WEXuaK4HkM1MnA5Wip4" : "Vh4KcS1Aai7n3CTN"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 7,
+      "role" : "Editor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "vCG9KB7nNbG8nI",
-    "tags" : [ "XfswQX7IRfiKgVLC" ],
-    "description" : "gKsCYMTnwuDz6RV6",
+    "npiSubjectHeading" : "4mPBgD6SXFGdm6",
+    "tags" : [ "rolzW0RwdaZOxs2" ],
+    "description" : "HSnvJNv97hEZ1uiBc1F",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9LfOZPaW8f"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1RBm0S3KQGLIe"
       },
-      "doi" : "https://www.example.com/qcELn4yC623P",
+      "doi" : "https://www.example.com/tWJUDU0hzqX0",
       "publicationInstance" : {
         "type" : "JournalShortCommunication",
-        "volume" : "h2zDshNehJGJTBmzv",
-        "issue" : "VwZDN7ZREJZd",
-        "articleNumber" : "ILdXMTOZJvQ",
+        "volume" : "oyN5wvceRqlARiyp",
+        "issue" : "138xbfTK5nQx5U2r3J",
+        "articleNumber" : "XTjuVEBfetmSBCH",
         "pages" : {
           "type" : "Range",
-          "begin" : "Zq8Bzt0JdIS69Me",
-          "end" : "Hd4Sp04HRXnJDOq2Lu"
+          "begin" : "KSTEZrtmKtWDcCvr6h",
+          "end" : "FhbCy4dw4XERyq8G1wh"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/F5dyEwQkTlUl5q",
-    "abstract" : "GLHPRhRhr2J21liT4"
+    "metadataSource" : "https://www.example.com/jqIiSoheV0eUX",
+    "abstract" : "efK7gft3t2RMs4V"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "HGMB5doH0P0sBe",
-      "mimeType" : "wTiwm0YkBfi7uUyn",
-      "size" : 262541493,
+      "name" : "hJsHm3F7rvO7N",
+      "mimeType" : "38ICalX3ZZ0nA2X8M",
+      "size" : 968892696,
       "license" : {
         "type" : "License",
-        "identifier" : "5bP5uB4CTXszdpR",
+        "identifier" : "Q3nCHnKBlL1IuAW",
         "labels" : {
-          "vIzYYpy6pSKn9EP" : "fKxH6apxamYPNI9Ud"
+          "ojpJjpSY2hE" : "E83I5hUFKT"
         },
-        "link" : "https://www.example.com/Eavb53s1A4f4jj3g"
+        "link" : "https://www.example.com/omeacJYapN"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiad",
-    "name" : "lKOZIHKLrxn",
+    "id" : "https://www.example.org/omnisplaceat",
+    "name" : "wkb4hIBnk3jC1xIrRUj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SSnvwWxasnBdfIQ",
-      "id" : "txE6WxoYniASJPJaR"
+      "source" : "P3KuMC0rRe4xzaxV",
+      "id" : "cW1EuUhbOzk1I9mhDwZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "7vFs1goNAu6rTx"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "5UnuEl6YGDWLtAtBR"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/evenietmagni" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/magnienim" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -2,132 +2,132 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
-  "owner" : "7EK66tahJBX0azD8nK0",
+  "owner" : "vxIH5AfGRnqv5",
   "resourceOwner" : {
-    "owner" : "7EK66tahJBX0azD8nK0",
-    "ownerAffiliation" : "https://www.example.org/accusamusnam"
+    "owner" : "vxIH5AfGRnqv5",
+    "ownerAffiliation" : "https://www.example.org/quisminima"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laborumpossimus",
+    "id" : "https://www.example.org/laborumiusto",
     "labels" : {
-      "MuqU0VPHv0zP" : "K2PiF9txEBC"
+      "c3q0PDGqw3m5EZTK" : "MnW7g1nEsi"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utsint",
-  "doi" : "https://doi.org/10.1234/perspiciatis",
+  "handle" : "https://www.example.org/exercitationemnon",
+  "doi" : "https://doi.org/10.1234/at",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "pWkncgKTDX4PKhSNkz",
-      "author" : "pt4TdQNVzSFnD1zC1",
+      "text" : "dDhRKrS7rUqPwroTsw7",
+      "author" : "BJZo5ecEQR5",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/nostrumvoluptas",
+  "link" : "https://www.example.org/utet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4WPMxtSAttPjuCrX",
+    "mainTitle" : "HBPWJMHwhMyYTU6b",
     "alternativeTitles" : {
-      "el" : "VqODWga2ULe6hKfM"
+      "es" : "6nZtc4AmKHTEu"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "jom0vTeqBWfjhBy35",
-      "month" : "OHXZTHcjNycc",
-      "day" : "Xr94Y7dKsf4eg9Oqzv"
+      "year" : "iTBOxbVB8OL4",
+      "month" : "rfnAOCz1iecotEYna",
+      "day" : "fomUFUZmiWh7khrw7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/f5JaAbBMkbnAcxq",
-        "name" : "nlM2tvmQNy",
-        "nameType" : "Personal",
-        "orcId" : "fQ3rffgsiNCGsiIi1",
-        "arpId" : "eI6uz4rCizlPJ21m"
+        "id" : "https://www.example.com/uoiujAkwmN",
+        "name" : "8kE9rudVELx1379d",
+        "nameType" : "Organizational",
+        "orcId" : "hZL4idyL87ihIDXc4",
+        "arpId" : "sHi2o7gdwD7cvx3a"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/javouaBL4A",
+        "id" : "https://www.example.com/9eRplzAdo9gr",
         "labels" : {
-          "MlfUsejw11AR0Ia" : "TyHjcfhiAQeHWsvSc"
+          "hJRbf29lYHyaGsdiwNk" : "2YnpVGQqz4C3tmx"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 5,
+      "role" : "ProjectManager",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VOEWZbvnuuyqnNapNL",
-        "name" : "p1jamhvUCbw4",
+        "id" : "https://www.example.com/buVSqSnzbRy9IOwB",
+        "name" : "UIlNGIW6BDZpKh",
         "nameType" : "Personal",
-        "orcId" : "C3jHOa6GFqAF5pMu",
-        "arpId" : "cqoQFZJP4kgGa5ENsR"
+        "orcId" : "DJIWCqYR6r",
+        "arpId" : "YeEttv1QhmUh"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VAshC23iaWgFHxFx",
+        "id" : "https://www.example.com/9TJPeFTO5jeqCj6n2Kn",
         "labels" : {
-          "NxsxoC2RuSqO8MI" : "yuHEQaIG0F"
+          "YmHc9ByTQ6iL7" : "cteO6Ha5WzF8x"
         }
       } ],
-      "role" : "RegistrationAuthority",
-      "sequence" : 9,
+      "role" : "ProjectManager",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "HojlVQkRS3nIw6Nak",
-    "tags" : [ "lxnMdXq3zDvRv" ],
-    "description" : "cLcS43b7Zeux3AIONq6",
+    "npiSubjectHeading" : "q9hYzltANDXCruJJG3",
+    "tags" : [ "WiBjUa2M70e46k2pn0" ],
+    "description" : "SLDlAfTCKTi6sP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Pv3OGOmFMQt"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PyGiTCVJaWp7L"
       },
-      "doi" : "https://www.example.com/7b8bFt15veap7qV5yw5",
+      "doi" : "https://www.example.com/QYe5sfahGIw",
       "publicationInstance" : {
         "type" : "JournalShortCommunication",
-        "volume" : "MzXrbe4eYK8qx7bt",
-        "issue" : "yaeWboB9Ou9usZOzE",
-        "articleNumber" : "bTHkKZ2cph5K",
+        "volume" : "LhquG4Dsdvthl4S",
+        "issue" : "Pz0wtwICP2pc1",
+        "articleNumber" : "tIZqvTUqsqdGMgfF9Q",
         "pages" : {
           "type" : "Range",
-          "begin" : "FpCzAwu3Ul",
-          "end" : "0U65dAWPbNV"
+          "begin" : "3WPcP5IsSksOX0vZDvU",
+          "end" : "Jr8Trsft3hAT0"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/zds1hsUtjGgt8tRpK",
-    "abstract" : "YvLDC8eom0mz72gCSav"
+    "metadataSource" : "https://www.example.com/OOcwlO82PO2v",
+    "abstract" : "bwCAYQJAXtsv1vovAp"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "hbqOmC2iKQxwS6DG5V",
-      "mimeType" : "siyjwZUCBJfw",
-      "size" : 1636004327,
+      "name" : "bs4p62WCwEWx",
+      "mimeType" : "R1Tz7OxY6XujDtkp1cn",
+      "size" : 1505025470,
       "license" : {
         "type" : "License",
-        "identifier" : "sFWsxoKuxLpENKe",
+        "identifier" : "cmsXzt2EtkXExyrEE",
         "labels" : {
-          "nmkw5Qwa5q79yy7Df5" : "zGVmsyvjNY4"
+          "o8dtUY6gdEuXdszThU" : "ii17dp5NvR"
         },
-        "link" : "https://www.example.com/hJIzCaQRzDa"
+        "link" : "https://www.example.com/3edtMk0suRmI7y8t"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -136,19 +136,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/solutanon",
-    "name" : "kfECKucnzV",
+    "id" : "https://www.example.org/cumquam",
+    "name" : "CVPOwa53C97SBTnrvg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "8FaEZLAJD8DPA1JTy5",
-      "id" : "deWWidd7amH"
+      "source" : "BeXnYpuvqn",
+      "id" : "KzD37scpAQGVRHxSGt4"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "5QT5McO3eyJEJe"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "LSTQYalV1a"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quidemodit" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/quibusdamsed" ],
+  "modelVersion" : "0.14.23"
 }

--- a/documentation/JournalShortCommunication.json
+++ b/documentation/JournalShortCommunication.json
@@ -1,154 +1,154 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "vxIH5AfGRnqv5",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "Eb3W6fYm8m66pNIJ",
   "resourceOwner" : {
-    "owner" : "vxIH5AfGRnqv5",
-    "ownerAffiliation" : "https://www.example.org/quisminima"
+    "owner" : "Eb3W6fYm8m66pNIJ",
+    "ownerAffiliation" : "https://www.example.org/utsaepe"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laborumiusto",
+    "id" : "https://www.example.org/voluptatelaborum",
     "labels" : {
-      "c3q0PDGqw3m5EZTK" : "MnW7g1nEsi"
+      "lXdsqPHiALgyDx" : "6yOEvkfKcY3heYhH5"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/exercitationemnon",
-  "doi" : "https://doi.org/10.1234/at",
+  "handle" : "https://www.example.org/aliquamdolorem",
+  "doi" : "https://doi.org/10.1234/facilis",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "dDhRKrS7rUqPwroTsw7",
-      "author" : "BJZo5ecEQR5",
+      "text" : "8Rxy7qnbRNyQB90",
+      "author" : "R3iEwSBOD3aenxHvYsr",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/utet",
+  "link" : "https://www.example.org/quiadolorem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HBPWJMHwhMyYTU6b",
+    "mainTitle" : "QIAEEWVNDR",
     "alternativeTitles" : {
-      "es" : "6nZtc4AmKHTEu"
+      "nb" : "SjvTnNPVTzETY"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "iTBOxbVB8OL4",
-      "month" : "rfnAOCz1iecotEYna",
-      "day" : "fomUFUZmiWh7khrw7"
+      "year" : "TPOJaclESLa1sYz63d",
+      "month" : "YAWz2rporTtDzkT",
+      "day" : "qiZjka05Wq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uoiujAkwmN",
-        "name" : "8kE9rudVELx1379d",
+        "id" : "https://www.example.com/lRy9iRVJEHTbKLzmR7",
+        "name" : "Oh0RxCgpUsY",
         "nameType" : "Organizational",
-        "orcId" : "hZL4idyL87ihIDXc4",
-        "arpId" : "sHi2o7gdwD7cvx3a"
+        "orcId" : "sVUx0izBuQXOUi0",
+        "arpId" : "OGZnJqIJc3kXc1td"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9eRplzAdo9gr",
+        "id" : "https://www.example.com/JTfZHsL7J0ggkRnJT",
         "labels" : {
-          "hJRbf29lYHyaGsdiwNk" : "2YnpVGQqz4C3tmx"
+          "R6M0iPyXlenjwI7ot0" : "hayfxFTac3"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 1,
+      "role" : "Designer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/buVSqSnzbRy9IOwB",
-        "name" : "UIlNGIW6BDZpKh",
-        "nameType" : "Personal",
-        "orcId" : "DJIWCqYR6r",
-        "arpId" : "YeEttv1QhmUh"
+        "id" : "https://www.example.com/rkZwMwoZjcdgHFKq92l",
+        "name" : "1XSJXX3bbLPv1fkx",
+        "nameType" : "Organizational",
+        "orcId" : "GzNHOqppSit7",
+        "arpId" : "WtfDU9RVTEyRN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9TJPeFTO5jeqCj6n2Kn",
+        "id" : "https://www.example.com/1Djj5Atarh",
         "labels" : {
-          "YmHc9ByTQ6iL7" : "cteO6Ha5WzF8x"
+          "HZjQH94mNxKlcGQofe6" : "3FwU1eaLcr"
         }
       } ],
-      "role" : "ProjectManager",
+      "role" : "WorkPackageLeader",
       "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "q9hYzltANDXCruJJG3",
-    "tags" : [ "WiBjUa2M70e46k2pn0" ],
-    "description" : "SLDlAfTCKTi6sP",
+    "npiSubjectHeading" : "3xmB9l5dm7gKTFBNy",
+    "tags" : [ "UYfrLSYvpNf8" ],
+    "description" : "ZR2hB2hwPc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PyGiTCVJaWp7L"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eRd7yZDnY2j"
       },
-      "doi" : "https://www.example.com/QYe5sfahGIw",
+      "doi" : "https://www.example.com/tGUq1g30gcpBBMHRB",
       "publicationInstance" : {
         "type" : "JournalShortCommunication",
-        "volume" : "LhquG4Dsdvthl4S",
-        "issue" : "Pz0wtwICP2pc1",
-        "articleNumber" : "tIZqvTUqsqdGMgfF9Q",
+        "volume" : "WGNdcptlEKuTWCeFq",
+        "issue" : "UWuPbtImglGCMb5",
+        "articleNumber" : "peSKT1jZKmfvXjqXR2",
         "pages" : {
           "type" : "Range",
-          "begin" : "3WPcP5IsSksOX0vZDvU",
-          "end" : "Jr8Trsft3hAT0"
+          "begin" : "4TI6SNpI3I",
+          "end" : "FJXfAhsiWdIA"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/OOcwlO82PO2v",
-    "abstract" : "bwCAYQJAXtsv1vovAp"
+    "metadataSource" : "https://www.example.com/Wkt8R2aWKd4u",
+    "abstract" : "iXWozLgzaUUvSs2s2"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bs4p62WCwEWx",
-      "mimeType" : "R1Tz7OxY6XujDtkp1cn",
-      "size" : 1505025470,
+      "name" : "cu1ERBetFTl",
+      "mimeType" : "riZHPRhj0RKpG0T4c",
+      "size" : 1144134008,
       "license" : {
         "type" : "License",
-        "identifier" : "cmsXzt2EtkXExyrEE",
+        "identifier" : "U2qddbo7ngZ17A",
         "labels" : {
-          "o8dtUY6gdEuXdszThU" : "ii17dp5NvR"
+          "v2cBKQQjsjR0Df" : "QmVXxo3nMjAcZa8bQ0"
         },
-        "link" : "https://www.example.com/3edtMk0suRmI7y8t"
+        "link" : "https://www.example.com/DNgKIW3zrKMikQU4"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cumquam",
-    "name" : "CVPOwa53C97SBTnrvg",
+    "id" : "https://www.example.org/voluptatempariatur",
+    "name" : "zNkndJdTmp6bsosd9",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "BeXnYpuvqn",
-      "id" : "KzD37scpAQGVRHxSGt4"
+      "source" : "o9j5xePEZzWMQzU2t",
+      "id" : "qI1JYZx3Rl"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "LSTQYalV1a"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "SAHmGwJ6gRlhYM"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -156,6 +156,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quibusdamsed" ],
-  "modelVersion" : "0.14.23"
+  "subjects" : [ "https://www.example.org/molestiaea" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "sQqLQwwVbKdH1RSIbSR",
+  "status" : "PUBLISHED",
+  "owner" : "Y1j3TblCh3DYGNxIPA",
   "resourceOwner" : {
-    "owner" : "sQqLQwwVbKdH1RSIbSR",
-    "ownerAffiliation" : "https://www.example.org/porroodit"
+    "owner" : "Y1j3TblCh3DYGNxIPA",
+    "ownerAffiliation" : "https://www.example.org/ettempora"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dictasint",
+    "id" : "https://www.example.org/abomnis",
     "labels" : {
-      "Boim1c6hUmy2L1pgh" : "zCNMucCkLnYf"
+      "9xJ21P5X1oRPL8uV" : "KYPZ3crmkSmiS"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnisid",
-  "doi" : "https://doi.org/10.1234/itaque",
+  "handle" : "https://www.example.org/ducimusqui",
+  "doi" : "https://doi.org/10.1234/vel",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,93 +27,94 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "8SQc03A9nqrzO",
-      "author" : "3JTXbcFEUMq",
+      "text" : "ppIx2WlImmqCJDc",
+      "author" : "2Xb73yK2SU",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/suscipitut",
+  "link" : "https://www.example.org/quosatque",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ewEufNJXrb",
+    "mainTitle" : "QnWPOPl0c2Y",
     "alternativeTitles" : {
-      "da" : "4AfoN2g68ErF"
+      "af" : "MpfUO92x1dlh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "mCUG2BqErtlk",
-      "month" : "8ajhXGnEe9MYb7",
-      "day" : "4cKMENeGHzaS96i8"
+      "year" : "M25fptRclQ",
+      "month" : "hLxil6H5q7geL",
+      "day" : "7Xpzb4FiYEdd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/m1pb4BQ8HyoQtaTSVM",
-        "name" : "10SbJGuOoKinMZoLgM",
+        "id" : "https://www.example.com/McWfkUrDot",
+        "name" : "f16aaMWEsSLuai",
         "nameType" : "Organizational",
-        "orcId" : "d0ghWIym0YhNts",
-        "arpId" : "zLK0t003gbU"
+        "orcId" : "eHtCqRznFsNPDfTAfN",
+        "arpId" : "VBSJJYvnNV10"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/j9gPcm9DJsBj2sIXN4",
+        "id" : "https://www.example.com/aCgL1noWxVYj2bcWkP",
         "labels" : {
-          "0QPi78C5iPtQ3" : "hKDrwxznuIEK9V0VXSK"
+          "8ojqBA2Ec9" : "BSnRY2Jw4gsSbmMvUl"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 8,
+      "role" : "Funder",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/l7VczSApf0adB",
-        "name" : "1RbeNKgKJavj9L",
+        "id" : "https://www.example.com/VOpsfr9v1u",
+        "name" : "gzsPG3LHX3sQtU4Z",
         "nameType" : "Organizational",
-        "orcId" : "v1488xjVT7KPKTRcqHS",
-        "arpId" : "bybzwQ9UJ7oabcsREaA"
+        "orcId" : "rbl5DM61qPuB",
+        "arpId" : "DTYQuiOgUV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0Bh3uxkeyk9",
+        "id" : "https://www.example.com/iN2pFIiKBmi02",
         "labels" : {
-          "4RiIYWPjdqiOkYK0XO" : "PNUNCeXBwRr"
+          "f5CADBhVuNBOoeM" : "bif7rRDcrPq7u"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 4,
+      "role" : "ProgrammeLeader",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5P9IFQ200rZGH",
-    "tags" : [ "xr5LVSQn2roSQut" ],
-    "description" : "ioxWC0CO9Pd",
+    "npiSubjectHeading" : "mDdo5LhP2V1",
+    "tags" : [ "NJfE05bNs6T7" ],
+    "description" : "lnovVgC4DzXNY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "s8tIIPFpp8gev7EgwZ",
+        "label" : "Gef5tTzVFsvf",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "nzyvTQGm0ydn",
-          "country" : "0GBjMXGtBpXk"
+          "label" : "jUnW4lhNNih",
+          "country" : "VqpysR1aZBgW0tTqh"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/nD4LnDO6VKtuHK0",
+          "id" : "https://www.example.com/18OJnVTVu76YkscElbo",
           "labels" : {
-            "gi4y4fsjS5aLkmbS" : "blRZshBymMGh"
+            "v4yDgbFV8akGGNkD4hr" : "Xobuel8Bc016"
           }
         },
-        "product" : "https://www.example.com/h6wODUHSXm"
+        "product" : "https://www.example.com/npEwRPVYSJt5YX9"
       },
-      "doi" : "https://www.example.com/g5x01OcHelLbKo0",
+      "doi" : "https://www.example.com/7XbZ8jim7N96MS",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -122,24 +123,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/FKka7EXhrjs",
-    "abstract" : "aJtbgxQESOfj"
+    "metadataSource" : "https://www.example.com/tKRHEt7nUK3cjb",
+    "abstract" : "4JXiquLEwT7E1CcNt"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "2pvKNCXdIh9nOAguA",
-      "mimeType" : "EL3OGDtM1nAwqeV",
-      "size" : 1188117532,
+      "name" : "Whr3RzEK3szgo8yrwE",
+      "mimeType" : "qsZxMI3gjr",
+      "size" : 1868083796,
       "license" : {
         "type" : "License",
-        "identifier" : "GZc4hSD6qem8oXD",
+        "identifier" : "l5vJ2xurUqMFB",
         "labels" : {
-          "o0ngviTuTtncTRq" : "13HJG1PkgDJFIVjM"
+          "ytOOdtQv07vSf" : "Spqb7WjUt6"
         },
-        "link" : "https://www.example.com/8KdHMOiUR8FbK6VB"
+        "link" : "https://www.example.com/ZDgiqPt6tXI"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -148,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiquos",
-    "name" : "ZUjyk1syr0ICzcvEyZM",
+    "id" : "https://www.example.org/earumest",
+    "name" : "VpjLcF6jELLX81",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "dmxaPDwMi5Ui5qrh0",
-      "id" : "dkodO1lfXBu6zr2jOM"
+      "source" : "9iPmeJk2mznEUPiH8Te",
+      "id" : "oDPaQpePuovNos"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "3PJ4WK4OFv9vySIS0"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "Zt0uTgoK1t8Igh8zGXv"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delenitiquia" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/cumducimus" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,104 +1,104 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "WGUVpk1vsd1WcfEwOO",
+  "status" : "NEW",
+  "owner" : "K1y23MGrXy07DQ",
   "resourceOwner" : {
-    "owner" : "WGUVpk1vsd1WcfEwOO",
-    "ownerAffiliation" : "https://www.example.org/illoipsam"
+    "owner" : "K1y23MGrXy07DQ",
+    "ownerAffiliation" : "https://www.example.org/suscipitaliquam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequaturdolores",
+    "id" : "https://www.example.org/minusconsequatur",
     "labels" : {
-      "8youneejpQ5fm" : "I8kbVvJ2byGv"
+      "XRZoebX3oYlb9I9y" : "c5imfwxqFTWEugo"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/occaecatibeatae",
-  "doi" : "https://doi.org/10.1234/magni",
+  "handle" : "https://www.example.org/laudantiumvoluptatem",
+  "doi" : "https://doi.org/10.1234/odio",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "0MAziwLcgXN7A",
-      "author" : "R01z9TeGIdRyTR2Mdt",
+      "text" : "kYrVmAfR4cA1K",
+      "author" : "0U3TV46ZwaKc1",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quoin",
+  "link" : "https://www.example.org/voluptatemreprehenderit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RybHetWEDAJndI",
+    "mainTitle" : "MqlBYA9ooMFJW3r",
     "alternativeTitles" : {
-      "sv" : "ZFfZAbmUw45oCVWvj"
+      "af" : "CCV0pZpqUSZIg"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AhM6HtSVioLE9q",
-      "month" : "cyjwDBkVhpiL9uRuSN",
-      "day" : "QqBsN4RtD9HkCq1zxcm"
+      "year" : "nQxJjli01d7h",
+      "month" : "yigVYPrAoGm4Two7Dj",
+      "day" : "4G2Vi3wlQT3vVyoqxWi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7oxT1QZMA3RZGJ",
-        "name" : "he2JaH0To2CnM",
-        "nameType" : "Organizational",
-        "orcId" : "95VGmJ7nxOtjIXIK1Q",
-        "arpId" : "Fltpumf1RjFt8IJOQ"
+        "id" : "https://www.example.com/IxQumf8eOQNANYv5C",
+        "name" : "l82iz7GEd2xo9",
+        "nameType" : "Personal",
+        "orcId" : "vqhdf11aabEnOWd",
+        "arpId" : "bJugyK5QzxHzWr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/H44t8GQ9NYf",
+        "id" : "https://www.example.com/t7DoT84gwylnRNNf",
         "labels" : {
-          "ZO5axdNAIn" : "9WkbI3k56EPVo"
+          "cS5uwZljmabqoOI96R" : "zB9MO4ePYFxd"
         }
       } ],
-      "role" : "RegistrationAgency",
+      "role" : "ContactPerson",
       "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Cz5isQoPrd",
-        "name" : "qcvCAFyGEJPgR",
-        "nameType" : "Personal",
-        "orcId" : "7fPyvP1PUiyyujzGrsH",
-        "arpId" : "yoYnlujbpwnDFQ"
+        "id" : "https://www.example.com/HvMkc7XqExW9ua4kgU",
+        "name" : "RIFn1uyJBigI7pU4L58",
+        "nameType" : "Organizational",
+        "orcId" : "PJ4MSLTHVn3kBdIeG",
+        "arpId" : "AC9ZVtbb9lwGgz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/8CO4orwFYle",
+        "id" : "https://www.example.com/DMvmdhDOqJ",
         "labels" : {
-          "Ei6pMZntD7hSAFg" : "3uLK5HKlOl"
+          "LZfNIUS8WCX6ZSkNy" : "VDHMArsfK3xVqU"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 6,
+      "role" : "Illustrator",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "aVTEuBVWH7huuCrCd",
-    "tags" : [ "AcPJP1HXPg5AVcKA" ],
-    "description" : "VXIbwSaaqcWPeCs4rwV",
+    "npiSubjectHeading" : "hvXmfsx9Yz7Kcxs3",
+    "tags" : [ "cPb0w0a5JAotzku" ],
+    "description" : "uPKdiGmUZ9lcDCVMdh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "UMpEVtjT9BOe4",
+        "label" : "wVIkaozTgrlIfl",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "KOcwKZi7y5mc",
-          "country" : "WJRzG1xIlzBa"
+          "label" : "mKR20fE38FaWi",
+          "country" : "ynh8dTkQT01xn1"
         },
         "time" : {
           "type" : "Instant",
@@ -106,14 +106,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/h5yyvELAbguQmgxD",
+          "id" : "https://www.example.com/NhzhQzxRc4To4P",
           "labels" : {
-            "iih9heNEadUsZEq3" : "1ZfumqfESBxSKhWA"
+            "Y0VEQ2Wvwl" : "ENDenzkfSxeYd2"
           }
         },
-        "product" : "https://www.example.com/ryX3mXIiO23Q"
+        "product" : "https://www.example.com/78h1PqQnUZ6KDd7QdQF"
       },
-      "doi" : "https://www.example.com/vaJ9HbhpwuZM",
+      "doi" : "https://www.example.com/3bZft5AekY9lOV",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -122,24 +122,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/158QQ5POSUzfrcNuch",
-    "abstract" : "mrrC1iS1vTMTrZ34rv6"
+    "metadataSource" : "https://www.example.com/nqCZdZHul1C",
+    "abstract" : "NXDIsItm0ny"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "IAt4Ken7TzK6",
-      "mimeType" : "RcRrzsWjO7OcHW1rlF",
-      "size" : 161057905,
+      "name" : "9iFMKuGYGNN",
+      "mimeType" : "XPKEM7gRWyjYdFrpFj",
+      "size" : 284309210,
       "license" : {
         "type" : "License",
-        "identifier" : "DcrwFEwq5EH5TxAC",
+        "identifier" : "yTCUqlKetjv",
         "labels" : {
-          "4H7DQ5jZNF" : "UBNlozUuyS07Xynx24J"
+          "KfCvMbX1NUcelr3mX0" : "TT2rdHIifOSd2w"
         },
-        "link" : "https://www.example.com/9Ugb1sKRUW"
+        "link" : "https://www.example.com/ukFDWEhldt2zjwFa7hx"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -148,19 +148,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/accusantiumminima",
-    "name" : "eec6w0vOG8qpn",
+    "id" : "https://www.example.org/recusandaevoluptas",
+    "name" : "6MDnbZxiNyAjE97",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "VImHUykoOi82ILc",
-      "id" : "BaO5wSZvxtfALv7UR"
+      "source" : "BPdglKBDAV6EnEFcc",
+      "id" : "IXTVTYVb2ehN8"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "976JMGktHIJi04AcPsB"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "3kzPe06asudQWtbr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/porroquis" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/voluptatumtenetur" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
-  "owner" : "Y1j3TblCh3DYGNxIPA",
+  "owner" : "WGUVpk1vsd1WcfEwOO",
   "resourceOwner" : {
-    "owner" : "Y1j3TblCh3DYGNxIPA",
-    "ownerAffiliation" : "https://www.example.org/ettempora"
+    "owner" : "WGUVpk1vsd1WcfEwOO",
+    "ownerAffiliation" : "https://www.example.org/illoipsam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/abomnis",
+    "id" : "https://www.example.org/consequaturdolores",
     "labels" : {
-      "9xJ21P5X1oRPL8uV" : "KYPZ3crmkSmiS"
+      "8youneejpQ5fm" : "I8kbVvJ2byGv"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ducimusqui",
-  "doi" : "https://doi.org/10.1234/vel",
+  "handle" : "https://www.example.org/occaecatibeatae",
+  "doi" : "https://doi.org/10.1234/magni",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,94 +27,93 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "ppIx2WlImmqCJDc",
-      "author" : "2Xb73yK2SU",
+      "text" : "0MAziwLcgXN7A",
+      "author" : "R01z9TeGIdRyTR2Mdt",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quosatque",
+  "link" : "https://www.example.org/quoin",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QnWPOPl0c2Y",
+    "mainTitle" : "RybHetWEDAJndI",
     "alternativeTitles" : {
-      "af" : "MpfUO92x1dlh"
+      "sv" : "ZFfZAbmUw45oCVWvj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "M25fptRclQ",
-      "month" : "hLxil6H5q7geL",
-      "day" : "7Xpzb4FiYEdd"
+      "year" : "AhM6HtSVioLE9q",
+      "month" : "cyjwDBkVhpiL9uRuSN",
+      "day" : "QqBsN4RtD9HkCq1zxcm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/McWfkUrDot",
-        "name" : "f16aaMWEsSLuai",
+        "id" : "https://www.example.com/7oxT1QZMA3RZGJ",
+        "name" : "he2JaH0To2CnM",
         "nameType" : "Organizational",
-        "orcId" : "eHtCqRznFsNPDfTAfN",
-        "arpId" : "VBSJJYvnNV10"
+        "orcId" : "95VGmJ7nxOtjIXIK1Q",
+        "arpId" : "Fltpumf1RjFt8IJOQ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aCgL1noWxVYj2bcWkP",
+        "id" : "https://www.example.com/H44t8GQ9NYf",
         "labels" : {
-          "8ojqBA2Ec9" : "BSnRY2Jw4gsSbmMvUl"
+          "ZO5axdNAIn" : "9WkbI3k56EPVo"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 5,
+      "role" : "RegistrationAgency",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VOpsfr9v1u",
-        "name" : "gzsPG3LHX3sQtU4Z",
-        "nameType" : "Organizational",
-        "orcId" : "rbl5DM61qPuB",
-        "arpId" : "DTYQuiOgUV"
+        "id" : "https://www.example.com/Cz5isQoPrd",
+        "name" : "qcvCAFyGEJPgR",
+        "nameType" : "Personal",
+        "orcId" : "7fPyvP1PUiyyujzGrsH",
+        "arpId" : "yoYnlujbpwnDFQ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iN2pFIiKBmi02",
+        "id" : "https://www.example.com/8CO4orwFYle",
         "labels" : {
-          "f5CADBhVuNBOoeM" : "bif7rRDcrPq7u"
+          "Ei6pMZntD7hSAFg" : "3uLK5HKlOl"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 0,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "mDdo5LhP2V1",
-    "tags" : [ "NJfE05bNs6T7" ],
-    "description" : "lnovVgC4DzXNY",
+    "npiSubjectHeading" : "aVTEuBVWH7huuCrCd",
+    "tags" : [ "AcPJP1HXPg5AVcKA" ],
+    "description" : "VXIbwSaaqcWPeCs4rwV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "Gef5tTzVFsvf",
+        "label" : "UMpEVtjT9BOe4",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "jUnW4lhNNih",
-          "country" : "VqpysR1aZBgW0tTqh"
+          "label" : "KOcwKZi7y5mc",
+          "country" : "WJRzG1xIlzBa"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2020-09-23T09:51:23.044996Z",
-          "to" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Instant",
+          "value" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/18OJnVTVu76YkscElbo",
+          "id" : "https://www.example.com/h5yyvELAbguQmgxD",
           "labels" : {
-            "v4yDgbFV8akGGNkD4hr" : "Xobuel8Bc016"
+            "iih9heNEadUsZEq3" : "1ZfumqfESBxSKhWA"
           }
         },
-        "product" : "https://www.example.com/npEwRPVYSJt5YX9"
+        "product" : "https://www.example.com/ryX3mXIiO23Q"
       },
-      "doi" : "https://www.example.com/7XbZ8jim7N96MS",
+      "doi" : "https://www.example.com/vaJ9HbhpwuZM",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -123,45 +122,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/tKRHEt7nUK3cjb",
-    "abstract" : "4JXiquLEwT7E1CcNt"
+    "metadataSource" : "https://www.example.com/158QQ5POSUzfrcNuch",
+    "abstract" : "mrrC1iS1vTMTrZ34rv6"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Whr3RzEK3szgo8yrwE",
-      "mimeType" : "qsZxMI3gjr",
-      "size" : 1868083796,
+      "name" : "IAt4Ken7TzK6",
+      "mimeType" : "RcRrzsWjO7OcHW1rlF",
+      "size" : 161057905,
       "license" : {
         "type" : "License",
-        "identifier" : "l5vJ2xurUqMFB",
+        "identifier" : "DcrwFEwq5EH5TxAC",
         "labels" : {
-          "ytOOdtQv07vSf" : "Spqb7WjUt6"
+          "4H7DQ5jZNF" : "UBNlozUuyS07Xynx24J"
         },
-        "link" : "https://www.example.com/ZDgiqPt6tXI"
+        "link" : "https://www.example.com/9Ugb1sKRUW"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/earumest",
-    "name" : "VpjLcF6jELLX81",
+    "id" : "https://www.example.org/accusantiumminima",
+    "name" : "eec6w0vOG8qpn",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "9iPmeJk2mznEUPiH8Te",
-      "id" : "oDPaQpePuovNos"
+      "source" : "VImHUykoOi82ILc",
+      "id" : "BaO5wSZvxtfALv7UR"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Zt0uTgoK1t8Igh8zGXv"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "976JMGktHIJi04AcPsB"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cumducimus" ],
+  "subjects" : [ "https://www.example.org/porroquis" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -2,24 +2,24 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "uihk0PwYg73qRcj5",
+  "owner" : "iNHaRK0Tt0tn",
   "resourceOwner" : {
-    "owner" : "uihk0PwYg73qRcj5",
-    "ownerAffiliation" : "https://www.example.org/voluptatemquia"
+    "owner" : "iNHaRK0Tt0tn",
+    "ownerAffiliation" : "https://www.example.org/ipsamea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/maioresaut",
+    "id" : "https://www.example.org/facilisea",
     "labels" : {
-      "1lYUSWVxUJxD2abF" : "1XNoXnnYb23jD"
+      "wNaGz3Egmr" : "PpPLSzb8ZqrBrYkz0Xk"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/optioautem",
-  "doi" : "https://doi.org/10.1234/quia",
+  "handle" : "https://www.example.org/doloresitaque",
+  "doi" : "https://doi.org/10.1234/molestiae",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REQUESTED",
@@ -27,78 +27,78 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "4ntOL8VLHxG0kr",
-      "author" : "XYTKqBgaLQB4O9",
+      "text" : "7YU4cdY2bOtP79x6",
+      "author" : "JzpZ8nvtG5w8fxJE",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/easunt",
+  "link" : "https://www.example.org/undevoluptas",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KglDcplvy8WiC",
+    "mainTitle" : "f3w7yLFdlKowjVH",
     "alternativeTitles" : {
-      "nl" : "JmwJWx7qVw"
+      "af" : "BDBegBk47e5yr17qauJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "qQbyadiRlQXgI",
-      "month" : "oC6DLF2HU5vu1B3nkkg",
-      "day" : "dn7uicisxEHJ"
+      "year" : "yBobx7XuUbgRK",
+      "month" : "r00IQja6RUevqHnoAK",
+      "day" : "CttVPgNijaSA9w4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZmbU48Hlu97mW4e2",
-        "name" : "2bD0EoVvi2UvhLrusn",
-        "nameType" : "Organizational",
-        "orcId" : "AwBSgv5y1StPydec",
-        "arpId" : "wDOBP1ExbCpp"
+        "id" : "https://www.example.com/aej6d5RtYnaOt9qpKXp",
+        "name" : "LPqZDEYGaW1",
+        "nameType" : "Personal",
+        "orcId" : "coPrk4YPXZr",
+        "arpId" : "biIrwZIAapZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/gY9aI8is73NsfE4i0G",
+        "id" : "https://www.example.com/hSOa0YInX6oz0D",
         "labels" : {
-          "Wayf3LUibu6CK" : "G3aG6gncsRHXl"
+          "98I7pCaYFWaUC" : "oxwf661eL62vEC"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 6,
+      "role" : "RightsHolder",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FOp10VPxGKWCrcZrI",
-        "name" : "asTUMWghSA7p1bomM",
+        "id" : "https://www.example.com/5OX1ccw6fEbcZ",
+        "name" : "3jrVw70vb7C9",
         "nameType" : "Organizational",
-        "orcId" : "l2zXLdjAw8wyWuQhc6Z",
-        "arpId" : "b8Nj2kBNTjbA"
+        "orcId" : "evjk9A8cK2r61z",
+        "arpId" : "GiaxPbmTqK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/100KnPtD1F",
+        "id" : "https://www.example.com/9KinIUNsMOw",
         "labels" : {
-          "FVbzbIGm3by" : "SQGhtgpeRCy2nPxJkZ"
+          "q1MtbG5b1Xl5JQcz9o" : "eouan4Sp0fv3"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 8,
+      "role" : "RelatedPerson",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Ofa8ygAriQkTi2",
-    "tags" : [ "nBLko58DUzw" ],
-    "description" : "b0izhnsXjU6J0yNjhsv",
+    "npiSubjectHeading" : "rMSKAP6JioRvtZFkb",
+    "tags" : [ "DdyuMDuIomKiNZi" ],
+    "description" : "9BsE3HluacnSu89qFz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "mex9qLZGniO",
+        "label" : "3EQaOQsrY4c9CgOI9bs",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "509XAUJA65sFSIrb9v5",
-          "country" : "PXlDjOvkuqhwN25"
+          "label" : "H4MafsYwmcLVbuLKj",
+          "country" : "cUhznvVrSUlc"
         },
         "time" : {
           "type" : "Instant",
@@ -106,14 +106,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/OTdaw2eJPVO8Np0",
+          "id" : "https://www.example.com/2OXyCPf7euySVtHf",
           "labels" : {
-            "lbFd1VnEdHiXfLhjH" : "EpRXtqEehJP"
+            "qJ6jCFU84tISwSe" : "rJPV6qFTqE"
           }
         },
-        "product" : "https://www.example.com/ENENFQODwKs"
+        "product" : "https://www.example.com/xLJvZJN1KkCNqWE"
       },
-      "doi" : "https://www.example.com/u3IKcMjICh6",
+      "doi" : "https://www.example.com/Y7ALoerMFBlKnb3S5",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -122,45 +122,45 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/IJI2AcRBLdQ476i7VX",
-    "abstract" : "fJnO0CAEJe8zaIh"
+    "metadataSource" : "https://www.example.com/JddsYrDCAjH27",
+    "abstract" : "R7KDcxepoQDy7acc"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "eDZ5IK2IftTYn5",
-      "mimeType" : "J7UY4vIrOxJ",
-      "size" : 565426518,
+      "name" : "2KgYE0kxdlr5R",
+      "mimeType" : "eKAcsc0nOIfwj41TL",
+      "size" : 1752407780,
       "license" : {
         "type" : "License",
-        "identifier" : "4tELZCUkTY96FEYFs",
+        "identifier" : "IyJzXAxBsJ",
         "labels" : {
-          "aDBg7BnorIWriAxWQR" : "NxZs2DwcOQTKXlJbSJ"
+          "m8bZnF4tKbv4jMi" : "AIZwwBbn72"
         },
-        "link" : "https://www.example.com/Xav2havVeZp"
+        "link" : "https://www.example.com/OEr0H5BF7zU"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/atnam",
-    "name" : "8CIqkDhKmcxVph9tC",
+    "id" : "https://www.example.org/voluptatemcorrupti",
+    "name" : "F0LNLDycRfzLc6TF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6Sthc5uDHNNgjDSFm",
-      "id" : "zMU91O4Q6psXRak2"
+      "source" : "ws583IvTj2HvPS",
+      "id" : "8We9o8UKwnvVqJ3mAz"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "fP2BP1jphotBI"
+      "applicationCode" : "sDX85uXiDbN0hPMj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/odithic" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/eoseligendi" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "Aqtsfpdd3b",
+  "status" : "NEW",
+  "owner" : "pKjqK2kqG34Ut",
   "resourceOwner" : {
-    "owner" : "Aqtsfpdd3b",
-    "ownerAffiliation" : "https://www.example.org/sapientecumque"
+    "owner" : "pKjqK2kqG34Ut",
+    "ownerAffiliation" : "https://www.example.org/estad"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autcum",
+    "id" : "https://www.example.org/delenitieaque",
     "labels" : {
-      "DIDLaX0cEfeMAN" : "hJ6Dki7zj1nVaZ4q"
+      "judb3Bt2O8m4MIQa8qr" : "MwB9QPNS6nsXtFuF"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/repudiandaetenetur",
-  "doi" : "https://doi.org/10.1234/dolorum",
+  "handle" : "https://www.example.org/omnisbeatae",
+  "doi" : "https://doi.org/10.1234/dicta",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,93 +27,94 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Dh5QLxdjZKRCdPV9ZMh",
-      "author" : "QA5waPa5QXdehX",
+      "text" : "MeC8UitOm3CsK",
+      "author" : "MxxskIZ23GsllcJQ",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/assumendaqui",
+  "link" : "https://www.example.org/laborumsoluta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "H74FfqNRWqJt9jM",
+    "mainTitle" : "3qbDPfsP6kw39R",
     "alternativeTitles" : {
-      "nn" : "OpxubVLNBL4ztdJ8C"
+      "it" : "eCKo5W1EXqWgU"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AAEvsHnB57nwUL22",
-      "month" : "0t6Xkll3e1bZSI",
-      "day" : "ylGL9LlHEMK7Ugq"
+      "year" : "FrbFPZPpT8OlJsyjkJ",
+      "month" : "mMrVWNkvijMQ",
+      "day" : "A8W5fl7NuclOr2xC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aBuG751ICsQZGUkip",
-        "name" : "W1EmQIkRqxQKboLti",
-        "nameType" : "Personal",
-        "orcId" : "Jwo6cs97ZQhmZr",
-        "arpId" : "3FLoqSePqPW9"
+        "id" : "https://www.example.com/oFUaKsCBZs",
+        "name" : "62Aga4iyHcO2ckIXa",
+        "nameType" : "Organizational",
+        "orcId" : "iTpRP7HH026eS3Y1",
+        "arpId" : "pQVeQ29BRgsKp"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aiHiNO04GJ",
+        "id" : "https://www.example.com/URfl0YsVFOnmjboVtUv",
         "labels" : {
-          "p2tx5zsiKr" : "043yfU6XRC32tz127c"
+          "DeDDnGyyDjepkSJbU" : "pFbbntWjn4B2vo7EO8"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 5,
+      "role" : "Designer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lj3YYVXc0pp6nWPS",
-        "name" : "kyXmKj10z1PiOiMRbq",
+        "id" : "https://www.example.com/7S6gUYMytJZ",
+        "name" : "nuAR2NHqHf",
         "nameType" : "Personal",
-        "orcId" : "RWoIzE0yr8bAjw3",
-        "arpId" : "owygnC9nW6kh"
+        "orcId" : "0irbuFSTZTTOcPT",
+        "arpId" : "dgNAwdrn2qi8tp6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ULCAUpLdFMD4",
+        "id" : "https://www.example.com/WoaMJGcEVqG17AON",
         "labels" : {
-          "VQhDMyvwkjGB" : "qDq4qORojg"
+          "c42Fwzz76Qdy6exT" : "o18idslsEsHW3UfYhy"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 0,
+      "role" : "Researcher",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "OL2f7BlBW6B",
-    "tags" : [ "tNIzaZ7AcdgN" ],
-    "description" : "KSzjbH6vrzWjnLVLr",
+    "npiSubjectHeading" : "g78VmAyQDri5G166",
+    "tags" : [ "RHlhEax5kPvfn8OU" ],
+    "description" : "A0l85aCErV8eo2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "OHx8rNVNuBlK8S08",
+        "label" : "Q1pUBwzZNOJJmpfNUSP",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "O1KKNxr8i2bYlR",
-          "country" : "3ZhtmU75ST4tw"
+          "label" : "Mk8KDQTMZdGq1",
+          "country" : "Q1ouymZw6VVU944"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/ajpLgcBzsvANhNnq58a",
+          "id" : "https://www.example.com/Mv5ht28qovD",
           "labels" : {
-            "Eq2k50fx69RJoOQC" : "XTXynIyJDZ9yIU"
+            "GPpLXOqCptk" : "m5unQhx9La"
           }
         },
-        "product" : "https://www.example.com/aUec7E9xsS7ef7aNn"
+        "product" : "https://www.example.com/4CQvhXMz4gHZ8oQa"
       },
-      "doi" : "https://www.example.com/EKbhluUClE8dz25j7B",
+      "doi" : "https://www.example.com/gNTQ0FQwKCg",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -122,24 +123,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/NExqNoFWDPNS",
-    "abstract" : "S0YrENeJhA50NH9Ac"
+    "metadataSource" : "https://www.example.com/A5VPBrMAWpFV0ui3zo",
+    "abstract" : "SPJq8tIPD0VcvB"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "pW1f2fcxJHYl5t4",
-      "mimeType" : "67sBQvB4QwqVljvScO",
-      "size" : 958481812,
+      "name" : "gb65S6HNos6A5RiTnJs",
+      "mimeType" : "nbR6ymgfG7XI0Fc",
+      "size" : 1669322651,
       "license" : {
         "type" : "License",
-        "identifier" : "uNPg7KKNWk",
+        "identifier" : "dhaOq46ti7vdwnfzta",
         "labels" : {
-          "0jB5L3WJSkZYpsVM1" : "6i3Z5xvrsbSIxWmxC"
+          "R96XLVNOWruIOq940q" : "TG5JZJdnktVOcPysuI"
         },
-        "link" : "https://www.example.com/7ggZDPIKUQTEBGNy8"
+        "link" : "https://www.example.com/zn1K6lum3kZJ"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -148,19 +149,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiest",
-    "name" : "RJL4IXSRQWGvprT",
+    "id" : "https://www.example.org/doloresnostrum",
+    "name" : "6pqneZOUTUm3AbN2uk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "pavLx2pK6yc",
-      "id" : "QxakBg5UUlgXE1"
+      "source" : "FISxu7DF3IaGf33W",
+      "id" : "LcvomUUU9jE"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "TCcYLUlCeAm"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "IXD54k2s27dPJwtkS6"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -168,6 +169,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloredolorum" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/necessitatibuset" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -2,119 +2,118 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "pKjqK2kqG34Ut",
+  "owner" : "uihk0PwYg73qRcj5",
   "resourceOwner" : {
-    "owner" : "pKjqK2kqG34Ut",
-    "ownerAffiliation" : "https://www.example.org/estad"
+    "owner" : "uihk0PwYg73qRcj5",
+    "ownerAffiliation" : "https://www.example.org/voluptatemquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/delenitieaque",
+    "id" : "https://www.example.org/maioresaut",
     "labels" : {
-      "judb3Bt2O8m4MIQa8qr" : "MwB9QPNS6nsXtFuF"
+      "1lYUSWVxUJxD2abF" : "1XNoXnnYb23jD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnisbeatae",
-  "doi" : "https://doi.org/10.1234/dicta",
+  "handle" : "https://www.example.org/optioautem",
+  "doi" : "https://doi.org/10.1234/quia",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "MeC8UitOm3CsK",
-      "author" : "MxxskIZ23GsllcJQ",
+      "text" : "4ntOL8VLHxG0kr",
+      "author" : "XYTKqBgaLQB4O9",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/laborumsoluta",
+  "link" : "https://www.example.org/easunt",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3qbDPfsP6kw39R",
+    "mainTitle" : "KglDcplvy8WiC",
     "alternativeTitles" : {
-      "it" : "eCKo5W1EXqWgU"
+      "nl" : "JmwJWx7qVw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FrbFPZPpT8OlJsyjkJ",
-      "month" : "mMrVWNkvijMQ",
-      "day" : "A8W5fl7NuclOr2xC"
+      "year" : "qQbyadiRlQXgI",
+      "month" : "oC6DLF2HU5vu1B3nkkg",
+      "day" : "dn7uicisxEHJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oFUaKsCBZs",
-        "name" : "62Aga4iyHcO2ckIXa",
+        "id" : "https://www.example.com/ZmbU48Hlu97mW4e2",
+        "name" : "2bD0EoVvi2UvhLrusn",
         "nameType" : "Organizational",
-        "orcId" : "iTpRP7HH026eS3Y1",
-        "arpId" : "pQVeQ29BRgsKp"
+        "orcId" : "AwBSgv5y1StPydec",
+        "arpId" : "wDOBP1ExbCpp"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/URfl0YsVFOnmjboVtUv",
+        "id" : "https://www.example.com/gY9aI8is73NsfE4i0G",
         "labels" : {
-          "DeDDnGyyDjepkSJbU" : "pFbbntWjn4B2vo7EO8"
+          "Wayf3LUibu6CK" : "G3aG6gncsRHXl"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 0,
+      "role" : "Sponsor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7S6gUYMytJZ",
-        "name" : "nuAR2NHqHf",
-        "nameType" : "Personal",
-        "orcId" : "0irbuFSTZTTOcPT",
-        "arpId" : "dgNAwdrn2qi8tp6"
+        "id" : "https://www.example.com/FOp10VPxGKWCrcZrI",
+        "name" : "asTUMWghSA7p1bomM",
+        "nameType" : "Organizational",
+        "orcId" : "l2zXLdjAw8wyWuQhc6Z",
+        "arpId" : "b8Nj2kBNTjbA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/WoaMJGcEVqG17AON",
+        "id" : "https://www.example.com/100KnPtD1F",
         "labels" : {
-          "c42Fwzz76Qdy6exT" : "o18idslsEsHW3UfYhy"
+          "FVbzbIGm3by" : "SQGhtgpeRCy2nPxJkZ"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 3,
+      "role" : "Advisor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "g78VmAyQDri5G166",
-    "tags" : [ "RHlhEax5kPvfn8OU" ],
-    "description" : "A0l85aCErV8eo2",
+    "npiSubjectHeading" : "Ofa8ygAriQkTi2",
+    "tags" : [ "nBLko58DUzw" ],
+    "description" : "b0izhnsXjU6J0yNjhsv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "Q1pUBwzZNOJJmpfNUSP",
+        "label" : "mex9qLZGniO",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "Mk8KDQTMZdGq1",
-          "country" : "Q1ouymZw6VVU944"
+          "label" : "509XAUJA65sFSIrb9v5",
+          "country" : "PXlDjOvkuqhwN25"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2020-09-23T09:51:23.044996Z",
-          "to" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Instant",
+          "value" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/Mv5ht28qovD",
+          "id" : "https://www.example.com/OTdaw2eJPVO8Np0",
           "labels" : {
-            "GPpLXOqCptk" : "m5unQhx9La"
+            "lbFd1VnEdHiXfLhjH" : "EpRXtqEehJP"
           }
         },
-        "product" : "https://www.example.com/4CQvhXMz4gHZ8oQa"
+        "product" : "https://www.example.com/ENENFQODwKs"
       },
-      "doi" : "https://www.example.com/gNTQ0FQwKCg",
+      "doi" : "https://www.example.com/u3IKcMjICh6",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -123,24 +122,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/A5VPBrMAWpFV0ui3zo",
-    "abstract" : "SPJq8tIPD0VcvB"
+    "metadataSource" : "https://www.example.com/IJI2AcRBLdQ476i7VX",
+    "abstract" : "fJnO0CAEJe8zaIh"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "gb65S6HNos6A5RiTnJs",
-      "mimeType" : "nbR6ymgfG7XI0Fc",
-      "size" : 1669322651,
+      "name" : "eDZ5IK2IftTYn5",
+      "mimeType" : "J7UY4vIrOxJ",
+      "size" : 565426518,
       "license" : {
         "type" : "License",
-        "identifier" : "dhaOq46ti7vdwnfzta",
+        "identifier" : "4tELZCUkTY96FEYFs",
         "labels" : {
-          "R96XLVNOWruIOq940q" : "TG5JZJdnktVOcPysuI"
+          "aDBg7BnorIWriAxWQR" : "NxZs2DwcOQTKXlJbSJ"
         },
-        "link" : "https://www.example.com/zn1K6lum3kZJ"
+        "link" : "https://www.example.com/Xav2havVeZp"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -149,19 +148,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloresnostrum",
-    "name" : "6pqneZOUTUm3AbN2uk",
+    "id" : "https://www.example.org/atnam",
+    "name" : "8CIqkDhKmcxVph9tC",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FISxu7DF3IaGf33W",
-      "id" : "LcvomUUU9jE"
+      "source" : "6Sthc5uDHNNgjDSFm",
+      "id" : "zMU91O4Q6psXRak2"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "IXD54k2s27dPJwtkS6"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "fP2BP1jphotBI"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -169,6 +168,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/necessitatibuset" ],
+  "subjects" : [ "https://www.example.org/odithic" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,150 +1,150 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "6h4fPIxAmNf",
+  "status" : "DRAFT_FOR_DELETION",
+  "owner" : "x0AcKBuIMws",
   "resourceOwner" : {
-    "owner" : "6h4fPIxAmNf",
-    "ownerAffiliation" : "https://www.example.org/suntin"
+    "owner" : "x0AcKBuIMws",
+    "ownerAffiliation" : "https://www.example.org/beataevoluptatem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/doloresvoluptas",
+    "id" : "https://www.example.org/utquis",
     "labels" : {
-      "gUnI9XzVgiWJT9" : "roQMZupentV"
+      "0jWKic35Ir" : "DPFnomzkwYOUV"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/estneque",
-  "doi" : "https://doi.org/10.1234/at",
+  "handle" : "https://www.example.org/natuscupiditate",
+  "doi" : "https://doi.org/10.1234/non",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "2BByHhLYrdZ9BqlSx4",
-      "author" : "AxT0lqm1SRS",
+      "text" : "CrfNaKp2ohC",
+      "author" : "5PEJKwgrPoQ4ly0",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/possimusaut",
+  "link" : "https://www.example.org/molestiaset",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bcVFORL1gLA8HmlTTh",
+    "mainTitle" : "BVKHZgGVwBAjXF",
     "alternativeTitles" : {
-      "fr" : "yngTba54sd"
+      "el" : "SWUgvUD6DxQnb7"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "BiXwthewI3SfnvU",
-      "month" : "tFrxAa82Hu",
-      "day" : "rugDH5s4atA19tgei5"
+      "year" : "jLA14KfrHM",
+      "month" : "CJncZwiEGXWdI2kuYHJ",
+      "day" : "8RWiBkoNWmHK0XK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZewdEdCWM3H47imIFT",
-        "name" : "i4RjZYBxGh9IJH",
+        "id" : "https://www.example.com/V17y9jDZK0hfFtFY",
+        "name" : "lIxF9lzDrCeLP",
         "nameType" : "Personal",
-        "orcId" : "Un64LEEFIoeqXZpWXSl",
-        "arpId" : "CoGFliM0SCZqKTZGO"
+        "orcId" : "366AyiulETADWfmbH",
+        "arpId" : "zqNIpZ1B8OBvu2UjC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vpy5QgKA59oCo",
+        "id" : "https://www.example.com/dQDmjDdAYqtEXXz",
         "labels" : {
-          "aXC6ez8lTigCvx4v" : "heMnBG3dAO"
+          "EfD4IQy7RwCi" : "fk2SxbINXGWJET"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 0,
+      "role" : "RelatedPerson",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0SIoclU7NCuffp2Jg",
-        "name" : "aFs4ccPWSdqJ",
+        "id" : "https://www.example.com/ucp9llETFLbYbI",
+        "name" : "hssx5hy0ARSIsZ",
         "nameType" : "Organizational",
-        "orcId" : "JUJEnasgkSK",
-        "arpId" : "baAtvny38xJDWAss"
+        "orcId" : "9qBRBeG9sIUy0sj9i4",
+        "arpId" : "TOSkSSFckJwd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/r7dzO19CR3kIWT",
+        "id" : "https://www.example.com/ayDFdwes7uE5NMvINX",
         "labels" : {
-          "mT5nwJdQK8XYQg7d" : "jOer99r345cAf8njsG"
+          "16hUgHgUJ2VR" : "QNeEvHNx3Dcwpk"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 5,
+      "role" : "ProgrammeLeader",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "52HMyKKtIY7C6lLb",
-    "tags" : [ "LyqG3mRH68To" ],
-    "description" : "eeq2JBMkVZB7sus2",
+    "npiSubjectHeading" : "Bha87TWHADdqu41",
+    "tags" : [ "vu2VHtot5pw0ZsQgDLX" ],
+    "description" : "fgilRbKjr1V5U6vttS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XFnoy3M8fHepjX7B"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zlWmA2XIdiHAsB3U"
         },
-        "seriesNumber" : "wr2vcZPdEE50",
+        "seriesNumber" : "aR7GJ7PN0jgpUk",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/sOBCHDX3seeBoOCC"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PFgrnWNeQXH5qswV"
         },
-        "isbnList" : [ "9791281001329" ]
+        "isbnList" : [ "9791950887339" ]
       },
-      "doi" : "https://www.example.com/IyBg5QyLk3W7h",
+      "doi" : "https://www.example.com/9kdLHPJIAb04er",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "pyQRjftOBctQ12jxFG",
-          "month" : "PhZ958nXyjhxleX1vu",
-          "day" : "yawOg789QDOeODmDXxx"
+          "year" : "vHazUScpPosWm9Ts",
+          "month" : "Psstbp0GVI8",
+          "day" : "IXWHESxBMN"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "JcFyrKYmhnS",
-            "end" : "oe2mrPZFlqpS"
+            "begin" : "kIV3Uy02Ssay",
+            "end" : "I6crC1Mr8ptYnwNFx"
           },
-          "pages" : "DAnliU2vTHbEE",
+          "pages" : "BOIWBWJb4whJNQL",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/8NP4bgF7HFLutLiO",
-    "abstract" : "vI5VFTLbxNCD22Gpy7"
+    "metadataSource" : "https://www.example.com/ah38yIVdHjrl1L",
+    "abstract" : "VVgQlr3Rwpqr7zRDhuR"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "GH7t7sqQVUJRNo",
-      "mimeType" : "W6UnhRUTysMQqCQ9od",
-      "size" : 1769246616,
+      "name" : "spiBKeTGwvwy",
+      "mimeType" : "YxCopm9QBvyN7p",
+      "size" : 350761992,
       "license" : {
         "type" : "License",
-        "identifier" : "gf6s31Tf0qni",
+        "identifier" : "kk4f6Ueu2pfVCt",
         "labels" : {
-          "qdCCTlSD9aBIAicTDm" : "Peo7ggewbN56VYWyR8"
+          "tGLBR4FqFAKc86DC" : "5LEc8ceH1V7JeuuIkKe"
         },
-        "link" : "https://www.example.com/qmeo4VaGq50"
+        "link" : "https://www.example.com/djDVjMgikXLNGMX"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dolorfuga",
-    "name" : "ZyM318p1KRHwDIvNG",
+    "id" : "https://www.example.org/insaepe",
+    "name" : "3g7qKotOnBJVb4ItL",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "9G7Uzd1ppgB",
-      "id" : "SxikzkvNT4iU"
+      "source" : "7mVxHXeywx8c9uZkKn",
+      "id" : "Pdr0TPuE96XtRys"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "GYzDZrGDkRn"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "NirTaW0p9x0ZFU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/utest" ],
+  "subjects" : [ "https://www.example.org/sintquod" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,150 +1,150 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "nev9qSkBNgY9q90",
+  "status" : "NEW",
+  "owner" : "6h4fPIxAmNf",
   "resourceOwner" : {
-    "owner" : "nev9qSkBNgY9q90",
-    "ownerAffiliation" : "https://www.example.org/abassumenda"
+    "owner" : "6h4fPIxAmNf",
+    "ownerAffiliation" : "https://www.example.org/suntin"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/solutaillum",
+    "id" : "https://www.example.org/doloresvoluptas",
     "labels" : {
-      "ZS4lOAR3T0" : "PK8cbObxF1CzE"
+      "gUnI9XzVgiWJT9" : "roQMZupentV"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/modiiusto",
-  "doi" : "https://doi.org/10.1234/non",
+  "handle" : "https://www.example.org/estneque",
+  "doi" : "https://doi.org/10.1234/at",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "cG8lTlUFXFrzKwv",
-      "author" : "0OkCx081C5Z",
+      "text" : "2BByHhLYrdZ9BqlSx4",
+      "author" : "AxT0lqm1SRS",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/exercitationemut",
+  "link" : "https://www.example.org/possimusaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jox0KAmICae",
+    "mainTitle" : "bcVFORL1gLA8HmlTTh",
     "alternativeTitles" : {
-      "ru" : "YcWhxqIVIjcgCMvk2"
+      "fr" : "yngTba54sd"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "9n4HJ65VsrDaQ",
-      "month" : "6k9SXGObt6iqE",
-      "day" : "F9Ih3By4Td"
+      "year" : "BiXwthewI3SfnvU",
+      "month" : "tFrxAa82Hu",
+      "day" : "rugDH5s4atA19tgei5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/qekU4Q6jV0spV",
-        "name" : "HHPLJBaSdGvf6FsJGHi",
-        "nameType" : "Organizational",
-        "orcId" : "egE8VuxBc14vOq4hJ",
-        "arpId" : "sAj6641mUJcUA"
+        "id" : "https://www.example.com/ZewdEdCWM3H47imIFT",
+        "name" : "i4RjZYBxGh9IJH",
+        "nameType" : "Personal",
+        "orcId" : "Un64LEEFIoeqXZpWXSl",
+        "arpId" : "CoGFliM0SCZqKTZGO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/eXNkle1WbJgNsjs4",
+        "id" : "https://www.example.com/vpy5QgKA59oCo",
         "labels" : {
-          "PdSuKQa2k6EUl" : "Ge0CNkbsum"
+          "aXC6ez8lTigCvx4v" : "heMnBG3dAO"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 6,
+      "role" : "DataCollector",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SjM1ls7Xf9W3KT",
-        "name" : "7r3jTK0MYH",
-        "nameType" : "Personal",
-        "orcId" : "4QKCSBxCFROmFeVoDg",
-        "arpId" : "N0CocbLaxBaX"
+        "id" : "https://www.example.com/0SIoclU7NCuffp2Jg",
+        "name" : "aFs4ccPWSdqJ",
+        "nameType" : "Organizational",
+        "orcId" : "JUJEnasgkSK",
+        "arpId" : "baAtvny38xJDWAss"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vk5MXPQcjz",
+        "id" : "https://www.example.com/r7dzO19CR3kIWT",
         "labels" : {
-          "EV5GTIovibGf3" : "lOCMeGHX9WxgUajfhp"
+          "mT5nwJdQK8XYQg7d" : "jOer99r345cAf8njsG"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 3,
+      "role" : "AcademicCoordinator",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "H57kazOO09E8glio",
-    "tags" : [ "xGSH6GJMtzS" ],
-    "description" : "fVc6ei6qfeJBH",
+    "npiSubjectHeading" : "52HMyKKtIY7C6lLb",
+    "tags" : [ "LyqG3mRH68To" ],
+    "description" : "eeq2JBMkVZB7sus2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8KTgmkvQTY83"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XFnoy3M8fHepjX7B"
         },
-        "seriesNumber" : "pYmGbYWhiWG",
+        "seriesNumber" : "wr2vcZPdEE50",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rHpFr6GfhoRI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/sOBCHDX3seeBoOCC"
         },
-        "isbnList" : [ "9781241364106" ]
+        "isbnList" : [ "9791281001329" ]
       },
-      "doi" : "https://www.example.com/6FHIzo3YfXQvi",
+      "doi" : "https://www.example.com/IyBg5QyLk3W7h",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "yhPpAk3wC2NKTZPtnR",
-          "month" : "D7JPMDmb27ZUEiLssb",
-          "day" : "WZBhUAhIqJ92kgQTl"
+          "year" : "pyQRjftOBctQ12jxFG",
+          "month" : "PhZ958nXyjhxleX1vu",
+          "day" : "yawOg789QDOeODmDXxx"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "cylzY0eYVHXw",
-            "end" : "dbRnzRAGsMnjft"
+            "begin" : "JcFyrKYmhnS",
+            "end" : "oe2mrPZFlqpS"
           },
-          "pages" : "JiJMGERYfEJ",
-          "illustrated" : true
+          "pages" : "DAnliU2vTHbEE",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/dGthnYWgYw1e37mJ6C",
-    "abstract" : "ctmmJgabhAfe0ZK"
+    "metadataSource" : "https://www.example.com/8NP4bgF7HFLutLiO",
+    "abstract" : "vI5VFTLbxNCD22Gpy7"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "B8Bh0hnyOhzEdFrZ",
-      "mimeType" : "EgsNpUEN1us",
-      "size" : 2019231290,
+      "name" : "GH7t7sqQVUJRNo",
+      "mimeType" : "W6UnhRUTysMQqCQ9od",
+      "size" : 1769246616,
       "license" : {
         "type" : "License",
-        "identifier" : "1kBdIpK79SjBPz",
+        "identifier" : "gf6s31Tf0qni",
         "labels" : {
-          "lOCR274Tz76dIZY" : "mu7oprYfUqZ6SHk"
+          "qdCCTlSD9aBIAicTDm" : "Peo7ggewbN56VYWyR8"
         },
-        "link" : "https://www.example.com/p5tahHXrPuHOxT"
+        "link" : "https://www.example.com/qmeo4VaGq50"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laudantiumet",
-    "name" : "KnGalIjRh46nsxuhP",
+    "id" : "https://www.example.org/dolorfuga",
+    "name" : "ZyM318p1KRHwDIvNG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "NxrT7dnhkpZU6GT",
-      "id" : "oeAZj337JIGg53o"
+      "source" : "9G7Uzd1ppgB",
+      "id" : "SxikzkvNT4iU"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "FKdro6oLIvtCpEB"
+      "applicationCode" : "GYzDZrGDkRn"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporibussuscipit" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/utest" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,150 +1,150 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "x0AcKBuIMws",
+  "status" : "DRAFT",
+  "owner" : "DPi7bAyGP24If",
   "resourceOwner" : {
-    "owner" : "x0AcKBuIMws",
-    "ownerAffiliation" : "https://www.example.org/beataevoluptatem"
+    "owner" : "DPi7bAyGP24If",
+    "ownerAffiliation" : "https://www.example.org/aperiameum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/utquis",
+    "id" : "https://www.example.org/exaliquid",
     "labels" : {
-      "0jWKic35Ir" : "DPFnomzkwYOUV"
+      "zhGvM25iFp8VHAX" : "RpAjU5cfBku"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/natuscupiditate",
-  "doi" : "https://doi.org/10.1234/non",
+  "handle" : "https://www.example.org/utsapiente",
+  "doi" : "https://doi.org/10.1234/recusandae",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "CrfNaKp2ohC",
-      "author" : "5PEJKwgrPoQ4ly0",
+      "text" : "PtY2ptBtGRJc",
+      "author" : "0OhR2UzojfG",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/molestiaset",
+  "link" : "https://www.example.org/expeditadolorem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BVKHZgGVwBAjXF",
+    "mainTitle" : "Wis4rU7Atm051ah",
     "alternativeTitles" : {
-      "el" : "SWUgvUD6DxQnb7"
+      "is" : "dcCgO3rZBj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "jLA14KfrHM",
-      "month" : "CJncZwiEGXWdI2kuYHJ",
-      "day" : "8RWiBkoNWmHK0XK"
+      "year" : "Kgd7Ar0eduFo5A8OD",
+      "month" : "tTRcQkaHNfKK",
+      "day" : "HGxdEHYMZ8wgLPk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/V17y9jDZK0hfFtFY",
-        "name" : "lIxF9lzDrCeLP",
-        "nameType" : "Personal",
-        "orcId" : "366AyiulETADWfmbH",
-        "arpId" : "zqNIpZ1B8OBvu2UjC"
+        "id" : "https://www.example.com/4Bg363D9InDYtdl8sRp",
+        "name" : "qm0tuLT1RdN",
+        "nameType" : "Organizational",
+        "orcId" : "KyLUw29c7p",
+        "arpId" : "02gXMxKeQLZqXERVr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dQDmjDdAYqtEXXz",
+        "id" : "https://www.example.com/CgIhuEFVf32zZOzqg",
         "labels" : {
-          "EfD4IQy7RwCi" : "fk2SxbINXGWJET"
+          "VmUgmnlA4FEZmKBKAj" : "7xUpaRiePBWmtoBr9dU"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 1,
+      "role" : "Designer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ucp9llETFLbYbI",
-        "name" : "hssx5hy0ARSIsZ",
-        "nameType" : "Organizational",
-        "orcId" : "9qBRBeG9sIUy0sj9i4",
-        "arpId" : "TOSkSSFckJwd"
+        "id" : "https://www.example.com/9Eyh9Q5uj4sUO3dipg9",
+        "name" : "CloqCZugeicc",
+        "nameType" : "Personal",
+        "orcId" : "5GOueX6tD8c",
+        "arpId" : "xbgrm7FljzDKzrmqb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ayDFdwes7uE5NMvINX",
+        "id" : "https://www.example.com/OraMi337OloTG",
         "labels" : {
-          "16hUgHgUJ2VR" : "QNeEvHNx3Dcwpk"
+          "1tyay9oayEbMlD" : "WDwuXyzjf8z7r"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 0,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Bha87TWHADdqu41",
-    "tags" : [ "vu2VHtot5pw0ZsQgDLX" ],
-    "description" : "fgilRbKjr1V5U6vttS",
+    "npiSubjectHeading" : "5t0vBIgOLhsBVjqV2",
+    "tags" : [ "qo4Z1Ek4Eji" ],
+    "description" : "iQkwDHAJ7CVkKGt4r6T",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zlWmA2XIdiHAsB3U"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/nebBEV7GX2UiZsc6I82"
         },
-        "seriesNumber" : "aR7GJ7PN0jgpUk",
+        "seriesNumber" : "LIpHEqCjhUXMAk",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PFgrnWNeQXH5qswV"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/RIOioEuhovENtmm"
         },
-        "isbnList" : [ "9791950887339" ]
+        "isbnList" : [ "9790886307225" ]
       },
-      "doi" : "https://www.example.com/9kdLHPJIAb04er",
+      "doi" : "https://www.example.com/v5QRgK0SAn6f",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "vHazUScpPosWm9Ts",
-          "month" : "Psstbp0GVI8",
-          "day" : "IXWHESxBMN"
+          "year" : "fzvIe6hz82IK",
+          "month" : "p6PRUS3FQYOGp4nhxJu",
+          "day" : "FzAMlVIN8L"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "kIV3Uy02Ssay",
-            "end" : "I6crC1Mr8ptYnwNFx"
+            "begin" : "yUlHcfzXxs0Dn",
+            "end" : "m0Bada4HBJiCFA"
           },
-          "pages" : "BOIWBWJb4whJNQL",
-          "illustrated" : false
+          "pages" : "hUxKDawAkqtlovUDpR",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/ah38yIVdHjrl1L",
-    "abstract" : "VVgQlr3Rwpqr7zRDhuR"
+    "metadataSource" : "https://www.example.com/wqX2rAbLzpSKKLGJXr",
+    "abstract" : "Db5UIg3j0X"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "spiBKeTGwvwy",
-      "mimeType" : "YxCopm9QBvyN7p",
-      "size" : 350761992,
+      "name" : "6Mt8Eq0H5k",
+      "mimeType" : "AS1NEzrqPdH",
+      "size" : 2095951352,
       "license" : {
         "type" : "License",
-        "identifier" : "kk4f6Ueu2pfVCt",
+        "identifier" : "mMTmclZZJ7E5VM",
         "labels" : {
-          "tGLBR4FqFAKc86DC" : "5LEc8ceH1V7JeuuIkKe"
+          "wYRRYXrODzvzM0K236" : "uMKv1O1BLD"
         },
-        "link" : "https://www.example.com/djDVjMgikXLNGMX"
+        "link" : "https://www.example.com/IbI5cThjE3nQAFI"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -153,19 +153,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/insaepe",
-    "name" : "3g7qKotOnBJVb4ItL",
+    "id" : "https://www.example.org/fugavoluptatem",
+    "name" : "GgKII6SmV8q68onfSN4",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "7mVxHXeywx8c9uZkKn",
-      "id" : "Pdr0TPuE96XtRys"
+      "source" : "kuMySDdC8ObpGDHgU1",
+      "id" : "hjdKcA7yr9DJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "NMA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "NirTaW0p9x0ZFU"
+      "applicationCode" : "mLKK47UyKY7wP"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -173,6 +173,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sintquod" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/quidemsit" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "Vtj5pGckRbciLz",
+  "status" : "PUBLISHED",
+  "owner" : "XrOXbfkQFXqtFTWKwC",
   "resourceOwner" : {
-    "owner" : "Vtj5pGckRbciLz",
-    "ownerAffiliation" : "https://www.example.org/deseruntab"
+    "owner" : "XrOXbfkQFXqtFTWKwC",
+    "ownerAffiliation" : "https://www.example.org/voluptatererum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/omnisvoluptas",
+    "id" : "https://www.example.org/adipisciullam",
     "labels" : {
-      "MyMQ9pEaFOcDUX5Eoo" : "yqRl2bihJOCs7Ton"
+      "MVB1BI85JZS0N3" : "tDPA6K3kPAcnNY"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/accusamusdoloribus",
-  "doi" : "https://doi.org/10.1234/id",
+  "handle" : "https://www.example.org/numquamvelit",
+  "doi" : "https://doi.org/10.1234/dolores",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "Pa87PZ9o8v9",
-      "author" : "R7HmU3q9r9",
+      "text" : "vaurjLQyYJKD9",
+      "author" : "r0t1Pk2xNipT2",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/rerumvoluptatem",
+  "link" : "https://www.example.org/iureexpedita",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5mHkBfxoIaFKYPphp",
+    "mainTitle" : "L8u9pqmMtR",
     "alternativeTitles" : {
-      "zh" : "oYjUnlJqB2y55enXB7J"
+      "sv" : "BO3effZSSFr"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "V5yDdE9gri",
-      "month" : "br8WqIjYxtCO2TogRV",
-      "day" : "X5RFaDUljIXmtf"
+      "year" : "JzLO1xUsiI3O",
+      "month" : "SAhAPz1pt5u",
+      "day" : "kjEV30mr2xsWa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/LAK8bP1OeTifc",
-        "name" : "G1aG29vjKrzk",
-        "nameType" : "Organizational",
-        "orcId" : "x10WLQb2sMdT6Ks",
-        "arpId" : "53JKSi94qte"
+        "id" : "https://www.example.com/r2p9B3c4TsSg3",
+        "name" : "ZZ620TeQ9ilNdbMjGR",
+        "nameType" : "Personal",
+        "orcId" : "OQxUI0y7ZK",
+        "arpId" : "CS3dc0572fL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/i10hHN3r9wlFGj",
+        "id" : "https://www.example.com/TlIDYLcww6R49di",
         "labels" : {
-          "TqTRYdAkGkJHEIJRUft" : "i3A5UE4PCiPCzYF"
+          "Cl2LyGMedemAHx" : "pJcWPlEn4ckjphfVE"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 5,
+      "role" : "CuratorOrganizer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Yyx3hMNldmMlFzZ5u",
-        "name" : "XmtQpmXPtRHbPazyM",
+        "id" : "https://www.example.com/qpM5YVdQJjwMGv",
+        "name" : "APRd7inVqH7ka",
         "nameType" : "Organizational",
-        "orcId" : "7O0Wbs4bG41l",
-        "arpId" : "BFPZ3ow5NGjK3QxXh"
+        "orcId" : "Q5uqNvzhp5olpc",
+        "arpId" : "Hf05vTmllNPWfPu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4swVwWxGwmExPumK",
+        "id" : "https://www.example.com/0WGdRdHds2vOUb7",
         "labels" : {
-          "y06tCV85lbi92Fo" : "FgkXZj4dUWMHJK9nV"
+          "PXx9ebe4dHpo4fWR" : "7iDTjeD2cYrGciH0hKX"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 6,
+      "role" : "ProjectManager",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "fRWR04ibBd9pt4dOS",
-    "tags" : [ "nsZtVwiBa8rcb2" ],
-    "description" : "KJAS7XR7dNVBQPW",
+    "npiSubjectHeading" : "YoJlCt8V8tbe44",
+    "tags" : [ "1l72P84Mdz" ],
+    "description" : "iA4wERXrvLasR1y",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EKJGXxoRSO6gQgt8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/LeaAC3eAYo"
         },
-        "seriesNumber" : "YZrcmp9EBwUcYE1HTw",
+        "seriesNumber" : "hH5xhR5pkzwuTR",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eerNn4b5l1EJwgL"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZggLt7WhKfFj"
         },
-        "isbnList" : [ "9781757466783" ]
+        "isbnList" : [ "9781870685078" ]
       },
-      "doi" : "https://www.example.com/vUIwueuQvobH1jh",
+      "doi" : "https://www.example.com/nTb6STKCG9UrB",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "MBCnMRRveJd",
-            "end" : "5Ems1yH1NHGpfkFT"
+            "begin" : "vv2JQrECSeAnV",
+            "end" : "7KX43PQNhrpyfVPC"
           },
-          "pages" : "wdcC7bdW2Oiy",
+          "pages" : "QuFxwTDgBFpE",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/mx5yIQeV0VBH",
-    "abstract" : "M03KK3vm3mGP"
+    "metadataSource" : "https://www.example.com/a6H1h9Ad7HZImtV",
+    "abstract" : "A7ilBezELf18yTkcph"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bO6tctbF07CRQ8X65",
-      "mimeType" : "qogaEBwY9ZENj",
-      "size" : 1231402539,
+      "name" : "VZZnZozR4uqmO9LV2bm",
+      "mimeType" : "jLbnhcg0lWxh4",
+      "size" : 1025477074,
       "license" : {
         "type" : "License",
-        "identifier" : "7HYufNgrAsPfM",
+        "identifier" : "bxFDqtTGYb",
         "labels" : {
-          "KiVzI6KVEvcqxfk" : "1U1ngicKUJsktwV0"
+          "jQ2ElI1cDGfh9sgnLo" : "2Z2Go2NbGKOL48lC4sK"
         },
-        "link" : "https://www.example.com/cYId7Z31V2LAf22Qk"
+        "link" : "https://www.example.com/9ZYrAynY6SG78cOZHB"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/atitaque",
-    "name" : "S6Qit5ekNvb",
+    "id" : "https://www.example.org/utquo",
+    "name" : "5CTqWf3elD6SlUOoyl",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "qnepNhO09TgBqkqo",
-      "id" : "wW6C4NvV7NA"
+      "source" : "dXL9ykZgU55DP",
+      "id" : "hUAypyC5LV7n7hUCXi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "gesyBdd26i98Ioln"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "0Hzuk5C4gvej2isz"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consequunturenim" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/perspiciatiseos" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "9AX5XKK4TtiYNIpxW",
+  "status" : "PUBLISHED",
+  "owner" : "iL2MGigh0tbTH",
   "resourceOwner" : {
-    "owner" : "9AX5XKK4TtiYNIpxW",
-    "ownerAffiliation" : "https://www.example.org/excepturiquidem"
+    "owner" : "iL2MGigh0tbTH",
+    "ownerAffiliation" : "https://www.example.org/sitquasi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/magnamdolores",
+    "id" : "https://www.example.org/estdignissimos",
     "labels" : {
-      "eRUown4FVhss6b" : "xQGuIh7xtChSe2wyrN"
+      "uavYUH5X81hqawy87d" : "nOj8AU8xxBQ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/exnesciunt",
-  "doi" : "https://doi.org/10.1234/numquam",
+  "handle" : "https://www.example.org/moditempore",
+  "doi" : "https://doi.org/10.1234/nam",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "FKxQkkFGKDZsMHkI",
-      "author" : "Wn0Nzd6OkbTT5lQNv",
+      "text" : "cYlaGkzXQA7KE41SzT",
+      "author" : "LhNX9ms82sRIsg5C",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/doloresunde",
+  "link" : "https://www.example.org/doloreet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WzsPAcBLSdETQ3Z",
+    "mainTitle" : "Q5tzxaYL7rIC1Tn",
     "alternativeTitles" : {
-      "en" : "4X4m5YwdBALwp64B36F"
+      "da" : "uSUOktp17pI4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "6I16k6Qee61w8",
-      "month" : "e0uSwF8qhNP2cpY7v",
-      "day" : "fEY1AWfM5zIqugMie"
+      "year" : "E7UPpqsw79XaRQkrFwT",
+      "month" : "HeK7MrG9N65ocHcBaF",
+      "day" : "1mRpD7UM8rSz8HR4l"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hTUZOmkoVSS",
-        "name" : "xivr3yhWZ21iz",
+        "id" : "https://www.example.com/91vro5xE5reL438UbyG",
+        "name" : "R7FnJi6uYWJn6vm0ouv",
         "nameType" : "Personal",
-        "orcId" : "kSb3H5kOInZdr7",
-        "arpId" : "H0qxFLsz0MAeLR3w"
+        "orcId" : "XUd2GkgXWjxpPp7JWI",
+        "arpId" : "vikT9B8za0onGX1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mNl5Qy9SJOdMdNOL",
+        "id" : "https://www.example.com/XqD88aHGaHIMSW",
         "labels" : {
-          "IJV9EaiVqyJn" : "v5anTME4fF4"
+          "A73mfHi6Id3wnSt" : "66p6cs0yrDSTOWKjd"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 8,
+      "role" : "Designer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/eIgLfSLvJ7mW",
-        "name" : "QZEIXzI26zspRi4Q",
-        "nameType" : "Personal",
-        "orcId" : "Qh3NYavfrzs",
-        "arpId" : "UBIvAI96WbOS"
+        "id" : "https://www.example.com/dm6lhMKAJK",
+        "name" : "dI53EYvbX4ChEi8G",
+        "nameType" : "Organizational",
+        "orcId" : "Vdmbu8Y4jsxTeo7Hm",
+        "arpId" : "HoATjU3mSqpcFxt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zzRxvArVFx3P",
+        "id" : "https://www.example.com/vI4fGUNmEJQ",
         "labels" : {
-          "MPZWqGKhZXZ4dAV" : "UdwApjh8wUs"
+          "WUSgCJMHrOLTFJM" : "b1qA3IFMRU"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 5,
+      "role" : "Sponsor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NgivVaSvKX",
-    "tags" : [ "ICp3tTL4Cbp0sAuLTUh" ],
-    "description" : "XYw0dswrKpZ",
+    "npiSubjectHeading" : "BpyN4uYpCJ90IdfZUy",
+    "tags" : [ "15Cw8GL7SxBDADyKh" ],
+    "description" : "b7dtwSGgLvI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Z01Y5zMqbreNHqTfO"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SfBWLMuPAEaqlH"
         },
-        "seriesNumber" : "31GxdEBeJxQoygU",
+        "seriesNumber" : "D4zycgSIJM",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HSShXtR9Ym3ZA5x9cpP"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fe4dmF7gMFtwaK"
         },
-        "isbnList" : [ "9791976498922" ]
+        "isbnList" : [ "9781857701623" ]
       },
-      "doi" : "https://www.example.com/Nc3grOn9mJbdf7",
+      "doi" : "https://www.example.com/I3jCdGh26UuU",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -113,32 +113,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "BR0xeQp3orxPEb5O1",
-            "end" : "xyYK9x9flTZIrEBZ"
+            "begin" : "JjxS8QkjQxZPKwfTgN",
+            "end" : "v4TiDoRm4xt8R2acDci"
           },
-          "pages" : "5re5ge02IPAZC2ue",
-          "illustrated" : false
+          "pages" : "mdVDfts7haR0IqqN",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0FqdRF8sSU6Jy5jtRAv",
-    "abstract" : "BBDEAuV0V9SZx26V4vZ"
+    "metadataSource" : "https://www.example.com/rHQwrHHyAePzl7bmP8R",
+    "abstract" : "rMHSgUDmTFNIS"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "BVA6qqBeMqhsqdU",
-      "mimeType" : "8X5p7apVUJ4",
-      "size" : 2084475563,
+      "name" : "vNJE8XZqF3pp9EQ",
+      "mimeType" : "o8tY4kMIxyeHwZ",
+      "size" : 544698922,
       "license" : {
         "type" : "License",
-        "identifier" : "90j8IsTaGIwpUITK",
+        "identifier" : "MVgDa6t4KTFFrTfe",
         "labels" : {
-          "kZydWoekrQ5R" : "ZKk5E0Wnk9"
+          "878EAmhOlqH1t6u" : "m7COtBlQyNJz5F34dga"
         },
-        "link" : "https://www.example.com/Lk5GdKfoY7"
+        "link" : "https://www.example.com/A5CBvXcfz9l0YImiv"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omniset",
-    "name" : "JUGf4P9HeC",
+    "id" : "https://www.example.org/nobisnemo",
+    "name" : "LoHGSAcS6qg8I",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "S7SYh74UIUf4nJp",
-      "id" : "jncovQrJYku"
+      "source" : "fpquf7LNfqgfY",
+      "id" : "bh5Qq1nHv9caeO91"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "hnJImDBQG9upfn"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "fLM1TgXvv35"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporibusrerum" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/cupiditateut" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "XrOXbfkQFXqtFTWKwC",
+  "status" : "NEW",
+  "owner" : "9AX5XKK4TtiYNIpxW",
   "resourceOwner" : {
-    "owner" : "XrOXbfkQFXqtFTWKwC",
-    "ownerAffiliation" : "https://www.example.org/voluptatererum"
+    "owner" : "9AX5XKK4TtiYNIpxW",
+    "ownerAffiliation" : "https://www.example.org/excepturiquidem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/adipisciullam",
+    "id" : "https://www.example.org/magnamdolores",
     "labels" : {
-      "MVB1BI85JZS0N3" : "tDPA6K3kPAcnNY"
+      "eRUown4FVhss6b" : "xQGuIh7xtChSe2wyrN"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/numquamvelit",
-  "doi" : "https://doi.org/10.1234/dolores",
+  "handle" : "https://www.example.org/exnesciunt",
+  "doi" : "https://doi.org/10.1234/numquam",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,85 +27,85 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "vaurjLQyYJKD9",
-      "author" : "r0t1Pk2xNipT2",
+      "text" : "FKxQkkFGKDZsMHkI",
+      "author" : "Wn0Nzd6OkbTT5lQNv",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/iureexpedita",
+  "link" : "https://www.example.org/doloresunde",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "L8u9pqmMtR",
+    "mainTitle" : "WzsPAcBLSdETQ3Z",
     "alternativeTitles" : {
-      "sv" : "BO3effZSSFr"
+      "en" : "4X4m5YwdBALwp64B36F"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "JzLO1xUsiI3O",
-      "month" : "SAhAPz1pt5u",
-      "day" : "kjEV30mr2xsWa"
+      "year" : "6I16k6Qee61w8",
+      "month" : "e0uSwF8qhNP2cpY7v",
+      "day" : "fEY1AWfM5zIqugMie"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/r2p9B3c4TsSg3",
-        "name" : "ZZ620TeQ9ilNdbMjGR",
+        "id" : "https://www.example.com/hTUZOmkoVSS",
+        "name" : "xivr3yhWZ21iz",
         "nameType" : "Personal",
-        "orcId" : "OQxUI0y7ZK",
-        "arpId" : "CS3dc0572fL"
+        "orcId" : "kSb3H5kOInZdr7",
+        "arpId" : "H0qxFLsz0MAeLR3w"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/TlIDYLcww6R49di",
+        "id" : "https://www.example.com/mNl5Qy9SJOdMdNOL",
         "labels" : {
-          "Cl2LyGMedemAHx" : "pJcWPlEn4ckjphfVE"
+          "IJV9EaiVqyJn" : "v5anTME4fF4"
         }
       } ],
       "role" : "CuratorOrganizer",
-      "sequence" : 6,
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/qpM5YVdQJjwMGv",
-        "name" : "APRd7inVqH7ka",
-        "nameType" : "Organizational",
-        "orcId" : "Q5uqNvzhp5olpc",
-        "arpId" : "Hf05vTmllNPWfPu"
+        "id" : "https://www.example.com/eIgLfSLvJ7mW",
+        "name" : "QZEIXzI26zspRi4Q",
+        "nameType" : "Personal",
+        "orcId" : "Qh3NYavfrzs",
+        "arpId" : "UBIvAI96WbOS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0WGdRdHds2vOUb7",
+        "id" : "https://www.example.com/zzRxvArVFx3P",
         "labels" : {
-          "PXx9ebe4dHpo4fWR" : "7iDTjeD2cYrGciH0hKX"
+          "MPZWqGKhZXZ4dAV" : "UdwApjh8wUs"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 9,
+      "role" : "CuratorOrganizer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YoJlCt8V8tbe44",
-    "tags" : [ "1l72P84Mdz" ],
-    "description" : "iA4wERXrvLasR1y",
+    "npiSubjectHeading" : "NgivVaSvKX",
+    "tags" : [ "ICp3tTL4Cbp0sAuLTUh" ],
+    "description" : "XYw0dswrKpZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/LeaAC3eAYo"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Z01Y5zMqbreNHqTfO"
         },
-        "seriesNumber" : "hH5xhR5pkzwuTR",
+        "seriesNumber" : "31GxdEBeJxQoygU",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZggLt7WhKfFj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HSShXtR9Ym3ZA5x9cpP"
         },
-        "isbnList" : [ "9781870685078" ]
+        "isbnList" : [ "9791976498922" ]
       },
-      "doi" : "https://www.example.com/nTb6STKCG9UrB",
+      "doi" : "https://www.example.com/Nc3grOn9mJbdf7",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "vv2JQrECSeAnV",
-            "end" : "7KX43PQNhrpyfVPC"
+            "begin" : "BR0xeQp3orxPEb5O1",
+            "end" : "xyYK9x9flTZIrEBZ"
           },
-          "pages" : "QuFxwTDgBFpE",
+          "pages" : "5re5ge02IPAZC2ue",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/a6H1h9Ad7HZImtV",
-    "abstract" : "A7ilBezELf18yTkcph"
+    "metadataSource" : "https://www.example.com/0FqdRF8sSU6Jy5jtRAv",
+    "abstract" : "BBDEAuV0V9SZx26V4vZ"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "VZZnZozR4uqmO9LV2bm",
-      "mimeType" : "jLbnhcg0lWxh4",
-      "size" : 1025477074,
+      "name" : "BVA6qqBeMqhsqdU",
+      "mimeType" : "8X5p7apVUJ4",
+      "size" : 2084475563,
       "license" : {
         "type" : "License",
-        "identifier" : "bxFDqtTGYb",
+        "identifier" : "90j8IsTaGIwpUITK",
         "labels" : {
-          "jQ2ElI1cDGfh9sgnLo" : "2Z2Go2NbGKOL48lC4sK"
+          "kZydWoekrQ5R" : "ZKk5E0Wnk9"
         },
-        "link" : "https://www.example.com/9ZYrAynY6SG78cOZHB"
+        "link" : "https://www.example.com/Lk5GdKfoY7"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utquo",
-    "name" : "5CTqWf3elD6SlUOoyl",
+    "id" : "https://www.example.org/omniset",
+    "name" : "JUGf4P9HeC",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "dXL9ykZgU55DP",
-      "id" : "hUAypyC5LV7n7hUCXi"
+      "source" : "S7SYh74UIUf4nJp",
+      "id" : "jncovQrJYku"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "0Hzuk5C4gvej2isz"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "hnJImDBQG9upfn"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/perspiciatiseos" ],
+  "subjects" : [ "https://www.example.org/temporibusrerum" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -2,110 +2,110 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
-  "owner" : "HV031Bekw4",
+  "owner" : "3KGsAMjPDFD",
   "resourceOwner" : {
-    "owner" : "HV031Bekw4",
-    "ownerAffiliation" : "https://www.example.org/pariaturmolestiae"
+    "owner" : "3KGsAMjPDFD",
+    "ownerAffiliation" : "https://www.example.org/nobisomnis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/estipsam",
+    "id" : "https://www.example.org/quisomnis",
     "labels" : {
-      "a8o7kJ5byO" : "jqXogLRU8busE"
+      "HuhpBnlwjj3" : "gmwUvtHuUI"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/estlaboriosam",
-  "doi" : "https://doi.org/10.1234/laudantium",
+  "handle" : "https://www.example.org/dignissimosharum",
+  "doi" : "https://doi.org/10.1234/a",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "P0aZJa7wiYB6z",
-      "author" : "txbebut8as82",
+      "text" : "cmn9QBIPIHNabs29tP",
+      "author" : "8Rj1LSx5GJPBa",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/eiusaperiam",
+  "link" : "https://www.example.org/temporeillum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EX7jw6rpNbh",
+    "mainTitle" : "MJIFoEaKpxpP7",
     "alternativeTitles" : {
-      "ru" : "0POW7tCu7z9"
+      "fi" : "kngRdv7lghms"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "uFmqBSFvfGn",
-      "month" : "5ZKY0HIoOZdG4V",
-      "day" : "apHgzyyuPLIFTM"
+      "year" : "KpxJOsYgghg",
+      "month" : "Lr0c8jKrNsaC00b1ib",
+      "day" : "yRtXvpirHu1i"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9A1GgDBOZSe24UHvXJQ",
-        "name" : "fjhcq5L883linTcCV",
-        "nameType" : "Personal",
-        "orcId" : "ldPrvkJfVAn",
-        "arpId" : "aZzcLhJAoQ4Sp2zGo"
+        "id" : "https://www.example.com/OhTIaAGJhd5Rmdta",
+        "name" : "3GgFGdtjnqASuo",
+        "nameType" : "Organizational",
+        "orcId" : "WwWzPFxFGYxVLxw",
+        "arpId" : "DNxuuxMjJFpL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XSfHj6RGFc",
+        "id" : "https://www.example.com/B5B0pThc5I",
         "labels" : {
-          "kNfWSGblqv4zZEWyZxQ" : "z8yU1FZ5FddPW"
+          "LxZZhI0QNSQHzCg4gbm" : "mwsfrDHRSbr4XIBaV"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 0,
+      "role" : "Producer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/zCl34HCljg1fG",
-        "name" : "wcLOyEdZ543mDMcPO",
+        "id" : "https://www.example.com/VKw91SZKDzoFp5VU4em",
+        "name" : "QqxBHupRmy",
         "nameType" : "Personal",
-        "orcId" : "SO2zEckic14ZLpI6",
-        "arpId" : "D1kDmOtSfuvany"
+        "orcId" : "VKH56m6xXL4O4ZzHo2C",
+        "arpId" : "I8o5YUs1zwoUEX4q47g"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/BmzV4Q5DqBb",
+        "id" : "https://www.example.com/3lxQkAafWCPrV",
         "labels" : {
-          "5NGafPbM9wvDCC" : "eraSGLIjA3W7D"
+          "2OQyjg56UHh" : "SZWdm5LdZqh"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 0,
+      "role" : "DataCollector",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "v7hh09CjrJd",
-    "tags" : [ "p8cmCviDvxR" ],
-    "description" : "twQoaLCGTkYE4c",
+    "npiSubjectHeading" : "GlCjZtmNQzZcSG0Xtk",
+    "tags" : [ "n4qfHtBePCby8" ],
+    "description" : "ur3kpj5iDIqUKR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BVW8oDo8Ogs18"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cF2XGMqZX7Y8"
         },
-        "seriesNumber" : "S5TIBQSgKIoKeafj",
+        "seriesNumber" : "O9roYvAlja",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XfXP6e9Ksyjc8xt2Z"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OA9mJM4pnJ67Xyb1"
         },
-        "isbnList" : [ "9781882945276" ]
+        "isbnList" : [ "9791083384392" ]
       },
-      "doi" : "https://www.example.com/ls5m0te510uXSBN2KL",
+      "doi" : "https://www.example.com/pRLYC2etngL2JYvcz",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -113,32 +113,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "gv2x0A7dZjLhuV",
-            "end" : "zyvKaAUOeOnuw"
+            "begin" : "tNsFA60IZZ3z7F",
+            "end" : "vOCH9QrDALpVPxMRT"
           },
-          "pages" : "poHtFhkbVBQYj4Dwl0a",
-          "illustrated" : true
+          "pages" : "oySlquvbNNufw",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/A6LrGea5ZAzW0rl",
-    "abstract" : "T7RGkoyP0V"
+    "metadataSource" : "https://www.example.com/4Xh7VVJPoxIMWkmn3aS",
+    "abstract" : "a44tIURsXg7jPXqd"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "NwVb5l12EcEKV",
-      "mimeType" : "LPwC1cUapVV8Ouda6J",
-      "size" : 1527766575,
+      "name" : "pGYHOnyfCQk",
+      "mimeType" : "J6bm7Ppzddi",
+      "size" : 385902707,
       "license" : {
         "type" : "License",
-        "identifier" : "OATZXgNe0W",
+        "identifier" : "nem4dR0iahUg994jNIT",
         "labels" : {
-          "VRMhc8g6mtet" : "BAfIQx3u4IKhcxX54"
+          "tWYexO0Y63Xrt9" : "LCp012dSr4"
         },
-        "link" : "https://www.example.com/cTZP8Z219uyMFJWGR"
+        "link" : "https://www.example.com/hjfmIn1WZIEqs"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/inet",
-    "name" : "1diY3KQjSXV7te0lEL",
+    "id" : "https://www.example.org/idvoluptate",
+    "name" : "6VoXtMiMVF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "lVYhqdt2mCUuY",
-      "id" : "HYRHYIKjJj0GwD"
+      "source" : "BUKmve1sW9y",
+      "id" : "QLq0Y8x8hL670ROZk0"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "GryhUe8ENZ2ZuR"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "QjXfBzZQigzXS7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/laudantiumofficia" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/mollitiaquo" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "OgS4sXmgyMn9HjK6E",
+  "status" : "NEW",
+  "owner" : "g8vuDLMSUS",
   "resourceOwner" : {
-    "owner" : "OgS4sXmgyMn9HjK6E",
-    "ownerAffiliation" : "https://www.example.org/atquecorporis"
+    "owner" : "g8vuDLMSUS",
+    "ownerAffiliation" : "https://www.example.org/nihilautem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/doloribusin",
+    "id" : "https://www.example.org/autemsuscipit",
     "labels" : {
-      "JXjVJXicgJ" : "v3yOuLPfGvq"
+      "A5wcaxOXikJ" : "DdF2QCh6BFkqTst"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nihildeserunt",
-  "doi" : "https://doi.org/10.1234/quae",
+  "handle" : "https://www.example.org/deseruntveniam",
+  "doi" : "https://doi.org/10.1234/repellat",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,85 +27,85 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "XpV8EZn5nJx5wamkOYH",
-      "author" : "kWfYIC4Pkvxn",
+      "text" : "wyCLReyCXWwBUodH",
+      "author" : "lPqDyKB3Axn",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/minussit",
+  "link" : "https://www.example.org/errorautem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "V1GMEx6ge0X",
+    "mainTitle" : "GD8wfDCb0Ro3d2wHP",
     "alternativeTitles" : {
-      "is" : "ZkOycjnmslsgMqfLf"
+      "fi" : "lwSMuH9bY09pmh7V"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Rxxxgu2gfRyb",
-      "month" : "0L2luR78hThx",
-      "day" : "HMD5lcRBmZ9LhGsiZ"
+      "year" : "jyh5UrRGre",
+      "month" : "HQ8f6LRZCfJYk8w0YW5",
+      "day" : "uU1q312uwP9yJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/q2Riw0gXLu8",
-        "name" : "rWVfdnk0ZsKQv02itU",
+        "id" : "https://www.example.com/6yo52IaaS83Py7",
+        "name" : "ntU9KTY1rTJZqhlUQ",
         "nameType" : "Organizational",
-        "orcId" : "JnExM2aj23F9",
-        "arpId" : "vQzv0uHGHVu1p6L"
+        "orcId" : "CkWP7ge8x81mLCN9",
+        "arpId" : "ereLG8VekGujE9hWOf"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/B9OyOLI3uEVvQKg",
+        "id" : "https://www.example.com/mQjMLXhUP0temGWX",
         "labels" : {
-          "nTlMM45kcIRjHyG" : "883DiH0xZMIvt1kUU"
+          "lVpfxPcdlQqEtsXSmG" : "8O76JNC92tPl9Yx"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 1,
+      "role" : "Journalist",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/06BvsoX18p7pZ1OHTZW",
-        "name" : "k95Fc2WL1x7Y",
+        "id" : "https://www.example.com/47sGsld7HWhYP5QVHi",
+        "name" : "OJZTNZMSN9zB",
         "nameType" : "Organizational",
-        "orcId" : "T1uZ8H1iftbBpvuvewY",
-        "arpId" : "B5jC8Vb4hLcdeSEvRiI"
+        "orcId" : "Y0ZxrMM6dz5Fr",
+        "arpId" : "Mb43fc472zXhF9VzJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6ON2vLPYZB",
+        "id" : "https://www.example.com/NNynA0jrlu",
         "labels" : {
-          "R41yS7MsSPGa1" : "ItmwB0ZIKhkd7"
+          "W1nAHfxCpkOSu" : "swjYbOklsNtHxiWSA"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 6,
+      "role" : "Distributor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "T7xrtwIpmk4ZykXG",
-    "tags" : [ "Y3V1txLi1A2lFHWo" ],
-    "description" : "D4muTYmYjZpF1XsURh",
+    "npiSubjectHeading" : "NLcRoKYP8y9",
+    "tags" : [ "oyotxGNqr9" ],
+    "description" : "1PgtR3oSWK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PLKE9c4C7jWKN9"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XcD7CvTmd53V"
         },
-        "seriesNumber" : "RYWjtmhBoWx2XK3",
+        "seriesNumber" : "99R7mnOKALSt5Bfq",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eiamJHJZ6q"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GjvpkKEwl7mQc"
         },
-        "isbnList" : [ "9790624301010" ]
+        "isbnList" : [ "9790776153857" ]
       },
-      "doi" : "https://www.example.com/xV0Y9zQCCzwQ4NHUV",
+      "doi" : "https://www.example.com/98izkaA98Til7I4",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "APJhD2GqBn8Eo8wc",
-            "end" : "srFSvpRSCcdqR1B"
+            "begin" : "NV6UoZZhGrx",
+            "end" : "sn7Gi5D93A5"
           },
-          "pages" : "A9Kd4zFxq3VLbL0E",
-          "illustrated" : true
+          "pages" : "cWMvENgKenuzjrLXP2",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/R6L7n7lCSXwAo",
-    "abstract" : "QkmHvZSOOfaHf"
+    "metadataSource" : "https://www.example.com/eiiEbCy2AS0z4AQwr6",
+    "abstract" : "yvC5TVZAsxu9Dm"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Ch7nq2kO4MFb",
-      "mimeType" : "G6og8BeGbcHz",
-      "size" : 1162132742,
+      "name" : "e66OOFrdfe5I",
+      "mimeType" : "hMULLVWraFNkeE",
+      "size" : 1374984780,
       "license" : {
         "type" : "License",
-        "identifier" : "9DoEUhm8tIrY",
+        "identifier" : "CWVE4NBHF9",
         "labels" : {
-          "ZAQY8K9g9yo14kp" : "5mntQ321QAuHIi"
+          "KHEJYwVqg7rmFM" : "2FP7KAYboZKo"
         },
-        "link" : "https://www.example.com/4P4p8iBsUSd"
+        "link" : "https://www.example.com/yH51EjVwH3Q"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/temporibustempora",
-    "name" : "F3gHKdk1pROjQCcBxAd",
+    "id" : "https://www.example.org/quosnecessitatibus",
+    "name" : "1FgyZaLbB1c0dFG4O",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Jap5jid5GtFxtCd4mm",
-      "id" : "JdjTo4id639"
+      "source" : "nykvp9Fp2iFLl",
+      "id" : "n31L5lXttd1WIy"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "CwFuZ9rQkwdAQeJOj"
+      "applicationCode" : "c3ZlYYZGlvGBKMeUR"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/natusnon" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/solutaqui" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
-  "owner" : "3KGsAMjPDFD",
+  "status" : "PUBLISHED",
+  "owner" : "OgS4sXmgyMn9HjK6E",
   "resourceOwner" : {
-    "owner" : "3KGsAMjPDFD",
-    "ownerAffiliation" : "https://www.example.org/nobisomnis"
+    "owner" : "OgS4sXmgyMn9HjK6E",
+    "ownerAffiliation" : "https://www.example.org/atquecorporis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quisomnis",
+    "id" : "https://www.example.org/doloribusin",
     "labels" : {
-      "HuhpBnlwjj3" : "gmwUvtHuUI"
+      "JXjVJXicgJ" : "v3yOuLPfGvq"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dignissimosharum",
-  "doi" : "https://doi.org/10.1234/a",
+  "handle" : "https://www.example.org/nihildeserunt",
+  "doi" : "https://doi.org/10.1234/quae",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "APPROVED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "cmn9QBIPIHNabs29tP",
-      "author" : "8Rj1LSx5GJPBa",
+      "text" : "XpV8EZn5nJx5wamkOYH",
+      "author" : "kWfYIC4Pkvxn",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/temporeillum",
+  "link" : "https://www.example.org/minussit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MJIFoEaKpxpP7",
+    "mainTitle" : "V1GMEx6ge0X",
     "alternativeTitles" : {
-      "fi" : "kngRdv7lghms"
+      "is" : "ZkOycjnmslsgMqfLf"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "KpxJOsYgghg",
-      "month" : "Lr0c8jKrNsaC00b1ib",
-      "day" : "yRtXvpirHu1i"
+      "year" : "Rxxxgu2gfRyb",
+      "month" : "0L2luR78hThx",
+      "day" : "HMD5lcRBmZ9LhGsiZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OhTIaAGJhd5Rmdta",
-        "name" : "3GgFGdtjnqASuo",
+        "id" : "https://www.example.com/q2Riw0gXLu8",
+        "name" : "rWVfdnk0ZsKQv02itU",
         "nameType" : "Organizational",
-        "orcId" : "WwWzPFxFGYxVLxw",
-        "arpId" : "DNxuuxMjJFpL"
+        "orcId" : "JnExM2aj23F9",
+        "arpId" : "vQzv0uHGHVu1p6L"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/B5B0pThc5I",
+        "id" : "https://www.example.com/B9OyOLI3uEVvQKg",
         "labels" : {
-          "LxZZhI0QNSQHzCg4gbm" : "mwsfrDHRSbr4XIBaV"
+          "nTlMM45kcIRjHyG" : "883DiH0xZMIvt1kUU"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 6,
+      "role" : "DataCollector",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VKw91SZKDzoFp5VU4em",
-        "name" : "QqxBHupRmy",
-        "nameType" : "Personal",
-        "orcId" : "VKH56m6xXL4O4ZzHo2C",
-        "arpId" : "I8o5YUs1zwoUEX4q47g"
+        "id" : "https://www.example.com/06BvsoX18p7pZ1OHTZW",
+        "name" : "k95Fc2WL1x7Y",
+        "nameType" : "Organizational",
+        "orcId" : "T1uZ8H1iftbBpvuvewY",
+        "arpId" : "B5jC8Vb4hLcdeSEvRiI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3lxQkAafWCPrV",
+        "id" : "https://www.example.com/6ON2vLPYZB",
         "labels" : {
-          "2OQyjg56UHh" : "SZWdm5LdZqh"
+          "R41yS7MsSPGa1" : "ItmwB0ZIKhkd7"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 3,
+      "role" : "Other",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "GlCjZtmNQzZcSG0Xtk",
-    "tags" : [ "n4qfHtBePCby8" ],
-    "description" : "ur3kpj5iDIqUKR",
+    "npiSubjectHeading" : "T7xrtwIpmk4ZykXG",
+    "tags" : [ "Y3V1txLi1A2lFHWo" ],
+    "description" : "D4muTYmYjZpF1XsURh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cF2XGMqZX7Y8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PLKE9c4C7jWKN9"
         },
-        "seriesNumber" : "O9roYvAlja",
+        "seriesNumber" : "RYWjtmhBoWx2XK3",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OA9mJM4pnJ67Xyb1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eiamJHJZ6q"
         },
-        "isbnList" : [ "9791083384392" ]
+        "isbnList" : [ "9790624301010" ]
       },
-      "doi" : "https://www.example.com/pRLYC2etngL2JYvcz",
+      "doi" : "https://www.example.com/xV0Y9zQCCzwQ4NHUV",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "tNsFA60IZZ3z7F",
-            "end" : "vOCH9QrDALpVPxMRT"
+            "begin" : "APJhD2GqBn8Eo8wc",
+            "end" : "srFSvpRSCcdqR1B"
           },
-          "pages" : "oySlquvbNNufw",
-          "illustrated" : false
+          "pages" : "A9Kd4zFxq3VLbL0E",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/4Xh7VVJPoxIMWkmn3aS",
-    "abstract" : "a44tIURsXg7jPXqd"
+    "metadataSource" : "https://www.example.com/R6L7n7lCSXwAo",
+    "abstract" : "QkmHvZSOOfaHf"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "pGYHOnyfCQk",
-      "mimeType" : "J6bm7Ppzddi",
-      "size" : 385902707,
+      "name" : "Ch7nq2kO4MFb",
+      "mimeType" : "G6og8BeGbcHz",
+      "size" : 1162132742,
       "license" : {
         "type" : "License",
-        "identifier" : "nem4dR0iahUg994jNIT",
+        "identifier" : "9DoEUhm8tIrY",
         "labels" : {
-          "tWYexO0Y63Xrt9" : "LCp012dSr4"
+          "ZAQY8K9g9yo14kp" : "5mntQ321QAuHIi"
         },
-        "link" : "https://www.example.com/hjfmIn1WZIEqs"
+        "link" : "https://www.example.com/4P4p8iBsUSd"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/idvoluptate",
-    "name" : "6VoXtMiMVF",
+    "id" : "https://www.example.org/temporibustempora",
+    "name" : "F3gHKdk1pROjQCcBxAd",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "BUKmve1sW9y",
-      "id" : "QLq0Y8x8hL670ROZk0"
+      "source" : "Jap5jid5GtFxtCd4mm",
+      "id" : "JdjTo4id639"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "QjXfBzZQigzXS7"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "CwFuZ9rQkwdAQeJOj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/mollitiaquo" ],
+  "subjects" : [ "https://www.example.org/natusnon" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
-  "owner" : "po5DmBMDn37Ns",
+  "status" : "PUBLISHED",
+  "owner" : "1aQ8sfphrqm",
   "resourceOwner" : {
-    "owner" : "po5DmBMDn37Ns",
-    "ownerAffiliation" : "https://www.example.org/solutarecusandae"
+    "owner" : "1aQ8sfphrqm",
+    "ownerAffiliation" : "https://www.example.org/sintmaxime"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nequealias",
+    "id" : "https://www.example.org/voluptatemqui",
     "labels" : {
-      "hLPkSUHKA6XOa" : "BnJGGbsEp2tn0yiq"
+      "ryWyxZEYtw" : "RkHzLsGNxLxayZJc"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sithic",
-  "doi" : "https://doi.org/10.1234/temporibus",
+  "handle" : "https://www.example.org/ametsed",
+  "doi" : "https://doi.org/10.1234/sit",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REQUESTED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "gjEGpmIrGd3x",
-      "author" : "qAJ3XZvqjfSq",
+      "text" : "lifwxjpf2Ql0dRmNXy",
+      "author" : "DdAyslLnSIuj",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/cumquisquam",
+  "link" : "https://www.example.org/esteaque",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zeHmyfhXiRsfh",
+    "mainTitle" : "bYiOBLoL3NdmHd6y8Ix",
     "alternativeTitles" : {
-      "sv" : "au5Tv7qMhRDRdae8u"
+      "nn" : "cVFCiZMi6MHvR"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "oFBTB90FQMrtIaRB31C",
-      "month" : "1xOZADefhGk7Y",
-      "day" : "uGObGgHJCjKM9El5"
+      "year" : "FzLQ6dCDsV2D",
+      "month" : "3W8J321PK6YIXCamv",
+      "day" : "hauAy6SddvQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/P4H9B3yIbQ",
-        "name" : "RiTLmlPXhIgsyP",
-        "nameType" : "Organizational",
-        "orcId" : "k4NDOBrFVHdSu",
-        "arpId" : "y22yuVjTYkymJHsR"
+        "id" : "https://www.example.com/UpXCoU41pDw",
+        "name" : "ulIoLSf7qjzi8Y",
+        "nameType" : "Personal",
+        "orcId" : "HXwoeVNBngnTnQ8dLX",
+        "arpId" : "6y7YqhLM5vlHypCS9AS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cnXwMPSLzxExMCBv",
+        "id" : "https://www.example.com/vGZXAcn4dpV9ki1g",
         "labels" : {
-          "wcMv418knRBXGtQs5x" : "2zbsB7mNuhjrS"
+          "9Jdp47mdKJ8E6BQ2" : "yauz49chWTNHfsYBsR"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 3,
+      "role" : "WorkPackageLeader",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/v3vqyKZVRvV8W9aW",
-        "name" : "H9Aw5lOowaBWs",
-        "nameType" : "Organizational",
-        "orcId" : "nfuCzqQv7spQzK5qR",
-        "arpId" : "rMzkR2dllQBRhjY"
+        "id" : "https://www.example.com/sbsDK2pv8ltnU0C",
+        "name" : "CLxAv8oHGd5",
+        "nameType" : "Personal",
+        "orcId" : "MMBcGM8r5Dp",
+        "arpId" : "iRPAj7ZOcFTg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/a8qr0xQ9Z11udzXAh",
+        "id" : "https://www.example.com/Z56QvAiGVUPM",
         "labels" : {
-          "5MEhMtgQOrIhWA" : "xlAW5ru0nufCO"
+          "BbP1ApXGWybr" : "RDdm2RLlkbbSwWYUkEU"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 9,
+      "role" : "RegistrationAuthority",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "hT8Dfv4OCkYXHE4",
-    "tags" : [ "5eQp99LAniITtNjDf" ],
-    "description" : "zCQiZLlfWIsnjIl0bL2",
+    "npiSubjectHeading" : "cNZAhP8bndOB86",
+    "tags" : [ "0qMz42tU4twmNq6" ],
+    "description" : "ELiheOkzWrL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/UjYhksCeDy7uN0E"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gyS3tg5oFGVt"
         },
-        "seriesNumber" : "VKWkoAvfXp",
+        "seriesNumber" : "sXvgSNBDFDi",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zJwQhd3IuYc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kgG8538cSrm4Ry"
         },
-        "isbnList" : [ "9780083028443" ]
+        "isbnList" : [ "9790949097605" ]
       },
-      "doi" : "https://www.example.com/rXakdedChvh",
+      "doi" : "https://www.example.com/tsjnJuwghWD9Fq6k0t",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "qvuuW3itMEDgvXy6V4",
-            "end" : "nVurl7Y67Dxr03Gp"
+            "begin" : "KIuDsPNNy5c91EJ",
+            "end" : "IR20Kx1qlQfWO14BT"
           },
-          "pages" : "ZJ3SnjeSKjq2RWt",
+          "pages" : "OXkh2tiuDu8e",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/NVVEihRsWYCDyJHoMS2",
-    "abstract" : "TlvED3kuqtBh8fBsB"
+    "metadataSource" : "https://www.example.com/ShTFvDJT2hhdZip",
+    "abstract" : "W9ZFfBlx8W"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "c2J3XEPeIznJJLHIzpr",
-      "mimeType" : "hS4i5PvRdUoPs",
-      "size" : 37449389,
+      "name" : "niDRLkR8hQt4YZCh",
+      "mimeType" : "OurhWHfAC7",
+      "size" : 392705923,
       "license" : {
         "type" : "License",
-        "identifier" : "cYDnSZjJkaLvibL2",
+        "identifier" : "HCItmYg0bntvUXA15xn",
         "labels" : {
-          "hNKFQJB1mT" : "WSlqz7eXZxCn5"
+          "oMNRmTgS3FYUnwj" : "NoTW52b9PruWI8e"
         },
-        "link" : "https://www.example.com/rfxwy0UtY5S5YcymNy"
+        "link" : "https://www.example.com/EJJrZJTbKXR8"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autab",
-    "name" : "uwzKOjzMiOpnjwwQZ",
+    "id" : "https://www.example.org/quoscorporis",
+    "name" : "m73ZwRTFXWngEwdt1",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ngyc5jormTOT",
-      "id" : "VjHBYiQs5uvHUyoiG"
+      "source" : "FdLQClwk6AsI4W",
+      "id" : "UqjNZQtbj1AW4It"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "g0iElNLxjQ"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "r81VTbZNfrH4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/pariaturvero" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/rationequi" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "1aQ8sfphrqm",
+  "status" : "DRAFT",
+  "owner" : "LFeN8igtOf",
   "resourceOwner" : {
-    "owner" : "1aQ8sfphrqm",
-    "ownerAffiliation" : "https://www.example.org/sintmaxime"
+    "owner" : "LFeN8igtOf",
+    "ownerAffiliation" : "https://www.example.org/quoesse"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemqui",
+    "id" : "https://www.example.org/deseruntrerum",
     "labels" : {
-      "ryWyxZEYtw" : "RkHzLsGNxLxayZJc"
+      "7fvECQjtOBY" : "J4GWK9ne3XQU3"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ametsed",
-  "doi" : "https://doi.org/10.1234/sit",
+  "handle" : "https://www.example.org/eumerror",
+  "doi" : "https://doi.org/10.1234/maiores",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "REJECTED",
@@ -27,85 +27,85 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "lifwxjpf2Ql0dRmNXy",
-      "author" : "DdAyslLnSIuj",
+      "text" : "XHLtzPdh5oT",
+      "author" : "6RLy6f0ov17oqb8a",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/esteaque",
+  "link" : "https://www.example.org/reiciendisvoluptatem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bYiOBLoL3NdmHd6y8Ix",
+    "mainTitle" : "L2G2cGTQxIN0p",
     "alternativeTitles" : {
-      "nn" : "cVFCiZMi6MHvR"
+      "da" : "duwxgO2a5jU7i"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FzLQ6dCDsV2D",
-      "month" : "3W8J321PK6YIXCamv",
-      "day" : "hauAy6SddvQ"
+      "year" : "VsgHAapc3xM",
+      "month" : "7gbtfsZuNZLd2f",
+      "day" : "u8ZbXETZjk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UpXCoU41pDw",
-        "name" : "ulIoLSf7qjzi8Y",
-        "nameType" : "Personal",
-        "orcId" : "HXwoeVNBngnTnQ8dLX",
-        "arpId" : "6y7YqhLM5vlHypCS9AS"
+        "id" : "https://www.example.com/9ZVAT013cCS8V4",
+        "name" : "oamR0NxZ3rU3Kd",
+        "nameType" : "Organizational",
+        "orcId" : "WvSSRfUVtI8dcSDIGQ",
+        "arpId" : "6edXDPHW66Q7JuxL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vGZXAcn4dpV9ki1g",
+        "id" : "https://www.example.com/SmJoyF6viN4",
         "labels" : {
-          "9Jdp47mdKJ8E6BQ2" : "yauz49chWTNHfsYBsR"
+          "1VH37faAazic3hIG43m" : "AEk6f0gkCAcb8JPuQ"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 4,
+      "role" : "RelatedPerson",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sbsDK2pv8ltnU0C",
-        "name" : "CLxAv8oHGd5",
-        "nameType" : "Personal",
-        "orcId" : "MMBcGM8r5Dp",
-        "arpId" : "iRPAj7ZOcFTg"
+        "id" : "https://www.example.com/ty52XG0pAF6k53q5v",
+        "name" : "CzoeEykmy61m1nWhZz",
+        "nameType" : "Organizational",
+        "orcId" : "q26AmeY55un7P",
+        "arpId" : "CYt05SIbUk"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Z56QvAiGVUPM",
+        "id" : "https://www.example.com/LiUjZRJOKy",
         "labels" : {
-          "BbP1ApXGWybr" : "RDdm2RLlkbbSwWYUkEU"
+          "MCXGgvPO9rACrqG" : "pTJNlGeFLaedW97En4Q"
         }
       } ],
-      "role" : "RegistrationAuthority",
-      "sequence" : 2,
+      "role" : "Illustrator",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cNZAhP8bndOB86",
-    "tags" : [ "0qMz42tU4twmNq6" ],
-    "description" : "ELiheOkzWrL",
+    "npiSubjectHeading" : "Coh4qVJGOHCgGpM4j",
+    "tags" : [ "mVGnYmqqOCP1h75" ],
+    "description" : "sEvpT11Muc9YdenR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gyS3tg5oFGVt"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6brSNZCDTH"
         },
-        "seriesNumber" : "sXvgSNBDFDi",
+        "seriesNumber" : "cLaGnsgehxw0xa5",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kgG8538cSrm4Ry"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OdTbiGnIAj"
         },
-        "isbnList" : [ "9790949097605" ]
+        "isbnList" : [ "9781008746251" ]
       },
-      "doi" : "https://www.example.com/tsjnJuwghWD9Fq6k0t",
+      "doi" : "https://www.example.com/dYX4jHdIRjRbZij",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "KIuDsPNNy5c91EJ",
-            "end" : "IR20Kx1qlQfWO14BT"
+            "begin" : "VsK8gUssCwl3F1MqH",
+            "end" : "qbHaBapqu6h5s6GDBG"
           },
-          "pages" : "OXkh2tiuDu8e",
+          "pages" : "AZbwmfTU0NE2nUlCB",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/ShTFvDJT2hhdZip",
-    "abstract" : "W9ZFfBlx8W"
+    "metadataSource" : "https://www.example.com/sG68R5wS8Kvzc",
+    "abstract" : "87d4KB2n0NKBs"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "niDRLkR8hQt4YZCh",
-      "mimeType" : "OurhWHfAC7",
-      "size" : 392705923,
+      "name" : "iIR4VQCITrK",
+      "mimeType" : "axGrpE9IqfP3E2sonP6",
+      "size" : 1193611279,
       "license" : {
         "type" : "License",
-        "identifier" : "HCItmYg0bntvUXA15xn",
+        "identifier" : "WUsolfCaDFwuwnosolK",
         "labels" : {
-          "oMNRmTgS3FYUnwj" : "NoTW52b9PruWI8e"
+          "DbsQ2ZAIXnE0dmR8I" : "hKiPRkCly54"
         },
-        "link" : "https://www.example.com/EJJrZJTbKXR8"
+        "link" : "https://www.example.com/WLgKnJ6Bu1Fw"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quoscorporis",
-    "name" : "m73ZwRTFXWngEwdt1",
+    "id" : "https://www.example.org/itaquedeserunt",
+    "name" : "l8FQfT0jVBXv7QD0Z",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FdLQClwk6AsI4W",
-      "id" : "UqjNZQtbj1AW4It"
+      "source" : "t1PQ7DBBatbujd2",
+      "id" : "UK7XNzdmQIe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "r81VTbZNfrH4"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "A9jpmzTdDj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/rationequi" ],
+  "subjects" : [ "https://www.example.org/modisit" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "LFeN8igtOf",
+  "status" : "NEW",
+  "owner" : "yrG05YlDEUrDt",
   "resourceOwner" : {
-    "owner" : "LFeN8igtOf",
-    "ownerAffiliation" : "https://www.example.org/quoesse"
+    "owner" : "yrG05YlDEUrDt",
+    "ownerAffiliation" : "https://www.example.org/estquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/deseruntrerum",
+    "id" : "https://www.example.org/omnisfuga",
     "labels" : {
-      "7fvECQjtOBY" : "J4GWK9ne3XQU3"
+      "Mmku5DyO8igW" : "NBJkoTWMWVtoqqLHyL"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eumerror",
-  "doi" : "https://doi.org/10.1234/maiores",
+  "handle" : "https://www.example.org/arepellendus",
+  "doi" : "https://doi.org/10.1234/aut",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "XHLtzPdh5oT",
-      "author" : "6RLy6f0ov17oqb8a",
+      "text" : "WPoDDxzkYeNugG78h",
+      "author" : "i5qaqX275pYmH",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/reiciendisvoluptatem",
+  "link" : "https://www.example.org/mollitiaid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "L2G2cGTQxIN0p",
+    "mainTitle" : "hDpR5qVEQdDPKa5A",
     "alternativeTitles" : {
-      "da" : "duwxgO2a5jU7i"
+      "no" : "lgc4885M9A96M7N8Q21"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "VsgHAapc3xM",
-      "month" : "7gbtfsZuNZLd2f",
-      "day" : "u8ZbXETZjk"
+      "year" : "ceIBpKrsuo53pLWM",
+      "month" : "IfSxxYhCNd",
+      "day" : "E7nN5xfixigOS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9ZVAT013cCS8V4",
-        "name" : "oamR0NxZ3rU3Kd",
-        "nameType" : "Organizational",
-        "orcId" : "WvSSRfUVtI8dcSDIGQ",
-        "arpId" : "6edXDPHW66Q7JuxL"
+        "id" : "https://www.example.com/Oa98v1Ir0awPQ",
+        "name" : "tF52MFs0VQFiejiqN",
+        "nameType" : "Personal",
+        "orcId" : "Dk3pq0obuO6MoLqBnC",
+        "arpId" : "HfncJLTitf"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/SmJoyF6viN4",
+        "id" : "https://www.example.com/27LiMXhht4L0SIijqCS",
         "labels" : {
-          "1VH37faAazic3hIG43m" : "AEk6f0gkCAcb8JPuQ"
+          "2JDmmg5I8O" : "vkIHUnLHUTV"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 7,
+      "role" : "Editor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ty52XG0pAF6k53q5v",
-        "name" : "CzoeEykmy61m1nWhZz",
+        "id" : "https://www.example.com/HIUWPAxYrkTFPEk",
+        "name" : "WdB6DnVgwoSW6",
         "nameType" : "Organizational",
-        "orcId" : "q26AmeY55un7P",
-        "arpId" : "CYt05SIbUk"
+        "orcId" : "FZcEj4Qak9MGwm",
+        "arpId" : "CzxaPQMKbYuOzjfRzI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LiUjZRJOKy",
+        "id" : "https://www.example.com/oSnBtGC4xj0AVEw9",
         "labels" : {
-          "MCXGgvPO9rACrqG" : "pTJNlGeFLaedW97En4Q"
+          "N9K9uGILeXgMD6ix" : "cmkXq5OnSdWHjvWoj1"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 9,
+      "role" : "DataManager",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Coh4qVJGOHCgGpM4j",
-    "tags" : [ "mVGnYmqqOCP1h75" ],
-    "description" : "sEvpT11Muc9YdenR",
+    "npiSubjectHeading" : "XNOWK0i2rFEmgNjKhT",
+    "tags" : [ "CmG1x6b1NHIP" ],
+    "description" : "7LEmQCFG4M4d8Qtwo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6brSNZCDTH"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Of3KQvKFTPQJX9BSg"
         },
-        "seriesNumber" : "cLaGnsgehxw0xa5",
+        "seriesNumber" : "KrongaaqvJw",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OdTbiGnIAj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ffOuF0GMhK9AsxbN5c"
         },
-        "isbnList" : [ "9781008746251" ]
+        "isbnList" : [ "9791037447951" ]
       },
-      "doi" : "https://www.example.com/dYX4jHdIRjRbZij",
+      "doi" : "https://www.example.com/iI9B6Z8Mwm",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "VsK8gUssCwl3F1MqH",
-            "end" : "qbHaBapqu6h5s6GDBG"
+            "begin" : "SiXsxRLpKWr8IO",
+            "end" : "ny9NDTHGLA3XpYN9Zk0"
           },
-          "pages" : "AZbwmfTU0NE2nUlCB",
-          "illustrated" : true
+          "pages" : "m6TEuxz0WfbXrmkyho",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/sG68R5wS8Kvzc",
-    "abstract" : "87d4KB2n0NKBs"
+    "metadataSource" : "https://www.example.com/T3PgAtXqyTkWs4Sc",
+    "abstract" : "bAmmXeu8KCRC4az8LF9"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "iIR4VQCITrK",
-      "mimeType" : "axGrpE9IqfP3E2sonP6",
-      "size" : 1193611279,
+      "name" : "FeSHd8MGm3TNSFDj",
+      "mimeType" : "sJXPeSpNgAa16LB",
+      "size" : 1113327577,
       "license" : {
         "type" : "License",
-        "identifier" : "WUsolfCaDFwuwnosolK",
+        "identifier" : "helyGpcxAKC",
         "labels" : {
-          "DbsQ2ZAIXnE0dmR8I" : "hKiPRkCly54"
+          "7qhwybxBRn" : "hllAPOV3YPeZ2g"
         },
-        "link" : "https://www.example.com/WLgKnJ6Bu1Fw"
+        "link" : "https://www.example.com/APmDc6S1RzRX8ai"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/itaquedeserunt",
-    "name" : "l8FQfT0jVBXv7QD0Z",
+    "id" : "https://www.example.org/quisquameum",
+    "name" : "bMRHtNppK03",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "t1PQ7DBBatbujd2",
-      "id" : "UK7XNzdmQIe"
+      "source" : "Tur7uPaAvrNTfSfzcDa",
+      "id" : "Wej4Vmvvw3Aq"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "A9jpmzTdDj"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "S9HKHykoP3MG"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/modisit" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/eumdebitis" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -2,110 +2,110 @@
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
-  "owner" : "uRob16eZXvCWgZ7ys",
+  "owner" : "VN1uWnXlVwKH2IH9h",
   "resourceOwner" : {
-    "owner" : "uRob16eZXvCWgZ7ys",
-    "ownerAffiliation" : "https://www.example.org/laborumlaborum"
+    "owner" : "VN1uWnXlVwKH2IH9h",
+    "ownerAffiliation" : "https://www.example.org/suntdolorum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/velititaque",
+    "id" : "https://www.example.org/repudiandaeaccusantium",
     "labels" : {
-      "T2GylRBkYbfU5RIb0dl" : "mkHL6xnZXKn"
+      "BarWs9AvoWeAi" : "7izrUPVYfPBmQ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "publishedDate" : "2015-07-14T17:31:28Z",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ineum",
-  "doi" : "https://doi.org/10.1234/soluta",
+  "handle" : "https://www.example.org/quomagnam",
+  "doi" : "https://doi.org/10.1234/deserunt",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "APPROVED",
+    "status" : "REJECTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "f8dXVLYZka1QyFY",
-      "author" : "6PEc7BxH4LCXS",
+      "text" : "qwzmJN5mR0iibToTIX",
+      "author" : "tdVhpuPbDWzwAzQv35",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/quivoluptatibus",
+  "link" : "https://www.example.org/laudantiumcorporis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "B4e2jG0UbW9pmyQky6",
+    "mainTitle" : "rVeXOlYVSJVB8",
     "alternativeTitles" : {
-      "en" : "DM7VtQdR2XXLCh"
+      "se" : "pXtDpz5meD2MpoGRgoW"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "JJy6bEBFLOO",
-      "month" : "3Wg4zFW4k28g",
-      "day" : "lIyDSqWRv3aw"
+      "year" : "SvSSNizYUzIgyzGF",
+      "month" : "g21XnCuuKY",
+      "day" : "pIiARy8MFCE9m"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XLlfAqvlCuYuDW4RpV",
-        "name" : "niq4AZnjnXQ",
+        "id" : "https://www.example.com/dZroc8Vgt8kk",
+        "name" : "rau1iMPQ5RpI",
         "nameType" : "Organizational",
-        "orcId" : "m9qjueTxxRSjhgu3op",
-        "arpId" : "LAkyU0Wn0Tm68qRR"
+        "orcId" : "A1GN2Hxpwvx",
+        "arpId" : "86PbV7SIqo0Rq7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/C1S2fgHA7Zj",
+        "id" : "https://www.example.com/Ug3uEpfA0Ni8",
         "labels" : {
-          "fJBSix3Wc87AeS" : "VVu5rT5RIJv5rO1w"
+          "CIiM9Esk6nxoa" : "I2v5wcM8j4"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 4,
+      "role" : "Supervisor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cj1hhRZZCx",
-        "name" : "VSHTrfUPYCA",
+        "id" : "https://www.example.com/YDEwQMS4pC",
+        "name" : "x83fcr7HGG5fmT",
         "nameType" : "Organizational",
-        "orcId" : "QJGFvNwHut4qUM1dpM",
-        "arpId" : "ZusroqdY1rVF4"
+        "orcId" : "QUXNotz5v84",
+        "arpId" : "0QdRdvx7ud"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/NDWfRppQhLmPzAUk",
+        "id" : "https://www.example.com/RdDEB3a2dvJLfl",
         "labels" : {
-          "3ktBujKYFt9u7PH" : "qKLHaPblusktaz1t1E"
+          "Av34lrVvTuNwz0lG" : "rCIfdCWOfBiA"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 3,
+      "role" : "DataCollector",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "sCgTPxpc6AJ6Wdixhd",
-    "tags" : [ "51f9cNdpNzDPJ" ],
-    "description" : "fXxDst4I49Y6CEFlDi",
+    "npiSubjectHeading" : "YJYzae0BRgqJAhGA",
+    "tags" : [ "YzLNWTepOxwhBVf5" ],
+    "description" : "dd05z9pyf0zfDd5a",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/pBraI3kHYvTkwjW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6DV3VgiexUzhu1m4y2"
         },
-        "seriesNumber" : "UCsr0694Ie2ioqHJJyw",
+        "seriesNumber" : "usW9VBn59zFCPM",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Rg1CKfaPQ2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XRWioYOGeLGmpQNonGI"
         },
-        "isbnList" : [ "9790224439373" ]
+        "isbnList" : [ "9791915167841" ]
       },
-      "doi" : "https://www.example.com/Yzk6UmKkB1",
+      "doi" : "https://www.example.com/UyVrBiDOnXb1pzQAyF",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "elbVpxM0bpRMDs",
-            "end" : "bEoPtTJTEWNXrF"
+            "begin" : "rCD5bQJ4ewBKIe1s",
+            "end" : "VMk4CoRgVIcTHscISun"
           },
-          "pages" : "uUKqmqxRMysFv",
-          "illustrated" : false
+          "pages" : "uBWffAUeJBCj",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/xgnB7VUuCOumlInc0R",
-    "abstract" : "VCpEUopVNIIwbc"
+    "metadataSource" : "https://www.example.com/2CZYXWse71yK5s",
+    "abstract" : "n458LHR8ljgSwRm8B"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "dqapl9m0fQoW",
-      "mimeType" : "zuw5JMyKuu6909JDAao",
-      "size" : 1259457112,
+      "name" : "33Qkf8O20apYp",
+      "mimeType" : "SQ8Tqg21SAegYdGTAY",
+      "size" : 1853066935,
       "license" : {
         "type" : "License",
-        "identifier" : "TZ9DR88KbS35cw7y8",
+        "identifier" : "nfqmuzeFeL2Qmbq2H",
         "labels" : {
-          "kGG7lc06PTlGK" : "g3NDXn1aWR"
+          "VioNDJ2SLmbJ" : "A7WytQAolyNEPmk9bhq"
         },
-        "link" : "https://www.example.com/WqBvVGj6S9"
+        "link" : "https://www.example.com/Em5Y05BvIUWsVtb"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quidemet",
-    "name" : "jucbNMy9wGzXIfFU46",
+    "id" : "https://www.example.org/eaat",
+    "name" : "kGqukY1f6Jq",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "k8WhECBq1Cakkg",
-      "id" : "xlHLOPKNNn6uP2ria7I"
+      "source" : "reZC2qXfKABtdq4ljl",
+      "id" : "zlOAjybuhHc"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "xgxXC8ZabvU"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "BFQQHfEdQW5wSg2Ol4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiapariatur" ],
+  "subjects" : [ "https://www.example.org/idasperiores" ],
   "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,25 +1,25 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
-  "owner" : "XR5oQaGQZkT1",
+  "status" : "DRAFT",
+  "owner" : "uRob16eZXvCWgZ7ys",
   "resourceOwner" : {
-    "owner" : "XR5oQaGQZkT1",
-    "ownerAffiliation" : "https://www.example.org/estsuscipit"
+    "owner" : "uRob16eZXvCWgZ7ys",
+    "ownerAffiliation" : "https://www.example.org/laborumlaborum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/odioet",
+    "id" : "https://www.example.org/velititaque",
     "labels" : {
-      "mvxdHvoXA3" : "4yxNf29OX4w"
+      "T2GylRBkYbfU5RIb0dl" : "mkHL6xnZXKn"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "2015-07-14T17:31:28Z",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/rationeut",
-  "doi" : "https://doi.org/10.1234/vitae",
+  "handle" : "https://www.example.org/ineum",
+  "doi" : "https://doi.org/10.1234/soluta",
   "doiRequest" : {
     "type" : "DoiRequest",
     "status" : "APPROVED",
@@ -27,85 +27,85 @@
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "L4Mc6CllpMfC7",
-      "author" : "t5ouFcgMiSa9MsqH",
+      "text" : "f8dXVLYZka1QyFY",
+      "author" : "6PEc7BxH4LCXS",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/numquamblanditiis",
+  "link" : "https://www.example.org/quivoluptatibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "OOfwkDfiAri",
+    "mainTitle" : "B4e2jG0UbW9pmyQky6",
     "alternativeTitles" : {
-      "pt" : "PZGZ8XCwidtK"
+      "en" : "DM7VtQdR2XXLCh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "MLvp54JWb6xlz",
-      "month" : "Mlk2QWv9ubo55r4",
-      "day" : "k3loHxo0zgC5Jvb"
+      "year" : "JJy6bEBFLOO",
+      "month" : "3Wg4zFW4k28g",
+      "day" : "lIyDSqWRv3aw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gtfgZdUl1ltXkC",
-        "name" : "7Bdg9TJ7l5aG8okxu",
+        "id" : "https://www.example.com/XLlfAqvlCuYuDW4RpV",
+        "name" : "niq4AZnjnXQ",
         "nameType" : "Organizational",
-        "orcId" : "DMMkFNxnsm",
-        "arpId" : "3AVeI4Suc3hm"
+        "orcId" : "m9qjueTxxRSjhgu3op",
+        "arpId" : "LAkyU0Wn0Tm68qRR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UP09GEJryk",
+        "id" : "https://www.example.com/C1S2fgHA7Zj",
         "labels" : {
-          "9nVRenAVqDkzOdC" : "T0cErUqmr53zN"
+          "fJBSix3Wc87AeS" : "VVu5rT5RIJv5rO1w"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 3,
+      "role" : "ContactPerson",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/as1YgvU2B9WpSO8VyPH",
-        "name" : "pPZeTymIRjNTKeMv",
+        "id" : "https://www.example.com/cj1hhRZZCx",
+        "name" : "VSHTrfUPYCA",
         "nameType" : "Organizational",
-        "orcId" : "uqwOzniEr2",
-        "arpId" : "q6uOASSCY5"
+        "orcId" : "QJGFvNwHut4qUM1dpM",
+        "arpId" : "ZusroqdY1rVF4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/P1pk8eJ99f2OjE",
+        "id" : "https://www.example.com/NDWfRppQhLmPzAUk",
         "labels" : {
-          "0NBa22ZcxHt8bXV" : "m4MVsOxTbyOtKEa"
+          "3ktBujKYFt9u7PH" : "qKLHaPblusktaz1t1E"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 7,
+      "role" : "Distributor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "TxTaaEjJdm",
-    "tags" : [ "W765hwoP5tDgBua3l" ],
-    "description" : "wHwudIGExZEC",
+    "npiSubjectHeading" : "sCgTPxpc6AJ6Wdixhd",
+    "tags" : [ "51f9cNdpNzDPJ" ],
+    "description" : "fXxDst4I49Y6CEFlDi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iwXMZNla6mrfI6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/pBraI3kHYvTkwjW"
         },
-        "seriesNumber" : "k7cOtmez2w",
+        "seriesNumber" : "UCsr0694Ie2ioqHJJyw",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gIEnzLpgAySb4DU"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Rg1CKfaPQ2"
         },
-        "isbnList" : [ "9791770276412" ]
+        "isbnList" : [ "9790224439373" ]
       },
-      "doi" : "https://www.example.com/5EqFX1ak1EJ",
+      "doi" : "https://www.example.com/Yzk6UmKkB1",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -113,53 +113,53 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7PYDqUVJjLT4",
-            "end" : "8E0oFoujVwmk1S2YL"
+            "begin" : "elbVpxM0bpRMDs",
+            "end" : "bEoPtTJTEWNXrF"
           },
-          "pages" : "hRKp86LAwkP4tLCX",
+          "pages" : "uUKqmqxRMysFv",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/XX2FIPGGHKq",
-    "abstract" : "XrHWYobaPy"
+    "metadataSource" : "https://www.example.com/xgnB7VUuCOumlInc0R",
+    "abstract" : "VCpEUopVNIIwbc"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "IIuRfOHKv0nhVlOZQdx",
-      "mimeType" : "YyIXB5PBaeDKXhFtW4",
-      "size" : 1672232792,
+      "name" : "dqapl9m0fQoW",
+      "mimeType" : "zuw5JMyKuu6909JDAao",
+      "size" : 1259457112,
       "license" : {
         "type" : "License",
-        "identifier" : "mkjmqZ4odbYq",
+        "identifier" : "TZ9DR88KbS35cw7y8",
         "labels" : {
-          "893ix0Nz4t3t" : "AIthbL1y40JQFfbB"
+          "kGG7lc06PTlGK" : "g3NDXn1aWR"
         },
-        "link" : "https://www.example.com/qqlQSTHlStKx0KD"
+        "link" : "https://www.example.com/WqBvVGj6S9"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sequiunde",
-    "name" : "P4na4qOleQoFT6eJR",
+    "id" : "https://www.example.org/quidemet",
+    "name" : "jucbNMy9wGzXIfFU46",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "g2dahyz3uovsp",
-      "id" : "v7BQ1g4omJZL6Jn9dE"
+      "source" : "k8WhECBq1Cakkg",
+      "id" : "xlHLOPKNNn6uP2ria7I"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NMA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "5npR2hw255"
+      "applicationCode" : "xgxXC8ZabvU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sedet" ],
-  "modelVersion" : "0.14.22"
+  "subjects" : [ "https://www.example.org/quiapariatur" ],
+  "modelVersion" : "0.14.24"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,111 +1,111 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
-  "owner" : "VN1uWnXlVwKH2IH9h",
+  "status" : "PUBLISHED",
+  "owner" : "MxzWXYGWrru",
   "resourceOwner" : {
-    "owner" : "VN1uWnXlVwKH2IH9h",
-    "ownerAffiliation" : "https://www.example.org/suntdolorum"
+    "owner" : "MxzWXYGWrru",
+    "ownerAffiliation" : "https://www.example.org/aperiamaut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repudiandaeaccusantium",
+    "id" : "https://www.example.org/temporibusmolestias",
     "labels" : {
-      "BarWs9AvoWeAi" : "7izrUPVYfPBmQ"
+      "Hn4wLh6JbRjtJTQmSDT" : "TmWzHtYESk26V"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quomagnam",
-  "doi" : "https://doi.org/10.1234/deserunt",
+  "handle" : "https://www.example.org/providentid",
+  "doi" : "https://doi.org/10.1234/recusandae",
   "doiRequest" : {
     "type" : "DoiRequest",
-    "status" : "REJECTED",
+    "status" : "REQUESTED",
     "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
     "createdDate" : "2020-09-23T09:51:23.044996ZZ",
     "messages" : [ {
       "type" : "DoiRequestMessage",
-      "text" : "qwzmJN5mR0iibToTIX",
-      "author" : "tdVhpuPbDWzwAzQv35",
+      "text" : "Or0hg14crhr0wHZ1",
+      "author" : "hNL0DiWYZBi",
       "timestamp" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "link" : "https://www.example.org/laudantiumcorporis",
+  "link" : "https://www.example.org/adasperiores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rVeXOlYVSJVB8",
+    "mainTitle" : "v56Yzor5OrMvH1mrL",
     "alternativeTitles" : {
-      "se" : "pXtDpz5meD2MpoGRgoW"
+      "el" : "AjFzaXYZne9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "SvSSNizYUzIgyzGF",
-      "month" : "g21XnCuuKY",
-      "day" : "pIiARy8MFCE9m"
+      "year" : "VFD5PC1NotTBdwOphN",
+      "month" : "u6SWPTRTchkWZvC",
+      "day" : "L8os1dWCnF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dZroc8Vgt8kk",
-        "name" : "rau1iMPQ5RpI",
-        "nameType" : "Organizational",
-        "orcId" : "A1GN2Hxpwvx",
-        "arpId" : "86PbV7SIqo0Rq7"
+        "id" : "https://www.example.com/XEOvQ0vxHo0",
+        "name" : "jMflMT8elaNSP5RsZ4k",
+        "nameType" : "Personal",
+        "orcId" : "t2SmXQdjOqk25gmGymM",
+        "arpId" : "yTBGMbIBFhgBcl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Ug3uEpfA0Ni8",
+        "id" : "https://www.example.com/tjtr3vx8QdNHFY3G",
         "labels" : {
-          "CIiM9Esk6nxoa" : "I2v5wcM8j4"
+          "AlNd0bT731M" : "Kj5hZl9QHnb7USfM4ip"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 6,
+      "role" : "ProjectLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/YDEwQMS4pC",
-        "name" : "x83fcr7HGG5fmT",
-        "nameType" : "Organizational",
-        "orcId" : "QUXNotz5v84",
-        "arpId" : "0QdRdvx7ud"
+        "id" : "https://www.example.com/74uxZisSOBZ",
+        "name" : "XQOvyMHKOYt",
+        "nameType" : "Personal",
+        "orcId" : "rXXQhQsYfXSXubs",
+        "arpId" : "nJrIfIEt1q"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RdDEB3a2dvJLfl",
+        "id" : "https://www.example.com/2iwfvtuqADi4zpOcgSc",
         "labels" : {
-          "Av34lrVvTuNwz0lG" : "rCIfdCWOfBiA"
+          "iuPbTI08sudzu7sWLP" : "d9JaffdXRzaU"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 4,
+      "role" : "WorkPackageLeader",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YJYzae0BRgqJAhGA",
-    "tags" : [ "YzLNWTepOxwhBVf5" ],
-    "description" : "dd05z9pyf0zfDd5a",
+    "npiSubjectHeading" : "URWcpW0gdv3PKTMRY",
+    "tags" : [ "ew8L6WY3Ra6kwAhMTM7" ],
+    "description" : "LJBFjqGZ84",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6DV3VgiexUzhu1m4y2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PwJCkZkpcGL6md2Zf"
         },
-        "seriesNumber" : "usW9VBn59zFCPM",
+        "seriesNumber" : "aIfV8WA62H",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XRWioYOGeLGmpQNonGI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yxS9hZrZmtElHT"
         },
-        "isbnList" : [ "9791915167841" ]
+        "isbnList" : [ "9780989158350" ]
       },
-      "doi" : "https://www.example.com/UyVrBiDOnXb1pzQAyF",
+      "doi" : "https://www.example.com/wkRpLQG0QZDZf9",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -113,32 +113,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rCD5bQJ4ewBKIe1s",
-            "end" : "VMk4CoRgVIcTHscISun"
+            "begin" : "MW81g7UQctmZ5",
+            "end" : "MkgCzd1DdR"
           },
-          "pages" : "uBWffAUeJBCj",
-          "illustrated" : true
+          "pages" : "a1QrmjtQHjcT4gl6bT",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/2CZYXWse71yK5s",
-    "abstract" : "n458LHR8ljgSwRm8B"
+    "metadataSource" : "https://www.example.com/MjRFUg2KL97gXMSISIX",
+    "abstract" : "BTFK6v6Ndo"
   },
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "File",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "33Qkf8O20apYp",
-      "mimeType" : "SQ8Tqg21SAegYdGTAY",
-      "size" : 1853066935,
+      "name" : "GjPwiGqaThWO3cuZj",
+      "mimeType" : "FIt3ZUEDg9",
+      "size" : 1985316461,
       "license" : {
         "type" : "License",
-        "identifier" : "nfqmuzeFeL2Qmbq2H",
+        "identifier" : "5YlcteyD30di3gHqAk",
         "labels" : {
-          "VioNDJ2SLmbJ" : "A7WytQAolyNEPmk9bhq"
+          "tr3mcKQBOt3" : "2xELXahrQ3bKuV"
         },
-        "link" : "https://www.example.com/Em5Y05BvIUWsVtb"
+        "link" : "https://www.example.com/1iatCItFgwcBTH276u"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -147,19 +147,19 @@
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eaat",
-    "name" : "kGqukY1f6Jq",
+    "id" : "https://www.example.org/repellendusconsequatur",
+    "name" : "ilLlvPHwSEzGgff",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "reZC2qXfKABtdq4ljl",
-      "id" : "zlOAjybuhHc"
+      "source" : "V7pwEFzoAg3KDzPqoa",
+      "id" : "q8M25fJAwnVfrilvG"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "BFQQHfEdQW5wSg2Ol4"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "G3zPXQb2JrNjeZ4U"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -167,6 +167,6 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/idasperiores" ],
-  "modelVersion" : "0.14.24"
+  "subjects" : [ "https://www.example.org/explicaboid" ],
+  "modelVersion" : "0.15.0"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -1077,10 +1077,10 @@ referencedSchemas:
     - type
     type: object
     properties:
-      pages:
-        $ref: '#/components/schemas/Pages'
       peerReviewed:
         type: boolean
+      pages:
+        $ref: '#/components/schemas/Pages'
       type:
         type: string
     discriminator:

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -1077,10 +1077,10 @@ referencedSchemas:
     - type
     type: object
     properties:
-      peerReviewed:
-        type: boolean
       pages:
         $ref: '#/components/schemas/Pages'
+      peerReviewed:
+        type: boolean
       type:
         type: string
     discriminator:

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -127,10 +127,6 @@ referencedSchemas:
     - $ref: '#/components/schemas/PublicationContext'
     - type: object
       properties:
-        venues:
-          type: array
-          items:
-            $ref: '#/components/schemas/Venue'
         type:
           type: string
   ArtisticDesign:
@@ -147,6 +143,10 @@ referencedSchemas:
           $ref: '#/components/schemas/ArtisticDesignSubtype'
         description:
           type: string
+        venues:
+          type: array
+          items:
+            $ref: '#/components/schemas/Venue'
         pages:
           $ref: '#/components/schemas/NullPages'
         type:

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/contexttypes/Artistic.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/contexttypes/Artistic.java
@@ -1,45 +1,8 @@
 package no.unit.nva.model.contexttypes;
 
-import static java.util.Objects.nonNull;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import no.unit.nva.model.contexttypes.venue.Venue;
-import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Artistic implements PublicationContext {
-    public static final String VENUES = "venues";
 
-    @JsonProperty(VENUES)
-    private final List<Venue> venues;
-
-    public Artistic(@JsonProperty(VENUES) List<Venue> venues) {
-        this.venues = nonNull(venues) ? venues : Collections.emptyList();
-    }
-
-    public List<Venue> getVenues() {
-        return venues;
-    }
-
-    @JacocoGenerated
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Artistic)) {
-            return false;
-        }
-        Artistic that = (Artistic) o;
-        return Objects.equals(getVenues(), that.getVenues());
-    }
-
-    @JacocoGenerated
-    @Override
-    public int hashCode() {
-        return Objects.hash(getVenues());
-    }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/contexttypes/Artistic.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/contexttypes/Artistic.java
@@ -1,8 +1,22 @@
 package no.unit.nva.model.contexttypes;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import nva.commons.core.JacocoGenerated;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class Artistic implements PublicationContext {
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o instanceof Artistic;
+    }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import no.unit.nva.model.contexttypes.venue.Venue;
+import no.unit.nva.model.instancetypes.artistic.venue.Venue;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.NullPages;
 import nva.commons.core.JacocoGenerated;

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import no.unit.nva.model.contexttypes.Artistic;
 import no.unit.nva.model.contexttypes.venue.Venue;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.NullPages;

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
@@ -63,7 +63,6 @@ public class ArtisticDesign implements PublicationInstance<NullPages> {
         return false;
     }
 
-    @JsonGetter
     public List<Venue> getVenues() {
         return venues;
     }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/ArtisticDesign.java
@@ -4,26 +4,39 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import no.unit.nva.model.contexttypes.Artistic;
+import no.unit.nva.model.contexttypes.venue.Venue;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.pages.NullPages;
 import nva.commons.core.JacocoGenerated;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+
+import static java.util.Objects.nonNull;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class ArtisticDesign implements PublicationInstance<NullPages> {
 
     public static final String SUBTYPE = "subtype";
     public static final String DESCRIPTION = "description";
+    public static final String VENUES = "venues";
+
     @JsonProperty(SUBTYPE)
     private final ArtisticDesignSubtype subtype;
     @JsonProperty(DESCRIPTION)
     private final String description;
+    @JsonProperty(VENUES)
+    private final List<Venue> venues;
+
 
     public ArtisticDesign(@JsonProperty(SUBTYPE) ArtisticDesignSubtype subtype,
-                          @JsonProperty(DESCRIPTION) String description) {
+                          @JsonProperty(DESCRIPTION) String description,
+                          @JsonProperty(VENUES) List<Venue> venues) {
         this.subtype = subtype;
         this.description = description;
+        this.venues = nonNull(venues) ? venues : Collections.emptyList();
     }
 
     public ArtisticDesignSubtype getSubtype() {
@@ -32,26 +45,6 @@ public class ArtisticDesign implements PublicationInstance<NullPages> {
 
     public String getDescription() {
         return description;
-    }
-
-    @JacocoGenerated
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ArtisticDesign)) {
-            return false;
-        }
-        ArtisticDesign that = (ArtisticDesign) o;
-        return Objects.equals(getSubtype(), that.getSubtype())
-                && Objects.equals(getDescription(), that.getDescription());
-    }
-
-    @JacocoGenerated
-    @Override
-    public int hashCode() {
-        return Objects.hash(getSubtype(), getDescription());
     }
 
     @JsonGetter
@@ -69,5 +62,31 @@ public class ArtisticDesign implements PublicationInstance<NullPages> {
     @Override
     public boolean isPeerReviewed() {
         return false;
+    }
+
+    @JsonGetter
+    public List<Venue> getVenues() {
+        return venues;
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ArtisticDesign)) {
+            return false;
+        }
+        ArtisticDesign that = (ArtisticDesign) o;
+        return Objects.equals(getSubtype(), that.getSubtype())
+                && Objects.equals(getDescription(), that.getDescription())
+                && Objects.equals(getVenues(), that.getVenues());
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSubtype(), getDescription(), getVenues());
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/venue/Venue.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/instancetypes/artistic/venue/Venue.java
@@ -1,4 +1,4 @@
-package no.unit.nva.model.contexttypes.venue;
+package no.unit.nva.model.instancetypes.artistic.venue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -21,7 +21,6 @@ import com.github.jsonldjava.utils.JsonUtils;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Set;
-import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.testing.PublicationGenerator;
 import no.unit.nva.model.util.ContextUtil;
 import org.javers.core.Javers;
@@ -120,5 +119,4 @@ public class PublicationTest {
         options.setPruneBlankNodeIdentifiers(true);
         return JsonLdProcessor.frame(input, frame, options);
     }
-
 }

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationContextBuilder.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationContextBuilder.java
@@ -3,7 +3,6 @@ package no.unit.nva.model.testing;
 import static no.unit.nva.model.testing.RandomUtils.randomLabel;
 import static no.unit.nva.model.testing.RandomUtils.randomLabels;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
-import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIsbn13;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -28,7 +27,6 @@ import no.unit.nva.model.contexttypes.Report;
 import no.unit.nva.model.contexttypes.Series;
 import no.unit.nva.model.contexttypes.place.Place;
 import no.unit.nva.model.contexttypes.place.UnconfirmedPlace;
-import no.unit.nva.model.contexttypes.venue.Venue;
 import no.unit.nva.model.exceptions.InvalidIsbnException;
 import no.unit.nva.model.exceptions.InvalidIssnException;
 import no.unit.nva.model.exceptions.InvalidUnconfirmedSeriesException;
@@ -169,17 +167,7 @@ public class PublicationContextBuilder {
     }
 
     private static Artistic randomArtisticDesign() {
-        return new Artistic(randomVenues());
-    }
-
-    private static List<Venue> randomVenues() {
-        return List.of(randomVenue(), randomVenue());
-    }
-
-    private static Venue randomVenue() {
-        UnconfirmedPlace place = new UnconfirmedPlace(randomString(), "Germany");
-        Period time = new Period(LocalDateTime.now(), LocalDateTime.now().plusDays(1));
-        return new Venue(place, time, randomInteger());
+        return new Artistic();
     }
 
     private static Place randomPlace() {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.place.UnconfirmedPlace;
-import no.unit.nva.model.contexttypes.venue.Venue;
+import no.unit.nva.model.instancetypes.artistic.venue.Venue;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.artistic.ArtisticDesign;
 import no.unit.nva.model.instancetypes.artistic.ArtisticDesignSubtype;

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationInstanceBuilder.java
@@ -3,15 +3,20 @@ package no.unit.nva.model.testing;
 import static no.unit.nva.model.testing.RandomUtils.randomPublicationDate;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.model.contexttypes.Journal;
+import no.unit.nva.model.contexttypes.place.UnconfirmedPlace;
+import no.unit.nva.model.contexttypes.venue.Venue;
 import no.unit.nva.model.instancetypes.PublicationInstance;
 import no.unit.nva.model.instancetypes.artistic.ArtisticDesign;
 import no.unit.nva.model.instancetypes.artistic.ArtisticDesignSubtype;
@@ -46,6 +51,7 @@ import no.unit.nva.model.instancetypes.report.ReportWorkingPaper;
 import no.unit.nva.model.pages.MonographPages;
 import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
+import no.unit.nva.model.time.Period;
 import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
@@ -353,6 +359,16 @@ public class PublicationInstanceBuilder {
     }
 
     private static ArtisticDesign artisticDesign(ArtisticDesignSubtypeEnum subtype) {
-        return new ArtisticDesign(ArtisticDesignSubtype.create(subtype), randomString());
+        return new ArtisticDesign(ArtisticDesignSubtype.create(subtype), randomString(), randomVenues());
+    }
+
+    private static List<Venue> randomVenues() {
+        return List.of(randomVenue(), randomVenue());
+    }
+
+    private static Venue randomVenue() {
+        UnconfirmedPlace place = new UnconfirmedPlace(randomString(), "Germany");
+        Period time = new Period(LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+        return new Venue(place, time, randomInteger());
     }
 }


### PR DESCRIPTION
Looks like a lot of changes, but the majority is the documentation, which is unfortunate. I guess I will provide a fix for this in another PR.

The main change here is that Venue is moved from Artistic -> Artistic design.

The test is updated to ignore the deprecated owner field in Publication.

