### PR TITLE
Allow files to appear in associatedArtifacts and FileSets

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,6 @@ wrapper {
     gradleVersion = "7.4.2"
 }
 
-
 dependencies {
     implementation group: 'nebula.lint', name: 'nebula.lint.gradle.plugin', version: '17.2.3'
     implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.7'

--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.github.bibsysdev'
-version '0.18.6'
+version '0.18.7'
 
 
 repositories {

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,138 +1,139 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "TQmLjoGgrNQrbS",
-    "ownerAffiliation" : "https://www.example.org/culpadebitis"
+    "owner" : "bkMcNnHX6e",
+    "ownerAffiliation" : "https://www.example.org/incorrupti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/faciliset",
+    "id" : "https://www.example.org/eosdolores",
     "labels" : {
-      "MZ5L4u20R1KJplUkl" : "UfuIojRIvTcr"
+      "Bh3PzmiJMlUj" : "87DghaYrVR5iB"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quisomnis",
-  "doi" : "https://doi.org/10.1234/veritatis",
-  "link" : "https://www.example.org/molestiasmolestias",
+  "handle" : "https://www.example.org/accusantiumeius",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/dolorummolestiae",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oWr3gCc1KDLj4Ng",
+    "mainTitle" : "ZxSUnZgcT3p",
     "alternativeTitles" : {
-      "de" : "PCCYMmvDC6hll"
+      "zh" : "NgPi8Q7KTdP9W4IVym"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "OMrAsmNFUFMA7EwlvRW",
-      "month" : "oDO9hoLcMxelPO",
-      "day" : "FYx7J24IH1"
+      "year" : "pQLACKPxJQpaJAsR",
+      "month" : "5Qa3p88sGyMXz",
+      "day" : "IQWHx8B3XQBPpw0WwYk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/eBj4oHErr1G",
-        "name" : "1ic7ZUt26Vs9T",
+        "id" : "https://www.example.com/G2tfy5MwnsvHlBS7C",
+        "name" : "LRcsj5AMm9DW",
         "nameType" : "Organizational",
-        "orcId" : "dAOljWEKruLf1"
+        "orcId" : "uftQd7lf7mq1Un"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/2zLXwuhlj6baM5",
+        "id" : "https://www.example.com/tGSJsbV33xw7QeLg",
         "labels" : {
-          "SRgp1DdzW42p" : "bH0MaagEpFWSQe36"
+          "SIxUN9FS3b" : "gOXSdqR6fxzuOIptDQd"
         }
       } ],
-      "role" : "Dramatist",
-      "sequence" : 6,
+      "role" : "AcademicCoordinator",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uVm4fJNHzDvAxFi",
-        "name" : "WWApt765iUwJt0R",
-        "nameType" : "Organizational",
-        "orcId" : "jZJDO8qxDzqZXW7iCn"
+        "id" : "https://www.example.com/ObUKamgNWBLHIqgnGR",
+        "name" : "x6O6FWSCLPkTWCAu6",
+        "nameType" : "Personal",
+        "orcId" : "lRw2OKmyooA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Bn3KBgIem4UZ3",
+        "id" : "https://www.example.com/jIYvnuQAWeoX4kz9u",
         "labels" : {
-          "qgZAJJazTuw" : "lxQSIFhT6eeeB"
+          "sWrI0sEcER0lraEls0" : "8H4LmnFn0P7BvqQ"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 9,
+      "role" : "Creator",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5N1rERXelBtihq",
-    "tags" : [ "FgCfloynlE0dV1nEa" ],
-    "description" : "pPFtg81SCRJWKjwym",
+    "npiSubjectHeading" : "0U4GVduQP9KU2X1o",
+    "tags" : [ "88S1G7uN10r" ],
+    "description" : "NrHkdYl30g4ITDrg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/yiZjo7qxZhPs9rjJK",
+      "doi" : "https://www.example.com/uCI60f8EyCuNxue9iP2",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "Building"
+          "type" : "Other",
+          "description" : "kwRAguL6Mg3qGGz"
         },
-        "description" : "YdPeI0YjVb6iYRCVeYu",
+        "description" : "CHtqJKjBCMD4nWds",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "C5LvdjSHZQ",
-          "description" : "AdPv5lH9iHNei",
+          "name" : "eK5y3Ul6hKYhrtg",
+          "description" : "ECI4l1l3tgKlw5kvl1",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1366933214
+          "sequence" : 1232698346
         }, {
           "type" : "MentionInPublication",
-          "title" : "UgzcjJ6ATg",
-          "issue" : "smApDCSJYdt9H",
+          "title" : "9yIAF9MNxOqG3B",
+          "issue" : "qA0RqTEhQh47xqa",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "kTt5ysCdlYATev1W",
-          "sequence" : 1604738892
+          "otherInformation" : "kgDBrCXku8KHmjDjS49",
+          "sequence" : 768429878
         }, {
           "type" : "Award",
-          "name" : "mWetoVEqFJHHAaDRhb",
-          "organizer" : "F0N8rLBAyk",
+          "name" : "iy33rivPZnnQOD",
+          "organizer" : "KGG1RyPG36xdCjZ0",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "ranking" : 1309234651,
-          "otherInformation" : "5VRoZxXuvs5XJHK",
-          "sequence" : 932103172
+          "ranking" : 1283001772,
+          "otherInformation" : "6N2p5D6hSUFWycxQ",
+          "sequence" : 1992805315
         }, {
           "type" : "Exhibition",
-          "name" : "D1tVkZGzHI9k8",
+          "name" : "inQhpoAPBzvOX2noD",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "uli4zWk5bWGSu7v",
-            "country" : "nW9ziJ1vFw"
+            "label" : "zl1V3ozCqUzlRuo9",
+            "country" : "VpQqfYKsxF7H"
           },
-          "organizer" : "5shObTMsxHj9FWfbsJ",
+          "organizer" : "nPxkNNN6NyFY",
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "o8mFuapcKWMNk",
-          "sequence" : 1001754935
+          "otherInformation" : "dPXIvdfyZZLWUnuiZ5Q",
+          "sequence" : 730333479
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -140,24 +141,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/HNfsGaPVZFsc",
-    "abstract" : "AmeFiQNyLEFeBhSPVn"
+    "metadataSource" : "https://www.example.com/zOmth7Imj7RRzA3cxjP",
+    "abstract" : "VQdQkCHQOD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sinterror",
-    "name" : "nwS480aRIrhkyNRZ6t",
+    "id" : "https://www.example.org/possimusaut",
+    "name" : "m8PitfnBeYyd3yBjAkx",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "weRUhdAsCB51LMv",
-      "id" : "PLoBfnJdfY"
+      "source" : "kqwrjRDeLUrKV",
+      "id" : "Jof0PrGCBe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Uni0d9TBW8l1FCsXGS"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "LEC3mtjMJpTdUzgEyI"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -165,22 +166,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velitdolores" ],
+  "subjects" : [ "https://www.example.org/autvelit" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "breZa7wV1fR",
-      "mimeType" : "eGZjW7FwCW59G",
-      "size" : 218129975,
+      "name" : "ehOq33WuXm",
+      "mimeType" : "8ARGJcwhTZcEoq2g",
+      "size" : 2114649192,
       "license" : {
         "type" : "License",
-        "identifier" : "Cz6VYivV9bbZCqF",
+        "identifier" : "AIQ6ol3AeHyGKvq",
         "labels" : {
-          "R6apMq47YLGJBxd" : "DwNcZgdw8a4e"
+          "Bb9u3ALkhkFR75" : "5RcGQnxTheQl9q"
         },
-        "link" : "https://www.example.com/TnZ7t2NlSf"
+        "link" : "https://www.example.com/OvpTQu0E0yVP6CFqSlI"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -190,21 +191,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "breZa7wV1fR",
-    "mimeType" : "eGZjW7FwCW59G",
-    "size" : 218129975,
+    "name" : "ehOq33WuXm",
+    "mimeType" : "8ARGJcwhTZcEoq2g",
+    "size" : 2114649192,
     "license" : {
       "type" : "License",
-      "identifier" : "Cz6VYivV9bbZCqF",
+      "identifier" : "AIQ6ol3AeHyGKvq",
       "labels" : {
-        "R6apMq47YLGJBxd" : "DwNcZgdw8a4e"
+        "Bb9u3ALkhkFR75" : "5RcGQnxTheQl9q"
       },
-      "link" : "https://www.example.com/TnZ7t2NlSf"
+      "link" : "https://www.example.com/OvpTQu0E0yVP6CFqSlI"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "TQmLjoGgrNQrbS",
+  "owner" : "bkMcNnHX6e",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,138 +1,138 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "UaHlOQpCDYM27",
-    "ownerAffiliation" : "https://www.example.org/errorincidunt"
+    "owner" : "TQmLjoGgrNQrbS",
+    "ownerAffiliation" : "https://www.example.org/culpadebitis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etdistinctio",
+    "id" : "https://www.example.org/faciliset",
     "labels" : {
-      "t8R48wkrFYH" : "BNvOrK7YRlxb"
+      "MZ5L4u20R1KJplUkl" : "UfuIojRIvTcr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utaccusamus",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/omnisautem",
+  "handle" : "https://www.example.org/quisomnis",
+  "doi" : "https://doi.org/10.1234/veritatis",
+  "link" : "https://www.example.org/molestiasmolestias",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1wV4MuXsDL",
+    "mainTitle" : "oWr3gCc1KDLj4Ng",
     "alternativeTitles" : {
-      "is" : "kWngdB1qRuJfUkWsZ3Y"
+      "de" : "PCCYMmvDC6hll"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tEe3Ru8RJ3vilOxa0N",
-      "month" : "5QtKNuOgcORWjfU4",
-      "day" : "XfZ2XWWcmSeCNj"
+      "year" : "OMrAsmNFUFMA7EwlvRW",
+      "month" : "oDO9hoLcMxelPO",
+      "day" : "FYx7J24IH1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/6NfftDBeqWV7nVWwP",
-        "name" : "Z2NFQyvU0K6r3QeWjd",
+        "id" : "https://www.example.com/eBj4oHErr1G",
+        "name" : "1ic7ZUt26Vs9T",
         "nameType" : "Organizational",
-        "orcId" : "y2jDxYz41IwdAlC"
+        "orcId" : "dAOljWEKruLf1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5fUjY2ZV7TLtecFFt2u",
+        "id" : "https://www.example.com/2zLXwuhlj6baM5",
         "labels" : {
-          "4txs65aNR9RQl5" : "4VEW6EqzRyR"
+          "SRgp1DdzW42p" : "bH0MaagEpFWSQe36"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 0,
+      "role" : "Dramatist",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ziW5SHb1LaOGJWj",
-        "name" : "O2GBZmyIinyA41",
-        "nameType" : "Personal",
-        "orcId" : "H4L3gw3GSi3ubcDDn"
+        "id" : "https://www.example.com/uVm4fJNHzDvAxFi",
+        "name" : "WWApt765iUwJt0R",
+        "nameType" : "Organizational",
+        "orcId" : "jZJDO8qxDzqZXW7iCn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/fysYnchsmRu8",
+        "id" : "https://www.example.com/Bn3KBgIem4UZ3",
         "labels" : {
-          "M0QaRLRGWpxlY" : "YGDXKUYIuSYV0YA5h"
+          "qgZAJJazTuw" : "lxQSIFhT6eeeB"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 6,
+      "role" : "ResearchGroup",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "xWpiNCHgn7h3PaRG2o",
-    "tags" : [ "7UtG3DsW3c4" ],
-    "description" : "pp1wHZQY8lUMkz",
+    "npiSubjectHeading" : "5N1rERXelBtihq",
+    "tags" : [ "FgCfloynlE0dV1nEa" ],
+    "description" : "pPFtg81SCRJWKjwym",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/3d7BG2otRo3S0H0p",
+      "doi" : "https://www.example.com/yiZjo7qxZhPs9rjJK",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "Interior"
+          "type" : "Building"
         },
-        "description" : "CpAa886ID8UIWh",
+        "description" : "YdPeI0YjVb6iYRCVeYu",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "RgfG6MWmoKhj",
-          "description" : "aF0ctDmPovqPFx1Rf",
+          "name" : "C5LvdjSHZQ",
+          "description" : "AdPv5lH9iHNei",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 125195644
+          "sequence" : 1366933214
         }, {
           "type" : "MentionInPublication",
-          "title" : "4ckngCRsvNCE",
-          "issue" : "mIMo6xaN34",
+          "title" : "UgzcjJ6ATg",
+          "issue" : "smApDCSJYdt9H",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "l2xWKLi9IhbY7emnLI",
-          "sequence" : 1399532729
+          "otherInformation" : "kTt5ysCdlYATev1W",
+          "sequence" : 1604738892
         }, {
           "type" : "Award",
-          "name" : "hxiY5cgHE6BTf5",
-          "organizer" : "9j4T2vRoYY42OZn",
+          "name" : "mWetoVEqFJHHAaDRhb",
+          "organizer" : "F0N8rLBAyk",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "ranking" : 1942690818,
-          "otherInformation" : "pLv1PGHEq9YdE7QF",
-          "sequence" : 1626383239
+          "ranking" : 1309234651,
+          "otherInformation" : "5VRoZxXuvs5XJHK",
+          "sequence" : 932103172
         }, {
           "type" : "Exhibition",
-          "name" : "l9QR8dkQxVk",
+          "name" : "D1tVkZGzHI9k8",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "RV0qHfIepJHjBVtGsAT",
-            "country" : "g8sUVtr0SrcX9J"
+            "label" : "uli4zWk5bWGSu7v",
+            "country" : "nW9ziJ1vFw"
           },
-          "organizer" : "t1EwiNS8OMcWe91mBW2",
+          "organizer" : "5shObTMsxHj9FWfbsJ",
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "SPUiFiKzINl",
-          "sequence" : 537320825
+          "otherInformation" : "o8mFuapcKWMNk",
+          "sequence" : 1001754935
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -140,24 +140,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/LvBblyptCY",
-    "abstract" : "Z5y0tmt6b6yKZ"
+    "metadataSource" : "https://www.example.com/HNfsGaPVZFsc",
+    "abstract" : "AmeFiQNyLEFeBhSPVn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/laborumnisi",
-    "name" : "ZjFfVtyFpn4cNiNhYfm",
+    "id" : "https://www.example.org/sinterror",
+    "name" : "nwS480aRIrhkyNRZ6t",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Yhg8ASto49QXY",
-      "id" : "L2uKbiYXDu"
+      "source" : "weRUhdAsCB51LMv",
+      "id" : "PLoBfnJdfY"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "RORVFrAaf2xmEZMLsYW"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Uni0d9TBW8l1FCsXGS"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -165,46 +165,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fugitoptio" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "mmCFMvoWM5y",
-    "mimeType" : "luW1oM2v2Bww81A",
-    "size" : 82039133,
-    "license" : {
-      "type" : "License",
-      "identifier" : "PUV9SsCT93yfovhHRk",
-      "labels" : {
-        "hM5vnu0o6B5" : "bffwEAFXMlLv8t"
-      },
-      "link" : "https://www.example.com/47k4raUbjk22QA"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/velitdolores" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "mmCFMvoWM5y",
-      "mimeType" : "luW1oM2v2Bww81A",
-      "size" : 82039133,
+      "name" : "breZa7wV1fR",
+      "mimeType" : "eGZjW7FwCW59G",
+      "size" : 218129975,
       "license" : {
         "type" : "License",
-        "identifier" : "PUV9SsCT93yfovhHRk",
+        "identifier" : "Cz6VYivV9bbZCqF",
         "labels" : {
-          "hM5vnu0o6B5" : "bffwEAFXMlLv8t"
+          "R6apMq47YLGJBxd" : "DwNcZgdw8a4e"
         },
-        "link" : "https://www.example.com/47k4raUbjk22QA"
+        "link" : "https://www.example.com/TnZ7t2NlSf"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "UaHlOQpCDYM27",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "breZa7wV1fR",
+    "mimeType" : "eGZjW7FwCW59G",
+    "size" : 218129975,
+    "license" : {
+      "type" : "License",
+      "identifier" : "Cz6VYivV9bbZCqF",
+      "labels" : {
+        "R6apMq47YLGJBxd" : "DwNcZgdw8a4e"
+      },
+      "link" : "https://www.example.com/TnZ7t2NlSf"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "TQmLjoGgrNQrbS",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,138 +1,138 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "5zhijMWTEv4R0A",
-    "ownerAffiliation" : "https://www.example.org/animitotam"
+    "owner" : "UaHlOQpCDYM27",
+    "ownerAffiliation" : "https://www.example.org/errorincidunt"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiasut",
+    "id" : "https://www.example.org/etdistinctio",
     "labels" : {
-      "1hhkpCMqJ5" : "MTWEkicbaqY"
+      "t8R48wkrFYH" : "BNvOrK7YRlxb"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eosquod",
-  "doi" : "https://doi.org/10.1234/pariatur",
-  "link" : "https://www.example.org/eligendisimilique",
+  "handle" : "https://www.example.org/utaccusamus",
+  "doi" : "https://doi.org/10.1234/at",
+  "link" : "https://www.example.org/omnisautem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EWIbXpMTxY",
+    "mainTitle" : "1wV4MuXsDL",
     "alternativeTitles" : {
-      "da" : "XDp8OVypGJ"
+      "is" : "kWngdB1qRuJfUkWsZ3Y"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "2LFpf7xmxE",
-      "month" : "2J5yC97U4nalM2RK5dl",
-      "day" : "BSKJjvanA8R04eJm2"
+      "year" : "tEe3Ru8RJ3vilOxa0N",
+      "month" : "5QtKNuOgcORWjfU4",
+      "day" : "XfZ2XWWcmSeCNj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/K5BqOAW0ly",
-        "name" : "Z8ohXThdOQY7FF4adz",
+        "id" : "https://www.example.com/6NfftDBeqWV7nVWwP",
+        "name" : "Z2NFQyvU0K6r3QeWjd",
         "nameType" : "Organizational",
-        "orcId" : "gKyeHwMTa8oGIzM"
+        "orcId" : "y2jDxYz41IwdAlC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/sxqkd6NzQH0CkQotA2o",
+        "id" : "https://www.example.com/5fUjY2ZV7TLtecFFt2u",
         "labels" : {
-          "rz62K2N354k6" : "gw6WHrFer6qJNrHz8E"
+          "4txs65aNR9RQl5" : "4VEW6EqzRyR"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 4,
+      "role" : "ProductionDesigner",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XWiBgCStlnWrZFTEYnD",
-        "name" : "vNjb1ZK8Ex84QI",
+        "id" : "https://www.example.com/ziW5SHb1LaOGJWj",
+        "name" : "O2GBZmyIinyA41",
         "nameType" : "Personal",
-        "orcId" : "eH4D8bW5qQCcp"
+        "orcId" : "H4L3gw3GSi3ubcDDn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/GSt647NwJyoi8cNyux",
+        "id" : "https://www.example.com/fysYnchsmRu8",
         "labels" : {
-          "6dbsCRu7TkU" : "SGYZJbDcLcnUvA1So"
+          "M0QaRLRGWpxlY" : "YGDXKUYIuSYV0YA5h"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 1,
+      "role" : "Choreographer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "pYMKAjbWeqA",
-    "tags" : [ "M4GbOotxGptM" ],
-    "description" : "TvFVVo9fwi2prNpkq3",
+    "npiSubjectHeading" : "xWpiNCHgn7h3PaRG2o",
+    "tags" : [ "7UtG3DsW3c4" ],
+    "description" : "pp1wHZQY8lUMkz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/nV5iXkQzDpBB",
+      "doi" : "https://www.example.com/3d7BG2otRo3S0H0p",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "LandscapeArchitecture"
+          "type" : "Interior"
         },
-        "description" : "RhdJ2WLWCqjhDuM",
+        "description" : "CpAa886ID8UIWh",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "66JNI0JnR2X9Kbppzhi",
-          "description" : "7zqU8FDyOxQim",
+          "name" : "RgfG6MWmoKhj",
+          "description" : "aF0ctDmPovqPFx1Rf",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 554914688
+          "sequence" : 125195644
         }, {
           "type" : "MentionInPublication",
-          "title" : "bnqCg0FTgVmb9",
-          "issue" : "Evikvkng5nSfZhp7B",
+          "title" : "4ckngCRsvNCE",
+          "issue" : "mIMo6xaN34",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "Hj2TRkhe7N",
-          "sequence" : 46605817
+          "otherInformation" : "l2xWKLi9IhbY7emnLI",
+          "sequence" : 1399532729
         }, {
           "type" : "Award",
-          "name" : "Kkc1SIq8Ejau",
-          "organizer" : "fGK3WxkNdJq2rry",
+          "name" : "hxiY5cgHE6BTf5",
+          "organizer" : "9j4T2vRoYY42OZn",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "ranking" : 1703377914,
-          "otherInformation" : "yCZokCoz0zzFCvTO3Sc",
-          "sequence" : 596918938
+          "ranking" : 1942690818,
+          "otherInformation" : "pLv1PGHEq9YdE7QF",
+          "sequence" : 1626383239
         }, {
           "type" : "Exhibition",
-          "name" : "7rSXXEMDXy0i7W8Wdco",
+          "name" : "l9QR8dkQxVk",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "qdwczdAUfCArUicd",
-            "country" : "1S9h5Te2knRA8h"
+            "label" : "RV0qHfIepJHjBVtGsAT",
+            "country" : "g8sUVtr0SrcX9J"
           },
-          "organizer" : "GG8qKsSRsLes13AzB",
+          "organizer" : "t1EwiNS8OMcWe91mBW2",
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "7ocTKkzuaiB7OUWNt",
-          "sequence" : 2126339288
+          "otherInformation" : "SPUiFiKzINl",
+          "sequence" : 537320825
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -140,45 +140,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/bzkZoR583hhRe",
-    "abstract" : "hlGOfiUq00c4h8Ka"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "6Xjjoa0bcscq",
-      "mimeType" : "PpwZ4jpRz8GAQ9Zyh",
-      "size" : 1455657547,
-      "license" : {
-        "type" : "License",
-        "identifier" : "x2Uqpi2lkQBBvra",
-        "labels" : {
-          "6W6xHI7Y8221umm85j" : "EnHIVn8sIu3hx"
-        },
-        "link" : "https://www.example.com/S0bqmorPYWgczBwViU"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/LvBblyptCY",
+    "abstract" : "Z5y0tmt6b6yKZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/illoeum",
-    "name" : "4ciGZz0zCjsEHfcgDaA",
+    "id" : "https://www.example.org/laborumnisi",
+    "name" : "ZjFfVtyFpn4cNiNhYfm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "c93JYAuGBUoxbT",
-      "id" : "D3k3OaQkKEObCL2Hm9y"
+      "source" : "Yhg8ASto49QXY",
+      "id" : "L2uKbiYXDu"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "rLkiMFAG5NRPzrYem"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "RORVFrAaf2xmEZMLsYW"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -186,25 +165,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consequaturmaiores" ],
+  "subjects" : [ "https://www.example.org/fugitoptio" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "6Xjjoa0bcscq",
-    "mimeType" : "PpwZ4jpRz8GAQ9Zyh",
-    "size" : 1455657547,
+    "name" : "mmCFMvoWM5y",
+    "mimeType" : "luW1oM2v2Bww81A",
+    "size" : 82039133,
     "license" : {
       "type" : "License",
-      "identifier" : "x2Uqpi2lkQBBvra",
+      "identifier" : "PUV9SsCT93yfovhHRk",
       "labels" : {
-        "6W6xHI7Y8221umm85j" : "EnHIVn8sIu3hx"
+        "hM5vnu0o6B5" : "bffwEAFXMlLv8t"
       },
-      "link" : "https://www.example.com/S0bqmorPYWgczBwViU"
+      "link" : "https://www.example.com/47k4raUbjk22QA"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "5zhijMWTEv4R0A"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "mmCFMvoWM5y",
+      "mimeType" : "luW1oM2v2Bww81A",
+      "size" : 82039133,
+      "license" : {
+        "type" : "License",
+        "identifier" : "PUV9SsCT93yfovhHRk",
+        "labels" : {
+          "hM5vnu0o6B5" : "bffwEAFXMlLv8t"
+        },
+        "link" : "https://www.example.com/47k4raUbjk22QA"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "UaHlOQpCDYM27",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,139 +1,138 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "bkMcNnHX6e",
-    "ownerAffiliation" : "https://www.example.org/incorrupti"
+    "owner" : "PIrgHjCo82C2ql18X3",
+    "ownerAffiliation" : "https://www.example.org/voluptatemillum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eosdolores",
+    "id" : "https://www.example.org/suscipitaut",
     "labels" : {
-      "Bh3PzmiJMlUj" : "87DghaYrVR5iB"
+      "ezHhWp8pJHW1" : "6ZukB3GrPmJ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/accusantiumeius",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/dolorummolestiae",
+  "handle" : "https://www.example.org/oditvoluptatum",
+  "doi" : "https://doi.org/10.1234/deserunt",
+  "link" : "https://www.example.org/eiuscorrupti",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZxSUnZgcT3p",
+    "mainTitle" : "9TiFp5xnCXHZYn6D",
     "alternativeTitles" : {
-      "zh" : "NgPi8Q7KTdP9W4IVym"
+      "es" : "zVdMQJ9SJ4KgkzSr4qm"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "pQLACKPxJQpaJAsR",
-      "month" : "5Qa3p88sGyMXz",
-      "day" : "IQWHx8B3XQBPpw0WwYk"
+      "year" : "FJuLXeDysMG",
+      "month" : "svqYQwPXBfFZarKr",
+      "day" : "ndHZ6YtZWa5OTg7p"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/G2tfy5MwnsvHlBS7C",
-        "name" : "LRcsj5AMm9DW",
+        "id" : "https://www.example.com/M8FOC8MsaZIX",
+        "name" : "bZpdxIuH2m0sOz6",
         "nameType" : "Organizational",
-        "orcId" : "uftQd7lf7mq1Un"
+        "orcId" : "lACQghlYRxYOI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tGSJsbV33xw7QeLg",
+        "id" : "https://www.example.com/h72YjeK9OkoP",
         "labels" : {
-          "SIxUN9FS3b" : "gOXSdqR6fxzuOIptDQd"
+          "6TV3uIkQ7p4j0A" : "KU2DqitO3qubFh1Ij"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 9,
+      "role" : "SoundDesigner",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ObUKamgNWBLHIqgnGR",
-        "name" : "x6O6FWSCLPkTWCAu6",
+        "id" : "https://www.example.com/r4rJhg2nL7C1X",
+        "name" : "cQlC7sOg87nA3",
         "nameType" : "Personal",
-        "orcId" : "lRw2OKmyooA"
+        "orcId" : "Xcj9YogHiG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/jIYvnuQAWeoX4kz9u",
+        "id" : "https://www.example.com/iTz1dFMpmC",
         "labels" : {
-          "sWrI0sEcER0lraEls0" : "8H4LmnFn0P7BvqQ"
+          "e5NdSAZmLeLeya" : "TVkPc05QG3lf"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 4,
+      "role" : "ArtisticDirector",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "0U4GVduQP9KU2X1o",
-    "tags" : [ "88S1G7uN10r" ],
-    "description" : "NrHkdYl30g4ITDrg",
+    "npiSubjectHeading" : "SgIfUY3TvDHV5",
+    "tags" : [ "n5iQMWYMrdBQDD" ],
+    "description" : "tXPRlwtRyo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/uCI60f8EyCuNxue9iP2",
+      "doi" : "https://www.example.com/qfhehXVdiwN5huqc",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "Other",
-          "description" : "kwRAguL6Mg3qGGz"
+          "type" : "Building"
         },
-        "description" : "CHtqJKjBCMD4nWds",
+        "description" : "20H6zfagCcNeXSqUc",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "eK5y3Ul6hKYhrtg",
-          "description" : "ECI4l1l3tgKlw5kvl1",
+          "name" : "667zXHciGSm5",
+          "description" : "smXnMTOkqi",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1232698346
+          "sequence" : 2090955134
         }, {
           "type" : "MentionInPublication",
-          "title" : "9yIAF9MNxOqG3B",
-          "issue" : "qA0RqTEhQh47xqa",
+          "title" : "tCWw04GcvAb",
+          "issue" : "fLkDyBzJWqJqjl3u7",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "kgDBrCXku8KHmjDjS49",
-          "sequence" : 768429878
+          "otherInformation" : "HemRmsIpep3",
+          "sequence" : 1064001416
         }, {
           "type" : "Award",
-          "name" : "iy33rivPZnnQOD",
-          "organizer" : "KGG1RyPG36xdCjZ0",
+          "name" : "SJhEsu70tPo",
+          "organizer" : "nlYeyjY2GO",
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "ranking" : 1283001772,
-          "otherInformation" : "6N2p5D6hSUFWycxQ",
-          "sequence" : 1992805315
+          "ranking" : 164948453,
+          "otherInformation" : "vxYlda9Y3So6m1",
+          "sequence" : 1335503019
         }, {
           "type" : "Exhibition",
-          "name" : "inQhpoAPBzvOX2noD",
+          "name" : "Rtn9JXvMYcBuo3Xr",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "zl1V3ozCqUzlRuo9",
-            "country" : "VpQqfYKsxF7H"
+            "label" : "syDbckQTA6m19C",
+            "country" : "KYRqAk3LnvZ"
           },
-          "organizer" : "nPxkNNN6NyFY",
+          "organizer" : "xfht9PpMWryR8wEOB",
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "otherInformation" : "dPXIvdfyZZLWUnuiZ5Q",
-          "sequence" : 730333479
+          "otherInformation" : "dDOcb149sR4",
+          "sequence" : 470370709
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -141,24 +140,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/zOmth7Imj7RRzA3cxjP",
-    "abstract" : "VQdQkCHQOD"
+    "metadataSource" : "https://www.example.com/LkP9l4ozetUml",
+    "abstract" : "0s7CwmXyfPGb256SeGp"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/possimusaut",
-    "name" : "m8PitfnBeYyd3yBjAkx",
+    "id" : "https://www.example.org/culpavoluptas",
+    "name" : "8ta9w6r9JDwNmV",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "kqwrjRDeLUrKV",
-      "id" : "Jof0PrGCBe"
+      "source" : "zSp4iMREo1kp4k",
+      "id" : "vIRZrfWTkG"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "LEC3mtjMJpTdUzgEyI"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "VgNkvlxV8jQ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -166,46 +165,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autvelit" ],
+  "subjects" : [ "https://www.example.org/molestiaeblanditiis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ehOq33WuXm",
-      "mimeType" : "8ARGJcwhTZcEoq2g",
-      "size" : 2114649192,
+      "name" : "sqsmhAtVxUvWfT",
+      "mimeType" : "fRIBQDWRuM1f9Knk7",
+      "size" : 815406007,
       "license" : {
         "type" : "License",
-        "identifier" : "AIQ6ol3AeHyGKvq",
+        "identifier" : "DF4zoOqgBwvS8OSAzt",
         "labels" : {
-          "Bb9u3ALkhkFR75" : "5RcGQnxTheQl9q"
+          "B7YnnKWeJsmvnAXgk" : "bYiq7CgKCkXp2i4"
         },
-        "link" : "https://www.example.com/OvpTQu0E0yVP6CFqSlI"
+        "link" : "https://www.example.com/qnGBWqG6lfyuIDMc0"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ehOq33WuXm",
-    "mimeType" : "8ARGJcwhTZcEoq2g",
-    "size" : 2114649192,
+    "name" : "sqsmhAtVxUvWfT",
+    "mimeType" : "fRIBQDWRuM1f9Knk7",
+    "size" : 815406007,
     "license" : {
       "type" : "License",
-      "identifier" : "AIQ6ol3AeHyGKvq",
+      "identifier" : "DF4zoOqgBwvS8OSAzt",
       "labels" : {
-        "Bb9u3ALkhkFR75" : "5RcGQnxTheQl9q"
+        "B7YnnKWeJsmvnAXgk" : "bYiq7CgKCkXp2i4"
       },
-      "link" : "https://www.example.com/OvpTQu0E0yVP6CFqSlI"
+      "link" : "https://www.example.com/qnGBWqG6lfyuIDMc0"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "bkMcNnHX6e",
+  "owner" : "PIrgHjCo82C2ql18X3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "h6t0OdXbKmRv4giK",
-    "ownerAffiliation" : "https://www.example.org/quasiut"
+    "owner" : "15Zzp2YOygvGFiEoj24",
+    "ownerAffiliation" : "https://www.example.org/quocommodi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorempossimus",
+    "id" : "https://www.example.org/autemdoloribus",
     "labels" : {
-      "A0xqwkpv9tZ3rz9w" : "Xw6m4j5r26riLG1c"
+      "wjxoyIuc72TVod9QoS6" : "g5I4BdFFRTLScf1"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quoiste",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/eosodio",
+  "handle" : "https://www.example.org/eaqueea",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/suntmaxime",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bBepJ94Gaut0k",
+    "mainTitle" : "P2S3K5zh6Nl",
     "alternativeTitles" : {
-      "fr" : "e29lasAZqjDOymQ0"
+      "fi" : "Mw9HbkdmYVl3zJ0CegL"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "fiQRrgUlAIvE",
-      "month" : "jA4p6m6fz1jrJS2HBPD",
-      "day" : "Spf8f7VrTF21Cf7fe"
+      "year" : "BFp025A3LN",
+      "month" : "Nn93d23x0j",
+      "day" : "uAR39Q2ak4ilnr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uza1c0t7akiYDYoOQe",
-        "name" : "LBFQOr1tNg3Zi",
-        "nameType" : "Organizational",
-        "orcId" : "amJGuUPFr3tPl"
+        "id" : "https://www.example.com/lzVBV8OgTuqsvaP",
+        "name" : "eJ9UyauyTKpr87zs",
+        "nameType" : "Personal",
+        "orcId" : "MP5W7HwoJ1B"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lIk12qzpYOIutWNAR",
+        "id" : "https://www.example.com/qmpiqU0tDFYmROnl",
         "labels" : {
-          "AB0vk1skZ6tyn4C3QpL" : "5danSwb0nLU7W"
+          "uZsAGgkNLH6c" : "FUU9bcO4dYF3Js"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 7,
+      "role" : "CostumeDesigner",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/pwDus6uuvDnt3NrTD",
-        "name" : "cIJgBaW2id",
+        "id" : "https://www.example.com/pdWMekKyFDa6c",
+        "name" : "rXtpirrAQDUsK7",
         "nameType" : "Personal",
-        "orcId" : "P7cTeO96Qnh5l3V8I"
+        "orcId" : "SihDSdnEEftG0RVmuA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LRVpyMCnBeDjYU",
+        "id" : "https://www.example.com/qh13xKrbjkfL",
         "labels" : {
-          "IG7q9kk9DQxaKa" : "OYVt1OAkHfHPoae3J"
+          "cbghqfZA1EI" : "BcVRX07TQof98"
         }
       } ],
-      "role" : "VfxSupervisor",
-      "sequence" : 3,
+      "role" : "Composer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9Y0S55Zi7L1y",
-    "tags" : [ "gh7AKlTnyagkjt" ],
-    "description" : "UVLS2Boybj",
+    "npiSubjectHeading" : "4no6LsR2NrZKGeE",
+    "tags" : [ "1ATARRe2Zu8Bdmt" ],
+    "description" : "vjdZKJLZHA4E0LUqhs",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/r8HBSQf0Al",
+      "doi" : "https://www.example.com/3VDxGxeEjoQ",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ServiceDesign"
+          "type" : "WebDesign"
         },
-        "description" : "r75Rnnqze0Orcy",
+        "description" : "HoLcj9EK5PfU9iCx5b",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "DFg10Qj7RVTIT",
-            "country" : "zfYiXl5FOuCRiRGT"
+            "label" : "kONbXPBw6dWlO3Rrg6P",
+            "country" : "EVXyrwukrzZ"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1566035703
+          "sequence" : 1046759435
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "wuTDqxu4iEOk7Ol",
-            "country" : "w4berqx6ZzvTTF2"
+            "label" : "0RN5uw4wBeSkwCWGtu",
+            "country" : "A4StwwDv8Ixqc"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 924251481
+          "sequence" : 506970656
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -120,45 +120,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/vh6BOeIZbRAEC562LMW",
-    "abstract" : "mL84DT879zn"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "fvkQLsEZESH",
-      "mimeType" : "Zwp12GqehDPx31y",
-      "size" : 915496876,
-      "license" : {
-        "type" : "License",
-        "identifier" : "eTemOeQ2aqX198GJV3q",
-        "labels" : {
-          "bZcYzYLwVPx" : "VZ11NU6pnjXoeh"
-        },
-        "link" : "https://www.example.com/GLh61myIu4CboUIG"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/TgXYklZ21MjQ",
+    "abstract" : "MknGIUXb5C58A"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/temporeipsa",
-    "name" : "Lrh1Ubj65Gsc2N5cLwT",
+    "id" : "https://www.example.org/animimagni",
+    "name" : "0ut0OvMgLpQgez",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "BZ196YDuDV",
-      "id" : "7SVlh0D453GP3iRzig"
+      "source" : "wRSLmsF4JqZyXORY",
+      "id" : "kxnD5SaLgqjqVv"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "mZKasJ1FPUm"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "OEe964DinIdASNde"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -166,25 +145,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/providentminima" ],
+  "subjects" : [ "https://www.example.org/etconsequuntur" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "fvkQLsEZESH",
-    "mimeType" : "Zwp12GqehDPx31y",
-    "size" : 915496876,
+    "name" : "7Wdf3ZasIUVKsto3W",
+    "mimeType" : "d2flfgVALZoOWAO1v6",
+    "size" : 594751306,
     "license" : {
       "type" : "License",
-      "identifier" : "eTemOeQ2aqX198GJV3q",
+      "identifier" : "cW5xUp5Y081tMOUlDTw",
       "labels" : {
-        "bZcYzYLwVPx" : "VZ11NU6pnjXoeh"
+        "FT6cvCTMRrYB" : "JFWDGlQx0oPzdyo6Vr"
       },
-      "link" : "https://www.example.com/GLh61myIu4CboUIG"
+      "link" : "https://www.example.com/JjbQuBrV8e"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "h6t0OdXbKmRv4giK"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "7Wdf3ZasIUVKsto3W",
+      "mimeType" : "d2flfgVALZoOWAO1v6",
+      "size" : 594751306,
+      "license" : {
+        "type" : "License",
+        "identifier" : "cW5xUp5Y081tMOUlDTw",
+        "labels" : {
+          "FT6cvCTMRrYB" : "JFWDGlQx0oPzdyo6Vr"
+        },
+        "link" : "https://www.example.com/JjbQuBrV8e"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "15Zzp2YOygvGFiEoj24",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "DAaa7RcAOqbb7",
-    "ownerAffiliation" : "https://www.example.org/nihilamet"
+    "owner" : "ZwjXdZjm7YQNVevygCW",
+    "ownerAffiliation" : "https://www.example.org/possimusveniam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eaoccaecati",
+    "id" : "https://www.example.org/laboriosamnisi",
     "labels" : {
-      "qewHp1F7UhZD" : "PNv1YnXzwvgZ9U5ayy"
+      "N6VWuH7l3bj6B3zn" : "QFYtCmnSsny3O05ydk"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/aliquamsequi",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/eaat",
+  "handle" : "https://www.example.org/etquia",
+  "doi" : "https://doi.org/10.1234/sit",
+  "link" : "https://www.example.org/liberoest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xM9IPeF5uNFH0xJ",
+    "mainTitle" : "9TPR4X4VBRLddq",
     "alternativeTitles" : {
-      "ca" : "D7qcVhkdbiPe4Q9A"
+      "no" : "36W2gFO1KdP"
     },
     "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FbphkyCBI2A2wEb",
-      "month" : "BJUHuXtYw78A59g",
-      "day" : "cw8dYqSIOW6YgXDf2"
+      "year" : "l4PXhTfFnbPSXk",
+      "month" : "WKSXryP1rt",
+      "day" : "dDCUj73VyzAC0NIc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xT17SeQ8Se",
-        "name" : "ybM1WkRFDawSw",
+        "id" : "https://www.example.com/hcXH2xru3io",
+        "name" : "lszG2QefSa",
         "nameType" : "Organizational",
-        "orcId" : "p5xORAWYVenx5jMwGH"
+        "orcId" : "o3jKDSnBlx0dMN9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PuYXEhTHQ4LEk0n",
+        "id" : "https://www.example.com/3pkNd7ZTK2NN7kHsl2",
         "labels" : {
-          "AJ63DVm0pN" : "LXjIZReyfzF2n"
+          "GOdeqCVCg4" : "ImjaBymDzVOqwyFt"
         }
       } ],
-      "role" : "CuratorOrganizer",
+      "role" : "DataManager",
       "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZmF3OJQn3ZvbPDit",
-        "name" : "Wrv7twks9jM8CVA",
-        "nameType" : "Organizational",
-        "orcId" : "E417ZfmHNVaWQE"
+        "id" : "https://www.example.com/Xfc9As6HpyKST",
+        "name" : "R74K3zYQFrNe",
+        "nameType" : "Personal",
+        "orcId" : "ExOh6BlfEKOK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/46YjT7f021q0v9",
+        "id" : "https://www.example.com/FzkEv658ObF4Qk4",
         "labels" : {
-          "vcBFBG1BB9TWh1FBdMO" : "UU4cQr98QqUqmC0"
+          "l2FNrwYscJsTvNzRbv" : "cvsylt2bMSjqLWfIY6H"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 8,
+      "role" : "VideoEditor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "TinXX5eGT9GEB7j6L",
-    "tags" : [ "0ukHHGM8qHVQhRyO6" ],
-    "description" : "tMweoA8u83ACFhW",
+    "npiSubjectHeading" : "XIdNjetEz7vwI70UID",
+    "tags" : [ "1wzeC02XH1" ],
+    "description" : "wZgGua3OAPuNWLVLpW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/E0hmyLnv0CmfSRr6Z",
+      "doi" : "https://www.example.com/xLll9XlxP9UdGJO",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ClothingDesign"
+          "type" : "LightDesign"
         },
-        "description" : "VI7BgcywQnWv",
+        "description" : "ywt4lb8t3m7F0fUXk9P",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "vUKEY3qMB40",
-            "country" : "Owd5BdBDDmi"
+            "label" : "QQ7TKyDpa3",
+            "country" : "2cANPhHDJ5om"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 546206479
+          "sequence" : 1861889210
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "xFws5xySJWBLQ",
-            "country" : "IaPYL2E2AWf3Z2jhAI"
+            "label" : "qI4rWyySVgKvBXHn5",
+            "country" : "d8PHBCMiCv"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 534929832
+          "sequence" : 383090138
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -120,24 +120,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/8CsixZWDfNampj",
-    "abstract" : "cGGRRg5XMETJ9"
+    "metadataSource" : "https://www.example.com/qj7zNen3bf3YY",
+    "abstract" : "2eThkcB4mnRG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sequivoluptates",
-    "name" : "NS8nDcITaK",
+    "id" : "https://www.example.org/estcorporis",
+    "name" : "032ATjUzl4SE",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "aZ0pn5G8fT",
-      "id" : "pEP8t4cT2nulkmyXd6"
+      "source" : "YPJaAeP1XKswI3hz8L9",
+      "id" : "47eIzcmm3nGRITEE"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "QrFA9qfm60hvvkjj1Li"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "cdB7nJ0aImc907zow"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,46 +145,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/porromodi" ],
+  "subjects" : [ "https://www.example.org/eiussint" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "P0hZeS5l1a",
-      "mimeType" : "EIZoUL7n7YgN",
-      "size" : 1080934891,
+      "name" : "JsXwUVSzmcTNtqU",
+      "mimeType" : "fnO6XH4xtIDPBSk",
+      "size" : 521223764,
       "license" : {
         "type" : "License",
-        "identifier" : "Z6hKrYhf9XA",
+        "identifier" : "fPdFXxvDrat",
         "labels" : {
-          "GDDVuOnjsJltO" : "HJsJfu2aSvkjneX3i"
+          "SjWOqmPQHl2d7o97" : "uc3GE5gJUJ"
         },
-        "link" : "https://www.example.com/R3u3HIaU1VpRn"
+        "link" : "https://www.example.com/stxVutttV4re"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "P0hZeS5l1a",
-    "mimeType" : "EIZoUL7n7YgN",
-    "size" : 1080934891,
+    "name" : "JsXwUVSzmcTNtqU",
+    "mimeType" : "fnO6XH4xtIDPBSk",
+    "size" : 521223764,
     "license" : {
       "type" : "License",
-      "identifier" : "Z6hKrYhf9XA",
+      "identifier" : "fPdFXxvDrat",
       "labels" : {
-        "GDDVuOnjsJltO" : "HJsJfu2aSvkjneX3i"
+        "SjWOqmPQHl2d7o97" : "uc3GE5gJUJ"
       },
-      "link" : "https://www.example.com/R3u3HIaU1VpRn"
+      "link" : "https://www.example.com/stxVutttV4re"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "DAaa7RcAOqbb7",
+  "owner" : "ZwjXdZjm7YQNVevygCW",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "15Zzp2YOygvGFiEoj24",
-    "ownerAffiliation" : "https://www.example.org/quocommodi"
+    "owner" : "DAaa7RcAOqbb7",
+    "ownerAffiliation" : "https://www.example.org/nihilamet"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemdoloribus",
+    "id" : "https://www.example.org/eaoccaecati",
     "labels" : {
-      "wjxoyIuc72TVod9QoS6" : "g5I4BdFFRTLScf1"
+      "qewHp1F7UhZD" : "PNv1YnXzwvgZ9U5ayy"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eaqueea",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/suntmaxime",
+  "handle" : "https://www.example.org/aliquamsequi",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/eaat",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "P2S3K5zh6Nl",
+    "mainTitle" : "xM9IPeF5uNFH0xJ",
     "alternativeTitles" : {
-      "fi" : "Mw9HbkdmYVl3zJ0CegL"
+      "ca" : "D7qcVhkdbiPe4Q9A"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "BFp025A3LN",
-      "month" : "Nn93d23x0j",
-      "day" : "uAR39Q2ak4ilnr"
+      "year" : "FbphkyCBI2A2wEb",
+      "month" : "BJUHuXtYw78A59g",
+      "day" : "cw8dYqSIOW6YgXDf2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lzVBV8OgTuqsvaP",
-        "name" : "eJ9UyauyTKpr87zs",
-        "nameType" : "Personal",
-        "orcId" : "MP5W7HwoJ1B"
+        "id" : "https://www.example.com/xT17SeQ8Se",
+        "name" : "ybM1WkRFDawSw",
+        "nameType" : "Organizational",
+        "orcId" : "p5xORAWYVenx5jMwGH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qmpiqU0tDFYmROnl",
+        "id" : "https://www.example.com/PuYXEhTHQ4LEk0n",
         "labels" : {
-          "uZsAGgkNLH6c" : "FUU9bcO4dYF3Js"
+          "AJ63DVm0pN" : "LXjIZReyfzF2n"
         }
       } ],
-      "role" : "CostumeDesigner",
-      "sequence" : 4,
+      "role" : "CuratorOrganizer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/pdWMekKyFDa6c",
-        "name" : "rXtpirrAQDUsK7",
-        "nameType" : "Personal",
-        "orcId" : "SihDSdnEEftG0RVmuA"
+        "id" : "https://www.example.com/ZmF3OJQn3ZvbPDit",
+        "name" : "Wrv7twks9jM8CVA",
+        "nameType" : "Organizational",
+        "orcId" : "E417ZfmHNVaWQE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qh13xKrbjkfL",
+        "id" : "https://www.example.com/46YjT7f021q0v9",
         "labels" : {
-          "cbghqfZA1EI" : "BcVRX07TQof98"
+          "vcBFBG1BB9TWh1FBdMO" : "UU4cQr98QqUqmC0"
         }
       } ],
-      "role" : "Composer",
-      "sequence" : 0,
+      "role" : "SoundDesigner",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "4no6LsR2NrZKGeE",
-    "tags" : [ "1ATARRe2Zu8Bdmt" ],
-    "description" : "vjdZKJLZHA4E0LUqhs",
+    "npiSubjectHeading" : "TinXX5eGT9GEB7j6L",
+    "tags" : [ "0ukHHGM8qHVQhRyO6" ],
+    "description" : "tMweoA8u83ACFhW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/3VDxGxeEjoQ",
+      "doi" : "https://www.example.com/E0hmyLnv0CmfSRr6Z",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "WebDesign"
+          "type" : "ClothingDesign"
         },
-        "description" : "HoLcj9EK5PfU9iCx5b",
+        "description" : "VI7BgcywQnWv",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "kONbXPBw6dWlO3Rrg6P",
-            "country" : "EVXyrwukrzZ"
+            "label" : "vUKEY3qMB40",
+            "country" : "Owd5BdBDDmi"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1046759435
+          "sequence" : 546206479
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "0RN5uw4wBeSkwCWGtu",
-            "country" : "A4StwwDv8Ixqc"
+            "label" : "xFws5xySJWBLQ",
+            "country" : "IaPYL2E2AWf3Z2jhAI"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 506970656
+          "sequence" : 534929832
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -120,24 +120,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/TgXYklZ21MjQ",
-    "abstract" : "MknGIUXb5C58A"
+    "metadataSource" : "https://www.example.com/8CsixZWDfNampj",
+    "abstract" : "cGGRRg5XMETJ9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/animimagni",
-    "name" : "0ut0OvMgLpQgez",
+    "id" : "https://www.example.org/sequivoluptates",
+    "name" : "NS8nDcITaK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "wRSLmsF4JqZyXORY",
-      "id" : "kxnD5SaLgqjqVv"
+      "source" : "aZ0pn5G8fT",
+      "id" : "pEP8t4cT2nulkmyXd6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "OEe964DinIdASNde"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "QrFA9qfm60hvvkjj1Li"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,46 +145,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etconsequuntur" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "7Wdf3ZasIUVKsto3W",
-    "mimeType" : "d2flfgVALZoOWAO1v6",
-    "size" : 594751306,
-    "license" : {
-      "type" : "License",
-      "identifier" : "cW5xUp5Y081tMOUlDTw",
-      "labels" : {
-        "FT6cvCTMRrYB" : "JFWDGlQx0oPzdyo6Vr"
-      },
-      "link" : "https://www.example.com/JjbQuBrV8e"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/porromodi" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "7Wdf3ZasIUVKsto3W",
-      "mimeType" : "d2flfgVALZoOWAO1v6",
-      "size" : 594751306,
+      "name" : "P0hZeS5l1a",
+      "mimeType" : "EIZoUL7n7YgN",
+      "size" : 1080934891,
       "license" : {
         "type" : "License",
-        "identifier" : "cW5xUp5Y081tMOUlDTw",
+        "identifier" : "Z6hKrYhf9XA",
         "labels" : {
-          "FT6cvCTMRrYB" : "JFWDGlQx0oPzdyo6Vr"
+          "GDDVuOnjsJltO" : "HJsJfu2aSvkjneX3i"
         },
-        "link" : "https://www.example.com/JjbQuBrV8e"
+        "link" : "https://www.example.com/R3u3HIaU1VpRn"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "15Zzp2YOygvGFiEoj24",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "P0hZeS5l1a",
+    "mimeType" : "EIZoUL7n7YgN",
+    "size" : 1080934891,
+    "license" : {
+      "type" : "License",
+      "identifier" : "Z6hKrYhf9XA",
+      "labels" : {
+        "GDDVuOnjsJltO" : "HJsJfu2aSvkjneX3i"
+      },
+      "link" : "https://www.example.com/R3u3HIaU1VpRn"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "DAaa7RcAOqbb7",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "ZwjXdZjm7YQNVevygCW",
-    "ownerAffiliation" : "https://www.example.org/possimusveniam"
+    "owner" : "ILLPIYAY4l",
+    "ownerAffiliation" : "https://www.example.org/explicabodicta"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laboriosamnisi",
+    "id" : "https://www.example.org/quised",
     "labels" : {
-      "N6VWuH7l3bj6B3zn" : "QFYtCmnSsny3O05ydk"
+      "6ikhajjbj6HWGCL" : "uJNfA2Pvaj6YK"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etquia",
-  "doi" : "https://doi.org/10.1234/sit",
-  "link" : "https://www.example.org/liberoest",
+  "handle" : "https://www.example.org/impeditaperiam",
+  "doi" : "https://doi.org/10.1234/ipsam",
+  "link" : "https://www.example.org/doloremsit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9TPR4X4VBRLddq",
+    "mainTitle" : "a6SXAl7oArsik2ZL81",
     "alternativeTitles" : {
-      "no" : "36W2gFO1KdP"
+      "af" : "xBEcqVM3IZk"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "l4PXhTfFnbPSXk",
-      "month" : "WKSXryP1rt",
-      "day" : "dDCUj73VyzAC0NIc"
+      "year" : "IFVBav226SNkMBERn",
+      "month" : "9AwlAliTj6HzFP556Q",
+      "day" : "mfYk9xPY5EsGK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hcXH2xru3io",
-        "name" : "lszG2QefSa",
-        "nameType" : "Organizational",
-        "orcId" : "o3jKDSnBlx0dMN9"
+        "id" : "https://www.example.com/cYESpfx8Qs",
+        "name" : "bVJGrPaG0P",
+        "nameType" : "Personal",
+        "orcId" : "Dd28x4xzyVIL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3pkNd7ZTK2NN7kHsl2",
+        "id" : "https://www.example.com/uM73eYU8O5he2D",
         "labels" : {
-          "GOdeqCVCg4" : "ImjaBymDzVOqwyFt"
+          "JnxqQTMGsd5AE" : "XII9EslzId"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 9,
+      "role" : "Illustrator",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Xfc9As6HpyKST",
-        "name" : "R74K3zYQFrNe",
-        "nameType" : "Personal",
-        "orcId" : "ExOh6BlfEKOK"
+        "id" : "https://www.example.com/CJUbcDLkqmY7NCWiZyi",
+        "name" : "omLxbtb7reEqT",
+        "nameType" : "Organizational",
+        "orcId" : "ffO0v6oXxGsmhlDX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FzkEv658ObF4Qk4",
+        "id" : "https://www.example.com/jv5dL2F28ZKNVwL",
         "labels" : {
-          "l2FNrwYscJsTvNzRbv" : "cvsylt2bMSjqLWfIY6H"
+          "7Co47Wv8AaFNmrl" : "PX6uEN4CGrlrahu"
         }
       } ],
-      "role" : "VideoEditor",
-      "sequence" : 0,
+      "role" : "ResearchGroup",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XIdNjetEz7vwI70UID",
-    "tags" : [ "1wzeC02XH1" ],
-    "description" : "wZgGua3OAPuNWLVLpW",
+    "npiSubjectHeading" : "5Kr4GKYmmJi0M7n",
+    "tags" : [ "SIp6c8aB0s0baFT" ],
+    "description" : "w8vBlgCYeVxpYsVemyW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/xLll9XlxP9UdGJO",
+      "doi" : "https://www.example.com/4FXeTiPzQ1J3WqVsBX",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "LightDesign"
+          "type" : "ClothingDesign"
         },
-        "description" : "ywt4lb8t3m7F0fUXk9P",
+        "description" : "hoGzGaLRb76OQ",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "QQ7TKyDpa3",
-            "country" : "2cANPhHDJ5om"
+            "label" : "XTfT8yqJfBGUO4",
+            "country" : "9hX24xbOnGqj"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1861889210
+          "sequence" : 192541201
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "qI4rWyySVgKvBXHn5",
-            "country" : "d8PHBCMiCv"
+            "label" : "ts3MCvav7qZUX3nP",
+            "country" : "JDvEHPXYEwTcF"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 383090138
+          "sequence" : 1643828077
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -120,24 +120,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/qj7zNen3bf3YY",
-    "abstract" : "2eThkcB4mnRG"
+    "metadataSource" : "https://www.example.com/SbRdpAhasoKpsWbSD",
+    "abstract" : "yzFkNQJtB59bWtLcDRT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estcorporis",
-    "name" : "032ATjUzl4SE",
+    "id" : "https://www.example.org/aiste",
+    "name" : "iYRLq9wPlUG9o8BGp84",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "YPJaAeP1XKswI3hz8L9",
-      "id" : "47eIzcmm3nGRITEE"
+      "source" : "cTXaNddDw5U2Dp0ge",
+      "id" : "PjcHlJ7thofhTIdm9cm"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "cdB7nJ0aImc907zow"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "aNdzDJxSNWBXJdQNjZ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,46 +145,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eiussint" ],
+  "subjects" : [ "https://www.example.org/hicminus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "JsXwUVSzmcTNtqU",
-      "mimeType" : "fnO6XH4xtIDPBSk",
-      "size" : 521223764,
+      "name" : "YZnjsHPvvPkCT4G",
+      "mimeType" : "kgcAFTJvENamQJlPn",
+      "size" : 728980093,
       "license" : {
         "type" : "License",
-        "identifier" : "fPdFXxvDrat",
+        "identifier" : "HcKNPpb6ksBxYZP4h",
         "labels" : {
-          "SjWOqmPQHl2d7o97" : "uc3GE5gJUJ"
+          "vvnoqSd6Mv" : "57EuOZjm91fMnjsLM"
         },
-        "link" : "https://www.example.com/stxVutttV4re"
+        "link" : "https://www.example.com/5OXwBqQFBh3"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "JsXwUVSzmcTNtqU",
-    "mimeType" : "fnO6XH4xtIDPBSk",
-    "size" : 521223764,
+    "name" : "YZnjsHPvvPkCT4G",
+    "mimeType" : "kgcAFTJvENamQJlPn",
+    "size" : 728980093,
     "license" : {
       "type" : "License",
-      "identifier" : "fPdFXxvDrat",
+      "identifier" : "HcKNPpb6ksBxYZP4h",
       "labels" : {
-        "SjWOqmPQHl2d7o97" : "uc3GE5gJUJ"
+        "vvnoqSd6Mv" : "57EuOZjm91fMnjsLM"
       },
-      "link" : "https://www.example.com/stxVutttV4re"
+      "link" : "https://www.example.com/5OXwBqQFBh3"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "ZwjXdZjm7YQNVevygCW",
+  "owner" : "ILLPIYAY4l",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,129 +1,129 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "G5bpHBnWp5qD9mlE8v",
-    "ownerAffiliation" : "https://www.example.org/totamqui"
+    "owner" : "6PIh7rv1Yt",
+    "ownerAffiliation" : "https://www.example.org/rerumquasi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/hicin",
+    "id" : "https://www.example.org/velid",
     "labels" : {
-      "UDUErfN1XLODgv" : "fdcecUbwCPJf"
+      "FqRSQjJHTX" : "gQTD4s4SBd7"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/evenietvelit",
+  "handle" : "https://www.example.org/asperioresvoluptates",
   "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/nonvoluptate",
+  "link" : "https://www.example.org/eligendiporro",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Wzi8iR2mDjRa",
+    "mainTitle" : "prow1jq2f48UbS",
     "alternativeTitles" : {
-      "da" : "P9AVw05Xq2"
+      "cs" : "ptBZJJaGwKfTt976c"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Ax54W9RsulX",
-      "month" : "SeeIrfMGlXCWrr4",
-      "day" : "RBkIhcqkYNMeQH"
+      "year" : "EHGgmsxNk0NVz4i",
+      "month" : "r5PW0p9ePheSos",
+      "day" : "DKo1llqDJQdls"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gO4grTfag91J",
-        "name" : "qsMrgLAyGjaSsvdtJA",
+        "id" : "https://www.example.com/moJkvkxH9hUDJ",
+        "name" : "BCuLJcdQcnBCCiq",
         "nameType" : "Personal",
-        "orcId" : "fCRbXg2g2SZJO"
+        "orcId" : "oKKTJo9iDVRxhaRH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oI0XQc1pWTCuQrj73eh",
+        "id" : "https://www.example.com/KtBGMVKkjw8p8A0",
         "labels" : {
-          "FJBFjOWDnT" : "o3TbPIh1rxiRls"
+          "lDKceyjKsYRuSY" : "VEyIxvT1R1GC"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 6,
+      "role" : "InteriorArchitect",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/4ULtRjyo3IC",
-        "name" : "ZfMPVbNNJB",
-        "nameType" : "Organizational",
-        "orcId" : "hdVYgnUsNT6RFiI5hU"
+        "id" : "https://www.example.com/IHLqIDOuR2IUFpYpKN3",
+        "name" : "yMxj8WeQhr",
+        "nameType" : "Personal",
+        "orcId" : "w1FMaBh6Xd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DDnqhNWFY9rB7ZoHzmb",
+        "id" : "https://www.example.com/yh2JdZN3YZJgaY7llQ",
         "labels" : {
-          "j3Sxpn0aK22" : "t4sQzVyLHknRMtG"
+          "rGOC4eTFdaSl" : "xDN2C9qpuMQx2uhu"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 3,
+      "role" : "DataCollector",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "gKWicxgGFQ5xZ8K",
-    "tags" : [ "lTCadx3lLBnmzcv" ],
-    "description" : "P0AEsURDIcqvbpQqt0Q",
+    "npiSubjectHeading" : "1JMreq7Wmeu",
+    "tags" : [ "gAy6dhviKOGJ80" ],
+    "description" : "XSMpdkDUw5vAG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/E2LuTdAsseTu"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8RYuMYTpt4o81llXhf"
         },
-        "seriesNumber" : "QH9Vi7uWgVlvZirX",
+        "seriesNumber" : "Uv7zR7Dydv8WHnFNVY",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/k4u631a5bTj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TcTHKbECFDvLf"
         },
-        "isbnList" : [ "9780903036245" ]
+        "isbnList" : [ "9791903091943" ]
       },
-      "doi" : "https://www.example.com/nB58dlH5NzGMcx2hO",
+      "doi" : "https://www.example.com/koJK1JxZi1bC1d",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "8fSTMTzfe97C",
-            "end" : "tw44X3SOiIOre"
+            "begin" : "KVfmD91bkf80S",
+            "end" : "xfeb1iY1i9"
           },
-          "pages" : "OG0S3RD3ZXz",
+          "pages" : "22nih8LuVO8ODV",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/UtmulMDdzOT",
-    "abstract" : "JNM8JVwEN9bQruJ"
+    "metadataSource" : "https://www.example.com/3SIQ4MryYL7C3Q84PW",
+    "abstract" : "5BA8WkOVz1nC0JmT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/esseconsequatur",
-    "name" : "l2c7bmoWUjtLw5bw",
+    "id" : "https://www.example.org/officiarepellendus",
+    "name" : "2BZNN9gnnyevP7pEIma",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "5qiLOfRYdm",
-      "id" : "6gWpUQ5fQuYQ63WDwh"
+      "source" : "vpb7zqYakEGZA3p",
+      "id" : "8Zn94G447eIU93cy6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "1AaGrx1prkOvcaVTKD"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "fjsmdrouCyAGP1xQVp"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporibussint" ],
+  "subjects" : [ "https://www.example.org/numquamnecessitatibus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "hVFODdLi6WUNyKnJsf",
-      "mimeType" : "YshTm32Hm2nZW8JTe5",
-      "size" : 1950925710,
+      "name" : "mX6L1cWy6RBwOkmE",
+      "mimeType" : "NIimiUotSP",
+      "size" : 1062273210,
       "license" : {
         "type" : "License",
-        "identifier" : "wD23mtIVFsWywRu",
+        "identifier" : "3ewkDOVmvKCO34I",
         "labels" : {
-          "Mu3m96td1KId2IeJ" : "KNn9DXqmwEZcyOdni"
+          "UvziKTAbUozlLKMt" : "pi7EnRZZPaVmeMu2"
         },
-        "link" : "https://www.example.com/PqbvOZvz2K8B0al"
+        "link" : "https://www.example.com/Qy505TVAiSitKq"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "hVFODdLi6WUNyKnJsf",
-    "mimeType" : "YshTm32Hm2nZW8JTe5",
-    "size" : 1950925710,
+    "name" : "mX6L1cWy6RBwOkmE",
+    "mimeType" : "NIimiUotSP",
+    "size" : 1062273210,
     "license" : {
       "type" : "License",
-      "identifier" : "wD23mtIVFsWywRu",
+      "identifier" : "3ewkDOVmvKCO34I",
       "labels" : {
-        "Mu3m96td1KId2IeJ" : "KNn9DXqmwEZcyOdni"
+        "UvziKTAbUozlLKMt" : "pi7EnRZZPaVmeMu2"
       },
-      "link" : "https://www.example.com/PqbvOZvz2K8B0al"
+      "link" : "https://www.example.com/Qy505TVAiSitKq"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "G5bpHBnWp5qD9mlE8v",
+  "owner" : "6PIh7rv1Yt",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -3,127 +3,127 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "eP5E4IaywaCiY",
-    "ownerAffiliation" : "https://www.example.org/enimlaborum"
+    "owner" : "G5bpHBnWp5qD9mlE8v",
+    "ownerAffiliation" : "https://www.example.org/totamqui"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/abrepellendus",
+    "id" : "https://www.example.org/hicin",
     "labels" : {
-      "t9lEwrCd7qQa02h" : "f1FKOOZRGwN2MOWILm"
+      "UDUErfN1XLODgv" : "fdcecUbwCPJf"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/reprehenderitminima",
-  "doi" : "https://doi.org/10.1234/fugiat",
-  "link" : "https://www.example.org/autsoluta",
+  "handle" : "https://www.example.org/evenietvelit",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/nonvoluptate",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "aGeeyINZUTYTW",
+    "mainTitle" : "Wzi8iR2mDjRa",
     "alternativeTitles" : {
-      "bg" : "NVeEaqIQ5slV229UbQ"
+      "da" : "P9AVw05Xq2"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4Tt3EOPT5B46tI",
-      "month" : "Z5OfqVunymSLz",
-      "day" : "eA3PhpJyxgj5m5cL"
+      "year" : "Ax54W9RsulX",
+      "month" : "SeeIrfMGlXCWrr4",
+      "day" : "RBkIhcqkYNMeQH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XvslUlO34ZmV45r",
-        "name" : "V3cGSKRJ5X2QpMorOG",
+        "id" : "https://www.example.com/gO4grTfag91J",
+        "name" : "qsMrgLAyGjaSsvdtJA",
         "nameType" : "Personal",
-        "orcId" : "GALdHjKay5wq"
+        "orcId" : "fCRbXg2g2SZJO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/USkLUeZjpGKABRa",
+        "id" : "https://www.example.com/oI0XQc1pWTCuQrj73eh",
         "labels" : {
-          "LN56ATPNGWU6fXCXons" : "LDdgIUTOLg6pesDPlN"
+          "FJBFjOWDnT" : "o3TbPIh1rxiRls"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 8,
+      "role" : "Editor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/kByRKcKpCj",
-        "name" : "CmDKpeda3e",
-        "nameType" : "Personal",
-        "orcId" : "iIaDgGS82h4eUQZ6Fwq"
+        "id" : "https://www.example.com/4ULtRjyo3IC",
+        "name" : "ZfMPVbNNJB",
+        "nameType" : "Organizational",
+        "orcId" : "hdVYgnUsNT6RFiI5hU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lYuKL8OUDe1c1Iw",
+        "id" : "https://www.example.com/DDnqhNWFY9rB7ZoHzmb",
         "labels" : {
-          "XaS6BjSuJT8" : "ciygbwgs0kH2Kr"
+          "j3Sxpn0aK22" : "t4sQzVyLHknRMtG"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 9,
+      "role" : "Illustrator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "TfeY0djCfhed6",
-    "tags" : [ "tanNIHWTBBJ" ],
-    "description" : "PJGoCp2mS23pVU",
+    "npiSubjectHeading" : "gKWicxgGFQ5xZ8K",
+    "tags" : [ "lTCadx3lLBnmzcv" ],
+    "description" : "P0AEsURDIcqvbpQqt0Q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/l9nCMfA6vvU1tAjWr"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/E2LuTdAsseTu"
         },
-        "seriesNumber" : "iJsia56RjEArpMl8XC",
+        "seriesNumber" : "QH9Vi7uWgVlvZirX",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4ltI7KTteJef"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/k4u631a5bTj"
         },
-        "isbnList" : [ "9790876643609" ]
+        "isbnList" : [ "9780903036245" ]
       },
-      "doi" : "https://www.example.com/61pukVKV4f4oS5LEoB",
+      "doi" : "https://www.example.com/nB58dlH5NzGMcx2hO",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "hueLkoYpQjdDCZfv",
-            "end" : "94OqnrrEGGswnDOC"
+            "begin" : "8fSTMTzfe97C",
+            "end" : "tw44X3SOiIOre"
           },
-          "pages" : "dXI4xTi99xKcn",
-          "illustrated" : false
+          "pages" : "OG0S3RD3ZXz",
+          "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Db5hRGSeYnbcHuhLz0",
-    "abstract" : "DYr5bG12VL2k"
+    "metadataSource" : "https://www.example.com/UtmulMDdzOT",
+    "abstract" : "JNM8JVwEN9bQruJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utnisi",
-    "name" : "kwNnPCw9eZb",
+    "id" : "https://www.example.org/esseconsequatur",
+    "name" : "l2c7bmoWUjtLw5bw",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FOUzDsEX5ezv1uvQUag",
-      "id" : "4fKDdpjELWdWk3hdwS"
+      "source" : "5qiLOfRYdm",
+      "id" : "6gWpUQ5fQuYQ63WDwh"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "8rJXJQXOwzEG"
+      "applicationCode" : "1AaGrx1prkOvcaVTKD"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quodillum" ],
+  "subjects" : [ "https://www.example.org/temporibussint" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "YqnfkLwhWOubSHiP",
-      "mimeType" : "QO1ORWmya2epqkD",
-      "size" : 2123713192,
+      "name" : "hVFODdLi6WUNyKnJsf",
+      "mimeType" : "YshTm32Hm2nZW8JTe5",
+      "size" : 1950925710,
       "license" : {
         "type" : "License",
-        "identifier" : "kacE2iwiLhR",
+        "identifier" : "wD23mtIVFsWywRu",
         "labels" : {
-          "B2YXvSmPHMU1sPf4U" : "4JbTqPj04DjGX6oWK"
+          "Mu3m96td1KId2IeJ" : "KNn9DXqmwEZcyOdni"
         },
-        "link" : "https://www.example.com/YnDdR6McC6"
+        "link" : "https://www.example.com/PqbvOZvz2K8B0al"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "YqnfkLwhWOubSHiP",
-    "mimeType" : "QO1ORWmya2epqkD",
-    "size" : 2123713192,
+    "name" : "hVFODdLi6WUNyKnJsf",
+    "mimeType" : "YshTm32Hm2nZW8JTe5",
+    "size" : 1950925710,
     "license" : {
       "type" : "License",
-      "identifier" : "kacE2iwiLhR",
+      "identifier" : "wD23mtIVFsWywRu",
       "labels" : {
-        "B2YXvSmPHMU1sPf4U" : "4JbTqPj04DjGX6oWK"
+        "Mu3m96td1KId2IeJ" : "KNn9DXqmwEZcyOdni"
       },
-      "link" : "https://www.example.com/YnDdR6McC6"
+      "link" : "https://www.example.com/PqbvOZvz2K8B0al"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "eP5E4IaywaCiY",
+  "owner" : "G5bpHBnWp5qD9mlE8v",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,129 +1,129 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "NFoIAeX94s",
-    "ownerAffiliation" : "https://www.example.org/quidemvoluptatem"
+    "owner" : "eP5E4IaywaCiY",
+    "ownerAffiliation" : "https://www.example.org/enimlaborum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/esteius",
+    "id" : "https://www.example.org/abrepellendus",
     "labels" : {
-      "U1tzNLEQNES" : "LnhACGaiVuoM"
+      "t9lEwrCd7qQa02h" : "f1FKOOZRGwN2MOWILm"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utofficiis",
-  "doi" : "https://doi.org/10.1234/aliquam",
-  "link" : "https://www.example.org/aperiamnon",
+  "handle" : "https://www.example.org/reprehenderitminima",
+  "doi" : "https://doi.org/10.1234/fugiat",
+  "link" : "https://www.example.org/autsoluta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YHK8pl7FCDhq1nKVu",
+    "mainTitle" : "aGeeyINZUTYTW",
     "alternativeTitles" : {
-      "pl" : "uDv0OhQ6UBeGTUFqDQ"
+      "bg" : "NVeEaqIQ5slV229UbQ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "YkqfshanBO",
-      "month" : "2HCQt4MlsCke",
-      "day" : "bDeD1F3ugSs"
+      "year" : "4Tt3EOPT5B46tI",
+      "month" : "Z5OfqVunymSLz",
+      "day" : "eA3PhpJyxgj5m5cL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9FaXEflTpi1H",
-        "name" : "FWBgKLNpAIA613Bu",
+        "id" : "https://www.example.com/XvslUlO34ZmV45r",
+        "name" : "V3cGSKRJ5X2QpMorOG",
         "nameType" : "Personal",
-        "orcId" : "DyoV5FhvOs"
+        "orcId" : "GALdHjKay5wq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mZPF8M9dbORF4O1460",
+        "id" : "https://www.example.com/USkLUeZjpGKABRa",
         "labels" : {
-          "aRGR91gNuIbSK" : "QraElkLhFQdYeaG"
+          "LN56ATPNGWU6fXCXons" : "LDdgIUTOLg6pesDPlN"
         }
       } ],
-      "role" : "ProjectLeader",
+      "role" : "LandscapeArchitect",
       "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/yOGBKSjqLzZKCAu",
-        "name" : "eRmNEAr6EEGGuhbvx",
-        "nameType" : "Organizational",
-        "orcId" : "P9788LosXhg9"
+        "id" : "https://www.example.com/kByRKcKpCj",
+        "name" : "CmDKpeda3e",
+        "nameType" : "Personal",
+        "orcId" : "iIaDgGS82h4eUQZ6Fwq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hdHYT2isAy",
+        "id" : "https://www.example.com/lYuKL8OUDe1c1Iw",
         "labels" : {
-          "KG32YsUz7DKcTUwT" : "nRfHqxs5REByFlf6e"
+          "XaS6BjSuJT8" : "ciygbwgs0kH2Kr"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 7,
+      "role" : "Producer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "hszMhk49TpRCvYYA",
-    "tags" : [ "dOsilRLZIDVbKl" ],
-    "description" : "jgxCGrCp4becyNTCDL5",
+    "npiSubjectHeading" : "TfeY0djCfhed6",
+    "tags" : [ "tanNIHWTBBJ" ],
+    "description" : "PJGoCp2mS23pVU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xtD01Xn49mOV"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/l9nCMfA6vvU1tAjWr"
         },
-        "seriesNumber" : "Rn8bGDMKQmx",
+        "seriesNumber" : "iJsia56RjEArpMl8XC",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/lU3CTKFq8pekVhb3V0D"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4ltI7KTteJef"
         },
-        "isbnList" : [ "9780931528019" ]
+        "isbnList" : [ "9790876643609" ]
       },
-      "doi" : "https://www.example.com/gvGmeWLEtu",
+      "doi" : "https://www.example.com/61pukVKV4f4oS5LEoB",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "LL1CQzitoDya6R3u",
-            "end" : "gcqFFVIhGdhgtchr"
+            "begin" : "hueLkoYpQjdDCZfv",
+            "end" : "94OqnrrEGGswnDOC"
           },
-          "pages" : "cUXXSVksfSmDUm",
-          "illustrated" : true
+          "pages" : "dXI4xTi99xKcn",
+          "illustrated" : false
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/2NbwQuRJ7T7O0DxHa",
-    "abstract" : "H3XgnsTZ3MFv"
+    "metadataSource" : "https://www.example.com/Db5hRGSeYnbcHuhLz0",
+    "abstract" : "DYr5bG12VL2k"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequunturdolor",
-    "name" : "Od6bMJZLXj",
+    "id" : "https://www.example.org/utnisi",
+    "name" : "kwNnPCw9eZb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "PdPHA8snsU",
-      "id" : "Q4LVOkxZeuBz6ENvNi"
+      "source" : "FOUzDsEX5ezv1uvQUag",
+      "id" : "4fKDdpjELWdWk3hdwS"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "A9Sgbr6U33W"
+      "applicationCode" : "8rJXJQXOwzEG"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autquis" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LYmUv1VnxCFHNqTb7",
-    "mimeType" : "1JiNzOMAFrVBI",
-    "size" : 330165917,
-    "license" : {
-      "type" : "License",
-      "identifier" : "BwNofTfLjPi",
-      "labels" : {
-        "mlxKU3H3mXsVYmU" : "x8TIXQG8bjUdq"
-      },
-      "link" : "https://www.example.com/9Y0ijiUH0AgNkw"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/quodillum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LYmUv1VnxCFHNqTb7",
-      "mimeType" : "1JiNzOMAFrVBI",
-      "size" : 330165917,
+      "name" : "YqnfkLwhWOubSHiP",
+      "mimeType" : "QO1ORWmya2epqkD",
+      "size" : 2123713192,
       "license" : {
         "type" : "License",
-        "identifier" : "BwNofTfLjPi",
+        "identifier" : "kacE2iwiLhR",
         "labels" : {
-          "mlxKU3H3mXsVYmU" : "x8TIXQG8bjUdq"
+          "B2YXvSmPHMU1sPf4U" : "4JbTqPj04DjGX6oWK"
         },
-        "link" : "https://www.example.com/9Y0ijiUH0AgNkw"
+        "link" : "https://www.example.com/YnDdR6McC6"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "NFoIAeX94s",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "YqnfkLwhWOubSHiP",
+    "mimeType" : "QO1ORWmya2epqkD",
+    "size" : 2123713192,
+    "license" : {
+      "type" : "License",
+      "identifier" : "kacE2iwiLhR",
+      "labels" : {
+        "B2YXvSmPHMU1sPf4U" : "4JbTqPj04DjGX6oWK"
+      },
+      "link" : "https://www.example.com/YnDdR6McC6"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "eP5E4IaywaCiY",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAbstracts.json
+++ b/documentation/BookAbstracts.json
@@ -1,150 +1,129 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "jmTjFjLf5V0TP4hs",
-    "ownerAffiliation" : "https://www.example.org/doloremexcepturi"
+    "owner" : "NFoIAeX94s",
+    "ownerAffiliation" : "https://www.example.org/quidemvoluptatem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/intempore",
+    "id" : "https://www.example.org/esteius",
     "labels" : {
-      "80X1XGGspgpiro7B" : "8HcCJjOeDT"
+      "U1tzNLEQNES" : "LnhACGaiVuoM"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eossint",
-  "doi" : "https://doi.org/10.1234/facere",
-  "link" : "https://www.example.org/nonipsa",
+  "handle" : "https://www.example.org/utofficiis",
+  "doi" : "https://doi.org/10.1234/aliquam",
+  "link" : "https://www.example.org/aperiamnon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "miXGfiFeK3B6Zs2",
+    "mainTitle" : "YHK8pl7FCDhq1nKVu",
     "alternativeTitles" : {
-      "pl" : "vIOxA15OaphKrnZzvIe"
+      "pl" : "uDv0OhQ6UBeGTUFqDQ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "b2XI8e2eZC",
-      "month" : "JkTY82WiLXizV2BSfKK",
-      "day" : "P2qKKpIEiu7MI0K"
+      "year" : "YkqfshanBO",
+      "month" : "2HCQt4MlsCke",
+      "day" : "bDeD1F3ugSs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0OgnuHP1Bz8BnHFQ",
-        "name" : "xklVvcNbe3X4C8f",
-        "nameType" : "Organizational",
-        "orcId" : "6rYf7tHzE6mRmM82"
+        "id" : "https://www.example.com/9FaXEflTpi1H",
+        "name" : "FWBgKLNpAIA613Bu",
+        "nameType" : "Personal",
+        "orcId" : "DyoV5FhvOs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OkZ31FaQngK",
+        "id" : "https://www.example.com/mZPF8M9dbORF4O1460",
         "labels" : {
-          "kXayGDUMNZKZLN" : "JvjckGEsdV"
+          "aRGR91gNuIbSK" : "QraElkLhFQdYeaG"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 1,
+      "role" : "ProjectLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0JydPtvWxC",
-        "name" : "BQBLrxOc1NYKLFASb",
-        "nameType" : "Personal",
-        "orcId" : "ooN4wWXmnLAhOCqZ"
+        "id" : "https://www.example.com/yOGBKSjqLzZKCAu",
+        "name" : "eRmNEAr6EEGGuhbvx",
+        "nameType" : "Organizational",
+        "orcId" : "P9788LosXhg9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/l114AJPU921h5wT",
+        "id" : "https://www.example.com/hdHYT2isAy",
         "labels" : {
-          "ZXPW4UH2uf3zThi" : "qYo1X49UlA"
+          "KG32YsUz7DKcTUwT" : "nRfHqxs5REByFlf6e"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 9,
+      "role" : "Journalist",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rPRMhSlawujIa1ke4JV",
-    "tags" : [ "MDXlbanYxThCwxDiS" ],
-    "description" : "6yfiBZSs2Miyuslsa",
+    "npiSubjectHeading" : "hszMhk49TpRCvYYA",
+    "tags" : [ "dOsilRLZIDVbKl" ],
+    "description" : "jgxCGrCp4becyNTCDL5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/B3ss1SEt2fx"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xtD01Xn49mOV"
         },
-        "seriesNumber" : "YD7yHjW6AET8il4",
+        "seriesNumber" : "Rn8bGDMKQmx",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/so3CmeikhQO3EZajniu"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/lU3CTKFq8pekVhb3V0D"
         },
-        "isbnList" : [ "9781857441444" ]
+        "isbnList" : [ "9780931528019" ]
       },
-      "doi" : "https://www.example.com/gNKv8T0uCD6p",
+      "doi" : "https://www.example.com/gvGmeWLEtu",
       "publicationInstance" : {
         "type" : "BookAbstracts",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "DFDbhbVdEiO5ZwWoFsr",
-            "end" : "e5a21S7qnaSvXlSXIJw"
+            "begin" : "LL1CQzitoDya6R3u",
+            "end" : "gcqFFVIhGdhgtchr"
           },
-          "pages" : "l1eeyqVCRxTq",
+          "pages" : "cUXXSVksfSmDUm",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/oXSNnxgTXU",
-    "abstract" : "HzfIEYjOjro2xGVI"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "shISOChpvEK",
-      "mimeType" : "GBHtUsvb15",
-      "size" : 2070762981,
-      "license" : {
-        "type" : "License",
-        "identifier" : "Khs7JzRIRg9B",
-        "labels" : {
-          "QcPhgLiZQE3" : "ztiaQVJKLu4xpM"
-        },
-        "link" : "https://www.example.com/Fbu4987boENxt3qNS"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/2NbwQuRJ7T7O0DxHa",
+    "abstract" : "H3XgnsTZ3MFv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nesciuntnihil",
-    "name" : "yIINFo2U2pHs3gB",
+    "id" : "https://www.example.org/consequunturdolor",
+    "name" : "Od6bMJZLXj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "iVYiMNN9aBBJlhb",
-      "id" : "SQnsmPMgFUS8F3bp"
+      "source" : "PdPHA8snsU",
+      "id" : "Q4LVOkxZeuBz6ENvNi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "RV6M6nrkWIBvmiYHWL"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "A9Sgbr6U33W"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/maximeet" ],
+  "subjects" : [ "https://www.example.org/autquis" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "shISOChpvEK",
-    "mimeType" : "GBHtUsvb15",
-    "size" : 2070762981,
+    "name" : "LYmUv1VnxCFHNqTb7",
+    "mimeType" : "1JiNzOMAFrVBI",
+    "size" : 330165917,
     "license" : {
       "type" : "License",
-      "identifier" : "Khs7JzRIRg9B",
+      "identifier" : "BwNofTfLjPi",
       "labels" : {
-        "QcPhgLiZQE3" : "ztiaQVJKLu4xpM"
+        "mlxKU3H3mXsVYmU" : "x8TIXQG8bjUdq"
       },
-      "link" : "https://www.example.com/Fbu4987boENxt3qNS"
+      "link" : "https://www.example.com/9Y0ijiUH0AgNkw"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "jmTjFjLf5V0TP4hs"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "LYmUv1VnxCFHNqTb7",
+      "mimeType" : "1JiNzOMAFrVBI",
+      "size" : 330165917,
+      "license" : {
+        "type" : "License",
+        "identifier" : "BwNofTfLjPi",
+        "labels" : {
+          "mlxKU3H3mXsVYmU" : "x8TIXQG8bjUdq"
+        },
+        "link" : "https://www.example.com/9Y0ijiUH0AgNkw"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "NFoIAeX94s",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "nxqVoOBAOcUN9RqUtCE",
-    "ownerAffiliation" : "https://www.example.org/eteaque"
+    "owner" : "sMs3zfTGmhW4Egs5",
+    "ownerAffiliation" : "https://www.example.org/doloribusa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quisvoluptatibus",
+    "id" : "https://www.example.org/quimolestias",
     "labels" : {
-      "5MiQfWxz2x4" : "CFzY51eRh2sCxmaosEy"
+      "D7o6FhcDpMg8v" : "Wks5WWMpfcUTVPSOoi"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etasperiores",
-  "doi" : "https://doi.org/10.1234/nulla",
-  "link" : "https://www.example.org/autillo",
+  "handle" : "https://www.example.org/dolorumvoluptates",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/inciduntitaque",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XD1Wa3hQntobdEHKdX",
+    "mainTitle" : "d3oTqucQ6iK7LzOuJaZ",
     "alternativeTitles" : {
-      "en" : "eq6qa2DKs2N"
+      "no" : "Tqdxvb8Bzxrno8h1d2Y"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4evn5yIBeoOvAD",
-      "month" : "GpJUojDcPFfJsnieHP",
-      "day" : "Oy5A0aqmeWI"
+      "year" : "n3mgQaHkd05",
+      "month" : "ke25JoWyI6HKVEk",
+      "day" : "P4A8e5Q5fLM5kFBOrYM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/6uAC9O7IAoScYy7",
-        "name" : "kcYgMRlmPiDHV",
-        "nameType" : "Organizational",
-        "orcId" : "IQxVx51U1N"
+        "id" : "https://www.example.com/bAoHgqxe6RHLnHZV",
+        "name" : "sZR7hjcUGf8u",
+        "nameType" : "Personal",
+        "orcId" : "j5KvidjonWTlz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VYp97952afyXUMkm3Ex",
+        "id" : "https://www.example.com/65QhNXJndeQb8o",
         "labels" : {
-          "andF1yjIzaQiBnbMJ" : "gKlzYBD7MNQXmIC"
+          "QROBBmv22S" : "Q7juxKYnrf3"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 2,
+      "role" : "ArchitecturalPlanner",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DPkSn3O33ygKzyXxsT",
-        "name" : "86SDMRomJ53I",
+        "id" : "https://www.example.com/WejmCEDi6kPMvEQn",
+        "name" : "aEqWM6JgItP5TH5APe",
         "nameType" : "Personal",
-        "orcId" : "C9Fk8ImCkPm"
+        "orcId" : "WToeC1KigYSoKA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/rdUZg1QOUmB",
+        "id" : "https://www.example.com/HKOeIByIoSWm",
         "labels" : {
-          "3ANZ8WS7lbnby" : "EO0bKLTAdnSE"
+          "v68K0hvKTf20fjpVGR" : "7scdIE14ZAa2asv"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 4,
+      "role" : "Consultant",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "OQRCrVNyrUzZ2vhjIyz",
-    "tags" : [ "blsjip3FidSOIKbqoW" ],
-    "description" : "uPVijA9TRvd28De8",
+    "npiSubjectHeading" : "FFE5B4ejHoyEaQHdc",
+    "tags" : [ "h3oC4hDSQNH" ],
+    "description" : "TwZxxVjae3iDahW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iSEXoc56AtPaicu"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Trk4uXwz4MToqalOX"
         },
-        "seriesNumber" : "wYtEnt9EpN",
+        "seriesNumber" : "vSPoKksIkEYpTLqPIf",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cgFdwbr6QnxLA8xP"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/oHMQJAZyvoGUI"
         },
-        "isbnList" : [ "9781084344396" ]
+        "isbnList" : [ "9781001248417" ]
       },
-      "doi" : "https://www.example.com/CbxLjJdZF6ly1F9oD5",
+      "doi" : "https://www.example.com/8Ck1PQ6VG7xYl1BzlZ",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "eiMMpiZEwJl9ph1",
-            "end" : "MG6fTLbNXTP5sapKFl"
+            "begin" : "FKQz3gdY6SMfdQB3Lds",
+            "end" : "nUMfLzzLfkdvO"
           },
-          "pages" : "btiEUX9WjbhfLZeO",
+          "pages" : "Tu0W8TfmTJuK3tQ37y",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/tXh3yXuaZJI",
-    "abstract" : "X7SmNeUFxoX"
+    "metadataSource" : "https://www.example.com/gbThZfTHuaJ",
+    "abstract" : "4KnCWt2gE5kQnm2HE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cupiditateet",
-    "name" : "Z7eXWKbf6O",
+    "id" : "https://www.example.org/occaecatialiquam",
+    "name" : "65F8mRPL88l4a1hfbk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "JxeF5t97q7v0ec3WCOR",
-      "id" : "Hmp3Mr77xGPV"
+      "source" : "pWjqik6Y7V1ji1vGNQ",
+      "id" : "6tmcPyiB0A"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "dFVbE4M0FIRCHd"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "HuRs7ejxqdSqU8f"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autemdolorum" ],
+  "subjects" : [ "https://www.example.org/saepecumque" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "j6lTku6vMyXtITU",
-      "mimeType" : "FQoYjbDuul",
-      "size" : 23113675,
+      "name" : "DIF6zmSUxDqDZN6OtN",
+      "mimeType" : "zBIRHUc20b4Y7j",
+      "size" : 934236227,
       "license" : {
         "type" : "License",
-        "identifier" : "LpxGtiUdRtMwC",
+        "identifier" : "OUFIqDF2YYQ",
         "labels" : {
-          "5MFLSxL8iOp7SvtL" : "kcca6JouMfTFxGidHQg"
+          "YYRoUSYunnAaEi" : "0WEuNe3h57AY5VjE"
         },
-        "link" : "https://www.example.com/ql9qsQSEu2"
+        "link" : "https://www.example.com/xoObfkLshZTGPHrh30"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "j6lTku6vMyXtITU",
-    "mimeType" : "FQoYjbDuul",
-    "size" : 23113675,
+    "name" : "DIF6zmSUxDqDZN6OtN",
+    "mimeType" : "zBIRHUc20b4Y7j",
+    "size" : 934236227,
     "license" : {
       "type" : "License",
-      "identifier" : "LpxGtiUdRtMwC",
+      "identifier" : "OUFIqDF2YYQ",
       "labels" : {
-        "5MFLSxL8iOp7SvtL" : "kcca6JouMfTFxGidHQg"
+        "YYRoUSYunnAaEi" : "0WEuNe3h57AY5VjE"
       },
-      "link" : "https://www.example.com/ql9qsQSEu2"
+      "link" : "https://www.example.com/xoObfkLshZTGPHrh30"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "nxqVoOBAOcUN9RqUtCE",
+  "owner" : "sMs3zfTGmhW4Egs5",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -3,127 +3,127 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "sMs3zfTGmhW4Egs5",
-    "ownerAffiliation" : "https://www.example.org/doloribusa"
+    "owner" : "KyragJY6DSfTnyR",
+    "ownerAffiliation" : "https://www.example.org/delenitiaccusantium"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quimolestias",
+    "id" : "https://www.example.org/commodiut",
     "labels" : {
-      "D7o6FhcDpMg8v" : "Wks5WWMpfcUTVPSOoi"
+      "j8d2MyFnEwyX1ua68" : "LEB3IwmJc6ai6hM"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolorumvoluptates",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/inciduntitaque",
+  "handle" : "https://www.example.org/aperiamaspernatur",
+  "doi" : "https://doi.org/10.1234/voluptates",
+  "link" : "https://www.example.org/doloremqui",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "d3oTqucQ6iK7LzOuJaZ",
+    "mainTitle" : "LJSBtWHtg6886",
     "alternativeTitles" : {
-      "no" : "Tqdxvb8Bzxrno8h1d2Y"
+      "en" : "KCEwb3nUOBXgsxKM8f"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "n3mgQaHkd05",
-      "month" : "ke25JoWyI6HKVEk",
-      "day" : "P4A8e5Q5fLM5kFBOrYM"
+      "year" : "wrJGy5A7rUmoP",
+      "month" : "CK58M9fueAx3zrw",
+      "day" : "qiObGWa6mPZzmVujcw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/bAoHgqxe6RHLnHZV",
-        "name" : "sZR7hjcUGf8u",
-        "nameType" : "Personal",
-        "orcId" : "j5KvidjonWTlz"
+        "id" : "https://www.example.com/jX6pq3Vmppc6A",
+        "name" : "HBkjvfmjaMo99j",
+        "nameType" : "Organizational",
+        "orcId" : "MU8GvKHO8PI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/65QhNXJndeQb8o",
+        "id" : "https://www.example.com/olSB1o0wuYRft9",
         "labels" : {
-          "QROBBmv22S" : "Q7juxKYnrf3"
+          "8Kd5EtrpZNkWQ6FheV5" : "AVL1C0PgcRDjZ5E7"
         }
       } ],
-      "role" : "ArchitecturalPlanner",
-      "sequence" : 4,
+      "role" : "ArtisticDirector",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WejmCEDi6kPMvEQn",
-        "name" : "aEqWM6JgItP5TH5APe",
+        "id" : "https://www.example.com/sRGVOQ5PUsL",
+        "name" : "zzXk5Pn4QVakoe",
         "nameType" : "Personal",
-        "orcId" : "WToeC1KigYSoKA"
+        "orcId" : "gIzJR6wEdFhlbkNR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/HKOeIByIoSWm",
+        "id" : "https://www.example.com/M5q93Nq8bVw3sNy3k",
         "labels" : {
-          "v68K0hvKTf20fjpVGR" : "7scdIE14ZAa2asv"
+          "2sgoTrQoLX9wKK" : "PLW16sUlMDVPBT"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 0,
+      "role" : "Director",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "FFE5B4ejHoyEaQHdc",
-    "tags" : [ "h3oC4hDSQNH" ],
-    "description" : "TwZxxVjae3iDahW",
+    "npiSubjectHeading" : "NDfBBK6akzzto52",
+    "tags" : [ "mvlz6LVo5r" ],
+    "description" : "NA8EiiRpHzhQmOXyi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Trk4uXwz4MToqalOX"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/oKLGBjUv0zOC1g0K"
         },
-        "seriesNumber" : "vSPoKksIkEYpTLqPIf",
+        "seriesNumber" : "WvAG1rIXs0QHAoG4D",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/oHMQJAZyvoGUI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OszHmNBQHLdxXlk"
         },
-        "isbnList" : [ "9781001248417" ]
+        "isbnList" : [ "9781964402994" ]
       },
-      "doi" : "https://www.example.com/8Ck1PQ6VG7xYl1BzlZ",
+      "doi" : "https://www.example.com/JaaDyl910Y0hkpr",
       "publicationInstance" : {
         "type" : "BookAnthology",
-        "peerReviewed" : false,
+        "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "FKQz3gdY6SMfdQB3Lds",
-            "end" : "nUMfLzzLfkdvO"
+            "begin" : "bi94mMlzvbkZNBWG",
+            "end" : "VsANsFLY4yB7"
           },
-          "pages" : "Tu0W8TfmTJuK3tQ37y",
-          "illustrated" : false
+          "pages" : "Dw0DzZIsBTPADqJ",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/gbThZfTHuaJ",
-    "abstract" : "4KnCWt2gE5kQnm2HE"
+    "metadataSource" : "https://www.example.com/0h8nQveVToFEDQ",
+    "abstract" : "7Tslkg0jpHlwxCHHyuI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/occaecatialiquam",
-    "name" : "65F8mRPL88l4a1hfbk",
+    "id" : "https://www.example.org/voluptatibusquia",
+    "name" : "U55rRmX9efBXUywb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "pWjqik6Y7V1ji1vGNQ",
-      "id" : "6tmcPyiB0A"
+      "source" : "Q8tecAAyG0jbG0hM4",
+      "id" : "xLekuVkPKncGEQQp9bp"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "HuRs7ejxqdSqU8f"
+      "applicationCode" : "A0eEw013Uz0NrBzlAq"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/saepecumque" ],
+  "subjects" : [ "https://www.example.org/autrepellendus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "DIF6zmSUxDqDZN6OtN",
-      "mimeType" : "zBIRHUc20b4Y7j",
-      "size" : 934236227,
+      "name" : "SqIXUkbH4weK",
+      "mimeType" : "co11LxDBzJRe",
+      "size" : 341127561,
       "license" : {
         "type" : "License",
-        "identifier" : "OUFIqDF2YYQ",
+        "identifier" : "fVzYzuHLWlJua",
         "labels" : {
-          "YYRoUSYunnAaEi" : "0WEuNe3h57AY5VjE"
+          "Y48W68PtVLOj" : "aHde6JpZxPH"
         },
-        "link" : "https://www.example.com/xoObfkLshZTGPHrh30"
+        "link" : "https://www.example.com/tSTRQxSP7xT3kttT1"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "DIF6zmSUxDqDZN6OtN",
-    "mimeType" : "zBIRHUc20b4Y7j",
-    "size" : 934236227,
+    "name" : "SqIXUkbH4weK",
+    "mimeType" : "co11LxDBzJRe",
+    "size" : 341127561,
     "license" : {
       "type" : "License",
-      "identifier" : "OUFIqDF2YYQ",
+      "identifier" : "fVzYzuHLWlJua",
       "labels" : {
-        "YYRoUSYunnAaEi" : "0WEuNe3h57AY5VjE"
+        "Y48W68PtVLOj" : "aHde6JpZxPH"
       },
-      "link" : "https://www.example.com/xoObfkLshZTGPHrh30"
+      "link" : "https://www.example.com/tSTRQxSP7xT3kttT1"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "sMs3zfTGmhW4Egs5",
+  "owner" : "KyragJY6DSfTnyR",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,129 +1,129 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "EgupAYLuqx",
-    "ownerAffiliation" : "https://www.example.org/officiaminus"
+    "owner" : "nxqVoOBAOcUN9RqUtCE",
+    "ownerAffiliation" : "https://www.example.org/eteaque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/enimfacilis",
+    "id" : "https://www.example.org/quisvoluptatibus",
     "labels" : {
-      "ny8Oe3iPlwnt" : "nrmcFRmx3Shj5sg4kp"
+      "5MiQfWxz2x4" : "CFzY51eRh2sCxmaosEy"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiaillum",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/necessitatibusreprehenderit",
+  "handle" : "https://www.example.org/etasperiores",
+  "doi" : "https://doi.org/10.1234/nulla",
+  "link" : "https://www.example.org/autillo",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vd5uVyDpQc3yZ",
+    "mainTitle" : "XD1Wa3hQntobdEHKdX",
     "alternativeTitles" : {
-      "ca" : "Xfql4ITb7tMaPTF"
+      "en" : "eq6qa2DKs2N"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "I9P3Cy5bzFoaNXXgVnW",
-      "month" : "sO8ODsC3HSZkoNu",
-      "day" : "UgAFn32nip"
+      "year" : "4evn5yIBeoOvAD",
+      "month" : "GpJUojDcPFfJsnieHP",
+      "day" : "Oy5A0aqmeWI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/W3gzonbnINvgT7",
-        "name" : "6G0WZC4SP7Zp2cCu",
+        "id" : "https://www.example.com/6uAC9O7IAoScYy7",
+        "name" : "kcYgMRlmPiDHV",
         "nameType" : "Organizational",
-        "orcId" : "z1nU8v3Dll2t"
+        "orcId" : "IQxVx51U1N"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/w07dDb9SfX1AHWpl",
+        "id" : "https://www.example.com/VYp97952afyXUMkm3Ex",
         "labels" : {
-          "8w4SYCkjF8z" : "DGL7KUBIVszF3IuF"
+          "andF1yjIzaQiBnbMJ" : "gKlzYBD7MNQXmIC"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 0,
+      "role" : "ProjectMember",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OEnj4lenXyO9jZ",
-        "name" : "U3is15TcHmmGW",
+        "id" : "https://www.example.com/DPkSn3O33ygKzyXxsT",
+        "name" : "86SDMRomJ53I",
         "nameType" : "Personal",
-        "orcId" : "Yft9YZdJ2aPPLfM9"
+        "orcId" : "C9Fk8ImCkPm"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/sNtzjGQzGW9",
+        "id" : "https://www.example.com/rdUZg1QOUmB",
         "labels" : {
-          "0OsAfBNFQj9LY8ZH6s" : "IoU9iuFdQc8XZGgTH"
+          "3ANZ8WS7lbnby" : "EO0bKLTAdnSE"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 8,
+      "role" : "Funder",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ua9xP2NlGCkbpzrxk6c",
-    "tags" : [ "pNIEQRqgVFUY5h2" ],
-    "description" : "XcuKgiyHNODQVcoK",
+    "npiSubjectHeading" : "OQRCrVNyrUzZ2vhjIyz",
+    "tags" : [ "blsjip3FidSOIKbqoW" ],
+    "description" : "uPVijA9TRvd28De8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Yo8v5Fdz41hHXfW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iSEXoc56AtPaicu"
         },
-        "seriesNumber" : "HMpOQvYRMF56yml",
+        "seriesNumber" : "wYtEnt9EpN",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cFWdS3j7vr5VN7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cgFdwbr6QnxLA8xP"
         },
-        "isbnList" : [ "9780896042407" ]
+        "isbnList" : [ "9781084344396" ]
       },
-      "doi" : "https://www.example.com/E2ieqmM3gjZL",
+      "doi" : "https://www.example.com/CbxLjJdZF6ly1F9oD5",
       "publicationInstance" : {
         "type" : "BookAnthology",
-        "peerReviewed" : true,
+        "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "o9FPmO4kgV9M7fi",
-            "end" : "cjRCepykQFf4Crfh10l"
+            "begin" : "eiMMpiZEwJl9ph1",
+            "end" : "MG6fTLbNXTP5sapKFl"
           },
-          "pages" : "71OXmQDcbFVQOInF",
+          "pages" : "btiEUX9WjbhfLZeO",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/v6DKX4gTkm7YRmiSw",
-    "abstract" : "WG5sXJvsE6qZJnOcyN"
+    "metadataSource" : "https://www.example.com/tXh3yXuaZJI",
+    "abstract" : "X7SmNeUFxoX"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/animimodi",
-    "name" : "8PU5ZycLKTS88LODQ",
+    "id" : "https://www.example.org/cupiditateet",
+    "name" : "Z7eXWKbf6O",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "sUkw8LRXcSykhi41kCS",
-      "id" : "aXJcjhTgz6hqJz"
+      "source" : "JxeF5t97q7v0ec3WCOR",
+      "id" : "Hmp3Mr77xGPV"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "19zZIf7QqK"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "dFVbE4M0FIRCHd"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/perspiciatisnatus" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "SQ5ZI9m6GTCtt",
-    "mimeType" : "0NcsfNiBjp20ztuD85",
-    "size" : 475775565,
-    "license" : {
-      "type" : "License",
-      "identifier" : "JkeNaCkZ3Nevmv",
-      "labels" : {
-        "6OKIDRywdd1rEL" : "ka6Tn0IL6YT"
-      },
-      "link" : "https://www.example.com/a8edP6oeBjA"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/autemdolorum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "SQ5ZI9m6GTCtt",
-      "mimeType" : "0NcsfNiBjp20ztuD85",
-      "size" : 475775565,
+      "name" : "j6lTku6vMyXtITU",
+      "mimeType" : "FQoYjbDuul",
+      "size" : 23113675,
       "license" : {
         "type" : "License",
-        "identifier" : "JkeNaCkZ3Nevmv",
+        "identifier" : "LpxGtiUdRtMwC",
         "labels" : {
-          "6OKIDRywdd1rEL" : "ka6Tn0IL6YT"
+          "5MFLSxL8iOp7SvtL" : "kcca6JouMfTFxGidHQg"
         },
-        "link" : "https://www.example.com/a8edP6oeBjA"
+        "link" : "https://www.example.com/ql9qsQSEu2"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "EgupAYLuqx",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "j6lTku6vMyXtITU",
+    "mimeType" : "FQoYjbDuul",
+    "size" : 23113675,
+    "license" : {
+      "type" : "License",
+      "identifier" : "LpxGtiUdRtMwC",
+      "labels" : {
+        "5MFLSxL8iOp7SvtL" : "kcca6JouMfTFxGidHQg"
+      },
+      "link" : "https://www.example.com/ql9qsQSEu2"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "nxqVoOBAOcUN9RqUtCE",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "e7q5ZSmAp4wbzp4MOpY",
-    "ownerAffiliation" : "https://www.example.org/voluptatumdolorem"
+    "owner" : "EgupAYLuqx",
+    "ownerAffiliation" : "https://www.example.org/officiaminus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/mollitiaperferendis",
+    "id" : "https://www.example.org/enimfacilis",
     "labels" : {
-      "rdRCBbhAfIiyd" : "XMZ13mmXh5UtYzO"
+      "ny8Oe3iPlwnt" : "nrmcFRmx3Shj5sg4kp"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sintminima",
-  "doi" : "https://doi.org/10.1234/laboriosam",
-  "link" : "https://www.example.org/vitaeaut",
+  "handle" : "https://www.example.org/quiaillum",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/necessitatibusreprehenderit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "o85bARoVacpopsgL",
+    "mainTitle" : "vd5uVyDpQc3yZ",
     "alternativeTitles" : {
-      "pl" : "D9dNrqlCrWOZcjPP"
+      "ca" : "Xfql4ITb7tMaPTF"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "lxBP6IV3nedCtt",
-      "month" : "RtEqg53vJutSL72w",
-      "day" : "LSxfwDKWuGIcHcgB"
+      "year" : "I9P3Cy5bzFoaNXXgVnW",
+      "month" : "sO8ODsC3HSZkoNu",
+      "day" : "UgAFn32nip"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/83m15o2DtmHliYq3rHx",
-        "name" : "QQUfypEBmpbwg",
+        "id" : "https://www.example.com/W3gzonbnINvgT7",
+        "name" : "6G0WZC4SP7Zp2cCu",
         "nameType" : "Organizational",
-        "orcId" : "AnJraqPqSdnwaSR3"
+        "orcId" : "z1nU8v3Dll2t"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/HWpNpttElGU",
+        "id" : "https://www.example.com/w07dDb9SfX1AHWpl",
         "labels" : {
-          "cjXxSw2yAFTBbLF" : "TqzueXqBJBFKDH"
+          "8w4SYCkjF8z" : "DGL7KUBIVszF3IuF"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 2,
+      "role" : "Researcher",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/2rkXKQvHWIFxYlt",
-        "name" : "fyUYrX3QSpYOfV",
+        "id" : "https://www.example.com/OEnj4lenXyO9jZ",
+        "name" : "U3is15TcHmmGW",
         "nameType" : "Personal",
-        "orcId" : "aItsDtXKxj1"
+        "orcId" : "Yft9YZdJ2aPPLfM9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mQCpbBOSpX2dVDb",
+        "id" : "https://www.example.com/sNtzjGQzGW9",
         "labels" : {
-          "UfHPokhE1dmiN0VRy" : "lpWVowmBWrtsQ3QFZNI"
+          "0OsAfBNFQj9LY8ZH6s" : "IoU9iuFdQc8XZGgTH"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 7,
+      "role" : "RegistrationAgency",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NMpBKbNuuTpZc",
-    "tags" : [ "U8n7udPOA9hwfK3GOl" ],
-    "description" : "XbKXWJsM3fAPPo",
+    "npiSubjectHeading" : "ua9xP2NlGCkbpzrxk6c",
+    "tags" : [ "pNIEQRqgVFUY5h2" ],
+    "description" : "XcuKgiyHNODQVcoK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/54LLr5zWLRiD"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Yo8v5Fdz41hHXfW"
         },
-        "seriesNumber" : "R2H1A5eK3cEO5NEg",
+        "seriesNumber" : "HMpOQvYRMF56yml",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kvRqs47476"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cFWdS3j7vr5VN7"
         },
-        "isbnList" : [ "9790093979567" ]
+        "isbnList" : [ "9780896042407" ]
       },
-      "doi" : "https://www.example.com/A6LasEIc8S",
+      "doi" : "https://www.example.com/E2ieqmM3gjZL",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "peerReviewed" : true,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "IlDDivnwwQUYuZ",
-            "end" : "r4kjKNzAxSoYGq"
+            "begin" : "o9FPmO4kgV9M7fi",
+            "end" : "cjRCepykQFf4Crfh10l"
           },
-          "pages" : "qerHnoU6UHPYMlUb1PK",
+          "pages" : "71OXmQDcbFVQOInF",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/d8Qy9soGDPHszb",
-    "abstract" : "Grk1ilNn2ok"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bTSuI3j7bSKDn7TIL",
-      "mimeType" : "WnOKCKUJHTyw5S",
-      "size" : 1520521657,
-      "license" : {
-        "type" : "License",
-        "identifier" : "filE89CynKnmleo72D2",
-        "labels" : {
-          "qpHPn3U2CY" : "cKpbDwDKB6WjK"
-        },
-        "link" : "https://www.example.com/hW9yHVpQkzyY"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/v6DKX4gTkm7YRmiSw",
+    "abstract" : "WG5sXJvsE6qZJnOcyN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ameteligendi",
-    "name" : "1S3mVyj2CZOfd47",
+    "id" : "https://www.example.org/animimodi",
+    "name" : "8PU5ZycLKTS88LODQ",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Z6K9a8qmRS",
-      "id" : "nXZeRZ1KOlE2rCY"
+      "source" : "sUkw8LRXcSykhi41kCS",
+      "id" : "aXJcjhTgz6hqJz"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "BDYLxwFaQtQlD3oGZ"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "19zZIf7QqK"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatibuslaudantium" ],
+  "subjects" : [ "https://www.example.org/perspiciatisnatus" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bTSuI3j7bSKDn7TIL",
-    "mimeType" : "WnOKCKUJHTyw5S",
-    "size" : 1520521657,
+    "name" : "SQ5ZI9m6GTCtt",
+    "mimeType" : "0NcsfNiBjp20ztuD85",
+    "size" : 475775565,
     "license" : {
       "type" : "License",
-      "identifier" : "filE89CynKnmleo72D2",
+      "identifier" : "JkeNaCkZ3Nevmv",
       "labels" : {
-        "qpHPn3U2CY" : "cKpbDwDKB6WjK"
+        "6OKIDRywdd1rEL" : "ka6Tn0IL6YT"
       },
-      "link" : "https://www.example.com/hW9yHVpQkzyY"
+      "link" : "https://www.example.com/a8edP6oeBjA"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "e7q5ZSmAp4wbzp4MOpY"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "SQ5ZI9m6GTCtt",
+      "mimeType" : "0NcsfNiBjp20ztuD85",
+      "size" : 475775565,
+      "license" : {
+        "type" : "License",
+        "identifier" : "JkeNaCkZ3Nevmv",
+        "labels" : {
+          "6OKIDRywdd1rEL" : "ka6Tn0IL6YT"
+        },
+        "link" : "https://www.example.com/a8edP6oeBjA"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "EgupAYLuqx",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,131 +1,131 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "WJsDHTUd6dIBHrj",
-    "ownerAffiliation" : "https://www.example.org/corporismagnam"
+    "owner" : "suj4cNQVGCYu68UoA",
+    "ownerAffiliation" : "https://www.example.org/sapientecorrupti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/illumfacere",
+    "id" : "https://www.example.org/quosrepudiandae",
     "labels" : {
-      "gEorZAaNM6QqT" : "DKn4p8EK1h7I"
+      "SznccZqzDWV6HtRh4Zz" : "ng3NDjG4Isr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suntharum",
-  "doi" : "https://doi.org/10.1234/expedita",
-  "link" : "https://www.example.org/sapienteaut",
+  "handle" : "https://www.example.org/maximemolestiae",
+  "doi" : "https://doi.org/10.1234/quidem",
+  "link" : "https://www.example.org/atqueincidunt",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bUup8aD1enxjm0gjQ",
+    "mainTitle" : "m7OH8ZNOM48Bijt7",
     "alternativeTitles" : {
-      "de" : "QzocCDEweCM9"
+      "da" : "YEwfKkBJVni"
     },
     "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ulwsNtezJ2tvBYh",
-      "month" : "ljkRjtGWBBWyval",
-      "day" : "h5SuAX0owqm"
+      "year" : "3HCMZ35DyJc4V",
+      "month" : "IyccFvrRRdQU",
+      "day" : "beRDjZxbvOXfQqS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hpHy1Wd3hpo",
-        "name" : "8oxlFiyGCQ7Kt3lX",
-        "nameType" : "Personal",
-        "orcId" : "IUBSlQPia3230QUYziN"
+        "id" : "https://www.example.com/N6SYyOL50cue",
+        "name" : "gJcykdaHM8dgiXBd",
+        "nameType" : "Organizational",
+        "orcId" : "Z80RZ28t2twHtWdKAiy"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xSXZUJ7BaYM31Xgn",
+        "id" : "https://www.example.com/1nOS1Cq52WzE8hG0nJ",
         "labels" : {
-          "apafqpkml4DiGOdOT" : "AkZLUnppju7MH4"
+          "QlRcI8lz3oCBbVs" : "nUpRMsC7xnWP"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 7,
+      "role" : "Conductor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/X4PIYrgvoub4XK27uZ",
-        "name" : "fmtCWPdrI1PwW73D8",
-        "nameType" : "Organizational",
-        "orcId" : "XuUpgTt23thvKYfIUOK"
+        "id" : "https://www.example.com/OgwOiroIlxog2Q",
+        "name" : "vmUZIOaRpvOxQU9T",
+        "nameType" : "Personal",
+        "orcId" : "XqoiGC7Uusevb0KbmXV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zRyHhztxVB",
+        "id" : "https://www.example.com/tFN6xM0S3oPpth68",
         "labels" : {
-          "sLIZ8tFnKn4mO" : "48F5qC4Uaqz1oulzE"
+          "eqEnBPLYbNRCkYFbzN" : "9jym0cb0YuDc64YwV"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 5,
+      "role" : "RegistrationAuthority",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "jZDP5tPaKLzl",
-    "tags" : [ "fmkE7cApKd6iH3x" ],
-    "description" : "1JA9VvEyJSPz9qb4Efw",
+    "npiSubjectHeading" : "w9BV92LN0T",
+    "tags" : [ "D65tTQZ022t" ],
+    "description" : "Nb8um8F6wm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rHfdfHSlP3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/NPHmTp26GC2TEIqP81"
         },
-        "seriesNumber" : "CdGQQzOFCucIUV",
+        "seriesNumber" : "p4omMbUQ6FgH2",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8PkWbWkPOjY"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8s14kB0VkPog"
         },
-        "isbnList" : [ "9791869932687" ]
+        "isbnList" : [ "9780069288540" ]
       },
-      "doi" : "https://www.example.com/cGNfUg5MeKKAhHY7mX",
+      "doi" : "https://www.example.com/vS5h3qwljZcmA2fJ",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Encyclopedia",
+        "contentType" : "PopularScienceMonograph",
         "originalResearch" : false,
-        "peerReviewed" : true,
+        "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "oQoVY14FBf1MIA1We",
-            "end" : "eJWWpbbJIF0"
+            "begin" : "PJ04mtTq5Qx7eRZ3F",
+            "end" : "8VYPSAfgF7kHuw"
           },
-          "pages" : "Z1VCn3vGDY",
-          "illustrated" : false
+          "pages" : "c2KbpiJwSuK",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/bKSl8QXKSa4",
-    "abstract" : "62Zjzkyw54"
+    "metadataSource" : "https://www.example.com/FtOkbTgJyY",
+    "abstract" : "oBVmmWT4YA3LLvCTzb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ameta",
-    "name" : "mcNa4StNFKj8tsxDsy5",
+    "id" : "https://www.example.org/utdolor",
+    "name" : "GFr4AjEKuGbpJFto",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6GbjU1pnwIte8q",
-      "id" : "wqQqTXgnHLg1Q2Ib4Y1"
+      "source" : "T1r27Ci3QMmk",
+      "id" : "J9oBZypgj7e"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "pdNoTBKyMr"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "pVpHLhA79z1"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,22 +133,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatemvoluptatem" ],
+  "subjects" : [ "https://www.example.org/aliquamipsa" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "atO8VZ1Gcsln",
-      "mimeType" : "9ApwKD6tt2Fl",
-      "size" : 2034186754,
+      "name" : "F9dpOMOvWebzikLmrV",
+      "mimeType" : "8vFEB6IKxC4T7IYjdG",
+      "size" : 529664027,
       "license" : {
         "type" : "License",
-        "identifier" : "NFKjUgHfZ5r54hgBozV",
+        "identifier" : "cHaJvQO9G7I4w3",
         "labels" : {
-          "eZUqo7H8sVnjrDd9T5" : "6aNIAI1ZxU1qYaXg"
+          "CIelpPSajhOFSX8bIi4" : "TabANYGiz2KD7"
         },
-        "link" : "https://www.example.com/XXX8gMKKLNjwlM"
+        "link" : "https://www.example.com/KTvnr46G72ZQWRU"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -158,21 +158,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "atO8VZ1Gcsln",
-    "mimeType" : "9ApwKD6tt2Fl",
-    "size" : 2034186754,
+    "name" : "F9dpOMOvWebzikLmrV",
+    "mimeType" : "8vFEB6IKxC4T7IYjdG",
+    "size" : 529664027,
     "license" : {
       "type" : "License",
-      "identifier" : "NFKjUgHfZ5r54hgBozV",
+      "identifier" : "cHaJvQO9G7I4w3",
       "labels" : {
-        "eZUqo7H8sVnjrDd9T5" : "6aNIAI1ZxU1qYaXg"
+        "CIelpPSajhOFSX8bIi4" : "TabANYGiz2KD7"
       },
-      "link" : "https://www.example.com/XXX8gMKKLNjwlM"
+      "link" : "https://www.example.com/KTvnr46G72ZQWRU"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "WJsDHTUd6dIBHrj",
+  "owner" : "suj4cNQVGCYu68UoA",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -3,129 +3,129 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "8k1pz3hzorX",
-    "ownerAffiliation" : "https://www.example.org/temporibuscum"
+    "owner" : "WJsDHTUd6dIBHrj",
+    "ownerAffiliation" : "https://www.example.org/corporismagnam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/estipsam",
+    "id" : "https://www.example.org/illumfacere",
     "labels" : {
-      "CoYu4UXp7o8lC7XW3A5" : "c5Yfq777413"
+      "gEorZAaNM6QqT" : "DKn4p8EK1h7I"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "publishedDate" : "1990-09-20T05:36:47Z",
+  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ullamest",
-  "doi" : "https://doi.org/10.1234/amet",
-  "link" : "https://www.example.org/praesentiumdicta",
+  "handle" : "https://www.example.org/suntharum",
+  "doi" : "https://doi.org/10.1234/expedita",
+  "link" : "https://www.example.org/sapienteaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lUQxbrsYTmA",
+    "mainTitle" : "bUup8aD1enxjm0gjQ",
     "alternativeTitles" : {
-      "it" : "uLi2KkxpYt5CPPsHL8"
+      "de" : "QzocCDEweCM9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AaONtzOBcBCLCXoe70",
-      "month" : "phAENelpIH1ZWZRGxb",
-      "day" : "AGqm29TfNUHVyF"
+      "year" : "ulwsNtezJ2tvBYh",
+      "month" : "ljkRjtGWBBWyval",
+      "day" : "h5SuAX0owqm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HK9esc6U7N5lTq",
-        "name" : "sqWRT0ixgSYXqWixQZV",
+        "id" : "https://www.example.com/hpHy1Wd3hpo",
+        "name" : "8oxlFiyGCQ7Kt3lX",
         "nameType" : "Personal",
-        "orcId" : "LOaXG5ANhHuA"
+        "orcId" : "IUBSlQPia3230QUYziN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/kgVjzBJWbE0XFBssj",
+        "id" : "https://www.example.com/xSXZUJ7BaYM31Xgn",
         "labels" : {
-          "issEtel5mIoUjAxG" : "5XSoBxrg9luOea0"
+          "apafqpkml4DiGOdOT" : "AkZLUnppju7MH4"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 3,
+      "role" : "Actor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cf5hPKWqQ4E",
-        "name" : "6WLtDjyeOjrtaR",
+        "id" : "https://www.example.com/X4PIYrgvoub4XK27uZ",
+        "name" : "fmtCWPdrI1PwW73D8",
         "nameType" : "Organizational",
-        "orcId" : "qUGg91N6YLK9ia1H"
+        "orcId" : "XuUpgTt23thvKYfIUOK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/m38u03n6Zy",
+        "id" : "https://www.example.com/zRyHhztxVB",
         "labels" : {
-          "XH3tF20tcw63WVBr" : "sppSVSjdCA"
+          "sLIZ8tFnKn4mO" : "48F5qC4Uaqz1oulzE"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 6,
+      "role" : "Producer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rC5eUUlhzsFxTNn",
-    "tags" : [ "OuNKRCg3w9IrTVR" ],
-    "description" : "pOY6BCCUqQLppnx",
+    "npiSubjectHeading" : "jZDP5tPaKLzl",
+    "tags" : [ "fmkE7cApKd6iH3x" ],
+    "description" : "1JA9VvEyJSPz9qb4Efw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/WEypMnMbFN6JTzBBG"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rHfdfHSlP3"
         },
-        "seriesNumber" : "NEykoT8CbRfjW",
+        "seriesNumber" : "CdGQQzOFCucIUV",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MIYOASLqriJ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8PkWbWkPOjY"
         },
-        "isbnList" : [ "9781850928751" ]
+        "isbnList" : [ "9791869932687" ]
       },
-      "doi" : "https://www.example.com/O6W1s4PSIu",
+      "doi" : "https://www.example.com/cGNfUg5MeKKAhHY7mX",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Textbook",
+        "contentType" : "Encyclopedia",
         "originalResearch" : false,
-        "peerReviewed" : false,
+        "peerReviewed" : true,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "08l0Twz96VoUIFd5Rt",
-            "end" : "O8j6mwaec2Q"
+            "begin" : "oQoVY14FBf1MIA1We",
+            "end" : "eJWWpbbJIF0"
           },
-          "pages" : "rd4gi19qoKBTY",
-          "illustrated" : true
+          "pages" : "Z1VCn3vGDY",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/hvBPosqvXC",
-    "abstract" : "zBHGppTQTlYvM"
+    "metadataSource" : "https://www.example.com/bKSl8QXKSa4",
+    "abstract" : "62Zjzkyw54"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequaturperspiciatis",
-    "name" : "2W1QlBkAXM",
+    "id" : "https://www.example.org/ameta",
+    "name" : "mcNa4StNFKj8tsxDsy5",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "M6yjm2JrYnUM",
-      "id" : "VmdEZxu5Xw9N3OMX"
+      "source" : "6GbjU1pnwIte8q",
+      "id" : "wqQqTXgnHLg1Q2Ib4Y1"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zdOZSm6GNC3B7u0uB"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "pdNoTBKyMr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nihildoloremque" ],
+  "subjects" : [ "https://www.example.org/voluptatemvoluptatem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "EZMeqSWoV4MC5OJ6w",
-      "mimeType" : "JLfhpOz094SBU",
-      "size" : 339976062,
+      "name" : "atO8VZ1Gcsln",
+      "mimeType" : "9ApwKD6tt2Fl",
+      "size" : 2034186754,
       "license" : {
         "type" : "License",
-        "identifier" : "RhSlHSAjJWnvnn",
+        "identifier" : "NFKjUgHfZ5r54hgBozV",
         "labels" : {
-          "6cUHDuAPv3rAa" : "bxaF5zoP8shlJ30Lr"
+          "eZUqo7H8sVnjrDd9T5" : "6aNIAI1ZxU1qYaXg"
         },
-        "link" : "https://www.example.com/xDn7DokNQjl"
+        "link" : "https://www.example.com/XXX8gMKKLNjwlM"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "EZMeqSWoV4MC5OJ6w",
-    "mimeType" : "JLfhpOz094SBU",
-    "size" : 339976062,
+    "name" : "atO8VZ1Gcsln",
+    "mimeType" : "9ApwKD6tt2Fl",
+    "size" : 2034186754,
     "license" : {
       "type" : "License",
-      "identifier" : "RhSlHSAjJWnvnn",
+      "identifier" : "NFKjUgHfZ5r54hgBozV",
       "labels" : {
-        "6cUHDuAPv3rAa" : "bxaF5zoP8shlJ30Lr"
+        "eZUqo7H8sVnjrDd9T5" : "6aNIAI1ZxU1qYaXg"
       },
-      "link" : "https://www.example.com/xDn7DokNQjl"
+      "link" : "https://www.example.com/XXX8gMKKLNjwlM"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "8k1pz3hzorX",
+  "owner" : "WJsDHTUd6dIBHrj",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,131 +1,131 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "4ZWJSaSZOa",
-    "ownerAffiliation" : "https://www.example.org/etofficia"
+    "owner" : "8k1pz3hzorX",
+    "ownerAffiliation" : "https://www.example.org/temporibuscum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etconsequatur",
+    "id" : "https://www.example.org/estipsam",
     "labels" : {
-      "ttMkfThC6YkRzAukXWV" : "XC4fpTIaZm"
+      "CoYu4UXp7o8lC7XW3A5" : "c5Yfq777413"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
+  "publishedDate" : "1990-09-20T05:36:47Z",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/totamexpedita",
-  "doi" : "https://doi.org/10.1234/tenetur",
-  "link" : "https://www.example.org/aut",
+  "handle" : "https://www.example.org/ullamest",
+  "doi" : "https://doi.org/10.1234/amet",
+  "link" : "https://www.example.org/praesentiumdicta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jPED31itOpadphua",
+    "mainTitle" : "lUQxbrsYTmA",
     "alternativeTitles" : {
-      "nb" : "pqwPzkLFZ6"
+      "it" : "uLi2KkxpYt5CPPsHL8"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "rlgVjaGctC0",
-      "month" : "XWgJk9gROGPphOT",
-      "day" : "9q05ssXNPrTR1SgbJXW"
+      "year" : "AaONtzOBcBCLCXoe70",
+      "month" : "phAENelpIH1ZWZRGxb",
+      "day" : "AGqm29TfNUHVyF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/EvocZiw5FvVTsHcuf61",
-        "name" : "vivxjdX6lW",
+        "id" : "https://www.example.com/HK9esc6U7N5lTq",
+        "name" : "sqWRT0ixgSYXqWixQZV",
         "nameType" : "Personal",
-        "orcId" : "2W6hO7xXIPmHY1"
+        "orcId" : "LOaXG5ANhHuA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yGEs7MdynbC1",
+        "id" : "https://www.example.com/kgVjzBJWbE0XFBssj",
         "labels" : {
-          "aib95U946hDK7d" : "PONTKcUnrCTNqS6BG"
+          "issEtel5mIoUjAxG" : "5XSoBxrg9luOea0"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 9,
+      "role" : "ArtisticDirector",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/owkpt3CA2JT0Km",
-        "name" : "8qkHptWWny",
+        "id" : "https://www.example.com/cf5hPKWqQ4E",
+        "name" : "6WLtDjyeOjrtaR",
         "nameType" : "Organizational",
-        "orcId" : "usJ82L4NqF0fjJ"
+        "orcId" : "qUGg91N6YLK9ia1H"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/G2fl2nhT52e",
+        "id" : "https://www.example.com/m38u03n6Zy",
         "labels" : {
-          "8NlRdVch9Wv" : "3nDeDXuLlBkSbY1o8S"
+          "XH3tF20tcw63WVBr" : "sppSVSjdCA"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 8,
+      "role" : "RegistrationAgency",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YOzYfikEo8J612uw",
-    "tags" : [ "bzzBVdmCG9" ],
-    "description" : "J0a98R5TU6PMiNZ",
+    "npiSubjectHeading" : "rC5eUUlhzsFxTNn",
+    "tags" : [ "OuNKRCg3w9IrTVR" ],
+    "description" : "pOY6BCCUqQLppnx",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mQ8qh7jMgAFwOKiq"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/WEypMnMbFN6JTzBBG"
         },
-        "seriesNumber" : "HjkKeG2MtK0",
+        "seriesNumber" : "NEykoT8CbRfjW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZoISmKQCNfv"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MIYOASLqriJ"
         },
-        "isbnList" : [ "9780860201786" ]
+        "isbnList" : [ "9781850928751" ]
       },
-      "doi" : "https://www.example.com/xTu6GIsnhiWbOmOT",
+      "doi" : "https://www.example.com/O6W1s4PSIu",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "AcademicMonograph",
+        "contentType" : "Textbook",
         "originalResearch" : false,
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "aTxjpHSMM4yQSU2Jf8",
-            "end" : "JpX3FflJlPl5FS"
+            "begin" : "08l0Twz96VoUIFd5Rt",
+            "end" : "O8j6mwaec2Q"
           },
-          "pages" : "Ppi68rlx35",
-          "illustrated" : false
+          "pages" : "rd4gi19qoKBTY",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/vt9rlvixB2",
-    "abstract" : "5ZFXW3HjsgGziJhOXh"
+    "metadataSource" : "https://www.example.com/hvBPosqvXC",
+    "abstract" : "zBHGppTQTlYvM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/officiadoloribus",
-    "name" : "aWRtzKgycicnfa",
+    "id" : "https://www.example.org/consequaturperspiciatis",
+    "name" : "2W1QlBkAXM",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZVCrEQl5NKdfng9L0",
-      "id" : "JPUA0GeBgkFGP83"
+      "source" : "M6yjm2JrYnUM",
+      "id" : "VmdEZxu5Xw9N3OMX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "y6vafKgyV2bEv"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "zdOZSm6GNC3B7u0uB"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/architectoet" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "6TpfFmITDv17QEuWdb",
-    "mimeType" : "lHgX4T0DJMKQ",
-    "size" : 1785219874,
-    "license" : {
-      "type" : "License",
-      "identifier" : "LXItx0rCtvkfw8",
-      "labels" : {
-        "85ytw2sExiu2RH3BB" : "XuYg0PtwaOyb"
-      },
-      "link" : "https://www.example.com/Yz7eqOQVT8HpOpSI8"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/nihildoloremque" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "6TpfFmITDv17QEuWdb",
-      "mimeType" : "lHgX4T0DJMKQ",
-      "size" : 1785219874,
+      "name" : "EZMeqSWoV4MC5OJ6w",
+      "mimeType" : "JLfhpOz094SBU",
+      "size" : 339976062,
       "license" : {
         "type" : "License",
-        "identifier" : "LXItx0rCtvkfw8",
+        "identifier" : "RhSlHSAjJWnvnn",
         "labels" : {
-          "85ytw2sExiu2RH3BB" : "XuYg0PtwaOyb"
+          "6cUHDuAPv3rAa" : "bxaF5zoP8shlJ30Lr"
         },
-        "link" : "https://www.example.com/Yz7eqOQVT8HpOpSI8"
+        "link" : "https://www.example.com/xDn7DokNQjl"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "4ZWJSaSZOa",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "EZMeqSWoV4MC5OJ6w",
+    "mimeType" : "JLfhpOz094SBU",
+    "size" : 339976062,
+    "license" : {
+      "type" : "License",
+      "identifier" : "RhSlHSAjJWnvnn",
+      "labels" : {
+        "6cUHDuAPv3rAa" : "bxaF5zoP8shlJ30Lr"
+      },
+      "link" : "https://www.example.com/xDn7DokNQjl"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "8k1pz3hzorX",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/BookMonograph.json
+++ b/documentation/BookMonograph.json
@@ -1,152 +1,131 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "DgDUjEt06dwTYLl5h4",
-    "ownerAffiliation" : "https://www.example.org/voluptatibuseum"
+    "owner" : "4ZWJSaSZOa",
+    "ownerAffiliation" : "https://www.example.org/etofficia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiquis",
+    "id" : "https://www.example.org/etconsequatur",
     "labels" : {
-      "zWeoxFHTFQvlEnI" : "C9WNnjkW4uUFiRBD"
+      "ttMkfThC6YkRzAukXWV" : "XC4fpTIaZm"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quilibero",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/voluptatemid",
+  "handle" : "https://www.example.org/totamexpedita",
+  "doi" : "https://doi.org/10.1234/tenetur",
+  "link" : "https://www.example.org/aut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IDbdIhCsLqOI",
+    "mainTitle" : "jPED31itOpadphua",
     "alternativeTitles" : {
-      "ru" : "521g27uCrrv1a8Hz1cm"
+      "nb" : "pqwPzkLFZ6"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "x19ikFD5TQLcre9",
-      "month" : "edPoZQiYRuk2EgfcMr",
-      "day" : "E8XL4llWlga6PZXSI"
+      "year" : "rlgVjaGctC0",
+      "month" : "XWgJk9gROGPphOT",
+      "day" : "9q05ssXNPrTR1SgbJXW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/tnAKATiSzt",
-        "name" : "ulbOvgwXPpm5F",
+        "id" : "https://www.example.com/EvocZiw5FvVTsHcuf61",
+        "name" : "vivxjdX6lW",
         "nameType" : "Personal",
-        "orcId" : "qI2LJoOt0aqx9hO5q0p"
+        "orcId" : "2W6hO7xXIPmHY1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5M0Hnm2j4H37XFfY",
+        "id" : "https://www.example.com/yGEs7MdynbC1",
         "labels" : {
-          "15RFQixihyvNNhS05" : "dnkMbUCIit"
+          "aib95U946hDK7d" : "PONTKcUnrCTNqS6BG"
         }
       } ],
-      "role" : "Soloist",
-      "sequence" : 1,
+      "role" : "Other",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8LZdhuNcpMp",
-        "name" : "0AtuF7QZeXz",
+        "id" : "https://www.example.com/owkpt3CA2JT0Km",
+        "name" : "8qkHptWWny",
         "nameType" : "Organizational",
-        "orcId" : "QaJPSpWKa1WquuoJmu"
+        "orcId" : "usJ82L4NqF0fjJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5vL8HxsmcK6D129M",
+        "id" : "https://www.example.com/G2fl2nhT52e",
         "labels" : {
-          "EvuRMCWqEtc9tNrK" : "tv7xwpIiA8njaC0PdME"
+          "8NlRdVch9Wv" : "3nDeDXuLlBkSbY1o8S"
         }
       } ],
-      "role" : "Scenographer",
-      "sequence" : 6,
+      "role" : "Consultant",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YhuMemaKQEG07Rnu",
-    "tags" : [ "BjbGOrUFGNH4" ],
-    "description" : "sU8HE5w8V3Q",
+    "npiSubjectHeading" : "YOzYfikEo8J612uw",
+    "tags" : [ "bzzBVdmCG9" ],
+    "description" : "J0a98R5TU6PMiNZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cMJPngCpxu"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mQ8qh7jMgAFwOKiq"
         },
-        "seriesNumber" : "rTVxKL9uxe",
+        "seriesNumber" : "HjkKeG2MtK0",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OuKqmmwycPq"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZoISmKQCNfv"
         },
-        "isbnList" : [ "9791890430817" ]
+        "isbnList" : [ "9780860201786" ]
       },
-      "doi" : "https://www.example.com/rPTtbGQQGGSJSj8Ch4N",
+      "doi" : "https://www.example.com/xTu6GIsnhiWbOmOT",
       "publicationInstance" : {
         "type" : "BookMonograph",
-        "contentType" : "Textbook",
+        "contentType" : "AcademicMonograph",
         "originalResearch" : false,
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "5lS16d3he1VmDSwO0P",
-            "end" : "qENF4EXCXmc"
+            "begin" : "aTxjpHSMM4yQSU2Jf8",
+            "end" : "JpX3FflJlPl5FS"
           },
-          "pages" : "GnROGrVU1VyFPqsO",
+          "pages" : "Ppi68rlx35",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/SVnj33D8z3KoK",
-    "abstract" : "EwcBOMJmCgMu"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "xJb0DLNjhlAyfzxNAY",
-      "mimeType" : "twiB9u8fz88tXR",
-      "size" : 1618437314,
-      "license" : {
-        "type" : "License",
-        "identifier" : "ugTTAScZUg0Wi",
-        "labels" : {
-          "6AWoSxpYjVXJns" : "xLgT1dhkOagVmUXe"
-        },
-        "link" : "https://www.example.com/z2XuE0g5ezv1IOzn"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/vt9rlvixB2",
+    "abstract" : "5ZFXW3HjsgGziJhOXh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/inperspiciatis",
-    "name" : "Fn39zLfPPM3q0h",
+    "id" : "https://www.example.org/officiadoloribus",
+    "name" : "aWRtzKgycicnfa",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2I4EuN3GJCiMqQ",
-      "id" : "wlMg2iATa4tj2ePIF8"
+      "source" : "ZVCrEQl5NKdfng9L0",
+      "id" : "JPUA0GeBgkFGP83"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "GLjuIYTlLUchGb3"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "y6vafKgyV2bEv"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -154,25 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consecteturullam" ],
+  "subjects" : [ "https://www.example.org/architectoet" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "xJb0DLNjhlAyfzxNAY",
-    "mimeType" : "twiB9u8fz88tXR",
-    "size" : 1618437314,
+    "name" : "6TpfFmITDv17QEuWdb",
+    "mimeType" : "lHgX4T0DJMKQ",
+    "size" : 1785219874,
     "license" : {
       "type" : "License",
-      "identifier" : "ugTTAScZUg0Wi",
+      "identifier" : "LXItx0rCtvkfw8",
       "labels" : {
-        "6AWoSxpYjVXJns" : "xLgT1dhkOagVmUXe"
+        "85ytw2sExiu2RH3BB" : "XuYg0PtwaOyb"
       },
-      "link" : "https://www.example.com/z2XuE0g5ezv1IOzn"
+      "link" : "https://www.example.com/Yz7eqOQVT8HpOpSI8"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "DgDUjEt06dwTYLl5h4"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "6TpfFmITDv17QEuWdb",
+      "mimeType" : "lHgX4T0DJMKQ",
+      "size" : 1785219874,
+      "license" : {
+        "type" : "License",
+        "identifier" : "LXItx0rCtvkfw8",
+        "labels" : {
+          "85ytw2sExiu2RH3BB" : "XuYg0PtwaOyb"
+        },
+        "link" : "https://www.example.com/Yz7eqOQVT8HpOpSI8"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "4ZWJSaSZOa",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,117 +1,117 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "RdbXzMGo3QHZF",
-    "ownerAffiliation" : "https://www.example.org/nonipsam"
+    "owner" : "AUOtxJmFPHLEcW91IB",
+    "ownerAffiliation" : "https://www.example.org/nonquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sintcorrupti",
+    "id" : "https://www.example.org/liberoveritatis",
     "labels" : {
-      "TxaWv8ErLh" : "qNyczu2lFgy"
+      "mMmZn5LzlPp" : "UD9QriNwGzZ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiaquo",
-  "doi" : "https://doi.org/10.1234/illo",
-  "link" : "https://www.example.org/accusantiumalias",
+  "handle" : "https://www.example.org/etquo",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/utlaborum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mHJY7GldZ0LbiLc",
+    "mainTitle" : "Tn2NKrVCeFX",
     "alternativeTitles" : {
-      "sv" : "nhkDRby5qN"
+      "no" : "ULVz2ZnljIJg80I3"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ik4QRnuLpOwHY",
-      "month" : "5UNPDIpq1hMI9MFg4e",
-      "day" : "YnV4KjphUD"
+      "year" : "hms1F0kK3uQGtXe",
+      "month" : "HLDO5z2Ppf5ko8sQcr4",
+      "day" : "rImg1dHcaFfU1V"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/RGVScMqs5aEVMAB2P2",
-        "name" : "5OuYtqX6AoGZ7s2Z9Hd",
-        "nameType" : "Personal",
-        "orcId" : "lj6h2Kj7lHJ"
+        "id" : "https://www.example.com/U77si4LzURfKY",
+        "name" : "YvF9nEzFCx4CjPWuB1",
+        "nameType" : "Organizational",
+        "orcId" : "4IdooXfWOr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4kguwY9XB5w0rua0",
+        "id" : "https://www.example.com/ikPy2ucNccxJ2N",
         "labels" : {
-          "p0pIFBp6Xdbg" : "bSUULPnv2hgk0"
+          "BDzzoIxR07XaoPaC" : "MQU95oPqV805"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 8,
+      "role" : "RegistrationAgency",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ztzN51LvNgmFISN",
-        "name" : "sD3tSsL6uCwJ0l",
-        "nameType" : "Organizational",
-        "orcId" : "qrDCm3lUNeI"
+        "id" : "https://www.example.com/rH4cm4Mlsxu",
+        "name" : "oLvC0wtcI3cxhWgg",
+        "nameType" : "Personal",
+        "orcId" : "iSgttCldLIDWC9fPLfG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/L0Ts2rZ6pgYrEFJ2",
+        "id" : "https://www.example.com/QkhWmYGEWvlB",
         "labels" : {
-          "2u1kjuwvZAb0TMApJF" : "qFewzbuRasQWSA0"
+          "iZft3KSwc30RYK" : "qLBefuYIUlLss"
         }
       } ],
-      "role" : "Dramaturge",
-      "sequence" : 7,
+      "role" : "Producer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "LyKTje6qyDUY9X6KV",
-    "tags" : [ "KDE9aRWQ7ekmimBqZz" ],
-    "description" : "Nv1XO6mt3MC2N2I",
+    "npiSubjectHeading" : "dcO3ppOwIrOKTXx7eA",
+    "tags" : [ "Xoo8EqbwD3" ],
+    "description" : "tPlQWMqhDacjo827sas",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/3kgJsAm0ftn03XaCJ"
+        "partOf" : "https://www.example.com/P9veLYZ35Ltq1q"
       },
-      "doi" : "https://www.example.com/lbNiJ3gwJjB",
+      "doi" : "https://www.example.com/OGO0bevRabbkma4",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "TextbookChapter",
-        "peerReviewed" : true,
+        "contentType" : "NonFictionChapter",
+        "peerReviewed" : false,
         "originalResearch" : true,
         "pages" : {
           "type" : "Range",
-          "begin" : "gBzwEY2H2BP6N6W",
-          "end" : "5Zb2AJtbjsmlW"
+          "begin" : "tJXQhEpUgaMM",
+          "end" : "69PwyJjwtMUx6E"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Iodf7qpgNNk233n1V9O",
-    "abstract" : "Cl4grEnxKrZip795"
+    "metadataSource" : "https://www.example.com/Vcsk3hwvVEf8wkPVY",
+    "abstract" : "vbw653z8zEKCdjM4n31"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/liberoprovident",
-    "name" : "4x8wBHfNBoBBUisKKb",
+    "id" : "https://www.example.org/consecteturpossimus",
+    "name" : "KqEyiyv5F6Qci0eW",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "un8Y7C2llNv3A5kUMDK",
-      "id" : "QZmzt2MMXyJFTh"
+      "source" : "MnJUxffONxSdx",
+      "id" : "Ofaw5LxmzfGakS2pHa0"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "GtvU9T6oakThvbYmdJi"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "FXEU9xSBnG2uwalZffD"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -119,46 +119,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/repellendusaliquid" ],
+  "subjects" : [ "https://www.example.org/asperiorescupiditate" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LfG35OgEOZi",
-      "mimeType" : "1yrNVZDsunU2x",
-      "size" : 980638474,
+      "name" : "U63OQVeuSjFkG",
+      "mimeType" : "xGgLu0AAkujT",
+      "size" : 651434153,
       "license" : {
         "type" : "License",
-        "identifier" : "GIq8esxbUR80",
+        "identifier" : "CL8u8whUD29QZ8jy",
         "labels" : {
-          "3CHuTZ3ddg7dQ" : "WJoLZAsQr9"
+          "s7UoxYVGQfTYMH1se" : "xsSQN7dg2LIs7wJ4"
         },
-        "link" : "https://www.example.com/ahF4srHwF0AT6sNc"
+        "link" : "https://www.example.com/AhhZnYoOCnM"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LfG35OgEOZi",
-    "mimeType" : "1yrNVZDsunU2x",
-    "size" : 980638474,
+    "name" : "U63OQVeuSjFkG",
+    "mimeType" : "xGgLu0AAkujT",
+    "size" : 651434153,
     "license" : {
       "type" : "License",
-      "identifier" : "GIq8esxbUR80",
+      "identifier" : "CL8u8whUD29QZ8jy",
       "labels" : {
-        "3CHuTZ3ddg7dQ" : "WJoLZAsQr9"
+        "s7UoxYVGQfTYMH1se" : "xsSQN7dg2LIs7wJ4"
       },
-      "link" : "https://www.example.com/ahF4srHwF0AT6sNc"
+      "link" : "https://www.example.com/AhhZnYoOCnM"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "RdbXzMGo3QHZF",
+  "owner" : "AUOtxJmFPHLEcW91IB",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -3,115 +3,115 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "AUOtxJmFPHLEcW91IB",
-    "ownerAffiliation" : "https://www.example.org/nonquia"
+    "owner" : "QCw4Omve4vN",
+    "ownerAffiliation" : "https://www.example.org/consequunturdolorem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/liberoveritatis",
+    "id" : "https://www.example.org/atconsequatur",
     "labels" : {
-      "mMmZn5LzlPp" : "UD9QriNwGzZ"
+      "ih612uzFfo5Lb" : "Jz3UnOtkY8s3KQ8u"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etquo",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/utlaborum",
+  "handle" : "https://www.example.org/dictadolore",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/etexcepturi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Tn2NKrVCeFX",
+    "mainTitle" : "q2ujRxFajrXnS1vB",
     "alternativeTitles" : {
-      "no" : "ULVz2ZnljIJg80I3"
+      "hu" : "2TIlqIZDubk3vqO"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "hms1F0kK3uQGtXe",
-      "month" : "HLDO5z2Ppf5ko8sQcr4",
-      "day" : "rImg1dHcaFfU1V"
+      "year" : "8YJgXjSnD2iZg",
+      "month" : "gcqP6DF9TDtK57bVl9B",
+      "day" : "6nZ5G54MLX1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/U77si4LzURfKY",
-        "name" : "YvF9nEzFCx4CjPWuB1",
-        "nameType" : "Organizational",
-        "orcId" : "4IdooXfWOr"
+        "id" : "https://www.example.com/ZpAppgUokxcVHZloQOQ",
+        "name" : "PshOddSHcWJ4",
+        "nameType" : "Personal",
+        "orcId" : "AQ9DmBPf5Ml7U"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ikPy2ucNccxJ2N",
+        "id" : "https://www.example.com/c8ACelBok6",
         "labels" : {
-          "BDzzoIxR07XaoPaC" : "MQU95oPqV805"
+          "152aK6gMkKKV" : "nOfTXvD0nGMQFhtIgJ1"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 5,
+      "role" : "Writer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rH4cm4Mlsxu",
-        "name" : "oLvC0wtcI3cxhWgg",
+        "id" : "https://www.example.com/LRMgZvmrFtVZ",
+        "name" : "Q5UVLW8atm968gum3",
         "nameType" : "Personal",
-        "orcId" : "iSgttCldLIDWC9fPLfG"
+        "orcId" : "5ZhyXQTa0qjAI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QkhWmYGEWvlB",
+        "id" : "https://www.example.com/xalPx18Qp9M7er5Cs",
         "labels" : {
-          "iZft3KSwc30RYK" : "qLBefuYIUlLss"
+          "XZVGl9JJJ2r" : "LnGCIUNnModVgzvq40L"
         }
       } ],
-      "role" : "Producer",
+      "role" : "EditorialBoardMember",
       "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "dcO3ppOwIrOKTXx7eA",
-    "tags" : [ "Xoo8EqbwD3" ],
-    "description" : "tPlQWMqhDacjo827sas",
+    "npiSubjectHeading" : "OraRDyo9SH",
+    "tags" : [ "dQcvKYDDx13Pk2" ],
+    "description" : "zrtwAszAnxmK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/P9veLYZ35Ltq1q"
+        "partOf" : "https://www.example.com/beS6bYdWctjvCfQKmH"
       },
-      "doi" : "https://www.example.com/OGO0bevRabbkma4",
+      "doi" : "https://www.example.com/nofZKIn0rOS",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "NonFictionChapter",
-        "peerReviewed" : false,
-        "originalResearch" : true,
+        "contentType" : "AcademicChapter",
+        "peerReviewed" : true,
+        "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "tJXQhEpUgaMM",
-          "end" : "69PwyJjwtMUx6E"
+          "begin" : "3BFmpYjs7G",
+          "end" : "JZHDdfBi8Qrpb"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Vcsk3hwvVEf8wkPVY",
-    "abstract" : "vbw653z8zEKCdjM4n31"
+    "metadataSource" : "https://www.example.com/kQR6fBWFggu2c",
+    "abstract" : "ELI1gBamp1r6bh8rIG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consecteturpossimus",
-    "name" : "KqEyiyv5F6Qci0eW",
+    "id" : "https://www.example.org/porronesciunt",
+    "name" : "Mq5OAQawpqD8QW",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "MnJUxffONxSdx",
-      "id" : "Ofaw5LxmzfGakS2pHa0"
+      "source" : "3cZ7RDwpYB",
+      "id" : "fyA9MVNhBsQ1GLU"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "FXEU9xSBnG2uwalZffD"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "exwzsYd79a1b4VO"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -119,46 +119,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/asperiorescupiditate" ],
+  "subjects" : [ "https://www.example.org/placeatid" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "U63OQVeuSjFkG",
-      "mimeType" : "xGgLu0AAkujT",
-      "size" : 651434153,
+      "name" : "NgI6s1Ei53APYYf",
+      "mimeType" : "yGUEEfrg3b",
+      "size" : 1767086462,
       "license" : {
         "type" : "License",
-        "identifier" : "CL8u8whUD29QZ8jy",
+        "identifier" : "838iWy9vMyp",
         "labels" : {
-          "s7UoxYVGQfTYMH1se" : "xsSQN7dg2LIs7wJ4"
+          "h4q3wyDhPegBHIOg0JY" : "fY4HRchizLjH9bX"
         },
-        "link" : "https://www.example.com/AhhZnYoOCnM"
+        "link" : "https://www.example.com/OyghKPRQihK1"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "U63OQVeuSjFkG",
-    "mimeType" : "xGgLu0AAkujT",
-    "size" : 651434153,
+    "name" : "NgI6s1Ei53APYYf",
+    "mimeType" : "yGUEEfrg3b",
+    "size" : 1767086462,
     "license" : {
       "type" : "License",
-      "identifier" : "CL8u8whUD29QZ8jy",
+      "identifier" : "838iWy9vMyp",
       "labels" : {
-        "s7UoxYVGQfTYMH1se" : "xsSQN7dg2LIs7wJ4"
+        "h4q3wyDhPegBHIOg0JY" : "fY4HRchizLjH9bX"
       },
-      "link" : "https://www.example.com/AhhZnYoOCnM"
+      "link" : "https://www.example.com/OyghKPRQihK1"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "AUOtxJmFPHLEcW91IB",
+  "owner" : "QCw4Omve4vN",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,117 +1,117 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "R22qqZIhoosq",
-    "ownerAffiliation" : "https://www.example.org/quiat"
+    "owner" : "RdbXzMGo3QHZF",
+    "ownerAffiliation" : "https://www.example.org/nonipsam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/minimaunde",
+    "id" : "https://www.example.org/sintcorrupti",
     "labels" : {
-      "Uq1IoP6blg4dgphaZ" : "PRkgYJUn27KjWIu"
+      "TxaWv8ErLh" : "qNyczu2lFgy"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velvoluptas",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/autemsapiente",
+  "handle" : "https://www.example.org/quiaquo",
+  "doi" : "https://doi.org/10.1234/illo",
+  "link" : "https://www.example.org/accusantiumalias",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ll80fuxxEKOP",
+    "mainTitle" : "mHJY7GldZ0LbiLc",
     "alternativeTitles" : {
-      "is" : "eJ3BQ17T8Muim"
+      "sv" : "nhkDRby5qN"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TLyUoRpgpRf2H9PLUIr",
-      "month" : "AYXiG5RorL9",
-      "day" : "XBhE7ScytWNs"
+      "year" : "ik4QRnuLpOwHY",
+      "month" : "5UNPDIpq1hMI9MFg4e",
+      "day" : "YnV4KjphUD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FUxqaLc02a1",
-        "name" : "pKexIVzXuPhnS",
-        "nameType" : "Organizational",
-        "orcId" : "ml2kiJk8ehZCS3K"
+        "id" : "https://www.example.com/RGVScMqs5aEVMAB2P2",
+        "name" : "5OuYtqX6AoGZ7s2Z9Hd",
+        "nameType" : "Personal",
+        "orcId" : "lj6h2Kj7lHJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/q5duDTKfWq",
+        "id" : "https://www.example.com/4kguwY9XB5w0rua0",
         "labels" : {
-          "12IXAzPXJ2L" : "hhoABihPqyJ9r"
+          "p0pIFBp6Xdbg" : "bSUULPnv2hgk0"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 9,
+      "role" : "LandscapeArchitect",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dWJAXYScubI",
-        "name" : "nNdIm0MTyBfEa",
-        "nameType" : "Personal",
-        "orcId" : "R9G46q6isU"
+        "id" : "https://www.example.com/ztzN51LvNgmFISN",
+        "name" : "sD3tSsL6uCwJ0l",
+        "nameType" : "Organizational",
+        "orcId" : "qrDCm3lUNeI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6TY2kci8OQFewJO3V",
+        "id" : "https://www.example.com/L0Ts2rZ6pgYrEFJ2",
         "labels" : {
-          "kBo53VpgD1zKKfK" : "YUgNBkzhvdrZSH3O"
+          "2u1kjuwvZAb0TMApJF" : "qFewzbuRasQWSA0"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 0,
+      "role" : "Dramaturge",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rbglpbDN16bfD1tl",
-    "tags" : [ "DJ1bZqae9adtZKaKCbQ" ],
-    "description" : "IOB9TKn68KF1l9",
+    "npiSubjectHeading" : "LyKTje6qyDUY9X6KV",
+    "tags" : [ "KDE9aRWQ7ekmimBqZz" ],
+    "description" : "Nv1XO6mt3MC2N2I",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/Ei7doKo8hKgAqku8C1Y"
+        "partOf" : "https://www.example.com/3kgJsAm0ftn03XaCJ"
       },
-      "doi" : "https://www.example.com/708imjQzcAqGNFDaNff",
+      "doi" : "https://www.example.com/lbNiJ3gwJjB",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "ExhibitionCatalogChapter",
-        "peerReviewed" : false,
-        "originalResearch" : false,
+        "contentType" : "TextbookChapter",
+        "peerReviewed" : true,
+        "originalResearch" : true,
         "pages" : {
           "type" : "Range",
-          "begin" : "zLQqvI4sB92Kq",
-          "end" : "UFWqPDCQ3HGY"
+          "begin" : "gBzwEY2H2BP6N6W",
+          "end" : "5Zb2AJtbjsmlW"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/8Yyn1ydZ8Ygv0UnfiR7",
-    "abstract" : "xK0rVZ1xhbdw"
+    "metadataSource" : "https://www.example.com/Iodf7qpgNNk233n1V9O",
+    "abstract" : "Cl4grEnxKrZip795"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/exet",
-    "name" : "AZz5iD7jOjt",
+    "id" : "https://www.example.org/liberoprovident",
+    "name" : "4x8wBHfNBoBBUisKKb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ccHn836viN7Lrq8At",
-      "id" : "c3MHR2aHjaz6GOZ"
+      "source" : "un8Y7C2llNv3A5kUMDK",
+      "id" : "QZmzt2MMXyJFTh"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "ZLKrzKli4044Uorqb"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "GtvU9T6oakThvbYmdJi"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -119,46 +119,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autanimi" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "yXMO1BvtTxwv5cg",
-    "mimeType" : "KTo0S4xRLD5nZ5tu4",
-    "size" : 992098745,
-    "license" : {
-      "type" : "License",
-      "identifier" : "i05wCZ7nF45mJ",
-      "labels" : {
-        "ZSwrlFd5ii49B97d" : "4PpUwSz2AJDRB1UTd"
-      },
-      "link" : "https://www.example.com/jUaUaaCiUpFc0"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/repellendusaliquid" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yXMO1BvtTxwv5cg",
-      "mimeType" : "KTo0S4xRLD5nZ5tu4",
-      "size" : 992098745,
+      "name" : "LfG35OgEOZi",
+      "mimeType" : "1yrNVZDsunU2x",
+      "size" : 980638474,
       "license" : {
         "type" : "License",
-        "identifier" : "i05wCZ7nF45mJ",
+        "identifier" : "GIq8esxbUR80",
         "labels" : {
-          "ZSwrlFd5ii49B97d" : "4PpUwSz2AJDRB1UTd"
+          "3CHuTZ3ddg7dQ" : "WJoLZAsQr9"
         },
-        "link" : "https://www.example.com/jUaUaaCiUpFc0"
+        "link" : "https://www.example.com/ahF4srHwF0AT6sNc"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "R22qqZIhoosq",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "LfG35OgEOZi",
+    "mimeType" : "1yrNVZDsunU2x",
+    "size" : 980638474,
+    "license" : {
+      "type" : "License",
+      "identifier" : "GIq8esxbUR80",
+      "labels" : {
+        "3CHuTZ3ddg7dQ" : "WJoLZAsQr9"
+      },
+      "link" : "https://www.example.com/ahF4srHwF0AT6sNc"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "RdbXzMGo3QHZF",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterArticle.json
+++ b/documentation/ChapterArticle.json
@@ -1,138 +1,117 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "mFvCVyqRGnxPb6pFP",
-    "ownerAffiliation" : "https://www.example.org/nobishic"
+    "owner" : "R22qqZIhoosq",
+    "ownerAffiliation" : "https://www.example.org/quiat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequunturminima",
+    "id" : "https://www.example.org/minimaunde",
     "labels" : {
-      "ZJy6ceenfa4" : "eiQRX75eSdJ"
+      "Uq1IoP6blg4dgphaZ" : "PRkgYJUn27KjWIu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quibusdamdolorem",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/eaet",
+  "handle" : "https://www.example.org/velvoluptas",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/autemsapiente",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RSeBY8O2IU5soEwXvaL",
+    "mainTitle" : "ll80fuxxEKOP",
     "alternativeTitles" : {
-      "da" : "KTZkQ0Qcdflc0VOVs"
+      "is" : "eJ3BQ17T8Muim"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "VQW5WHCGh33yeyk",
-      "month" : "5RZ49VIayeAohi58x",
-      "day" : "TuHmfLUGyQmXI68jZ"
+      "year" : "TLyUoRpgpRf2H9PLUIr",
+      "month" : "AYXiG5RorL9",
+      "day" : "XBhE7ScytWNs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gSz28BooD5wGp",
-        "name" : "0w36pHam8N",
-        "nameType" : "Personal",
-        "orcId" : "Xj3cVF6Wka"
+        "id" : "https://www.example.com/FUxqaLc02a1",
+        "name" : "pKexIVzXuPhnS",
+        "nameType" : "Organizational",
+        "orcId" : "ml2kiJk8ehZCS3K"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6tFSMrvwWd9CTTg",
+        "id" : "https://www.example.com/q5duDTKfWq",
         "labels" : {
-          "YDgmsDYzyyFTctG" : "X6L90OinZnRyBUr"
+          "12IXAzPXJ2L" : "hhoABihPqyJ9r"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 2,
+      "role" : "Designer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UrWABopFLg",
-        "name" : "Ha8AdoCETqb",
+        "id" : "https://www.example.com/dWJAXYScubI",
+        "name" : "nNdIm0MTyBfEa",
         "nameType" : "Personal",
-        "orcId" : "u1R4bW4gMMt7voJuu"
+        "orcId" : "R9G46q6isU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5pdgRlYP49",
+        "id" : "https://www.example.com/6TY2kci8OQFewJO3V",
         "labels" : {
-          "YRLPig7EnqpJY" : "gbkQ6OqzJCFKu4H"
+          "kBo53VpgD1zKKfK" : "YUgNBkzhvdrZSH3O"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 3,
+      "role" : "Sponsor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "0sFbtEwq0nCowm4",
-    "tags" : [ "YgIni481rxNU4" ],
-    "description" : "BPyeG46lYdnWTHP",
+    "npiSubjectHeading" : "rbglpbDN16bfD1tl",
+    "tags" : [ "DJ1bZqae9adtZKaKCbQ" ],
+    "description" : "IOB9TKn68KF1l9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/GVJ25xZw1u9Z0P"
+        "partOf" : "https://www.example.com/Ei7doKo8hKgAqku8C1Y"
       },
-      "doi" : "https://www.example.com/TI7fKelYRlDZ8LmCF",
+      "doi" : "https://www.example.com/708imjQzcAqGNFDaNff",
       "publicationInstance" : {
         "type" : "ChapterArticle",
-        "contentType" : "TextbookChapter",
+        "contentType" : "ExhibitionCatalogChapter",
         "peerReviewed" : false,
-        "originalResearch" : true,
+        "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "e4L40UmpFANtr",
-          "end" : "IzZcwddmRHYPeI3tW"
+          "begin" : "zLQqvI4sB92Kq",
+          "end" : "UFWqPDCQ3HGY"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/GixGEsTdaJFgcGddAt5",
-    "abstract" : "6ybtQWbLK2vxKCqKQTu"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "DuFhJ2zt1bLw",
-      "mimeType" : "qZjrCkxfC4S9IbE",
-      "size" : 1821632219,
-      "license" : {
-        "type" : "License",
-        "identifier" : "7ZRY1ZxqGZOKk93",
-        "labels" : {
-          "aSD240jOXqwSkCng" : "Jc3VDzArHZ6x"
-        },
-        "link" : "https://www.example.com/AntEQRelmvTuvZ"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/8Yyn1ydZ8Ygv0UnfiR7",
+    "abstract" : "xK0rVZ1xhbdw"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ullamautem",
-    "name" : "RibPwtoAEkXaI7",
+    "id" : "https://www.example.org/exet",
+    "name" : "AZz5iD7jOjt",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "AqtbbLlne5m1LLrW",
-      "id" : "XQ1ATxExKPHQOA"
+      "source" : "ccHn836viN7Lrq8At",
+      "id" : "c3MHR2aHjaz6GOZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "JvMIPiwHWl8m7wrpm"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ZLKrzKli4044Uorqb"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -140,25 +119,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veroadipisci" ],
+  "subjects" : [ "https://www.example.org/autanimi" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "DuFhJ2zt1bLw",
-    "mimeType" : "qZjrCkxfC4S9IbE",
-    "size" : 1821632219,
+    "name" : "yXMO1BvtTxwv5cg",
+    "mimeType" : "KTo0S4xRLD5nZ5tu4",
+    "size" : 992098745,
     "license" : {
       "type" : "License",
-      "identifier" : "7ZRY1ZxqGZOKk93",
+      "identifier" : "i05wCZ7nF45mJ",
       "labels" : {
-        "aSD240jOXqwSkCng" : "Jc3VDzArHZ6x"
+        "ZSwrlFd5ii49B97d" : "4PpUwSz2AJDRB1UTd"
       },
-      "link" : "https://www.example.com/AntEQRelmvTuvZ"
+      "link" : "https://www.example.com/jUaUaaCiUpFc0"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "mFvCVyqRGnxPb6pFP"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "yXMO1BvtTxwv5cg",
+      "mimeType" : "KTo0S4xRLD5nZ5tu4",
+      "size" : 992098745,
+      "license" : {
+        "type" : "License",
+        "identifier" : "i05wCZ7nF45mJ",
+        "labels" : {
+          "ZSwrlFd5ii49B97d" : "4PpUwSz2AJDRB1UTd"
+        },
+        "link" : "https://www.example.com/jUaUaaCiUpFc0"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "R22qqZIhoosq",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -3,113 +3,113 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "unzunGsngR6YxL",
-    "ownerAffiliation" : "https://www.example.org/ametvero"
+    "owner" : "nBPuXlHjP66",
+    "ownerAffiliation" : "https://www.example.org/explicabonon"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ealaborum",
+    "id" : "https://www.example.org/eosaspernatur",
     "labels" : {
-      "XwebLQ68h3az2LheT" : "h0tQxjFOws07M"
+      "iLBDuZhQn7DIJAl00bn" : "tyFgKwSA5eUaj3zsY"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etut",
-  "doi" : "https://doi.org/10.1234/illo",
-  "link" : "https://www.example.org/nullaut",
+  "handle" : "https://www.example.org/velitaccusamus",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/utvel",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RJ9OGofAoXBw8Yporb",
+    "mainTitle" : "dxF1a90oLBZd6ZJfgl",
     "alternativeTitles" : {
-      "se" : "uijY56q789dcUQW3U"
+      "se" : "sTdfc2l8D6B"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "cYLZT8G87Z2c",
-      "month" : "K8jTh0NZT7fUnRI",
-      "day" : "xQs8ZraqGsUR"
+      "year" : "xvnFVkxpoejcoOGARy9",
+      "month" : "AaCioVDhg4Pu",
+      "day" : "JlYKCKeCYMXWJoM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/CcYWaYP4uAOkSWOo",
-        "name" : "faEyVf48iz1GdCd0",
-        "nameType" : "Personal",
-        "orcId" : "EuSG9W8i33N"
+        "id" : "https://www.example.com/8QvdqBliwZc",
+        "name" : "BXsd5PAOaSHLDi5gE",
+        "nameType" : "Organizational",
+        "orcId" : "FlsTMdmNWg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Iq1nXnWfRjrsczfM5",
+        "id" : "https://www.example.com/Q9E9lbhjxXkHf",
         "labels" : {
-          "xwG90VgwCZiMUj" : "nOWlb4x6tR2WpJ"
+          "NgW7wwNTIw06lq6DWH" : "6wZRD4hogqaUO"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 9,
+      "role" : "AcademicCoordinator",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wJ8vT3uixog4",
-        "name" : "jRu0Du4az2dR0yfXKry",
-        "nameType" : "Personal",
-        "orcId" : "0kPtRDTBRzrQHQSUFwV"
+        "id" : "https://www.example.com/Fd704s55dMe",
+        "name" : "OnUAJSrJFNXLLkPIc0",
+        "nameType" : "Organizational",
+        "orcId" : "4YfRGfwRN35EPFmPR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VOvmgW3E9SmiSiSmtOm",
+        "id" : "https://www.example.com/uzkREwxLYrIlQ9JC",
         "labels" : {
-          "QXxHPvyN7uDZcD" : "HbKMIsCkfAkzHWJek0"
+          "l1cdvxe5xhKj6wF" : "boFnTtISLuESTkkl"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 7,
+      "role" : "Distributor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "bh3EyCaX8JmwDBd8l",
-    "tags" : [ "sdEm1NsFRaBKw16T" ],
-    "description" : "wM7AbkESumMlAgk2",
+    "npiSubjectHeading" : "9v7M5d5danAZIJFdYM",
+    "tags" : [ "QZwKxE8yS9l2Y3" ],
+    "description" : "uWPSpGBPrFqliHpr3ec",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/0VBMad8TuYAYit"
+        "partOf" : "https://www.example.com/XStTWR5rnRO0inIB7"
       },
-      "doi" : "https://www.example.com/jLVfwJ0rfw",
+      "doi" : "https://www.example.com/1NiOk88kM8",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "nm6HR2ByBbUD8SDrxf",
-          "end" : "HIjyic5cidFlOy"
+          "begin" : "ObpmZK2bjE8etfT4",
+          "end" : "jwM17Y9yEF0H0lfwAQ"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/DLuCP1nY7Vhi",
-    "abstract" : "QxlHI9XsHx3G8"
+    "metadataSource" : "https://www.example.com/B83OSkv787fCblmSkSD",
+    "abstract" : "0yUWLgKhvYdOQzyV4z"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eiusiure",
-    "name" : "2F3IRv9hJrYm8fP4KH",
+    "id" : "https://www.example.org/aliquidrepudiandae",
+    "name" : "tNRp05UxoAY",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Phg3JwPqnT",
-      "id" : "6iVZnOhmZvHZjdyc"
+      "source" : "SnWAun4CymPFTwi7L6",
+      "id" : "B30yHwuTroOumK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "bRHcwVpZQQU89"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "35tjtDiE34YBzCv9"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,46 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sapientevoluptatem" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "WRt26SjrwJIBQ",
-    "mimeType" : "i1sA3Jbodk5ih",
-    "size" : 2025634312,
-    "license" : {
-      "type" : "License",
-      "identifier" : "xq6ljIwgEnrg",
-      "labels" : {
-        "i5Hz9oUIBhN8L" : "XXcMvTzDbnUm5Tz5BrT"
-      },
-      "link" : "https://www.example.com/gjHzC5iExSm"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/inqui" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "WRt26SjrwJIBQ",
-      "mimeType" : "i1sA3Jbodk5ih",
-      "size" : 2025634312,
+      "name" : "xAJuy7TtMsjrSnZe",
+      "mimeType" : "1HjLLc7zL8n4r",
+      "size" : 2113269774,
       "license" : {
         "type" : "License",
-        "identifier" : "xq6ljIwgEnrg",
+        "identifier" : "1f3aoiXbF6NoPFZW",
         "labels" : {
-          "i5Hz9oUIBhN8L" : "XXcMvTzDbnUm5Tz5BrT"
+          "ZrhQzg2Fak84n" : "duDgDZSgTgzkrg"
         },
-        "link" : "https://www.example.com/gjHzC5iExSm"
+        "link" : "https://www.example.com/rFHCNaDxS6D5Q"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "unzunGsngR6YxL",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "xAJuy7TtMsjrSnZe",
+    "mimeType" : "1HjLLc7zL8n4r",
+    "size" : 2113269774,
+    "license" : {
+      "type" : "License",
+      "identifier" : "1f3aoiXbF6NoPFZW",
+      "labels" : {
+        "ZrhQzg2Fak84n" : "duDgDZSgTgzkrg"
+      },
+      "link" : "https://www.example.com/rFHCNaDxS6D5Q"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "nBPuXlHjP66",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,136 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "8EAFw59muf",
-    "ownerAffiliation" : "https://www.example.org/consequaturnemo"
+    "owner" : "unzunGsngR6YxL",
+    "ownerAffiliation" : "https://www.example.org/ametvero"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nesciuntvoluptas",
+    "id" : "https://www.example.org/ealaborum",
     "labels" : {
-      "yZyiSnghS8e4far" : "oBZik3GQIjWqlRhvJV9"
+      "XwebLQ68h3az2LheT" : "h0tQxjFOws07M"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/iureadipisci",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/adlaudantium",
+  "handle" : "https://www.example.org/etut",
+  "doi" : "https://doi.org/10.1234/illo",
+  "link" : "https://www.example.org/nullaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "d5khUABUhWN45N89p",
+    "mainTitle" : "RJ9OGofAoXBw8Yporb",
     "alternativeTitles" : {
-      "it" : "9iK0jrsbcr"
+      "se" : "uijY56q789dcUQW3U"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "QUj5rg2NzGhTDRrcT",
-      "month" : "yZGoWGMyvthcrBb",
-      "day" : "Br0zjM2LyPcJ5wOmrMS"
+      "year" : "cYLZT8G87Z2c",
+      "month" : "K8jTh0NZT7fUnRI",
+      "day" : "xQs8ZraqGsUR"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/27RNypRY63OcdCFL",
-        "name" : "wQsgbwxoyroFgK",
+        "id" : "https://www.example.com/CcYWaYP4uAOkSWOo",
+        "name" : "faEyVf48iz1GdCd0",
         "nameType" : "Personal",
-        "orcId" : "nZWjT59210onyYRXT2"
+        "orcId" : "EuSG9W8i33N"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yhNuVMq5wx",
+        "id" : "https://www.example.com/Iq1nXnWfRjrsczfM5",
         "labels" : {
-          "vzHBcXkI5hSh18A" : "tTnUEw6rL3ak"
+          "xwG90VgwCZiMUj" : "nOWlb4x6tR2WpJ"
         }
       } ],
-      "role" : "RegistrationAuthority",
-      "sequence" : 1,
+      "role" : "Journalist",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/whD6cbM26MTYxN3G",
-        "name" : "hX1SMlULwmsOrz525",
-        "nameType" : "Organizational",
-        "orcId" : "Z6wRf2YtYBlrv0wh"
+        "id" : "https://www.example.com/wJ8vT3uixog4",
+        "name" : "jRu0Du4az2dR0yfXKry",
+        "nameType" : "Personal",
+        "orcId" : "0kPtRDTBRzrQHQSUFwV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ABFNYEozKoiOo7De",
+        "id" : "https://www.example.com/VOvmgW3E9SmiSiSmtOm",
         "labels" : {
-          "Zb4H4ij4wR5G" : "VTpDDVCDzl20GZPQWH"
+          "QXxHPvyN7uDZcD" : "HbKMIsCkfAkzHWJek0"
         }
       } ],
       "role" : "CuratorOrganizer",
-      "sequence" : 8,
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "08oSpsxTx7c1IIk",
-    "tags" : [ "nTByXADlhAX1" ],
-    "description" : "xvnLgucSyLlf",
+    "npiSubjectHeading" : "bh3EyCaX8JmwDBd8l",
+    "tags" : [ "sdEm1NsFRaBKw16T" ],
+    "description" : "wM7AbkESumMlAgk2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/OLdmbWHsXdgar"
+        "partOf" : "https://www.example.com/0VBMad8TuYAYit"
       },
-      "doi" : "https://www.example.com/gony2oFvFUQYu",
+      "doi" : "https://www.example.com/jLVfwJ0rfw",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "GEjf7CyQZbq19JUKmI",
-          "end" : "V2eazThcN4w0JP"
+          "begin" : "nm6HR2ByBbUD8SDrxf",
+          "end" : "HIjyic5cidFlOy"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/q4O2sayauQDefH",
-    "abstract" : "YUVZ6i9uJPwxmF"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lX2MNWOWpU3",
-      "mimeType" : "i2fL0GHIMZ",
-      "size" : 491346440,
-      "license" : {
-        "type" : "License",
-        "identifier" : "79JTxFYHGISSfLogo9",
-        "labels" : {
-          "QoeIwu5pjJqFgbwgBwc" : "lbmhiWPh6xssZhG"
-        },
-        "link" : "https://www.example.com/Jlr8jgEWuQ"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/DLuCP1nY7Vhi",
+    "abstract" : "QxlHI9XsHx3G8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fugiatqui",
-    "name" : "3GysFzGOhz9Tyg",
+    "id" : "https://www.example.org/eiusiure",
+    "name" : "2F3IRv9hJrYm8fP4KH",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "KZrgBaQQjWigGl",
-      "id" : "qwPSWF8E4fAuWM8V"
+      "source" : "Phg3JwPqnT",
+      "id" : "6iVZnOhmZvHZjdyc"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Isc1vbzds5X"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "bRHcwVpZQQU89"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -138,25 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delenitised" ],
+  "subjects" : [ "https://www.example.org/sapientevoluptatem" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lX2MNWOWpU3",
-    "mimeType" : "i2fL0GHIMZ",
-    "size" : 491346440,
+    "name" : "WRt26SjrwJIBQ",
+    "mimeType" : "i1sA3Jbodk5ih",
+    "size" : 2025634312,
     "license" : {
       "type" : "License",
-      "identifier" : "79JTxFYHGISSfLogo9",
+      "identifier" : "xq6ljIwgEnrg",
       "labels" : {
-        "QoeIwu5pjJqFgbwgBwc" : "lbmhiWPh6xssZhG"
+        "i5Hz9oUIBhN8L" : "XXcMvTzDbnUm5Tz5BrT"
       },
-      "link" : "https://www.example.com/Jlr8jgEWuQ"
+      "link" : "https://www.example.com/gjHzC5iExSm"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "8EAFw59muf"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "WRt26SjrwJIBQ",
+      "mimeType" : "i1sA3Jbodk5ih",
+      "size" : 2025634312,
+      "license" : {
+        "type" : "License",
+        "identifier" : "xq6ljIwgEnrg",
+        "labels" : {
+          "i5Hz9oUIBhN8L" : "XXcMvTzDbnUm5Tz5BrT"
+        },
+        "link" : "https://www.example.com/gjHzC5iExSm"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "unzunGsngR6YxL",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,115 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "nBPuXlHjP66",
-    "ownerAffiliation" : "https://www.example.org/explicabonon"
+    "owner" : "lBBOPvJYQ1",
+    "ownerAffiliation" : "https://www.example.org/atqueincidunt"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eosaspernatur",
+    "id" : "https://www.example.org/modierror",
     "labels" : {
-      "iLBDuZhQn7DIJAl00bn" : "tyFgKwSA5eUaj3zsY"
+      "nJHxF4IefAjLkZJQnpg" : "R37SKOo9DQixubu2140"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velitaccusamus",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/utvel",
+  "handle" : "https://www.example.org/sintexpedita",
+  "doi" : "https://doi.org/10.1234/illum",
+  "link" : "https://www.example.org/fugiatvoluptatem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "dxF1a90oLBZd6ZJfgl",
+    "mainTitle" : "jdhHAjIk2IbJLw8imE6",
     "alternativeTitles" : {
-      "se" : "sTdfc2l8D6B"
+      "fr" : "KxviiUoCACF9de"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "xvnFVkxpoejcoOGARy9",
-      "month" : "AaCioVDhg4Pu",
-      "day" : "JlYKCKeCYMXWJoM"
+      "year" : "z9x4P6O8TxRigblt1",
+      "month" : "OZJlNY7Dl7Q",
+      "day" : "QN2yuTdynrLyi6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8QvdqBliwZc",
-        "name" : "BXsd5PAOaSHLDi5gE",
-        "nameType" : "Organizational",
-        "orcId" : "FlsTMdmNWg"
+        "id" : "https://www.example.com/ZwLTJ9xzEPvu",
+        "name" : "DCDWT4v0X9bZI176",
+        "nameType" : "Personal",
+        "orcId" : "ymJeCnGErV3XM2YNr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Q9E9lbhjxXkHf",
+        "id" : "https://www.example.com/5ZNidUcrjw31sdcc",
         "labels" : {
-          "NgW7wwNTIw06lq6DWH" : "6wZRD4hogqaUO"
+          "ej62cfNL5bDZuMMd" : "RTelVmW9tUm"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 5,
+      "role" : "ProjectLeader",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Fd704s55dMe",
-        "name" : "OnUAJSrJFNXLLkPIc0",
-        "nameType" : "Organizational",
-        "orcId" : "4YfRGfwRN35EPFmPR"
+        "id" : "https://www.example.com/r4TlVwBVJ88wcp",
+        "name" : "4bTpyht48sMh",
+        "nameType" : "Personal",
+        "orcId" : "WunEU7xffS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uzkREwxLYrIlQ9JC",
+        "id" : "https://www.example.com/hM8HDa1etDnjcQQ",
         "labels" : {
-          "l1cdvxe5xhKj6wF" : "boFnTtISLuESTkkl"
+          "qtgUS8E5MxEGVnc" : "F19GTqiNLypekOXbj"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 9,
+      "role" : "LandscapeArchitect",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9v7M5d5danAZIJFdYM",
-    "tags" : [ "QZwKxE8yS9l2Y3" ],
-    "description" : "uWPSpGBPrFqliHpr3ec",
+    "npiSubjectHeading" : "eoxbXjX1BJ3",
+    "tags" : [ "0CK2PkMziZjjXz" ],
+    "description" : "uWQ3YaVBHC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/XStTWR5rnRO0inIB7"
+        "partOf" : "https://www.example.com/dZMrPRUCVn"
       },
-      "doi" : "https://www.example.com/1NiOk88kM8",
+      "doi" : "https://www.example.com/vm7Otg9DxVjJoeBR",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "ObpmZK2bjE8etfT4",
-          "end" : "jwM17Y9yEF0H0lfwAQ"
+          "begin" : "4GpRnfWpYZZoP",
+          "end" : "jqz04VnkHxZN5Qa"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/B83OSkv787fCblmSkSD",
-    "abstract" : "0yUWLgKhvYdOQzyV4z"
+    "metadataSource" : "https://www.example.com/3a4DBFBDgjU",
+    "abstract" : "RxErVGdyRHnXjDT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aliquidrepudiandae",
-    "name" : "tNRp05UxoAY",
+    "id" : "https://www.example.org/corruptiitaque",
+    "name" : "kERrYmTt2aAp",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SnWAun4CymPFTwi7L6",
-      "id" : "B30yHwuTroOumK"
+      "source" : "0ftt0DRbaPCdmvVA",
+      "id" : "jOiCwWsUGKTG"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "35tjtDiE34YBzCv9"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "e6zhgomh9gp"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,46 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inqui" ],
+  "subjects" : [ "https://www.example.org/omnisaliquam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "xAJuy7TtMsjrSnZe",
-      "mimeType" : "1HjLLc7zL8n4r",
-      "size" : 2113269774,
+      "name" : "WrmXdwdQwHDzFdFby",
+      "mimeType" : "Bu8Ty4LXKFd",
+      "size" : 1891559312,
       "license" : {
         "type" : "License",
-        "identifier" : "1f3aoiXbF6NoPFZW",
+        "identifier" : "sNAFmw74IPVG3JImP",
         "labels" : {
-          "ZrhQzg2Fak84n" : "duDgDZSgTgzkrg"
+          "qx64zeu8bDRYr" : "gqi9ZEevnSUGiqW"
         },
-        "link" : "https://www.example.com/rFHCNaDxS6D5Q"
+        "link" : "https://www.example.com/m1BeO0O6Pffkn"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "xAJuy7TtMsjrSnZe",
-    "mimeType" : "1HjLLc7zL8n4r",
-    "size" : 2113269774,
+    "name" : "WrmXdwdQwHDzFdFby",
+    "mimeType" : "Bu8Ty4LXKFd",
+    "size" : 1891559312,
     "license" : {
       "type" : "License",
-      "identifier" : "1f3aoiXbF6NoPFZW",
+      "identifier" : "sNAFmw74IPVG3JImP",
       "labels" : {
-        "ZrhQzg2Fak84n" : "duDgDZSgTgzkrg"
+        "qx64zeu8bDRYr" : "gqi9ZEevnSUGiqW"
       },
-      "link" : "https://www.example.com/rFHCNaDxS6D5Q"
+      "link" : "https://www.example.com/m1BeO0O6Pffkn"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "nBPuXlHjP66",
+  "owner" : "lBBOPvJYQ1",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -3,113 +3,113 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "lBBOPvJYQ1",
-    "ownerAffiliation" : "https://www.example.org/atqueincidunt"
+    "owner" : "ucwYseA8hnI",
+    "ownerAffiliation" : "https://www.example.org/cupiditatevoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/modierror",
+    "id" : "https://www.example.org/autemmagni",
     "labels" : {
-      "nJHxF4IefAjLkZJQnpg" : "R37SKOo9DQixubu2140"
+      "QA66NDr7kxK" : "ega7rLkYqsSk"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sintexpedita",
-  "doi" : "https://doi.org/10.1234/illum",
-  "link" : "https://www.example.org/fugiatvoluptatem",
+  "handle" : "https://www.example.org/culpaqui",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/earumodio",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jdhHAjIk2IbJLw8imE6",
+    "mainTitle" : "qqm8Nv3X7VFEgA",
     "alternativeTitles" : {
-      "fr" : "KxviiUoCACF9de"
+      "af" : "z6C9GiJ2ddXJgxT"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "z9x4P6O8TxRigblt1",
-      "month" : "OZJlNY7Dl7Q",
-      "day" : "QN2yuTdynrLyi6"
+      "year" : "9qNm6vapnM",
+      "month" : "tqXxERZ2k1",
+      "day" : "7ftexEh5jzGcfuwC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZwLTJ9xzEPvu",
-        "name" : "DCDWT4v0X9bZI176",
-        "nameType" : "Personal",
-        "orcId" : "ymJeCnGErV3XM2YNr"
+        "id" : "https://www.example.com/t7cMnTyOhgsd",
+        "name" : "gZQgGQ4TY3ZIoI",
+        "nameType" : "Organizational",
+        "orcId" : "KJfEY98H2tmHtmGHmG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5ZNidUcrjw31sdcc",
+        "id" : "https://www.example.com/buyHr0nWC3C",
         "labels" : {
-          "ej62cfNL5bDZuMMd" : "RTelVmW9tUm"
+          "DMKHetV5sRbd0rJ" : "D3L3E10CDaf"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 1,
+      "role" : "Composer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/r4TlVwBVJ88wcp",
-        "name" : "4bTpyht48sMh",
+        "id" : "https://www.example.com/eWwMqp2ZEU9ds",
+        "name" : "FvYvZdm4HU5",
         "nameType" : "Personal",
-        "orcId" : "WunEU7xffS"
+        "orcId" : "7AaNLUKIKfc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hM8HDa1etDnjcQQ",
+        "id" : "https://www.example.com/9rhm9pBLyGIJraFB",
         "labels" : {
-          "qtgUS8E5MxEGVnc" : "F19GTqiNLypekOXbj"
+          "Q93dDZtFiTP0TX2" : "cTuAXDucED8KmRqqOM"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 7,
+      "role" : "Screenwriter",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "eoxbXjX1BJ3",
-    "tags" : [ "0CK2PkMziZjjXz" ],
-    "description" : "uWQ3YaVBHC",
+    "npiSubjectHeading" : "gNbBzu4iAN",
+    "tags" : [ "ZJx1u0ChIWEU9" ],
+    "description" : "U7nkyV1CtnubOIFTEsK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/dZMrPRUCVn"
+        "partOf" : "https://www.example.com/8q7Xt7ztq9Y807uT8"
       },
-      "doi" : "https://www.example.com/vm7Otg9DxVjJoeBR",
+      "doi" : "https://www.example.com/lqEtwZAOCg",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "4GpRnfWpYZZoP",
-          "end" : "jqz04VnkHxZN5Qa"
+          "begin" : "DmqmsSo6Fv9",
+          "end" : "0IZdiQHkf1sahQ0OyL"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/3a4DBFBDgjU",
-    "abstract" : "RxErVGdyRHnXjDT"
+    "metadataSource" : "https://www.example.com/NXhpSxVKUzNrIHnvZ",
+    "abstract" : "B6D8CprPqR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/corruptiitaque",
-    "name" : "kERrYmTt2aAp",
+    "id" : "https://www.example.org/quiapraesentium",
+    "name" : "KDL1Cu0yTAftG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "0ftt0DRbaPCdmvVA",
-      "id" : "jOiCwWsUGKTG"
+      "source" : "L3R74Wiap91j8Ij",
+      "id" : "0QSKwKeB9Te"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "e6zhgomh9gp"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "h5yEJ8y14OL0I"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,22 +117,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/omnisaliquam" ],
+  "subjects" : [ "https://www.example.org/quiiste" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "WrmXdwdQwHDzFdFby",
-      "mimeType" : "Bu8Ty4LXKFd",
-      "size" : 1891559312,
+      "name" : "aZOj3CFhgdVHNchOa",
+      "mimeType" : "WNXn9LxNbrc1I",
+      "size" : 1955316668,
       "license" : {
         "type" : "License",
-        "identifier" : "sNAFmw74IPVG3JImP",
+        "identifier" : "zhznUMIE3QD8gTf",
         "labels" : {
-          "qx64zeu8bDRYr" : "gqi9ZEevnSUGiqW"
+          "RHtQs0fyI1b0" : "wu4qSVKXycET"
         },
-        "link" : "https://www.example.com/m1BeO0O6Pffkn"
+        "link" : "https://www.example.com/UAVhbRlaYF"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -142,21 +142,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "WrmXdwdQwHDzFdFby",
-    "mimeType" : "Bu8Ty4LXKFd",
-    "size" : 1891559312,
+    "name" : "aZOj3CFhgdVHNchOa",
+    "mimeType" : "WNXn9LxNbrc1I",
+    "size" : 1955316668,
     "license" : {
       "type" : "License",
-      "identifier" : "sNAFmw74IPVG3JImP",
+      "identifier" : "zhznUMIE3QD8gTf",
       "labels" : {
-        "qx64zeu8bDRYr" : "gqi9ZEevnSUGiqW"
+        "RHtQs0fyI1b0" : "wu4qSVKXycET"
       },
-      "link" : "https://www.example.com/m1BeO0O6Pffkn"
+      "link" : "https://www.example.com/UAVhbRlaYF"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "lBBOPvJYQ1",
+  "owner" : "ucwYseA8hnI",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,115 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "EJ9Kea3txl",
-    "ownerAffiliation" : "https://www.example.org/idlibero"
+    "owner" : "78RoNQj0Lt",
+    "ownerAffiliation" : "https://www.example.org/etanimi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quirerum",
+    "id" : "https://www.example.org/utut",
     "labels" : {
-      "M4UDiQ27Ad" : "c5oaXWlwL3Ym1jCJJ8"
+      "lkMWGp3FyYX" : "xjna6zWw6l"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/itaqueducimus",
-  "doi" : "https://doi.org/10.1234/ratione",
-  "link" : "https://www.example.org/estvoluptatem",
+  "handle" : "https://www.example.org/molestiaeeaque",
+  "doi" : "https://doi.org/10.1234/repudiandae",
+  "link" : "https://www.example.org/voluptatemsed",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9FeWin87fzHxFEBaS",
+    "mainTitle" : "vOhKMK9ay5hZ",
     "alternativeTitles" : {
-      "bg" : "xK5UpUv52ookTvz3Qr"
+      "ca" : "OOTRqjiwYwU9Qb"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tQkWre54C3mb",
-      "month" : "FOEvjnmjsQDcw5HsD",
-      "day" : "K4W69qO1o7K"
+      "year" : "ltcL1BqHJv4aFDVFuJU",
+      "month" : "3AM0w84hzpA",
+      "day" : "zZJ0LlmjQQXOyjLrQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VzW4zPpaWIhUO9zJ9",
-        "name" : "einmnvM5QkWQ",
-        "nameType" : "Personal",
-        "orcId" : "y6ycmsm06RtbT1"
+        "id" : "https://www.example.com/JwvRzWzydBO8guLV",
+        "name" : "hF3uswpb0K",
+        "nameType" : "Organizational",
+        "orcId" : "lCQARUl6WCzy3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/IMNA9GNmqB",
+        "id" : "https://www.example.com/Fapm2Jfvv6fIzc4cY",
         "labels" : {
-          "moiLNXi53EF051a0" : "4FGQtzr9ZtTxaXUgyZx"
+          "PTIkRyIPGzEYz" : "YTlvmNV7iF9G"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 7,
+      "role" : "Actor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IyOGjNROJ5j5NZjr",
-        "name" : "UmtskP4rDZfzbEltt",
+        "id" : "https://www.example.com/o9lgTlAXwSn5g",
+        "name" : "sMN2wiQ5MugHralUK6e",
         "nameType" : "Organizational",
-        "orcId" : "GUSVNQ5LPh4"
+        "orcId" : "VI5LwVUmjQhwgWcb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/gUKZl4r6L95wH",
+        "id" : "https://www.example.com/cwUlnQCMA9p",
         "labels" : {
-          "5LsleXqNAs6fjBXi" : "8ZtGbWltOYxVJMAJH4a"
+          "tHBJ5L06OHol3svgh" : "HY75vNJLisa2gSE"
         }
       } ],
-      "role" : "VfxSupervisor",
-      "sequence" : 4,
+      "role" : "ProjectManager",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6SatNyIi4v42BAHR",
-    "tags" : [ "x4uU8qFmK2CgzxUrn" ],
-    "description" : "iiuPnOYGgHIpNg",
+    "npiSubjectHeading" : "cmMgxEJgk0yrD4vc",
+    "tags" : [ "jjaBKRzFQq5U5Y4g" ],
+    "description" : "1NbUeatOYeaKMCSmUV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/4IYZEZd8kFWvg"
+        "partOf" : "https://www.example.com/aE0Yea3t4RzsrMO"
       },
-      "doi" : "https://www.example.com/QyBUwDYUwd1",
+      "doi" : "https://www.example.com/qXu2zJtILXm1E7UGcs",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "goLb0Wian01OAghI",
-          "end" : "EaPmfwrfNVxUw5bL"
+          "begin" : "rKwdKcJn45",
+          "end" : "qM8E5QOlQEhaSy"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/MvEl92H32XN",
-    "abstract" : "UxM3PWtcFcmypCqG"
+    "metadataSource" : "https://www.example.com/2vJWBywsp6X7r8ol",
+    "abstract" : "4h5KsEkOhgzqPDZiDY3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eosfuga",
-    "name" : "guBiL0Mk7660fK",
+    "id" : "https://www.example.org/omnisquod",
+    "name" : "fcttUfVGKUxvGCCx0K",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "3nd6bKCVdzMwqmJJizR",
-      "id" : "AoMpVXmv1K"
+      "source" : "nGdz1apcoy",
+      "id" : "gEmEfY9HdJl7"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "FLc6YrlYFKpeWSmLKd"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "UOCd7HRxPxvaKkEhet6"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,46 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velitaut" ],
+  "subjects" : [ "https://www.example.org/debitisinventore" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "xBUeUKghHX2O",
-      "mimeType" : "UeI4m4QmtmgFcAQh",
-      "size" : 811701758,
+      "name" : "6SmtBAIH5Ym9",
+      "mimeType" : "qEo9YDn2KouI54P1",
+      "size" : 1206750965,
       "license" : {
         "type" : "License",
-        "identifier" : "uzoLhe1TuHvN58khzzX",
+        "identifier" : "F1efm0HVjAQZmJ",
         "labels" : {
-          "YMqhY4lxvJ" : "UP8xl5Q7Vlak"
+          "4nlg3UAbcK8hv" : "345qV1j3FU"
         },
-        "link" : "https://www.example.com/4kZzuYUHMlVl4"
+        "link" : "https://www.example.com/oD1iyhal7mCUa1a7KC"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "xBUeUKghHX2O",
-    "mimeType" : "UeI4m4QmtmgFcAQh",
-    "size" : 811701758,
+    "name" : "6SmtBAIH5Ym9",
+    "mimeType" : "qEo9YDn2KouI54P1",
+    "size" : 1206750965,
     "license" : {
       "type" : "License",
-      "identifier" : "uzoLhe1TuHvN58khzzX",
+      "identifier" : "F1efm0HVjAQZmJ",
       "labels" : {
-        "YMqhY4lxvJ" : "UP8xl5Q7Vlak"
+        "4nlg3UAbcK8hv" : "345qV1j3FU"
       },
-      "link" : "https://www.example.com/4kZzuYUHMlVl4"
+      "link" : "https://www.example.com/oD1iyhal7mCUa1a7KC"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "EJ9Kea3txl",
+  "owner" : "78RoNQj0Lt",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,136 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Fhkme7tTKiym",
-    "ownerAffiliation" : "https://www.example.org/eosaut"
+    "owner" : "jxxIhMzE7odNSm1F",
+    "ownerAffiliation" : "https://www.example.org/sedea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/magnammagnam",
+    "id" : "https://www.example.org/abplaceat",
     "labels" : {
-      "JRX2rIB6rUCDk3" : "aygDpKDgLpaizPe"
+      "W2bZa9HUfbwwb9ik8Um" : "H4ET33gRzp3uJ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/laboreveritatis",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/temporibusmolestias",
+  "handle" : "https://www.example.org/beataemolestiae",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/nemoest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GjhQ3AjUIs",
+    "mainTitle" : "w7gfJvtzHY",
     "alternativeTitles" : {
-      "nl" : "MpNpxNbTa60wFM"
+      "sv" : "HXM6I7xxlyLpFxf"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "xsdpTwutHWlTGpd",
-      "month" : "AfSyCr3TSY",
-      "day" : "vHadd52Hyp8"
+      "year" : "wAyE7ZM60yXJhqtl",
+      "month" : "wXFUJtzepB5KNV",
+      "day" : "WCsVhvAxqyMe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lv38mXIkUHei",
-        "name" : "MbEWyeTKqXd90",
-        "nameType" : "Organizational",
-        "orcId" : "Ev5k8RgHNyxj"
+        "id" : "https://www.example.com/OzPhChkWaAD0DA",
+        "name" : "zULRyWk2hkp",
+        "nameType" : "Personal",
+        "orcId" : "ndDSXBlCCFsS5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hNdRzOClcteDRt",
+        "id" : "https://www.example.com/i2OssLWx0qniXjK",
         "labels" : {
-          "OJ0V9xtXw1" : "BWfIoxo3DCL"
+          "eHMsmIhuLfO" : "f47KXHRifx"
         }
       } ],
-      "role" : "Director",
-      "sequence" : 8,
+      "role" : "LandscapeArchitect",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/RXI0PWAryPbekW",
-        "name" : "oPqvYqRIaIzzFgXZv3W",
-        "nameType" : "Organizational",
-        "orcId" : "wLr6CFRjZ8q"
+        "id" : "https://www.example.com/tmR0GfZjmtah",
+        "name" : "Ng6s1EbgBGnU7Wk4u8",
+        "nameType" : "Personal",
+        "orcId" : "4UWwRQKCRRO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/09VdmJcAcX8bYH9OsLK",
+        "id" : "https://www.example.com/3U5gkNdKuLF",
         "labels" : {
-          "rVMoUtezj0mGd" : "moDlUEIdQe"
+          "xx9Ax9EIi6SaeyAL9" : "N9ntlPtWvD7nn"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 0,
+      "role" : "DataManager",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5T3nQCYSB1",
-    "tags" : [ "pKb0MWVMbm" ],
-    "description" : "wLMd1jRdVikhTUgOE3",
+    "npiSubjectHeading" : "w0oh7cRafxDEUEL",
+    "tags" : [ "O2rG6XlzE5onFgeK" ],
+    "description" : "VKDmJtYlgdNwPlpM",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/sKUVCq8CSUZ5WGiTdv"
+        "partOf" : "https://www.example.com/mEjI5GPvB6PlG4y8"
       },
-      "doi" : "https://www.example.com/jMLZJkDQG0GAixrs",
+      "doi" : "https://www.example.com/aG8178jYC5gx",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "mntHDgdki2hq",
-          "end" : "rFpFrf0Y3CwktOEJq"
+          "begin" : "TeCVZSCQwD30nADuTda",
+          "end" : "wv7DQAIPqYCVxNSCOr"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/2EeXVmogjyTA6oMoQV",
-    "abstract" : "XGWloGQT2W"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "JuOqo3fx4r",
-      "mimeType" : "iH5x9epHm3vwIM2K",
-      "size" : 2038998439,
-      "license" : {
-        "type" : "License",
-        "identifier" : "5ZE08dBqR5sKrot",
-        "labels" : {
-          "xlNGLpOCol55m" : "zIHuqE8GjWTfLJ1jpdL"
-        },
-        "link" : "https://www.example.com/kZfvyUNxhBG62zwpJZ"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/PbYYeCqmk4z1x1cabd",
+    "abstract" : "MZynU7GY6P8loZl2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eosquia",
-    "name" : "JFhDuTC1tV6DZM",
+    "id" : "https://www.example.org/quiconsequuntur",
+    "name" : "GPWvqi5Z8GAsqzSxk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "cLarKsH0wTmX5",
-      "id" : "ZvH8GfkKQGU5wG"
+      "source" : "lA7VSUUn9jS4YUncU",
+      "id" : "E2G7PeYvIM1r"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "jqZbjIA60hqv3MZS"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "x3zjfHMuVkavky"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -138,25 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dictaerror" ],
+  "subjects" : [ "https://www.example.org/quodrerum" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "JuOqo3fx4r",
-    "mimeType" : "iH5x9epHm3vwIM2K",
-    "size" : 2038998439,
+    "name" : "rAcK6aGZNC0SOVNo0",
+    "mimeType" : "RGirUxJduE85r",
+    "size" : 1886574797,
     "license" : {
       "type" : "License",
-      "identifier" : "5ZE08dBqR5sKrot",
+      "identifier" : "RqejDXgN2E1KtiCX5",
       "labels" : {
-        "xlNGLpOCol55m" : "zIHuqE8GjWTfLJ1jpdL"
+        "flsCuHiA265" : "75qXqyiakuAdNxKp1wO"
       },
-      "link" : "https://www.example.com/kZfvyUNxhBG62zwpJZ"
+      "link" : "https://www.example.com/R1wAV5fbLZ45Klr"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "Fhkme7tTKiym"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "rAcK6aGZNC0SOVNo0",
+      "mimeType" : "RGirUxJduE85r",
+      "size" : 1886574797,
+      "license" : {
+        "type" : "License",
+        "identifier" : "RqejDXgN2E1KtiCX5",
+        "labels" : {
+          "flsCuHiA265" : "75qXqyiakuAdNxKp1wO"
+        },
+        "link" : "https://www.example.com/R1wAV5fbLZ45Klr"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "jxxIhMzE7odNSm1F",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,115 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "jxxIhMzE7odNSm1F",
-    "ownerAffiliation" : "https://www.example.org/sedea"
+    "owner" : "EJ9Kea3txl",
+    "ownerAffiliation" : "https://www.example.org/idlibero"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/abplaceat",
+    "id" : "https://www.example.org/quirerum",
     "labels" : {
-      "W2bZa9HUfbwwb9ik8Um" : "H4ET33gRzp3uJ"
+      "M4UDiQ27Ad" : "c5oaXWlwL3Ym1jCJJ8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/beataemolestiae",
-  "doi" : "https://doi.org/10.1234/culpa",
-  "link" : "https://www.example.org/nemoest",
+  "handle" : "https://www.example.org/itaqueducimus",
+  "doi" : "https://doi.org/10.1234/ratione",
+  "link" : "https://www.example.org/estvoluptatem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "w7gfJvtzHY",
+    "mainTitle" : "9FeWin87fzHxFEBaS",
     "alternativeTitles" : {
-      "sv" : "HXM6I7xxlyLpFxf"
+      "bg" : "xK5UpUv52ookTvz3Qr"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "wAyE7ZM60yXJhqtl",
-      "month" : "wXFUJtzepB5KNV",
-      "day" : "WCsVhvAxqyMe"
+      "year" : "tQkWre54C3mb",
+      "month" : "FOEvjnmjsQDcw5HsD",
+      "day" : "K4W69qO1o7K"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OzPhChkWaAD0DA",
-        "name" : "zULRyWk2hkp",
+        "id" : "https://www.example.com/VzW4zPpaWIhUO9zJ9",
+        "name" : "einmnvM5QkWQ",
         "nameType" : "Personal",
-        "orcId" : "ndDSXBlCCFsS5"
+        "orcId" : "y6ycmsm06RtbT1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/i2OssLWx0qniXjK",
+        "id" : "https://www.example.com/IMNA9GNmqB",
         "labels" : {
-          "eHMsmIhuLfO" : "f47KXHRifx"
+          "moiLNXi53EF051a0" : "4FGQtzr9ZtTxaXUgyZx"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 9,
+      "role" : "Choreographer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/tmR0GfZjmtah",
-        "name" : "Ng6s1EbgBGnU7Wk4u8",
-        "nameType" : "Personal",
-        "orcId" : "4UWwRQKCRRO"
+        "id" : "https://www.example.com/IyOGjNROJ5j5NZjr",
+        "name" : "UmtskP4rDZfzbEltt",
+        "nameType" : "Organizational",
+        "orcId" : "GUSVNQ5LPh4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3U5gkNdKuLF",
+        "id" : "https://www.example.com/gUKZl4r6L95wH",
         "labels" : {
-          "xx9Ax9EIi6SaeyAL9" : "N9ntlPtWvD7nn"
+          "5LsleXqNAs6fjBXi" : "8ZtGbWltOYxVJMAJH4a"
         }
       } ],
-      "role" : "DataManager",
+      "role" : "VfxSupervisor",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "w0oh7cRafxDEUEL",
-    "tags" : [ "O2rG6XlzE5onFgeK" ],
-    "description" : "VKDmJtYlgdNwPlpM",
+    "npiSubjectHeading" : "6SatNyIi4v42BAHR",
+    "tags" : [ "x4uU8qFmK2CgzxUrn" ],
+    "description" : "iiuPnOYGgHIpNg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/mEjI5GPvB6PlG4y8"
+        "partOf" : "https://www.example.com/4IYZEZd8kFWvg"
       },
-      "doi" : "https://www.example.com/aG8178jYC5gx",
+      "doi" : "https://www.example.com/QyBUwDYUwd1",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "TeCVZSCQwD30nADuTda",
-          "end" : "wv7DQAIPqYCVxNSCOr"
+          "begin" : "goLb0Wian01OAghI",
+          "end" : "EaPmfwrfNVxUw5bL"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/PbYYeCqmk4z1x1cabd",
-    "abstract" : "MZynU7GY6P8loZl2"
+    "metadataSource" : "https://www.example.com/MvEl92H32XN",
+    "abstract" : "UxM3PWtcFcmypCqG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiconsequuntur",
-    "name" : "GPWvqi5Z8GAsqzSxk",
+    "id" : "https://www.example.org/eosfuga",
+    "name" : "guBiL0Mk7660fK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "lA7VSUUn9jS4YUncU",
-      "id" : "E2G7PeYvIM1r"
+      "source" : "3nd6bKCVdzMwqmJJizR",
+      "id" : "AoMpVXmv1K"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "x3zjfHMuVkavky"
+      "applicationCode" : "FLc6YrlYFKpeWSmLKd"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,46 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quodrerum" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "rAcK6aGZNC0SOVNo0",
-    "mimeType" : "RGirUxJduE85r",
-    "size" : 1886574797,
-    "license" : {
-      "type" : "License",
-      "identifier" : "RqejDXgN2E1KtiCX5",
-      "labels" : {
-        "flsCuHiA265" : "75qXqyiakuAdNxKp1wO"
-      },
-      "link" : "https://www.example.com/R1wAV5fbLZ45Klr"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/velitaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "rAcK6aGZNC0SOVNo0",
-      "mimeType" : "RGirUxJduE85r",
-      "size" : 1886574797,
+      "name" : "xBUeUKghHX2O",
+      "mimeType" : "UeI4m4QmtmgFcAQh",
+      "size" : 811701758,
       "license" : {
         "type" : "License",
-        "identifier" : "RqejDXgN2E1KtiCX5",
+        "identifier" : "uzoLhe1TuHvN58khzzX",
         "labels" : {
-          "flsCuHiA265" : "75qXqyiakuAdNxKp1wO"
+          "YMqhY4lxvJ" : "UP8xl5Q7Vlak"
         },
-        "link" : "https://www.example.com/R1wAV5fbLZ45Klr"
+        "link" : "https://www.example.com/4kZzuYUHMlVl4"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "jxxIhMzE7odNSm1F",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "xBUeUKghHX2O",
+    "mimeType" : "UeI4m4QmtmgFcAQh",
+    "size" : 811701758,
+    "license" : {
+      "type" : "License",
+      "identifier" : "uzoLhe1TuHvN58khzzX",
+      "labels" : {
+        "YMqhY4lxvJ" : "UP8xl5Q7Vlak"
+      },
+      "link" : "https://www.example.com/4kZzuYUHMlVl4"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "EJ9Kea3txl",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,115 +1,115 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "78RoNQj0Lt",
-    "ownerAffiliation" : "https://www.example.org/etanimi"
+    "owner" : "jMdATZZryONCn80Uvfc",
+    "ownerAffiliation" : "https://www.example.org/autquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/utut",
+    "id" : "https://www.example.org/omnisaut",
     "labels" : {
-      "lkMWGp3FyYX" : "xjna6zWw6l"
+      "Qtnox2nevnb9fMlcFDV" : "yREwKEhTI6xhvsz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/molestiaeeaque",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/voluptatemsed",
+  "handle" : "https://www.example.org/laborumlaboriosam",
+  "doi" : "https://doi.org/10.1234/laudantium",
+  "link" : "https://www.example.org/consecteturtemporibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vOhKMK9ay5hZ",
+    "mainTitle" : "IC8jzYhwxmztkiYIJ",
     "alternativeTitles" : {
-      "ca" : "OOTRqjiwYwU9Qb"
+      "hu" : "UwZqHRUOphiR9oN"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ltcL1BqHJv4aFDVFuJU",
-      "month" : "3AM0w84hzpA",
-      "day" : "zZJ0LlmjQQXOyjLrQ"
+      "year" : "uLNx7GtGhlv9J",
+      "month" : "uD52uVXmHwDALfZs0E",
+      "day" : "wtIjsTuoTzdKh7x"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/JwvRzWzydBO8guLV",
-        "name" : "hF3uswpb0K",
+        "id" : "https://www.example.com/ZAkQzuxvY0V",
+        "name" : "pcW5B1i7ZM",
         "nameType" : "Organizational",
-        "orcId" : "lCQARUl6WCzy3"
+        "orcId" : "fDZ4oxBrav2iY1IDgR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Fapm2Jfvv6fIzc4cY",
+        "id" : "https://www.example.com/0RX42dAuzJN",
         "labels" : {
-          "PTIkRyIPGzEYz" : "YTlvmNV7iF9G"
+          "8OW5wey82lx" : "3AxQQQdYTyQAAxB1ry"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 5,
+      "role" : "EditorialBoardMember",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/o9lgTlAXwSn5g",
-        "name" : "sMN2wiQ5MugHralUK6e",
+        "id" : "https://www.example.com/eAdkzs03w6d1",
+        "name" : "eWIZzYPLpuL",
         "nameType" : "Organizational",
-        "orcId" : "VI5LwVUmjQhwgWcb"
+        "orcId" : "Cq05jS8HaO5mOK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cwUlnQCMA9p",
+        "id" : "https://www.example.com/oScTOTKnjfR1Rf96zUF",
         "labels" : {
-          "tHBJ5L06OHol3svgh" : "HY75vNJLisa2gSE"
+          "27ud49npECXy" : "x1VKMSbqXlUMycK"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 5,
+      "role" : "EditorialBoardMember",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cmMgxEJgk0yrD4vc",
-    "tags" : [ "jjaBKRzFQq5U5Y4g" ],
-    "description" : "1NbUeatOYeaKMCSmUV",
+    "npiSubjectHeading" : "sxRPRgqu23garJxQ2B3",
+    "tags" : [ "z6dNswU5xkF3F" ],
+    "description" : "5vn8Wpxdo5db",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Chapter",
-        "partOf" : "https://www.example.com/aE0Yea3t4RzsrMO"
+        "partOf" : "https://www.example.com/p42GBcRD3wpqKhclc"
       },
-      "doi" : "https://www.example.com/qXu2zJtILXm1E7UGcs",
+      "doi" : "https://www.example.com/N6H5P0bYxwZ6vA",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "peerReviewed" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "rKwdKcJn45",
-          "end" : "qM8E5QOlQEhaSy"
+          "begin" : "Q8ZgD92e5791NYY",
+          "end" : "hVjnYPQHQjCE7ezlub"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/2vJWBywsp6X7r8ol",
-    "abstract" : "4h5KsEkOhgzqPDZiDY3"
+    "metadataSource" : "https://www.example.com/v1o4vwLXxSe",
+    "abstract" : "IsyI9dodmm2ZQzYh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omnisquod",
-    "name" : "fcttUfVGKUxvGCCx0K",
+    "id" : "https://www.example.org/quoddistinctio",
+    "name" : "TDeqEV3cQN1Hz0p5wIs",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "nGdz1apcoy",
-      "id" : "gEmEfY9HdJl7"
+      "source" : "bCEtK8WCMaZ4R8dQ8",
+      "id" : "gwukbK7Lma9dYwvRD"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "UOCd7HRxPxvaKkEhet6"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "WXjEzI9bakP"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -117,46 +117,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/debitisinventore" ],
+  "subjects" : [ "https://www.example.org/ipsamet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "6SmtBAIH5Ym9",
-      "mimeType" : "qEo9YDn2KouI54P1",
-      "size" : 1206750965,
+      "name" : "O9ttk7UJZRe",
+      "mimeType" : "8lJ26brP0bCDpqQJ8",
+      "size" : 1873142247,
       "license" : {
         "type" : "License",
-        "identifier" : "F1efm0HVjAQZmJ",
+        "identifier" : "bxPz145c2cQx2vW4",
         "labels" : {
-          "4nlg3UAbcK8hv" : "345qV1j3FU"
+          "fFjTfxU4VRSUTPX0c" : "UZQK4dngYT1"
         },
-        "link" : "https://www.example.com/oD1iyhal7mCUa1a7KC"
+        "link" : "https://www.example.com/FRcLIH9v07YH"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "6SmtBAIH5Ym9",
-    "mimeType" : "qEo9YDn2KouI54P1",
-    "size" : 1206750965,
+    "name" : "O9ttk7UJZRe",
+    "mimeType" : "8lJ26brP0bCDpqQJ8",
+    "size" : 1873142247,
     "license" : {
       "type" : "License",
-      "identifier" : "F1efm0HVjAQZmJ",
+      "identifier" : "bxPz145c2cQx2vW4",
       "labels" : {
-        "4nlg3UAbcK8hv" : "345qV1j3FU"
+        "fFjTfxU4VRSUTPX0c" : "UZQK4dngYT1"
       },
-      "link" : "https://www.example.com/oD1iyhal7mCUa1a7KC"
+      "link" : "https://www.example.com/FRcLIH9v07YH"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "78RoNQj0Lt",
+  "owner" : "jMdATZZryONCn80Uvfc",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "Hcmpf9r18RnHkLPfj",
-    "ownerAffiliation" : "https://www.example.org/eiusanimi"
+    "owner" : "CTmQGdUnm39Jc",
+    "ownerAffiliation" : "https://www.example.org/quodex"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/maioresillum",
+    "id" : "https://www.example.org/eaqueenim",
     "labels" : {
-      "rOsHvULDillIjhuoK" : "32anXnTV5S"
+      "kOQ5oAaOoUL" : "UFZ12kg0ZSjrCYRTFm"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nesciuntharum",
-  "doi" : "https://doi.org/10.1234/eligendi",
-  "link" : "https://www.example.org/undeeum",
+  "handle" : "https://www.example.org/doloremarchitecto",
+  "doi" : "https://doi.org/10.1234/tempore",
+  "link" : "https://www.example.org/cumqueea",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "c8iaSOhDPYHMsCp9",
+    "mainTitle" : "TRHUzfIo2Y4Uh6",
     "alternativeTitles" : {
-      "pl" : "NjRaVQAeGJhrx"
+      "pt" : "TSYoDMhiO2G4Bl"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "5IA2spEfBz57ZKz6",
-      "month" : "e3PrIg5eyQgdroMUn",
-      "day" : "wsQZTF7tNIFWDl3eG"
+      "year" : "imz6mIMA4qmwSNQiId",
+      "month" : "dlsGBtCEfxCOw1tDwaw",
+      "day" : "OKy7RoEkBa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/mUJftKrVFb1rNIV",
-        "name" : "hlPW6JdtiG",
+        "id" : "https://www.example.com/CdKDaTdtvBZW8H",
+        "name" : "OFI59CwGKHse",
         "nameType" : "Personal",
-        "orcId" : "V0DZGvlqYRSNPV6"
+        "orcId" : "yNhcvRYKrPkySZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/kXcM21tWGe",
+        "id" : "https://www.example.com/wcn4G73voiZaJM",
         "labels" : {
-          "ALHLl235eM2Xt1" : "F4GyrLUCBq6TglzNt7I"
+          "XLCDe7x2I8s2CYkCr" : "el3tytRjeaRPwirVuf"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 2,
+      "role" : "Architect",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/nxCHZzk6Rfwm",
-        "name" : "diMPJY5MOEe9tb",
+        "id" : "https://www.example.com/6ztlDJOII7Ieo",
+        "name" : "HUsiJl8RPtMY83N",
         "nameType" : "Organizational",
-        "orcId" : "uij3pTO1BMZuzA6"
+        "orcId" : "zx5zVlBvIRCw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aLnf5VWUHXeE",
+        "id" : "https://www.example.com/ZFZP3bzwtaUaJ",
         "labels" : {
-          "QXXO1qjNT8KptwJ" : "Xb6NdHRIz9NNDI5ka4F"
+          "cwrX4slhG06N9JXHzH" : "7AIhyaaE8wsRIgt"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 2,
+      "role" : "Editor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "CZ0lKo79z5oTJUAQE",
-    "tags" : [ "rxDOPAikqLyECrevu" ],
-    "description" : "8JOKMBnOAxf32",
+    "npiSubjectHeading" : "5hrwd600G3agqc",
+    "tags" : [ "9p0KxtlDQsf" ],
+    "description" : "BdNWrRzaH35h",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7akF1PD8E8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2NYWiCRdCotn4Xrci6U"
       },
-      "doi" : "https://www.example.com/7wNr7Rwspf",
+      "doi" : "https://www.example.com/5Ute049YOel6VeGOtK",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "rgDfRPnEiLHruu3",
-        "issue" : "KYQkW3hGiAOR",
-        "articleNumber" : "TJ9SNKBBI0IN6eh1sJm",
+        "volume" : "ylAzzE8pIJCY7EXE7R",
+        "issue" : "6gnjb82fAkxqzCVxB",
+        "articleNumber" : "WGQfeHdOLkRZvoicE",
         "pages" : {
           "type" : "Range",
-          "begin" : "FamNoHjcQ1L",
-          "end" : "gRvxv3P2raytWf"
+          "begin" : "WcQBqJ5aHav",
+          "end" : "Vfua1uAMGiLpZVF0k"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/BilwBc6pCeTVjb",
-    "abstract" : "awcW0GvyV1bnKumqTv"
+    "metadataSource" : "https://www.example.com/y5UqtBQ7Y6ncMQ",
+    "abstract" : "ertgdBXCRFYUpYWF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sintblanditiis",
-    "name" : "8pOQCsBDXs",
+    "id" : "https://www.example.org/voluptatemcorporis",
+    "name" : "1aoWazAzbq9u3yy99n",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ElehSmRSmtg2G0tNGz2",
-      "id" : "q8vetg2inzRcQnGYT"
+      "source" : "fvt1EqFAb6nvz",
+      "id" : "Bhq5cYKWT3r"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "SQZBBe3nDEQY8E8MqQ"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "NTNKdtFd768WRCnU7L"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/animirepellat" ],
+  "subjects" : [ "https://www.example.org/blanditiiscum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "kJnKqgUqvHafs",
-      "mimeType" : "skEFkVwKg5Ra6aeLW",
-      "size" : 439946620,
+      "name" : "UvlR1qHaIZG0Kq8bXX",
+      "mimeType" : "jiRcq4YwnRIMdBJcV",
+      "size" : 619726178,
       "license" : {
         "type" : "License",
-        "identifier" : "kK3iiEm0opt6s9MV",
+        "identifier" : "FIf0t0u8BlMj1Rkg",
         "labels" : {
-          "jXm0yy3NBX2lARB" : "a051lbTJuC7OLFb0bp"
+          "HDSx3LsLu4S8q" : "C8UyXadDXszQ"
         },
-        "link" : "https://www.example.com/zGc0yw7W0qhQgC"
+        "link" : "https://www.example.com/QrGp4eFgJxfNB4isjuq"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "kJnKqgUqvHafs",
-    "mimeType" : "skEFkVwKg5Ra6aeLW",
-    "size" : 439946620,
+    "name" : "UvlR1qHaIZG0Kq8bXX",
+    "mimeType" : "jiRcq4YwnRIMdBJcV",
+    "size" : 619726178,
     "license" : {
       "type" : "License",
-      "identifier" : "kK3iiEm0opt6s9MV",
+      "identifier" : "FIf0t0u8BlMj1Rkg",
       "labels" : {
-        "jXm0yy3NBX2lARB" : "a051lbTJuC7OLFb0bp"
+        "HDSx3LsLu4S8q" : "C8UyXadDXszQ"
       },
-      "link" : "https://www.example.com/zGc0yw7W0qhQgC"
+      "link" : "https://www.example.com/QrGp4eFgJxfNB4isjuq"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "Hcmpf9r18RnHkLPfj",
+  "owner" : "CTmQGdUnm39Jc",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Sb3wjkCKsN",
-    "ownerAffiliation" : "https://www.example.org/quamex"
+    "owner" : "Hcmpf9r18RnHkLPfj",
+    "ownerAffiliation" : "https://www.example.org/eiusanimi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quidolorem",
+    "id" : "https://www.example.org/maioresillum",
     "labels" : {
-      "bSM7BYH2lS5X9d0TYJ" : "fF8whdpw0KwJgdFl"
+      "rOsHvULDillIjhuoK" : "32anXnTV5S"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velitconsequuntur",
-  "doi" : "https://doi.org/10.1234/perspiciatis",
-  "link" : "https://www.example.org/quossit",
+  "handle" : "https://www.example.org/nesciuntharum",
+  "doi" : "https://doi.org/10.1234/eligendi",
+  "link" : "https://www.example.org/undeeum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6IFrCFFVX8Iuq1EA",
+    "mainTitle" : "c8iaSOhDPYHMsCp9",
     "alternativeTitles" : {
-      "it" : "tMAMFY2gBmYm"
+      "pl" : "NjRaVQAeGJhrx"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "1gGNTLp5kcBNtf6ju7M",
-      "month" : "I6hhangi0K",
-      "day" : "nB1cSsslkeyWwIOfGB"
+      "year" : "5IA2spEfBz57ZKz6",
+      "month" : "e3PrIg5eyQgdroMUn",
+      "day" : "wsQZTF7tNIFWDl3eG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XcWrySfES3FogdW",
-        "name" : "6UTIyUBFs9pE",
+        "id" : "https://www.example.com/mUJftKrVFb1rNIV",
+        "name" : "hlPW6JdtiG",
         "nameType" : "Personal",
-        "orcId" : "ZSu0OSnDLeCpSUN"
+        "orcId" : "V0DZGvlqYRSNPV6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bwJCplkYp5I5a",
+        "id" : "https://www.example.com/kXcM21tWGe",
         "labels" : {
-          "CskpasEiPsAd" : "7mUD5ZEKN3ITBI"
+          "ALHLl235eM2Xt1" : "F4GyrLUCBq6TglzNt7I"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 0,
+      "role" : "LightDesigner",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/EtyE7vwTK8Wv8V4u",
-        "name" : "9ONK1XGcetr1T",
-        "nameType" : "Personal",
-        "orcId" : "1q9TBWkksIqSC"
+        "id" : "https://www.example.com/nxCHZzk6Rfwm",
+        "name" : "diMPJY5MOEe9tb",
+        "nameType" : "Organizational",
+        "orcId" : "uij3pTO1BMZuzA6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Nh9bwSZRQQPpAQFimc6",
+        "id" : "https://www.example.com/aLnf5VWUHXeE",
         "labels" : {
-          "1i1VW1HGwdrb1" : "Q25pneMGAUmdto99M"
+          "QXXO1qjNT8KptwJ" : "Xb6NdHRIz9NNDI5ka4F"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 7,
+      "role" : "DataCurator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "pyyiDmLwFMMEwDY",
-    "tags" : [ "F7MhFeJs6hqK" ],
-    "description" : "ZxhvnZDztl65JU7a",
+    "npiSubjectHeading" : "CZ0lKo79z5oTJUAQE",
+    "tags" : [ "rxDOPAikqLyECrevu" ],
+    "description" : "8JOKMBnOAxf32",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/KY6sXh0JAo"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7akF1PD8E8"
       },
-      "doi" : "https://www.example.com/MF7mEe0Pg3a17hPFh",
+      "doi" : "https://www.example.com/7wNr7Rwspf",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "193rjMoiCoX8r44",
-        "issue" : "B8qkXtpj8LRrQv",
-        "articleNumber" : "RW10IZqobI0e3R",
+        "volume" : "rgDfRPnEiLHruu3",
+        "issue" : "KYQkW3hGiAOR",
+        "articleNumber" : "TJ9SNKBBI0IN6eh1sJm",
         "pages" : {
           "type" : "Range",
-          "begin" : "wCmN1Jen6uIIc3mx4M",
-          "end" : "AsC61ayep3njCPmGy"
+          "begin" : "FamNoHjcQ1L",
+          "end" : "gRvxv3P2raytWf"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/QSsAkXWJr8AC9QFQ",
-    "abstract" : "XZDqHhobVhizDTL"
+    "metadataSource" : "https://www.example.com/BilwBc6pCeTVjb",
+    "abstract" : "awcW0GvyV1bnKumqTv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quosrecusandae",
-    "name" : "Z5bu9ff4H0yBiOase",
+    "id" : "https://www.example.org/sintblanditiis",
+    "name" : "8pOQCsBDXs",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "0eo74EPJqcqkC9RuF",
-      "id" : "7HZnyoKeLJ"
+      "source" : "ElehSmRSmtg2G0tNGz2",
+      "id" : "q8vetg2inzRcQnGYT"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "inPhbrbp70zdSdaZ"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "SQZBBe3nDEQY8E8MqQ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fugiatofficia" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ZXqRwuDKHiNgQp32",
-    "mimeType" : "Wb6FsJkN8n4sZgHq8j",
-    "size" : 1664777978,
-    "license" : {
-      "type" : "License",
-      "identifier" : "KdbY6UP7RkO4ppD",
-      "labels" : {
-        "OV1h9npq65NeW08gDW" : "3IInmJsspvlE3G0V"
-      },
-      "link" : "https://www.example.com/zeKK9F5KcghU"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/animirepellat" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZXqRwuDKHiNgQp32",
-      "mimeType" : "Wb6FsJkN8n4sZgHq8j",
-      "size" : 1664777978,
+      "name" : "kJnKqgUqvHafs",
+      "mimeType" : "skEFkVwKg5Ra6aeLW",
+      "size" : 439946620,
       "license" : {
         "type" : "License",
-        "identifier" : "KdbY6UP7RkO4ppD",
+        "identifier" : "kK3iiEm0opt6s9MV",
         "labels" : {
-          "OV1h9npq65NeW08gDW" : "3IInmJsspvlE3G0V"
+          "jXm0yy3NBX2lARB" : "a051lbTJuC7OLFb0bp"
         },
-        "link" : "https://www.example.com/zeKK9F5KcghU"
+        "link" : "https://www.example.com/zGc0yw7W0qhQgC"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "Sb3wjkCKsN",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "kJnKqgUqvHafs",
+    "mimeType" : "skEFkVwKg5Ra6aeLW",
+    "size" : 439946620,
+    "license" : {
+      "type" : "License",
+      "identifier" : "kK3iiEm0opt6s9MV",
+      "labels" : {
+        "jXm0yy3NBX2lARB" : "a051lbTJuC7OLFb0bp"
+      },
+      "link" : "https://www.example.com/zGc0yw7W0qhQgC"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "Hcmpf9r18RnHkLPfj",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "CTmQGdUnm39Jc",
-    "ownerAffiliation" : "https://www.example.org/quodex"
+    "owner" : "yR5wY1HNd9sXiWLZ2Du",
+    "ownerAffiliation" : "https://www.example.org/rationequisquam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eaqueenim",
+    "id" : "https://www.example.org/estiure",
     "labels" : {
-      "kOQ5oAaOoUL" : "UFZ12kg0ZSjrCYRTFm"
+      "1FgeDdk46aUjqr0CiUs" : "kM45bEcLh5B"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/doloremarchitecto",
-  "doi" : "https://doi.org/10.1234/tempore",
-  "link" : "https://www.example.org/cumqueea",
+  "handle" : "https://www.example.org/etharum",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/estlaudantium",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TRHUzfIo2Y4Uh6",
+    "mainTitle" : "BxOJTnLPywr8obubH",
     "alternativeTitles" : {
-      "pt" : "TSYoDMhiO2G4Bl"
+      "en" : "t90r7jqYY9nuCK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "imz6mIMA4qmwSNQiId",
-      "month" : "dlsGBtCEfxCOw1tDwaw",
-      "day" : "OKy7RoEkBa"
+      "year" : "3MHmtxhZddo0a2b",
+      "month" : "n9H9NW7zsgHFWO5HJBD",
+      "day" : "5tTwK1bTGrNLfLi7X"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/CdKDaTdtvBZW8H",
-        "name" : "OFI59CwGKHse",
-        "nameType" : "Personal",
-        "orcId" : "yNhcvRYKrPkySZ"
+        "id" : "https://www.example.com/49Rpp6ai1wi6tHFPqDC",
+        "name" : "0zZVhug7Wot2",
+        "nameType" : "Organizational",
+        "orcId" : "njQTLNZTc9V5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wcn4G73voiZaJM",
+        "id" : "https://www.example.com/TMVMqH6tU7O6VS",
         "labels" : {
-          "XLCDe7x2I8s2CYkCr" : "el3tytRjeaRPwirVuf"
+          "2zV8drOo7pnD3S" : "HPZXkiHYOg5wKJk"
         }
       } ],
-      "role" : "Architect",
+      "role" : "InteriorArchitect",
       "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/6ztlDJOII7Ieo",
-        "name" : "HUsiJl8RPtMY83N",
-        "nameType" : "Organizational",
-        "orcId" : "zx5zVlBvIRCw"
+        "id" : "https://www.example.com/8Pf82K0HmV",
+        "name" : "erRGIDjsUVN0tFGK",
+        "nameType" : "Personal",
+        "orcId" : "2OhcaTnn8A"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ZFZP3bzwtaUaJ",
+        "id" : "https://www.example.com/RaxWPcjeKxNo6hVhK",
         "labels" : {
-          "cwrX4slhG06N9JXHzH" : "7AIhyaaE8wsRIgt"
+          "FK446zNc2cc" : "s2tw81Eu8d3h"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 3,
+      "role" : "LandscapeArchitect",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5hrwd600G3agqc",
-    "tags" : [ "9p0KxtlDQsf" ],
-    "description" : "BdNWrRzaH35h",
+    "npiSubjectHeading" : "lQxaJq8YfM",
+    "tags" : [ "BGCncs353dpnZwvKk0" ],
+    "description" : "qhbuvwmPxs",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2NYWiCRdCotn4Xrci6U"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/arn6n0suP1BXhaaoJD"
       },
-      "doi" : "https://www.example.com/5Ute049YOel6VeGOtK",
+      "doi" : "https://www.example.com/xLUDnCWrrTyVaaz",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "ylAzzE8pIJCY7EXE7R",
-        "issue" : "6gnjb82fAkxqzCVxB",
-        "articleNumber" : "WGQfeHdOLkRZvoicE",
+        "volume" : "vEW1UdCfCm",
+        "issue" : "YxTuG0Q8Ci2BDc",
+        "articleNumber" : "drA7hsfZJ2JnPu2iHn",
         "pages" : {
           "type" : "Range",
-          "begin" : "WcQBqJ5aHav",
-          "end" : "Vfua1uAMGiLpZVF0k"
+          "begin" : "eGnhVRTPi0TF09",
+          "end" : "KH54ZRM9mV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/y5UqtBQ7Y6ncMQ",
-    "abstract" : "ertgdBXCRFYUpYWF"
+    "metadataSource" : "https://www.example.com/znE1sZOolQ",
+    "abstract" : "tN3ytV6WHK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemcorporis",
-    "name" : "1aoWazAzbq9u3yy99n",
+    "id" : "https://www.example.org/errornulla",
+    "name" : "LLqyt5vqDnts",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "fvt1EqFAb6nvz",
-      "id" : "Bhq5cYKWT3r"
+      "source" : "2lfSJHVji3hLvbYoU3X",
+      "id" : "kIlb0F6oKBftZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "NTNKdtFd768WRCnU7L"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "seJXnRQrU4ezcYo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,22 +120,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/blanditiiscum" ],
+  "subjects" : [ "https://www.example.org/ametvero" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "UvlR1qHaIZG0Kq8bXX",
-      "mimeType" : "jiRcq4YwnRIMdBJcV",
-      "size" : 619726178,
+      "name" : "HD8g8Vdvp6XHxK6GrI",
+      "mimeType" : "zxKfWB6XZJYDR8wbP4Y",
+      "size" : 1885922387,
       "license" : {
         "type" : "License",
-        "identifier" : "FIf0t0u8BlMj1Rkg",
+        "identifier" : "r8feZLFnad0Sn9P8",
         "labels" : {
-          "HDSx3LsLu4S8q" : "C8UyXadDXszQ"
+          "LQqwnVvJJXACrEoT8" : "TAOpOWiPKJi"
         },
-        "link" : "https://www.example.com/QrGp4eFgJxfNB4isjuq"
+        "link" : "https://www.example.com/5bWhCSTWNJtTVY"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -145,21 +145,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "UvlR1qHaIZG0Kq8bXX",
-    "mimeType" : "jiRcq4YwnRIMdBJcV",
-    "size" : 619726178,
+    "name" : "HD8g8Vdvp6XHxK6GrI",
+    "mimeType" : "zxKfWB6XZJYDR8wbP4Y",
+    "size" : 1885922387,
     "license" : {
       "type" : "License",
-      "identifier" : "FIf0t0u8BlMj1Rkg",
+      "identifier" : "r8feZLFnad0Sn9P8",
       "labels" : {
-        "HDSx3LsLu4S8q" : "C8UyXadDXszQ"
+        "LQqwnVvJJXACrEoT8" : "TAOpOWiPKJi"
       },
-      "link" : "https://www.example.com/QrGp4eFgJxfNB4isjuq"
+      "link" : "https://www.example.com/5bWhCSTWNJtTVY"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "CTmQGdUnm39Jc",
+  "owner" : "yR5wY1HNd9sXiWLZ2Du",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -3,137 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "CLAOXdBGvSueYnda",
-    "ownerAffiliation" : "https://www.example.org/laborumreprehenderit"
+    "owner" : "Sb3wjkCKsN",
+    "ownerAffiliation" : "https://www.example.org/quamex"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repudiandaeaut",
+    "id" : "https://www.example.org/quidolorem",
     "labels" : {
-      "UF41SkwXTBjZLxrMGm" : "g6ffyuaNyUJ8VB"
+      "bSM7BYH2lS5X9d0TYJ" : "fF8whdpw0KwJgdFl"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/inciduntveniam",
-  "doi" : "https://doi.org/10.1234/corrupti",
-  "link" : "https://www.example.org/praesentiumsed",
+  "handle" : "https://www.example.org/velitconsequuntur",
+  "doi" : "https://doi.org/10.1234/perspiciatis",
+  "link" : "https://www.example.org/quossit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "anG2SzH070H",
+    "mainTitle" : "6IFrCFFVX8Iuq1EA",
     "alternativeTitles" : {
-      "fi" : "lrgPgZno8sa6wn16"
+      "it" : "tMAMFY2gBmYm"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "o0xY1Md1NPidS5Fs8",
-      "month" : "LTBT9nPnJ0HqxTVxtyg",
-      "day" : "rAFN1zGhj3LqD"
+      "year" : "1gGNTLp5kcBNtf6ju7M",
+      "month" : "I6hhangi0K",
+      "day" : "nB1cSsslkeyWwIOfGB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fzgF5L8kxfF3MX",
-        "name" : "z3aWu0KpcdHDUqrSJU",
-        "nameType" : "Organizational",
-        "orcId" : "lqYVwWpzTcodH"
+        "id" : "https://www.example.com/XcWrySfES3FogdW",
+        "name" : "6UTIyUBFs9pE",
+        "nameType" : "Personal",
+        "orcId" : "ZSu0OSnDLeCpSUN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/E2KK9yO5XI8dXpTB",
+        "id" : "https://www.example.com/bwJCplkYp5I5a",
         "labels" : {
-          "LPhkRNntHVsxdDjc" : "MLt844E43W"
+          "CskpasEiPsAd" : "7mUD5ZEKN3ITBI"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 2,
+      "role" : "Other",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jcTylCmZZWau2W7LRO",
-        "name" : "xvUruWWgFQ1GaaBVp",
+        "id" : "https://www.example.com/EtyE7vwTK8Wv8V4u",
+        "name" : "9ONK1XGcetr1T",
         "nameType" : "Personal",
-        "orcId" : "YRlgDl425qeSLU0Wkn"
+        "orcId" : "1q9TBWkksIqSC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cUPitju1wAkgyD8N",
+        "id" : "https://www.example.com/Nh9bwSZRQQPpAQFimc6",
         "labels" : {
-          "qbFwCvel6P" : "deMWBTanRayLK"
+          "1i1VW1HGwdrb1" : "Q25pneMGAUmdto99M"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 9,
+      "role" : "LightDesigner",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "bdUADB8os3lNA9IKNd9",
-    "tags" : [ "zT0HMMEFEk60v" ],
-    "description" : "CPMbsxG5A6744eh5i",
+    "npiSubjectHeading" : "pyyiDmLwFMMEwDY",
+    "tags" : [ "F7MhFeJs6hqK" ],
+    "description" : "ZxhvnZDztl65JU7a",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/q7Md6zWxbTTHZ0"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/KY6sXh0JAo"
       },
-      "doi" : "https://www.example.com/BKVHXsAZ44c1BYhN",
+      "doi" : "https://www.example.com/MF7mEe0Pg3a17hPFh",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "FNByq3JZXTTSM",
-        "issue" : "PNS8HYnS3UzT",
-        "articleNumber" : "8z00IZKwydU10m8Zo2W",
+        "volume" : "193rjMoiCoX8r44",
+        "issue" : "B8qkXtpj8LRrQv",
+        "articleNumber" : "RW10IZqobI0e3R",
         "pages" : {
           "type" : "Range",
-          "begin" : "grIKBuITJimL",
-          "end" : "DCyCLnq5MJNzXiE13Zw"
+          "begin" : "wCmN1Jen6uIIc3mx4M",
+          "end" : "AsC61ayep3njCPmGy"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/fkMGqmKZP29tLEL583q",
-    "abstract" : "Az4kEr2ay7vqm"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wk4UTbFaVDnH",
-      "mimeType" : "ffK6wHXmpAe",
-      "size" : 568217577,
-      "license" : {
-        "type" : "License",
-        "identifier" : "WOsz7s4kj9D9N",
-        "labels" : {
-          "W3hE4WaLYM4aEQ" : "LIryo0U9FCMcsl"
-        },
-        "link" : "https://www.example.com/QwOQqTLJHb72"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/QSsAkXWJr8AC9QFQ",
+    "abstract" : "XZDqHhobVhizDTL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aspernaturoccaecati",
-    "name" : "DPCKrg13lx7",
+    "id" : "https://www.example.org/quosrecusandae",
+    "name" : "Z5bu9ff4H0yBiOase",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "qSurakSXWNB4V",
-      "id" : "DTJkIrxS5A"
+      "source" : "0eo74EPJqcqkC9RuF",
+      "id" : "7HZnyoKeLJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "XKIPjoIRiUOgwJ"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "inPhbrbp70zdSdaZ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/corruptiporro" ],
+  "subjects" : [ "https://www.example.org/fugiatofficia" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "wk4UTbFaVDnH",
-    "mimeType" : "ffK6wHXmpAe",
-    "size" : 568217577,
+    "name" : "ZXqRwuDKHiNgQp32",
+    "mimeType" : "Wb6FsJkN8n4sZgHq8j",
+    "size" : 1664777978,
     "license" : {
       "type" : "License",
-      "identifier" : "WOsz7s4kj9D9N",
+      "identifier" : "KdbY6UP7RkO4ppD",
       "labels" : {
-        "W3hE4WaLYM4aEQ" : "LIryo0U9FCMcsl"
+        "OV1h9npq65NeW08gDW" : "3IInmJsspvlE3G0V"
       },
-      "link" : "https://www.example.com/QwOQqTLJHb72"
+      "link" : "https://www.example.com/zeKK9F5KcghU"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "CLAOXdBGvSueYnda"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "ZXqRwuDKHiNgQp32",
+      "mimeType" : "Wb6FsJkN8n4sZgHq8j",
+      "size" : 1664777978,
+      "license" : {
+        "type" : "License",
+        "identifier" : "KdbY6UP7RkO4ppD",
+        "labels" : {
+          "OV1h9npq65NeW08gDW" : "3IInmJsspvlE3G0V"
+        },
+        "link" : "https://www.example.com/zeKK9F5KcghU"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "Sb3wjkCKsN",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,104 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "ETd8IooC4m",
-    "ownerAffiliation" : "https://www.example.org/magnamet"
+    "owner" : "YeIpShvjK2IFs3kmg",
+    "ownerAffiliation" : "https://www.example.org/quisut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sedcupiditate",
+    "id" : "https://www.example.org/molestiaeeius",
     "labels" : {
-      "K04sZZllobxbr" : "8mhnKntczT"
+      "hDiyxAPFAKFkjRx5J" : "a6lmUj9WII9aA95R"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sintfacilis",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/perspiciatisminima",
+  "handle" : "https://www.example.org/necessitatibusaut",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/maximeillo",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7aVcLaSkeVeuCC",
+    "mainTitle" : "FqizJ6vzIxWe",
     "alternativeTitles" : {
-      "cs" : "USXJPn1Ykjpy"
+      "af" : "5PqtErv41Eru03UvUC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "JOsA0G6FlRbRy46DNBQ",
-      "month" : "9NqCPOo1UG",
-      "day" : "kuQYxO554g0BLBg"
+      "year" : "miO1R5EKkN",
+      "month" : "UmAsvm1IAHj",
+      "day" : "Di6nyRRSOZDF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jY6kM9z7wNQfIqHHv4b",
-        "name" : "4hgoaL4C66DaD9w",
+        "id" : "https://www.example.com/VyJGfLyJQ2LQWO",
+        "name" : "SwiaZfIVGTrtB",
         "nameType" : "Organizational",
-        "orcId" : "N6kaJUnmUP"
+        "orcId" : "kAka8syMHRxXGRA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LxVK3vascB",
+        "id" : "https://www.example.com/n0EyyJqMcN0eyNW",
         "labels" : {
-          "BB5PkkmciewDTDXPz4" : "mzySshplzO3cfUlj"
+          "FLo34NpqGFd" : "xIJQAkep7XoGks5"
         }
       } ],
-      "role" : "Screenwriter",
+      "role" : "Distributor",
       "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/NjmpKP6VbedW2F7uD",
-        "name" : "jn7A4zaBDmaIcOlqtU",
-        "nameType" : "Personal",
-        "orcId" : "HWNHAaFdLv"
+        "id" : "https://www.example.com/WyjZBxOVCjkT5kdq",
+        "name" : "YVwXU6tpIrhkDV9j",
+        "nameType" : "Organizational",
+        "orcId" : "cdUNA8Mfd7O6XkWZ1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DtDdFmP9tENvFQvTzdE",
+        "id" : "https://www.example.com/abfZHRahMPqV1yvoxK2",
         "labels" : {
-          "EQNzUdtLpftX6l" : "Nt2VoTaYNCBp15h"
+          "IzOUynBQZYQpQ5lXEl" : "b5kuEgUhSgxUpNidKE"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 6,
+      "role" : "SoundDesigner",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5etmSp3NCeVXdXKcB",
-    "tags" : [ "VxV6eT5fSKr" ],
-    "description" : "xEFIvrpBVq",
+    "npiSubjectHeading" : "DVUWDFuM7GM8X8qjr",
+    "tags" : [ "rcfp0jvvbZY8G1X" ],
+    "description" : "o3SOdxrjAgoyM6T5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "0tAnJLf4HZ1NAb55",
+        "label" : "YDnCIAiMQe",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "aUCGYAJFPMv",
-          "country" : "cKlqqVhMe0U3w4aT"
+          "label" : "5hSWyek0S0QSC",
+          "country" : "ARXa1aAZ57AJWEmt0"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/R77qDHeeGLHGvK7dwy",
+          "id" : "https://www.example.com/9pLzZZB0IGlu",
           "labels" : {
-            "VZHDvioXey5V6uV" : "WADRqbWkeWG"
+            "IWw3u1tb3i4" : "sAt4LSvPOzZAh6X8LD7"
           }
         },
-        "product" : "https://www.example.com/Z00oBcGeJDsg7awraaa"
+        "product" : "https://www.example.com/K1iUlvAGpj6nf"
       },
-      "doi" : "https://www.example.com/88CO8CnyHiYVcyc62P",
+      "doi" : "https://www.example.com/WKhqzk1V8ZC7pXjNqG",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -107,45 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/NcMnYCcypJ4HEp",
-    "abstract" : "tGwVTxCn9QlRZ4TPhN"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "aAroV3mJ2CBuDZN",
-      "mimeType" : "EePmORoGY9CXMX",
-      "size" : 1603809202,
-      "license" : {
-        "type" : "License",
-        "identifier" : "lbQ9ljPJrbSm",
-        "labels" : {
-          "V7EMIH306pw" : "zT53Kt51M3UY0kf"
-        },
-        "link" : "https://www.example.com/tMFZKGepz4stZZ1y"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/A4l3rCG8oKt",
+    "abstract" : "T1uffKxlrxcW97ypb2M"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eaquemaxime",
-    "name" : "Me0ZY08LVFEKF92",
+    "id" : "https://www.example.org/voluptatemitaque",
+    "name" : "gaQ8bfCzcSK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZsBeL84M7yI4oqlFXml",
-      "id" : "p4q2OAGY0sgxMBj"
+      "source" : "NzXattjtBDfE",
+      "id" : "pKxqvs8MOW"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zCiG8vAJU33u4"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "el8fMI5fr1o"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/modiaccusantium" ],
+  "subjects" : [ "https://www.example.org/sedsuscipit" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "aAroV3mJ2CBuDZN",
-    "mimeType" : "EePmORoGY9CXMX",
-    "size" : 1603809202,
+    "name" : "E7aLEnzSyO5OfRw1lj",
+    "mimeType" : "ayR8Cc6Bwsb",
+    "size" : 1073853141,
     "license" : {
       "type" : "License",
-      "identifier" : "lbQ9ljPJrbSm",
+      "identifier" : "7XEVsEaprkAbA0e5",
       "labels" : {
-        "V7EMIH306pw" : "zT53Kt51M3UY0kf"
+        "2yBN80dBIjT" : "ykPihoPvvugSxZ1m"
       },
-      "link" : "https://www.example.com/tMFZKGepz4stZZ1y"
+      "link" : "https://www.example.com/IMTG4BAnxSmq"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "ETd8IooC4m"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "E7aLEnzSyO5OfRw1lj",
+      "mimeType" : "ayR8Cc6Bwsb",
+      "size" : 1073853141,
+      "license" : {
+        "type" : "License",
+        "identifier" : "7XEVsEaprkAbA0e5",
+        "labels" : {
+          "2yBN80dBIjT" : "ykPihoPvvugSxZ1m"
+        },
+        "link" : "https://www.example.com/IMTG4BAnxSmq"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "YeIpShvjK2IFs3kmg",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,105 +1,104 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "YeIpShvjK2IFs3kmg",
-    "ownerAffiliation" : "https://www.example.org/quisut"
+    "owner" : "WxK0omNFkd4EFHxN",
+    "ownerAffiliation" : "https://www.example.org/voluptatemea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiaeeius",
+    "id" : "https://www.example.org/atperspiciatis",
     "labels" : {
-      "hDiyxAPFAKFkjRx5J" : "a6lmUj9WII9aA95R"
+      "CjvMxbTXzSsB4QdT8" : "rgfkgrnOefvCVdR"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/necessitatibusaut",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/maximeillo",
+  "handle" : "https://www.example.org/eaeum",
+  "doi" : "https://doi.org/10.1234/nisi",
+  "link" : "https://www.example.org/aliquidmolestias",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FqizJ6vzIxWe",
+    "mainTitle" : "1ypWegZZ6foajgc0W",
     "alternativeTitles" : {
-      "af" : "5PqtErv41Eru03UvUC"
+      "ca" : "OJCLTX4UZlVfSgU"
     },
     "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "miO1R5EKkN",
-      "month" : "UmAsvm1IAHj",
-      "day" : "Di6nyRRSOZDF"
+      "year" : "MFw8D5XcDJd9",
+      "month" : "HFgLvqIzZkhPYwoOghk",
+      "day" : "urIV4bPh183fTy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VyJGfLyJQ2LQWO",
-        "name" : "SwiaZfIVGTrtB",
+        "id" : "https://www.example.com/3s0JQpTKKzJ77N1a",
+        "name" : "qq9ihqSIIir",
         "nameType" : "Organizational",
-        "orcId" : "kAka8syMHRxXGRA"
+        "orcId" : "Nugxs2ctQrjg5vKnW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/n0EyyJqMcN0eyNW",
+        "id" : "https://www.example.com/SDCbuMO48A",
         "labels" : {
-          "FLo34NpqGFd" : "xIJQAkep7XoGks5"
+          "0BI8KWI79vSL38dYsa" : "ebdlq9PR4ftQ"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 0,
+      "role" : "Architect",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WyjZBxOVCjkT5kdq",
-        "name" : "YVwXU6tpIrhkDV9j",
-        "nameType" : "Organizational",
-        "orcId" : "cdUNA8Mfd7O6XkWZ1"
+        "id" : "https://www.example.com/MOeHyvb0tp5YDGlGs",
+        "name" : "m39pOf7sz5",
+        "nameType" : "Personal",
+        "orcId" : "vdN3eAf2mh3Fl81p"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/abfZHRahMPqV1yvoxK2",
+        "id" : "https://www.example.com/03Ea4btyvw4Ckyj",
         "labels" : {
-          "IzOUynBQZYQpQ5lXEl" : "b5kuEgUhSgxUpNidKE"
+          "mdEBW6lPo1kY" : "z4YP4vis8WK"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 2,
+      "role" : "ProjectManager",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "DVUWDFuM7GM8X8qjr",
-    "tags" : [ "rcfp0jvvbZY8G1X" ],
-    "description" : "o3SOdxrjAgoyM6T5",
+    "npiSubjectHeading" : "f6vmtPhN8bKoK",
+    "tags" : [ "qEkyWYidcxNEX1pzKA" ],
+    "description" : "sjIQIAiuU1WK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "YDnCIAiMQe",
+        "label" : "6zFd3EUdC65fNu",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "5hSWyek0S0QSC",
-          "country" : "ARXa1aAZ57AJWEmt0"
+          "label" : "5WVZbKuhlTC7MNYM",
+          "country" : "s1VRumGm54Gd8"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2020-09-23T09:51:23.044996Z",
-          "to" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Instant",
+          "value" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/9pLzZZB0IGlu",
+          "id" : "https://www.example.com/A3j965nFQsrx7idrEt",
           "labels" : {
-            "IWw3u1tb3i4" : "sAt4LSvPOzZAh6X8LD7"
+            "JA7fyeMUPu6OkAa3x99" : "c8FYQjJfsNUQn7h9x8"
           }
         },
-        "product" : "https://www.example.com/K1iUlvAGpj6nf"
+        "product" : "https://www.example.com/fVUai75xFPbE"
       },
-      "doi" : "https://www.example.com/WKhqzk1V8ZC7pXjNqG",
+      "doi" : "https://www.example.com/4Xa84AmhUxhqvlummD",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -108,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/A4l3rCG8oKt",
-    "abstract" : "T1uffKxlrxcW97ypb2M"
+    "metadataSource" : "https://www.example.com/PCDxCfk9Y9Fel6RrG",
+    "abstract" : "sVX7dqTzq4lFC4"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemitaque",
-    "name" : "gaQ8bfCzcSK",
+    "id" : "https://www.example.org/voluptasvoluptas",
+    "name" : "TOXNshN1NtHMCYyM",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "NzXattjtBDfE",
-      "id" : "pKxqvs8MOW"
+      "source" : "IpxFukbFB7ac6nx",
+      "id" : "KdZGy9QdIM9DIBx"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "el8fMI5fr1o"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "NdtgpmIltmhjTuFXg"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sedsuscipit" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "E7aLEnzSyO5OfRw1lj",
-    "mimeType" : "ayR8Cc6Bwsb",
-    "size" : 1073853141,
-    "license" : {
-      "type" : "License",
-      "identifier" : "7XEVsEaprkAbA0e5",
-      "labels" : {
-        "2yBN80dBIjT" : "ykPihoPvvugSxZ1m"
-      },
-      "link" : "https://www.example.com/IMTG4BAnxSmq"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/inciduntsit" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "E7aLEnzSyO5OfRw1lj",
-      "mimeType" : "ayR8Cc6Bwsb",
-      "size" : 1073853141,
+      "name" : "VnyBVwh7c4iwP",
+      "mimeType" : "kUqMwZhXG3etfWqrWh",
+      "size" : 218076987,
       "license" : {
         "type" : "License",
-        "identifier" : "7XEVsEaprkAbA0e5",
+        "identifier" : "zZ4dUcr6UAcz",
         "labels" : {
-          "2yBN80dBIjT" : "ykPihoPvvugSxZ1m"
+          "kJDYwtjPTVHSHR" : "lAeE5dfn99ReQN98"
         },
-        "link" : "https://www.example.com/IMTG4BAnxSmq"
+        "link" : "https://www.example.com/vFXwfDNyRQGerD9fH"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "YeIpShvjK2IFs3kmg",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "VnyBVwh7c4iwP",
+    "mimeType" : "kUqMwZhXG3etfWqrWh",
+    "size" : 218076987,
+    "license" : {
+      "type" : "License",
+      "identifier" : "zZ4dUcr6UAcz",
+      "labels" : {
+        "kJDYwtjPTVHSHR" : "lAeE5dfn99ReQN98"
+      },
+      "link" : "https://www.example.com/vFXwfDNyRQGerD9fH"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "WxK0omNFkd4EFHxN",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "6bHcURVdAJUTA7",
-    "ownerAffiliation" : "https://www.example.org/ipsumdolores"
+    "owner" : "TON0BJVkq7R",
+    "ownerAffiliation" : "https://www.example.org/oditautem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/maximenam",
+    "id" : "https://www.example.org/rerumsit",
     "labels" : {
-      "un4iJDYgLwxzqP98Ozk" : "3pYdhoh4knAm9Jq9mE4"
+      "TUBDcOwsI6t2B" : "2y3r0Wf81CXnhqCQxxF"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etet",
-  "doi" : "https://doi.org/10.1234/saepe",
-  "link" : "https://www.example.org/voluptateaperiam",
+  "handle" : "https://www.example.org/autemdolores",
+  "doi" : "https://doi.org/10.1234/veniam",
+  "link" : "https://www.example.org/atoptio",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "D2h3R1MvrBfLL7rafNM",
+    "mainTitle" : "nkEHGxRyw3sp",
     "alternativeTitles" : {
-      "fi" : "OaBAKM9E55Z"
+      "nl" : "iXZmCFo4HD7WOtbfW"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "dSXdXgpLFmoU29",
-      "month" : "eXLhmyWLRSf0",
-      "day" : "yV2No9iq20H4IC3kFN"
+      "year" : "4SKCihAvUApLT5AT",
+      "month" : "2KgFHueEHor1Vbt",
+      "day" : "q62a5WC8MVCLYtmWrOc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wVx7pUOXMKw3yhXdZt",
-        "name" : "d4wEqaeTnsjEk2kovB",
+        "id" : "https://www.example.com/i5jeNZ6yowT1",
+        "name" : "ZMXto8BzD2fQJ0jzN",
         "nameType" : "Personal",
-        "orcId" : "hyDh6j4swbKX6"
+        "orcId" : "O8YxDFgrupM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XTOqw1N0VNzPRkdcs",
+        "id" : "https://www.example.com/RZj6SVKwAegCfXB",
         "labels" : {
-          "wLVrmXMjQr" : "MqUhPUvNB5GOMZuy"
+          "DSaI8P4CuALds0w" : "m8lKyyDKuzj"
         }
       } ],
-      "role" : "CostumeDesigner",
-      "sequence" : 9,
+      "role" : "Conductor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3eYcT5qOPGxvF6N",
-        "name" : "cxSndeQCrAAJLz2qi",
-        "nameType" : "Personal",
-        "orcId" : "gLdo6f9699aZUfMUG"
+        "id" : "https://www.example.com/177BQCUFHIk0",
+        "name" : "nbi5kS7jN1OZzasAiY7",
+        "nameType" : "Organizational",
+        "orcId" : "IzxKZvvElk"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5ykXK67nEMEmQCH",
+        "id" : "https://www.example.com/hf6CSN6lk1CYTEsbJ",
         "labels" : {
-          "Jv4mSvbLDHEVc" : "FVFqpPQsQyv"
+          "T1Suk9yl6qpNsBpKW" : "OdzlAXYeKEjsCmii8r"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 4,
+      "role" : "Conductor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "58KhAMCcO0Z5ZHvceMC",
-    "tags" : [ "Hay8uJYwIRm1tR" ],
-    "description" : "LgFK4I7nDHrjo075Q",
+    "npiSubjectHeading" : "8bqxUY7Ac3h",
+    "tags" : [ "BoymzsGiMz1RQOVwpzi" ],
+    "description" : "vlvCr9qQhkoS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "jYDfJwYUbrR",
+        "label" : "epwzCDBCj2Jd",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "tv5c2lAJ8YwYLr6",
-          "country" : "qwE0RVA3biUxhP0w"
+          "label" : "fvxY4SoacZ6Kk2C6i0v",
+          "country" : "PSxmnx2A8VakDpEdSf"
         },
         "time" : {
           "type" : "Instant",
@@ -91,14 +91,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/MTxi93dX61r",
+          "id" : "https://www.example.com/AORZHT7Vn9WbuwDI",
           "labels" : {
-            "Pp9B4Nd8QQQRCp1Za60" : "rxJk8m9oAudx7"
+            "1aVkuuXs8xVHxzbH8" : "v8Jm4wXRN7Q"
           }
         },
-        "product" : "https://www.example.com/H0JYuBc8owUsudNf0"
+        "product" : "https://www.example.com/jvguJVaULdP6"
       },
-      "doi" : "https://www.example.com/UZctKm9fCOWr2",
+      "doi" : "https://www.example.com/kHdlVvQFWgUEne",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/bb81YjcXhlU9",
-    "abstract" : "jBSu6eU8qS6BkoP5CI"
+    "metadataSource" : "https://www.example.com/3jviDKChLc",
+    "abstract" : "wPeGBzpqBp4Ka"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estvoluptatibus",
-    "name" : "2AFqSlZgtH3",
+    "id" : "https://www.example.org/utitaque",
+    "name" : "G4M1kLlZ9lTkx5N9SK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "VLrcXGznfsMoIl",
-      "id" : "3fgl4VwPcVhpB5C"
+      "source" : "eSi1tJqfsuJOR",
+      "id" : "k2woLr1m1iEcvCSs2i"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "GlWRS5r7JZDu7"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "oPlFrNKYAST6"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,22 +132,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sitveniam" ],
+  "subjects" : [ "https://www.example.org/porroaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZgYXOtJkUgFXX",
-      "mimeType" : "nJ6545v5N8uO4qEt0Z1",
-      "size" : 14051143,
+      "name" : "DTCqoYPZKwGrXtjVKU3",
+      "mimeType" : "J7wls5U7XWs1gLh",
+      "size" : 592679678,
       "license" : {
         "type" : "License",
-        "identifier" : "aaous7XttN6",
+        "identifier" : "5BjYIffJpf8E",
         "labels" : {
-          "jiYMZMMEevCtQQbv3H4" : "j1I0gxvjHBk54UJ1x"
+          "2b75FqGww6dLyZ" : "DiGsqnUl5c8yqcE"
         },
-        "link" : "https://www.example.com/bWP3eXEJmkp"
+        "link" : "https://www.example.com/IWeusR5Q86"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -157,21 +157,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ZgYXOtJkUgFXX",
-    "mimeType" : "nJ6545v5N8uO4qEt0Z1",
-    "size" : 14051143,
+    "name" : "DTCqoYPZKwGrXtjVKU3",
+    "mimeType" : "J7wls5U7XWs1gLh",
+    "size" : 592679678,
     "license" : {
       "type" : "License",
-      "identifier" : "aaous7XttN6",
+      "identifier" : "5BjYIffJpf8E",
       "labels" : {
-        "jiYMZMMEevCtQQbv3H4" : "j1I0gxvjHBk54UJ1x"
+        "2b75FqGww6dLyZ" : "DiGsqnUl5c8yqcE"
       },
-      "link" : "https://www.example.com/bWP3eXEJmkp"
+      "link" : "https://www.example.com/IWeusR5Q86"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "6bHcURVdAJUTA7",
+  "owner" : "TON0BJVkq7R",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -3,87 +3,87 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "WxK0omNFkd4EFHxN",
-    "ownerAffiliation" : "https://www.example.org/voluptatemea"
+    "owner" : "6bHcURVdAJUTA7",
+    "ownerAffiliation" : "https://www.example.org/ipsumdolores"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/atperspiciatis",
+    "id" : "https://www.example.org/maximenam",
     "labels" : {
-      "CjvMxbTXzSsB4QdT8" : "rgfkgrnOefvCVdR"
+      "un4iJDYgLwxzqP98Ozk" : "3pYdhoh4knAm9Jq9mE4"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eaeum",
-  "doi" : "https://doi.org/10.1234/nisi",
-  "link" : "https://www.example.org/aliquidmolestias",
+  "handle" : "https://www.example.org/etet",
+  "doi" : "https://doi.org/10.1234/saepe",
+  "link" : "https://www.example.org/voluptateaperiam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1ypWegZZ6foajgc0W",
+    "mainTitle" : "D2h3R1MvrBfLL7rafNM",
     "alternativeTitles" : {
-      "ca" : "OJCLTX4UZlVfSgU"
+      "fi" : "OaBAKM9E55Z"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "MFw8D5XcDJd9",
-      "month" : "HFgLvqIzZkhPYwoOghk",
-      "day" : "urIV4bPh183fTy"
+      "year" : "dSXdXgpLFmoU29",
+      "month" : "eXLhmyWLRSf0",
+      "day" : "yV2No9iq20H4IC3kFN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3s0JQpTKKzJ77N1a",
-        "name" : "qq9ihqSIIir",
-        "nameType" : "Organizational",
-        "orcId" : "Nugxs2ctQrjg5vKnW"
+        "id" : "https://www.example.com/wVx7pUOXMKw3yhXdZt",
+        "name" : "d4wEqaeTnsjEk2kovB",
+        "nameType" : "Personal",
+        "orcId" : "hyDh6j4swbKX6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/SDCbuMO48A",
+        "id" : "https://www.example.com/XTOqw1N0VNzPRkdcs",
         "labels" : {
-          "0BI8KWI79vSL38dYsa" : "ebdlq9PR4ftQ"
+          "wLVrmXMjQr" : "MqUhPUvNB5GOMZuy"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 6,
+      "role" : "CostumeDesigner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MOeHyvb0tp5YDGlGs",
-        "name" : "m39pOf7sz5",
+        "id" : "https://www.example.com/3eYcT5qOPGxvF6N",
+        "name" : "cxSndeQCrAAJLz2qi",
         "nameType" : "Personal",
-        "orcId" : "vdN3eAf2mh3Fl81p"
+        "orcId" : "gLdo6f9699aZUfMUG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/03Ea4btyvw4Ckyj",
+        "id" : "https://www.example.com/5ykXK67nEMEmQCH",
         "labels" : {
-          "mdEBW6lPo1kY" : "z4YP4vis8WK"
+          "Jv4mSvbLDHEVc" : "FVFqpPQsQyv"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 7,
+      "role" : "ProjectMember",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "f6vmtPhN8bKoK",
-    "tags" : [ "qEkyWYidcxNEX1pzKA" ],
-    "description" : "sjIQIAiuU1WK",
+    "npiSubjectHeading" : "58KhAMCcO0Z5ZHvceMC",
+    "tags" : [ "Hay8uJYwIRm1tR" ],
+    "description" : "LgFK4I7nDHrjo075Q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "6zFd3EUdC65fNu",
+        "label" : "jYDfJwYUbrR",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "5WVZbKuhlTC7MNYM",
-          "country" : "s1VRumGm54Gd8"
+          "label" : "tv5c2lAJ8YwYLr6",
+          "country" : "qwE0RVA3biUxhP0w"
         },
         "time" : {
           "type" : "Instant",
@@ -91,14 +91,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/A3j965nFQsrx7idrEt",
+          "id" : "https://www.example.com/MTxi93dX61r",
           "labels" : {
-            "JA7fyeMUPu6OkAa3x99" : "c8FYQjJfsNUQn7h9x8"
+            "Pp9B4Nd8QQQRCp1Za60" : "rxJk8m9oAudx7"
           }
         },
-        "product" : "https://www.example.com/fVUai75xFPbE"
+        "product" : "https://www.example.com/H0JYuBc8owUsudNf0"
       },
-      "doi" : "https://www.example.com/4Xa84AmhUxhqvlummD",
+      "doi" : "https://www.example.com/UZctKm9fCOWr2",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "peerReviewed" : false,
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/PCDxCfk9Y9Fel6RrG",
-    "abstract" : "sVX7dqTzq4lFC4"
+    "metadataSource" : "https://www.example.com/bb81YjcXhlU9",
+    "abstract" : "jBSu6eU8qS6BkoP5CI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptasvoluptas",
-    "name" : "TOXNshN1NtHMCYyM",
+    "id" : "https://www.example.org/estvoluptatibus",
+    "name" : "2AFqSlZgtH3",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "IpxFukbFB7ac6nx",
-      "id" : "KdZGy9QdIM9DIBx"
+      "source" : "VLrcXGznfsMoIl",
+      "id" : "3fgl4VwPcVhpB5C"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "NdtgpmIltmhjTuFXg"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "GlWRS5r7JZDu7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inciduntsit" ],
+  "subjects" : [ "https://www.example.org/sitveniam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "VnyBVwh7c4iwP",
-      "mimeType" : "kUqMwZhXG3etfWqrWh",
-      "size" : 218076987,
+      "name" : "ZgYXOtJkUgFXX",
+      "mimeType" : "nJ6545v5N8uO4qEt0Z1",
+      "size" : 14051143,
       "license" : {
         "type" : "License",
-        "identifier" : "zZ4dUcr6UAcz",
+        "identifier" : "aaous7XttN6",
         "labels" : {
-          "kJDYwtjPTVHSHR" : "lAeE5dfn99ReQN98"
+          "jiYMZMMEevCtQQbv3H4" : "j1I0gxvjHBk54UJ1x"
         },
-        "link" : "https://www.example.com/vFXwfDNyRQGerD9fH"
+        "link" : "https://www.example.com/bWP3eXEJmkp"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "VnyBVwh7c4iwP",
-    "mimeType" : "kUqMwZhXG3etfWqrWh",
-    "size" : 218076987,
+    "name" : "ZgYXOtJkUgFXX",
+    "mimeType" : "nJ6545v5N8uO4qEt0Z1",
+    "size" : 14051143,
     "license" : {
       "type" : "License",
-      "identifier" : "zZ4dUcr6UAcz",
+      "identifier" : "aaous7XttN6",
       "labels" : {
-        "kJDYwtjPTVHSHR" : "lAeE5dfn99ReQN98"
+        "jiYMZMMEevCtQQbv3H4" : "j1I0gxvjHBk54UJ1x"
       },
-      "link" : "https://www.example.com/vFXwfDNyRQGerD9fH"
+      "link" : "https://www.example.com/bWP3eXEJmkp"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "WxK0omNFkd4EFHxN",
+  "owner" : "6bHcURVdAJUTA7",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,52 +1,52 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "UCs1U2lmGBp9V9rr",
-    "ownerAffiliation" : "https://www.example.org/etquis"
+    "owner" : "K9uFkBhaDqG9",
+    "ownerAffiliation" : "https://www.example.org/nostrumtenetur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autquam",
+    "id" : "https://www.example.org/quisamet",
     "labels" : {
-      "WfoVhrBi1PJWhn4z4m" : "RsgOaqdQIbT4vD"
+      "48WdIJfJxjns" : "EB37uLC3YmrJNMz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/molestiaeid",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/doloresrem",
+  "handle" : "https://www.example.org/quidemet",
+  "doi" : "https://doi.org/10.1234/accusamus",
+  "link" : "https://www.example.org/sintnihil",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7BdcwTCNpYD4V2Vo3",
+    "mainTitle" : "lQ4teSQl7ZhjZuu7Fb",
     "alternativeTitles" : {
-      "it" : "CaRo66CCTbn44Z"
+      "is" : "jDfeLbmCYG"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ttmg8aAuYHco6kyt4",
-      "month" : "QVYjyf7o4rUXXeinTpH",
-      "day" : "lNzP46B0s1wC"
+      "year" : "HNQADvy8sCBN9JS",
+      "month" : "owVvyTfz3T0rGxf",
+      "day" : "tN3GGYvx4BFSOUm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xZd6AYKBBIfkcU7kB",
-        "name" : "FxGWBvmOHtP",
+        "id" : "https://www.example.com/HYkZ2Aw2IdZcZiIB9W",
+        "name" : "eZsxFTVKR9487",
         "nameType" : "Organizational",
-        "orcId" : "rmzgKRTXyrXrmW"
+        "orcId" : "wH31n0cTo0b6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/g5cHS1BPvwIzN",
+        "id" : "https://www.example.com/igauuQ1Bdnil47Ik",
         "labels" : {
-          "MXmAdQChyPc" : "z7qPSi0xYgRddknnF"
+          "TUwwadZobCzOrqh7l4" : "GxpQ4m2dk5mI310"
         }
       } ],
       "role" : "Distributor",
@@ -56,50 +56,49 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/exY1d3kHnTn1",
-        "name" : "4xSDUuJrK0aqD5hI2F",
-        "nameType" : "Personal",
-        "orcId" : "JD6EQprSR7gAZAhE2s"
+        "id" : "https://www.example.com/8rO13lNFUh5",
+        "name" : "MkB4DS1ggJZm7O48c",
+        "nameType" : "Organizational",
+        "orcId" : "CFdax6cOPEqdS4g8d"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/nP0DVGVy91",
+        "id" : "https://www.example.com/rpZ1adrZMH",
         "labels" : {
-          "AXkIhterPVSR" : "CzKIzkkrr8nD"
+          "PX0HoJStWpww2" : "qurmgVN3lbVDX"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 3,
+      "role" : "Director",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "eDBGCd9ru5QJ45IH0Kc",
-    "tags" : [ "BdkwOp9LpWRIhCdl" ],
-    "description" : "TBLW1v5OaKY",
+    "npiSubjectHeading" : "XDS95TV9g5qhmnTa",
+    "tags" : [ "NeVhpkAjXRzex" ],
+    "description" : "9dr3y29eFC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "Jeky0OgvaFOJjWU4P2W",
+        "label" : "V0jnFKkwKj3R",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "KxZUO7ozC326F",
-          "country" : "j3EaBhgUhWk"
+          "label" : "p06L9uMj2u64b",
+          "country" : "piL4dfg5s1wJb"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2020-09-23T09:51:23.044996Z",
-          "to" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Instant",
+          "value" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/xM0efHMaG2As2usiugM",
+          "id" : "https://www.example.com/SLymEfWoPa8cAP6Em92",
           "labels" : {
-            "aLlIYn6hjccPseV" : "lJyXYntWqjc3Uoa2EI"
+            "mOyMBjv22A0onEK0r" : "hZ354PPNTN8NeI"
           }
         },
-        "product" : "https://www.example.com/YLaEs5dT9eYu1sIW"
+        "product" : "https://www.example.com/dV33KHqMxisB2ArnV"
       },
-      "doi" : "https://www.example.com/C3LArqLh3kvf0a",
+      "doi" : "https://www.example.com/79AyLIWVQ69Q",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -108,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/mycMrewIoeqop",
-    "abstract" : "D9fo4eBGmqKB2RkxTH"
+    "metadataSource" : "https://www.example.com/IXP6GQ5O7roGb",
+    "abstract" : "yfNsN9MdDz6Et93Ql"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatema",
-    "name" : "oBhAPgKTCFo67",
+    "id" : "https://www.example.org/totamvoluptas",
+    "name" : "JVfJPO1NeY3Z6EP",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "gqxKGGMoJkU9ROGZ",
-      "id" : "6eGDznTKamaF"
+      "source" : "Vssg7l9Hbme",
+      "id" : "V9cjRbUQHGgQ9vfe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "KxlTuQwamCk6x"
+      "applicationCode" : "aHEmOq9B6d4IsgeOSVj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ipsavoluptas" ],
+  "subjects" : [ "https://www.example.org/repellenduseligendi" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ov2qgw9BbXm17LImuZo",
-      "mimeType" : "Rscefgzfry0xtVquCT2",
-      "size" : 654319735,
+      "name" : "8MEbIpqb9gVZ1",
+      "mimeType" : "w0ZlUOBERO6",
+      "size" : 1404896438,
       "license" : {
         "type" : "License",
-        "identifier" : "ma63ju8D6uWwMuRF",
+        "identifier" : "8pJwAFg5mqp0FSm04",
         "labels" : {
-          "QbdN3g91nPbAZ1lwJ" : "Hb5gUeR5o5"
+          "HETtG34ROovMQiGEY8V" : "tRITSzi3LWVAbQ"
         },
-        "link" : "https://www.example.com/oHVvXDttKQK"
+        "link" : "https://www.example.com/VPtoH2gmvH"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ov2qgw9BbXm17LImuZo",
-    "mimeType" : "Rscefgzfry0xtVquCT2",
-    "size" : 654319735,
+    "name" : "8MEbIpqb9gVZ1",
+    "mimeType" : "w0ZlUOBERO6",
+    "size" : 1404896438,
     "license" : {
       "type" : "License",
-      "identifier" : "ma63ju8D6uWwMuRF",
+      "identifier" : "8pJwAFg5mqp0FSm04",
       "labels" : {
-        "QbdN3g91nPbAZ1lwJ" : "Hb5gUeR5o5"
+        "HETtG34ROovMQiGEY8V" : "tRITSzi3LWVAbQ"
       },
-      "link" : "https://www.example.com/oHVvXDttKQK"
+      "link" : "https://www.example.com/VPtoH2gmvH"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "UCs1U2lmGBp9V9rr",
+  "owner" : "K9uFkBhaDqG9",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "VvsKFP71iKcD40V23",
-    "ownerAffiliation" : "https://www.example.org/illumdeleniti"
+    "owner" : "UCs1U2lmGBp9V9rr",
+    "ownerAffiliation" : "https://www.example.org/etquis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/necessitatibusmodi",
+    "id" : "https://www.example.org/autquam",
     "labels" : {
-      "on5c3azQWDbrnrSEHf" : "NKPJlnZ9ijcAeEkl"
+      "WfoVhrBi1PJWhn4z4m" : "RsgOaqdQIbT4vD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/estasperiores",
-  "doi" : "https://doi.org/10.1234/itaque",
-  "link" : "https://www.example.org/errorconsequuntur",
+  "handle" : "https://www.example.org/molestiaeid",
+  "doi" : "https://doi.org/10.1234/at",
+  "link" : "https://www.example.org/doloresrem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9Sd3RSzpBJvLy5f",
+    "mainTitle" : "7BdcwTCNpYD4V2Vo3",
     "alternativeTitles" : {
-      "pt" : "cqLg2jdP6J"
+      "it" : "CaRo66CCTbn44Z"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "GDiyBJzlUkTj3",
-      "month" : "vtTIg2roGULVHaIe5M6",
-      "day" : "soouXqCxk1eaeyP"
+      "year" : "ttmg8aAuYHco6kyt4",
+      "month" : "QVYjyf7o4rUXXeinTpH",
+      "day" : "lNzP46B0s1wC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/drqJVAjbff",
-        "name" : "HSkzCgWsOA",
-        "nameType" : "Personal",
-        "orcId" : "jRepyk3ZDVrk2Pjx"
+        "id" : "https://www.example.com/xZd6AYKBBIfkcU7kB",
+        "name" : "FxGWBvmOHtP",
+        "nameType" : "Organizational",
+        "orcId" : "rmzgKRTXyrXrmW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LFPBRKoT23O",
+        "id" : "https://www.example.com/g5cHS1BPvwIzN",
         "labels" : {
-          "takJBrHIvUfYMlJ" : "gSP39xTisjTEb0jV"
+          "MXmAdQChyPc" : "z7qPSi0xYgRddknnF"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 3,
+      "role" : "Distributor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3pobJbkeplYIHja32k",
-        "name" : "tPGOV45ULTtdDrs",
+        "id" : "https://www.example.com/exY1d3kHnTn1",
+        "name" : "4xSDUuJrK0aqD5hI2F",
         "nameType" : "Personal",
-        "orcId" : "4JTuuR6jQuo1mH"
+        "orcId" : "JD6EQprSR7gAZAhE2s"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oZzxKeW7gHQG",
+        "id" : "https://www.example.com/nP0DVGVy91",
         "labels" : {
-          "hzPkLzkvfP4" : "kEwU7JRqCczIAOfa"
+          "AXkIhterPVSR" : "CzKIzkkrr8nD"
         }
       } ],
-      "role" : "Director",
-      "sequence" : 5,
+      "role" : "ProjectManager",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9SUqTEYK45kEwujI8",
-    "tags" : [ "TY2GPTawVXYvR0JmDi" ],
-    "description" : "RYB4Km7TyaO5",
+    "npiSubjectHeading" : "eDBGCd9ru5QJ45IH0Kc",
+    "tags" : [ "BdkwOp9LpWRIhCdl" ],
+    "description" : "TBLW1v5OaKY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "TioKN6MJeMhtpVc",
+        "label" : "Jeky0OgvaFOJjWU4P2W",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "qNLlhWUqWCg",
-          "country" : "c0PtGUDz9sH0ms"
+          "label" : "KxZUO7ozC326F",
+          "country" : "j3EaBhgUhWk"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/CO4gU0bJqVPbYEC",
+          "id" : "https://www.example.com/xM0efHMaG2As2usiugM",
           "labels" : {
-            "bA8uASP8d9IOHMmeoUF" : "Ijkr9DNRV37fIut2"
+            "aLlIYn6hjccPseV" : "lJyXYntWqjc3Uoa2EI"
           }
         },
-        "product" : "https://www.example.com/QTLfChRgBcso6GIDweq"
+        "product" : "https://www.example.com/YLaEs5dT9eYu1sIW"
       },
-      "doi" : "https://www.example.com/zjUQK0RihKHnbdgDk",
+      "doi" : "https://www.example.com/C3LArqLh3kvf0a",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/1UxBAqKJZkAshWosQ7V",
-    "abstract" : "lQ9bIiKBQ8tNSzDZn"
+    "metadataSource" : "https://www.example.com/mycMrewIoeqop",
+    "abstract" : "D9fo4eBGmqKB2RkxTH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitquia",
-    "name" : "vxUHmVNRfK6AzatAdX",
+    "id" : "https://www.example.org/voluptatema",
+    "name" : "oBhAPgKTCFo67",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XFLPcEcDs0V",
-      "id" : "SF5fnmuFD63D5bMY"
+      "source" : "gqxKGGMoJkU9ROGZ",
+      "id" : "6eGDznTKamaF"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "AdW78iMCJ6fqEYE"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "KxlTuQwamCk6x"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/assumendasint" ],
+  "subjects" : [ "https://www.example.org/ipsavoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "6GbTG7HT1Po2w",
-      "mimeType" : "15BdG689JBFg",
-      "size" : 1688265496,
+      "name" : "ov2qgw9BbXm17LImuZo",
+      "mimeType" : "Rscefgzfry0xtVquCT2",
+      "size" : 654319735,
       "license" : {
         "type" : "License",
-        "identifier" : "56PQH6xy5BZKYL",
+        "identifier" : "ma63ju8D6uWwMuRF",
         "labels" : {
-          "iqf8fuI5eCV" : "fAZKgQ5Xf9Xr65"
+          "QbdN3g91nPbAZ1lwJ" : "Hb5gUeR5o5"
         },
-        "link" : "https://www.example.com/KjQVAd3t8k"
+        "link" : "https://www.example.com/oHVvXDttKQK"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "6GbTG7HT1Po2w",
-    "mimeType" : "15BdG689JBFg",
-    "size" : 1688265496,
+    "name" : "ov2qgw9BbXm17LImuZo",
+    "mimeType" : "Rscefgzfry0xtVquCT2",
+    "size" : 654319735,
     "license" : {
       "type" : "License",
-      "identifier" : "56PQH6xy5BZKYL",
+      "identifier" : "ma63ju8D6uWwMuRF",
       "labels" : {
-        "iqf8fuI5eCV" : "fAZKgQ5Xf9Xr65"
+        "QbdN3g91nPbAZ1lwJ" : "Hb5gUeR5o5"
       },
-      "link" : "https://www.example.com/KjQVAd3t8k"
+      "link" : "https://www.example.com/oHVvXDttKQK"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "VvsKFP71iKcD40V23",
+  "owner" : "UCs1U2lmGBp9V9rr",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "XIOTZ6lXAq",
-    "ownerAffiliation" : "https://www.example.org/doloresdolor"
+    "owner" : "VvsKFP71iKcD40V23",
+    "ownerAffiliation" : "https://www.example.org/illumdeleniti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sedtemporibus",
+    "id" : "https://www.example.org/necessitatibusmodi",
     "labels" : {
-      "IgTbPSOlEs" : "EZa99AFR0CYul"
+      "on5c3azQWDbrnrSEHf" : "NKPJlnZ9ijcAeEkl"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etvoluptas",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/quiaaut",
+  "handle" : "https://www.example.org/estasperiores",
+  "doi" : "https://doi.org/10.1234/itaque",
+  "link" : "https://www.example.org/errorconsequuntur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AcxGV4iVbfq0LTUfQMi",
+    "mainTitle" : "9Sd3RSzpBJvLy5f",
     "alternativeTitles" : {
-      "de" : "40SAYpFmOVstyrkK"
+      "pt" : "cqLg2jdP6J"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "E3ZOCA67gTC3qa8",
-      "month" : "BIhr8vVoZLkRk",
-      "day" : "IGyXGU8w3dsPxFa"
+      "year" : "GDiyBJzlUkTj3",
+      "month" : "vtTIg2roGULVHaIe5M6",
+      "day" : "soouXqCxk1eaeyP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/yMu8yFmeTrcO",
-        "name" : "XOCK5SnI6B",
+        "id" : "https://www.example.com/drqJVAjbff",
+        "name" : "HSkzCgWsOA",
         "nameType" : "Personal",
-        "orcId" : "WA4bM4huHd8u9g"
+        "orcId" : "jRepyk3ZDVrk2Pjx"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Y95TXCxAB7RsRSD",
+        "id" : "https://www.example.com/LFPBRKoT23O",
         "labels" : {
-          "x8G5ygm2X5O2bvfb5x" : "ZcWYJAFTUIxLHN"
+          "takJBrHIvUfYMlJ" : "gSP39xTisjTEb0jV"
         }
       } ],
-      "role" : "Screenwriter",
-      "sequence" : 1,
+      "role" : "RegistrationAgency",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cCcksfCtf9K40",
-        "name" : "hwFfvQdgSeM",
-        "nameType" : "Organizational",
-        "orcId" : "UrZp76yV1YTa0L0"
+        "id" : "https://www.example.com/3pobJbkeplYIHja32k",
+        "name" : "tPGOV45ULTtdDrs",
+        "nameType" : "Personal",
+        "orcId" : "4JTuuR6jQuo1mH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LgiH4GXkZ1",
+        "id" : "https://www.example.com/oZzxKeW7gHQG",
         "labels" : {
-          "Y2WNTeFx1xy" : "fV1NArHNQetD0L1Yv"
+          "hzPkLzkvfP4" : "kEwU7JRqCczIAOfa"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 7,
+      "role" : "Director",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "FXWQ3Z0sOGDxArPxjy",
-    "tags" : [ "pRghSUwzWb0FZNU" ],
-    "description" : "aa4hJKAKugR",
+    "npiSubjectHeading" : "9SUqTEYK45kEwujI8",
+    "tags" : [ "TY2GPTawVXYvR0JmDi" ],
+    "description" : "RYB4Km7TyaO5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "QJxRZ7cLCZriDmf4",
+        "label" : "TioKN6MJeMhtpVc",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "94ByZfG2lOPVT",
-          "country" : "HVhaNMVQpDlKDFYwyuM"
+          "label" : "qNLlhWUqWCg",
+          "country" : "c0PtGUDz9sH0ms"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/0Du0Z1dHlFH7R2aH",
+          "id" : "https://www.example.com/CO4gU0bJqVPbYEC",
           "labels" : {
-            "oEM7rkmhUXbVEV" : "IlWlaQ8DvHHW1qMr"
+            "bA8uASP8d9IOHMmeoUF" : "Ijkr9DNRV37fIut2"
           }
         },
-        "product" : "https://www.example.com/HRjJdT9r5CpB2abRv"
+        "product" : "https://www.example.com/QTLfChRgBcso6GIDweq"
       },
-      "doi" : "https://www.example.com/km5oyY9DQaMCdcW",
+      "doi" : "https://www.example.com/zjUQK0RihKHnbdgDk",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/gargFusLRdWG",
-    "abstract" : "mO8ugWzMFi3Z1S7OHL"
+    "metadataSource" : "https://www.example.com/1UxBAqKJZkAshWosQ7V",
+    "abstract" : "lQ9bIiKBQ8tNSzDZn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/veritatisab",
-    "name" : "YDUeZkj6GXA2",
+    "id" : "https://www.example.org/sitquia",
+    "name" : "vxUHmVNRfK6AzatAdX",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "oUORMxdySgC9BdJ",
-      "id" : "XzeUPgkK3xkVyDdRoF"
+      "source" : "XFLPcEcDs0V",
+      "id" : "SF5fnmuFD63D5bMY"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "zRLzgfj72VYoZ"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "AdW78iMCJ6fqEYE"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/expeditavoluptas" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "frrtGyPa1Kb",
-    "mimeType" : "xuXoXgWx3eD0N",
-    "size" : 896175356,
-    "license" : {
-      "type" : "License",
-      "identifier" : "7pDcLVZ7X5ur3njwE",
-      "labels" : {
-        "8ppGyGLPhPD8A" : "WrCCippRqdJZXQ"
-      },
-      "link" : "https://www.example.com/XMYwcJzimEXjhCYnsZ"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/assumendasint" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "frrtGyPa1Kb",
-      "mimeType" : "xuXoXgWx3eD0N",
-      "size" : 896175356,
+      "name" : "6GbTG7HT1Po2w",
+      "mimeType" : "15BdG689JBFg",
+      "size" : 1688265496,
       "license" : {
         "type" : "License",
-        "identifier" : "7pDcLVZ7X5ur3njwE",
+        "identifier" : "56PQH6xy5BZKYL",
         "labels" : {
-          "8ppGyGLPhPD8A" : "WrCCippRqdJZXQ"
+          "iqf8fuI5eCV" : "fAZKgQ5Xf9Xr65"
         },
-        "link" : "https://www.example.com/XMYwcJzimEXjhCYnsZ"
+        "link" : "https://www.example.com/KjQVAd3t8k"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "XIOTZ6lXAq",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "6GbTG7HT1Po2w",
+    "mimeType" : "15BdG689JBFg",
+    "size" : 1688265496,
+    "license" : {
+      "type" : "License",
+      "identifier" : "56PQH6xy5BZKYL",
+      "labels" : {
+        "iqf8fuI5eCV" : "fAZKgQ5Xf9Xr65"
+      },
+      "link" : "https://www.example.com/KjQVAd3t8k"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "VvsKFP71iKcD40V23",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -3,102 +3,103 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "Y24NqBb1YXSU3jxm",
-    "ownerAffiliation" : "https://www.example.org/sapientenam"
+    "owner" : "XIOTZ6lXAq",
+    "ownerAffiliation" : "https://www.example.org/doloresdolor"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatumsint",
+    "id" : "https://www.example.org/sedtemporibus",
     "labels" : {
-      "9STWXht40wPG2" : "aa5SGGUcarDlSIl"
+      "IgTbPSOlEs" : "EZa99AFR0CYul"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiatotam",
-  "doi" : "https://doi.org/10.1234/officiis",
-  "link" : "https://www.example.org/autarchitecto",
+  "handle" : "https://www.example.org/etvoluptas",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/quiaaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "swYy3Kh8Rsqt",
+    "mainTitle" : "AcxGV4iVbfq0LTUfQMi",
     "alternativeTitles" : {
-      "no" : "ecKmjWiBSmX86ijz2"
+      "de" : "40SAYpFmOVstyrkK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "4Qrk26PZqnW7gqgXEf",
-      "month" : "QdnOH1KOwopKql",
-      "day" : "0LiZVHr8pTcpfrsN"
+      "year" : "E3ZOCA67gTC3qa8",
+      "month" : "BIhr8vVoZLkRk",
+      "day" : "IGyXGU8w3dsPxFa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9qRc1vi5DnXxKi1q",
-        "name" : "tcFnLokfFOJmXxUxN",
+        "id" : "https://www.example.com/yMu8yFmeTrcO",
+        "name" : "XOCK5SnI6B",
         "nameType" : "Personal",
-        "orcId" : "p0nNAcLxsCjBQ"
+        "orcId" : "WA4bM4huHd8u9g"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xsr83T8jxP",
+        "id" : "https://www.example.com/Y95TXCxAB7RsRSD",
         "labels" : {
-          "9NTP3kGSHrW4aYF7TNI" : "ZSnorMzifQ"
+          "x8G5ygm2X5O2bvfb5x" : "ZcWYJAFTUIxLHN"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 7,
+      "role" : "Screenwriter",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/s9pJFThffDTVhCnO",
-        "name" : "408DB6xYR2E",
-        "nameType" : "Personal",
-        "orcId" : "8LXh9LUI1zebH1ewiy"
+        "id" : "https://www.example.com/cCcksfCtf9K40",
+        "name" : "hwFfvQdgSeM",
+        "nameType" : "Organizational",
+        "orcId" : "UrZp76yV1YTa0L0"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QSR4L7qbnjF9HP3",
+        "id" : "https://www.example.com/LgiH4GXkZ1",
         "labels" : {
-          "VaTuxHDV6QoGbJ" : "KHnc4alkIG1yhNR"
+          "Y2WNTeFx1xy" : "fV1NArHNQetD0L1Yv"
         }
       } ],
-      "role" : "ArchitecturalPlanner",
-      "sequence" : 0,
+      "role" : "Writer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "pHdlbRhT3iQSivSxl3",
-    "tags" : [ "kSLbOVmjrG" ],
-    "description" : "ZiLBqwC88wpM8JIlJ",
+    "npiSubjectHeading" : "FXWQ3Z0sOGDxArPxjy",
+    "tags" : [ "pRghSUwzWb0FZNU" ],
+    "description" : "aa4hJKAKugR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "K9z9etRejo1",
+        "label" : "QJxRZ7cLCZriDmf4",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "naIDZNEUDB4qyee",
-          "country" : "RZ060q9RyX"
+          "label" : "94ByZfG2lOPVT",
+          "country" : "HVhaNMVQpDlKDFYwyuM"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/tYCNwlDUS4xg",
+          "id" : "https://www.example.com/0Du0Z1dHlFH7R2aH",
           "labels" : {
-            "ArIdC50BqU" : "F94QOHtgGwKMhoGh6u"
+            "oEM7rkmhUXbVEV" : "IlWlaQ8DvHHW1qMr"
           }
         },
-        "product" : "https://www.example.com/zDDl7LHagdHXGq7a8"
+        "product" : "https://www.example.com/HRjJdT9r5CpB2abRv"
       },
-      "doi" : "https://www.example.com/SQnVP8CLwk4",
+      "doi" : "https://www.example.com/km5oyY9DQaMCdcW",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "peerReviewed" : false,
@@ -107,45 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/r9Y6kmudnx4DDEbbs",
-    "abstract" : "Nb33VMlXVyw"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "8o2jcBQD8U2KM",
-      "mimeType" : "a5Y9Sta17W4WiPAiN",
-      "size" : 1242468304,
-      "license" : {
-        "type" : "License",
-        "identifier" : "zfICq9kFz9ZpAv",
-        "labels" : {
-          "EsUJ9rBj3Mh8ONqM" : "TsloRfX2kPw4"
-        },
-        "link" : "https://www.example.com/CXL3D8IwVBYHOIE"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/gargFusLRdWG",
+    "abstract" : "mO8ugWzMFi3Z1S7OHL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cumquequo",
-    "name" : "24gWKnWSuCr1Ey",
+    "id" : "https://www.example.org/veritatisab",
+    "name" : "YDUeZkj6GXA2",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XrlWSBlUTz",
-      "id" : "s7cA2AKaOwPSw3BY"
+      "source" : "oUORMxdySgC9BdJ",
+      "id" : "XzeUPgkK3xkVyDdRoF"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "PIxQQbYe7Tz6i5KSp"
+      "applicationCode" : "zRLzgfj72VYoZ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/estvoluptatem" ],
+  "subjects" : [ "https://www.example.org/expeditavoluptas" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "8o2jcBQD8U2KM",
-    "mimeType" : "a5Y9Sta17W4WiPAiN",
-    "size" : 1242468304,
+    "name" : "frrtGyPa1Kb",
+    "mimeType" : "xuXoXgWx3eD0N",
+    "size" : 896175356,
     "license" : {
       "type" : "License",
-      "identifier" : "zfICq9kFz9ZpAv",
+      "identifier" : "7pDcLVZ7X5ur3njwE",
       "labels" : {
-        "EsUJ9rBj3Mh8ONqM" : "TsloRfX2kPw4"
+        "8ppGyGLPhPD8A" : "WrCCippRqdJZXQ"
       },
-      "link" : "https://www.example.com/CXL3D8IwVBYHOIE"
+      "link" : "https://www.example.com/XMYwcJzimEXjhCYnsZ"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "Y24NqBb1YXSU3jxm"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "frrtGyPa1Kb",
+      "mimeType" : "xuXoXgWx3eD0N",
+      "size" : 896175356,
+      "license" : {
+        "type" : "License",
+        "identifier" : "7pDcLVZ7X5ur3njwE",
+        "labels" : {
+          "8ppGyGLPhPD8A" : "WrCCippRqdJZXQ"
+        },
+        "link" : "https://www.example.com/XMYwcJzimEXjhCYnsZ"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "XIOTZ6lXAq",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "di85XWr8TUr7LM",
-    "ownerAffiliation" : "https://www.example.org/temporavoluptas"
+    "owner" : "R9HaXkWc47FUE",
+    "ownerAffiliation" : "https://www.example.org/estsit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aperiamquis",
+    "id" : "https://www.example.org/nesciuntharum",
     "labels" : {
-      "F2cEPF3RG6aRXrHZ" : "bxRrXVfKDkn"
+      "648x2AtxpGiFfZn" : "7VbGrxGyRnNa"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/assumendaalias",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/sedaliquam",
+  "handle" : "https://www.example.org/aperiamvoluptatibus",
+  "doi" : "https://doi.org/10.1234/facere",
+  "link" : "https://www.example.org/nequeut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xJRTe70wnFohyuxnTJ",
+    "mainTitle" : "fKrpr98D3miwV",
     "alternativeTitles" : {
-      "en" : "9x2tPhthVVa"
+      "pl" : "pMc8Av35M2BLdkFNv"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "jwuZPJNgRcZsH",
-      "month" : "pJHiB2tzU57nx7Ed",
-      "day" : "uSbIZoMyD99r"
+      "year" : "QNzZz1X6AEUzgeM",
+      "month" : "DjzQ2Ap3tFvj8q",
+      "day" : "pflH1SkSGl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/c39mq7qwO6Jghui4",
-        "name" : "96KhNvM27f",
-        "nameType" : "Organizational",
-        "orcId" : "eVoD5FbgexcwOEPg"
+        "id" : "https://www.example.com/xgwopX1ymdeXEMV",
+        "name" : "qBjEnKuXbaAL",
+        "nameType" : "Personal",
+        "orcId" : "UASBeE3rls9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CmRndnyAbIkARGZJ",
+        "id" : "https://www.example.com/kFDOhvuPWGy4",
         "labels" : {
-          "PGb5cTLJj836cC1sRvj" : "d8dMgmB5fnr8kR9SEAJ"
+          "MuGpkknW3bVU4S" : "a4uxtbSHOrGjOG"
         }
       } ],
-      "role" : "Dramatist",
-      "sequence" : 8,
+      "role" : "Actor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SWNWytVVQP4",
-        "name" : "gy1G0EnKEdLAcbmDv0",
-        "nameType" : "Organizational",
-        "orcId" : "lds4vScrhIOx3"
+        "id" : "https://www.example.com/hEm51B2ZhS",
+        "name" : "YWMeRJJpemMNrGSTp",
+        "nameType" : "Personal",
+        "orcId" : "lbIMecO7bEjczx0"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cpQUsYXnyztuy7SK",
+        "id" : "https://www.example.com/oyMYLW3erftTV9ddcmL",
         "labels" : {
-          "Unx6hmS4Cjtq88GO3G" : "cKOXYBeMXd7BNriN"
+          "8XlC3Yq6ZaybQ9NyGoR" : "mBeqXGGbDN52"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 4,
+      "role" : "Creator",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "VwY55IULqdb3",
-    "tags" : [ "q8mGrGU2P2pfLh" ],
-    "description" : "taU6LvNdZvsam3pJA",
+    "npiSubjectHeading" : "SzxffuziAkFeMUEd2aa",
+    "tags" : [ "ygrBCWq4cniN7" ],
+    "description" : "mWUgiG0JlUbygB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ihcdp4DCqIlMrKgu34"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Co2vA97DQ4jAIl"
         }
       },
-      "doi" : "https://www.example.com/E6CqNppt8KeGG07l",
+      "doi" : "https://www.example.com/HeJuSPGFqY207HOHgt",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
-        "related" : [ "https://www.example.com/GD71HK6LLhN5" ],
+        "related" : [ "https://www.example.com/5dDY2HyHPSwTJAqyn" ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "GPAp73UAmliv",
-            "end" : "hFHIjc0TXXvEoSQ1"
+            "begin" : "M3TLmkRab8MQNl7",
+            "end" : "fO8y2Pq85H"
           },
-          "pages" : "TiIwVRPptp1",
-          "illustrated" : false
+          "pages" : "mzexwbSYZX1",
+          "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Tc088PZ3bIOeX",
-    "abstract" : "Z11WrzJzRgzXVNFg"
+    "metadataSource" : "https://www.example.com/hnZDnutvh5csagMw0",
+    "abstract" : "yx88Mg2w2ERwv6bxU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/inciduntnulla",
-    "name" : "BCV6JLtaKUPD",
+    "id" : "https://www.example.org/eosvoluptatibus",
+    "name" : "xW7q8MFxIr",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "52d9rKzDtFAVv0m3S",
-      "id" : "seZswPPtn2C9TKb5"
+      "source" : "B3FX7q6EX26jMyOXN",
+      "id" : "HCmoHv0Gt4sdwp"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "SFMndOxGkDlRQ8"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "HPQ3j7UHSpI99kg0y"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiveritatis" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "3pxITL9m0WTFSqop",
-    "mimeType" : "dMRii5OV7smmx",
-    "size" : 1877999840,
-    "license" : {
-      "type" : "License",
-      "identifier" : "1yQrQv38J0pwqB14SM",
-      "labels" : {
-        "i10YvM2C2uvlXY3wJ" : "rcOUXLyxHoAshQ"
-      },
-      "link" : "https://www.example.com/k7B0rCISqFfnWyvF2ay"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/autquaerat" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "3pxITL9m0WTFSqop",
-      "mimeType" : "dMRii5OV7smmx",
-      "size" : 1877999840,
+      "name" : "5h71xvZd8Ws",
+      "mimeType" : "MuXqsoJYUNNJCIeR8d",
+      "size" : 615731782,
       "license" : {
         "type" : "License",
-        "identifier" : "1yQrQv38J0pwqB14SM",
+        "identifier" : "RShGFfRE8sbp73hD1g",
         "labels" : {
-          "i10YvM2C2uvlXY3wJ" : "rcOUXLyxHoAshQ"
+          "kGJ59S9Izd42ege" : "066aRGzCRz"
         },
-        "link" : "https://www.example.com/k7B0rCISqFfnWyvF2ay"
+        "link" : "https://www.example.com/u7POG82Szz4UcJd5"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "di85XWr8TUr7LM",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "5h71xvZd8Ws",
+    "mimeType" : "MuXqsoJYUNNJCIeR8d",
+    "size" : 615731782,
+    "license" : {
+      "type" : "License",
+      "identifier" : "RShGFfRE8sbp73hD1g",
+      "labels" : {
+        "kGJ59S9Izd42ege" : "066aRGzCRz"
+      },
+      "link" : "https://www.example.com/u7POG82Szz4UcJd5"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "R9HaXkWc47FUE",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -3,122 +3,122 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "R9HaXkWc47FUE",
-    "ownerAffiliation" : "https://www.example.org/estsit"
+    "owner" : "ceKP6V7ZJYEll",
+    "ownerAffiliation" : "https://www.example.org/ata"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nesciuntharum",
+    "id" : "https://www.example.org/voluptatemdebitis",
     "labels" : {
-      "648x2AtxpGiFfZn" : "7VbGrxGyRnNa"
+      "b5gDQ7gga6ebpr" : "Rj8gX24JmPCQOD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/aperiamvoluptatibus",
-  "doi" : "https://doi.org/10.1234/facere",
-  "link" : "https://www.example.org/nequeut",
+  "handle" : "https://www.example.org/etillum",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/siteum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fKrpr98D3miwV",
+    "mainTitle" : "hIw7h7P6PO5Rx6F",
     "alternativeTitles" : {
-      "pl" : "pMc8Av35M2BLdkFNv"
+      "el" : "y81yu6kTVBC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "QNzZz1X6AEUzgeM",
-      "month" : "DjzQ2Ap3tFvj8q",
-      "day" : "pflH1SkSGl"
+      "year" : "TyypjlizW3",
+      "month" : "ZKJZT8P2ZXv4alyy92x",
+      "day" : "yj69VhpZIn86x"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xgwopX1ymdeXEMV",
-        "name" : "qBjEnKuXbaAL",
+        "id" : "https://www.example.com/OhAbGyfyb3plKjPFII",
+        "name" : "5VtCPbcCPIasYp",
         "nameType" : "Personal",
-        "orcId" : "UASBeE3rls9"
+        "orcId" : "j7FiAr7OnmeVj1naT2"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/kFDOhvuPWGy4",
+        "id" : "https://www.example.com/YrF9LQz90Jln",
         "labels" : {
-          "MuGpkknW3bVU4S" : "a4uxtbSHOrGjOG"
+          "AJiG7VxQucEl5j" : "oJN1sMgEGK"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 0,
+      "role" : "CostumeDesigner",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hEm51B2ZhS",
-        "name" : "YWMeRJJpemMNrGSTp",
+        "id" : "https://www.example.com/BkRgM5dIo6e88xJUnx",
+        "name" : "vIkbtdX3TCjwM",
         "nameType" : "Personal",
-        "orcId" : "lbIMecO7bEjczx0"
+        "orcId" : "S5lMMDoMyRFvwovZOJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oyMYLW3erftTV9ddcmL",
+        "id" : "https://www.example.com/m1G1hkkK4UBJL",
         "labels" : {
-          "8XlC3Yq6ZaybQ9NyGoR" : "mBeqXGGbDN52"
+          "jxhZVr19Vm" : "qDmDDw2OhnWpBsPdF"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 6,
+      "role" : "ArtisticDirector",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "SzxffuziAkFeMUEd2aa",
-    "tags" : [ "ygrBCWq4cniN7" ],
-    "description" : "mWUgiG0JlUbygB",
+    "npiSubjectHeading" : "cloRSdGvMz1z",
+    "tags" : [ "UECeXi2kuULujaRbOuR" ],
+    "description" : "Eh6lfJtaZJbQip",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Co2vA97DQ4jAIl"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JVuLqqEhF8KtAiQLp5G"
         }
       },
-      "doi" : "https://www.example.com/HeJuSPGFqY207HOHgt",
+      "doi" : "https://www.example.com/SvaJnyCB8AZyVkWS",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
-        "related" : [ "https://www.example.com/5dDY2HyHPSwTJAqyn" ],
+        "related" : [ "https://www.example.com/UMYUz57AhTEPoNG" ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "M3TLmkRab8MQNl7",
-            "end" : "fO8y2Pq85H"
+            "begin" : "wAPqBGHIHigq",
+            "end" : "GvQ0bdP41KvDXJXH"
           },
-          "pages" : "mzexwbSYZX1",
+          "pages" : "ckkFpXBBWK80SlAl",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/hnZDnutvh5csagMw0",
-    "abstract" : "yx88Mg2w2ERwv6bxU"
+    "metadataSource" : "https://www.example.com/gXNR68tgMtCi3Jje",
+    "abstract" : "Ud4ooMy6gRJ0L"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eosvoluptatibus",
-    "name" : "xW7q8MFxIr",
+    "id" : "https://www.example.org/autut",
+    "name" : "Phdh7sL8XDR8DlKcB",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "B3FX7q6EX26jMyOXN",
-      "id" : "HCmoHv0Gt4sdwp"
+      "source" : "5xpn6L3ner7Q1gkRXWx",
+      "id" : "iPRikFnhQlyaWEXEg9m"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "HPQ3j7UHSpI99kg0y"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "rbBFRyamUHO7khYs"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autquaerat" ],
+  "subjects" : [ "https://www.example.org/eaeius" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "5h71xvZd8Ws",
-      "mimeType" : "MuXqsoJYUNNJCIeR8d",
-      "size" : 615731782,
+      "name" : "3OsyivNIIv",
+      "mimeType" : "x21igorPSTAMNw",
+      "size" : 1688612054,
       "license" : {
         "type" : "License",
-        "identifier" : "RShGFfRE8sbp73hD1g",
+        "identifier" : "UUoWcx0gVQn",
         "labels" : {
-          "kGJ59S9Izd42ege" : "066aRGzCRz"
+          "PCr01WWZgL" : "rdnVBHeanPgunp"
         },
-        "link" : "https://www.example.com/u7POG82Szz4UcJd5"
+        "link" : "https://www.example.com/fePfVFV4si28zGXuQ"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "5h71xvZd8Ws",
-    "mimeType" : "MuXqsoJYUNNJCIeR8d",
-    "size" : 615731782,
+    "name" : "3OsyivNIIv",
+    "mimeType" : "x21igorPSTAMNw",
+    "size" : 1688612054,
     "license" : {
       "type" : "License",
-      "identifier" : "RShGFfRE8sbp73hD1g",
+      "identifier" : "UUoWcx0gVQn",
       "labels" : {
-        "kGJ59S9Izd42ege" : "066aRGzCRz"
+        "PCr01WWZgL" : "rdnVBHeanPgunp"
       },
-      "link" : "https://www.example.com/u7POG82Szz4UcJd5"
+      "link" : "https://www.example.com/fePfVFV4si28zGXuQ"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "R9HaXkWc47FUE",
+  "owner" : "ceKP6V7ZJYEll",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -3,143 +3,122 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "zf4ontFUCrnYqMI",
-    "ownerAffiliation" : "https://www.example.org/porrooptio"
+    "owner" : "di85XWr8TUr7LM",
+    "ownerAffiliation" : "https://www.example.org/temporavoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/placeatautem",
+    "id" : "https://www.example.org/aperiamquis",
     "labels" : {
-      "9F5AH8WoySA5TArHX" : "qxu8G9NeLKMPFAsDL"
+      "F2cEPF3RG6aRXrHZ" : "bxRrXVfKDkn"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiquam",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/abodit",
+  "handle" : "https://www.example.org/assumendaalias",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/sedaliquam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nT5krQfqw0",
+    "mainTitle" : "xJRTe70wnFohyuxnTJ",
     "alternativeTitles" : {
-      "it" : "K0t6HYhvRr20wrwPqtm"
+      "en" : "9x2tPhthVVa"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "SR8kdxwLdg6I",
-      "month" : "jRRtXnYwFdsEuskk",
-      "day" : "ipy2eLQSDOL"
+      "year" : "jwuZPJNgRcZsH",
+      "month" : "pJHiB2tzU57nx7Ed",
+      "day" : "uSbIZoMyD99r"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7P0IDOHmTazR6FBdr",
-        "name" : "SHLI7qrmF5tH",
+        "id" : "https://www.example.com/c39mq7qwO6Jghui4",
+        "name" : "96KhNvM27f",
         "nameType" : "Organizational",
-        "orcId" : "ORqUods8KlkqB"
+        "orcId" : "eVoD5FbgexcwOEPg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UK9L45cz68wW",
+        "id" : "https://www.example.com/CmRndnyAbIkARGZJ",
         "labels" : {
-          "HdEOVdhuozefNtni" : "qnfLK8s72slB"
+          "PGb5cTLJj836cC1sRvj" : "d8dMgmB5fnr8kR9SEAJ"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 9,
+      "role" : "Dramatist",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/itWtfxDYCR1S8",
-        "name" : "ZWpLPgooM2AGE2gtI",
-        "nameType" : "Personal",
-        "orcId" : "w5VRlOk9Hzmw0eflNm"
+        "id" : "https://www.example.com/SWNWytVVQP4",
+        "name" : "gy1G0EnKEdLAcbmDv0",
+        "nameType" : "Organizational",
+        "orcId" : "lds4vScrhIOx3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/v4XdsdoDcI6BZ3VAJi",
+        "id" : "https://www.example.com/cpQUsYXnyztuy7SK",
         "labels" : {
-          "U1Ag7X2tsKr2" : "eyBNdeMzC4y"
+          "Unx6hmS4Cjtq88GO3G" : "cKOXYBeMXd7BNriN"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 0,
+      "role" : "ArtisticDirector",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XuCNCw8XkcxcynPV",
-    "tags" : [ "Zqm1mLmkZfprAliWFt" ],
-    "description" : "GduSbVu2QYUE0A6hH",
+    "npiSubjectHeading" : "VwY55IULqdb3",
+    "tags" : [ "q8mGrGU2P2pfLh" ],
+    "description" : "taU6LvNdZvsam3pJA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hSjw5oYP8X5a"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ihcdp4DCqIlMrKgu34"
         }
       },
-      "doi" : "https://www.example.com/vwcxkjTmimRlPvYZv",
+      "doi" : "https://www.example.com/E6CqNppt8KeGG07l",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
-        "related" : [ "https://www.example.com/1cg9dlIeU5mvViKyu5" ],
+        "related" : [ "https://www.example.com/GD71HK6LLhN5" ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "h6RJUNxx0O3efPM",
-            "end" : "UNyn8yhIQrfjQYgA2b6"
+            "begin" : "GPAp73UAmliv",
+            "end" : "hFHIjc0TXXvEoSQ1"
           },
-          "pages" : "1p9obkpbmY4IPq",
-          "illustrated" : true
+          "pages" : "TiIwVRPptp1",
+          "illustrated" : false
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/yOhwMdsddJfvcDCNda",
-    "abstract" : "czGiDZGfqMm"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "qZY1bphiXfVMJ",
-      "mimeType" : "dfCJzVnFZovz",
-      "size" : 701685483,
-      "license" : {
-        "type" : "License",
-        "identifier" : "jCvsEuxJl2Q7VK9PZl8",
-        "labels" : {
-          "hmtUvEoGBQc2f" : "TcqfLsAAjbLXn0Awx6"
-        },
-        "link" : "https://www.example.com/AJjuMKhQz3DkpyiFaL"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/Tc088PZ3bIOeX",
+    "abstract" : "Z11WrzJzRgzXVNFg"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiqui",
-    "name" : "RrIoDLS2XBJWc",
+    "id" : "https://www.example.org/inciduntnulla",
+    "name" : "BCV6JLtaKUPD",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6RehzhPZTJST7oqkkc",
-      "id" : "1moy4FxdItcQI3"
+      "source" : "52d9rKzDtFAVv0m3S",
+      "id" : "seZswPPtn2C9TKb5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "RYccrrX9NVr"
+      "applicationCode" : "SFMndOxGkDlRQ8"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -147,25 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inciduntreprehenderit" ],
+  "subjects" : [ "https://www.example.org/quiveritatis" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "qZY1bphiXfVMJ",
-    "mimeType" : "dfCJzVnFZovz",
-    "size" : 701685483,
+    "name" : "3pxITL9m0WTFSqop",
+    "mimeType" : "dMRii5OV7smmx",
+    "size" : 1877999840,
     "license" : {
       "type" : "License",
-      "identifier" : "jCvsEuxJl2Q7VK9PZl8",
+      "identifier" : "1yQrQv38J0pwqB14SM",
       "labels" : {
-        "hmtUvEoGBQc2f" : "TcqfLsAAjbLXn0Awx6"
+        "i10YvM2C2uvlXY3wJ" : "rcOUXLyxHoAshQ"
       },
-      "link" : "https://www.example.com/AJjuMKhQz3DkpyiFaL"
+      "link" : "https://www.example.com/k7B0rCISqFfnWyvF2ay"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "zf4ontFUCrnYqMI"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "3pxITL9m0WTFSqop",
+      "mimeType" : "dMRii5OV7smmx",
+      "size" : 1877999840,
+      "license" : {
+        "type" : "License",
+        "identifier" : "1yQrQv38J0pwqB14SM",
+        "labels" : {
+          "i10YvM2C2uvlXY3wJ" : "rcOUXLyxHoAshQ"
+        },
+        "link" : "https://www.example.com/k7B0rCISqFfnWyvF2ay"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "di85XWr8TUr7LM",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "ceKP6V7ZJYEll",
-    "ownerAffiliation" : "https://www.example.org/ata"
+    "owner" : "TGlGH5WKp6",
+    "ownerAffiliation" : "https://www.example.org/exercitationemaut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemdebitis",
+    "id" : "https://www.example.org/earumrerum",
     "labels" : {
-      "b5gDQ7gga6ebpr" : "Rj8gX24JmPCQOD"
+      "gnlge2VSpHAitbc2pPJ" : "Hl4TNDoJbI"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etillum",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/siteum",
+  "handle" : "https://www.example.org/quosodio",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/inciduntest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hIw7h7P6PO5Rx6F",
+    "mainTitle" : "CD8eDmNQJKY8Yyy4",
     "alternativeTitles" : {
-      "el" : "y81yu6kTVBC"
+      "cs" : "ulekjKSHRJJESQ2hPGw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TyypjlizW3",
-      "month" : "ZKJZT8P2ZXv4alyy92x",
-      "day" : "yj69VhpZIn86x"
+      "year" : "7QCBaZVf8kfoWe",
+      "month" : "5ADrAD8WhM21ugNSh",
+      "day" : "o0OOTq1dUU2HItgqQy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OhAbGyfyb3plKjPFII",
-        "name" : "5VtCPbcCPIasYp",
+        "id" : "https://www.example.com/g2npvSpgiLQs",
+        "name" : "8mx2Wq55e2f5KqIYIQ",
         "nameType" : "Personal",
-        "orcId" : "j7FiAr7OnmeVj1naT2"
+        "orcId" : "auUGF9oiZwHoaCD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YrF9LQz90Jln",
+        "id" : "https://www.example.com/IpV7xV8bL8NT",
         "labels" : {
-          "AJiG7VxQucEl5j" : "oJN1sMgEGK"
+          "cnYDHL0lUmSyf1r" : "cRJYXuBL3R"
         }
       } ],
-      "role" : "CostumeDesigner",
-      "sequence" : 5,
+      "role" : "Supervisor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BkRgM5dIo6e88xJUnx",
-        "name" : "vIkbtdX3TCjwM",
+        "id" : "https://www.example.com/HVM0myz4RzKWq0ww",
+        "name" : "r5zD5xwHy93W0mV",
         "nameType" : "Personal",
-        "orcId" : "S5lMMDoMyRFvwovZOJ"
+        "orcId" : "PX3fSFqJbAIj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/m1G1hkkK4UBJL",
+        "id" : "https://www.example.com/JI4pvVqBnhE",
         "labels" : {
-          "jxhZVr19Vm" : "qDmDDw2OhnWpBsPdF"
+          "LdlsYgbCNd0TGL" : "xPBw4tElS9TaBZ0zj0T"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 5,
+      "role" : "Funder",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cloRSdGvMz1z",
-    "tags" : [ "UECeXi2kuULujaRbOuR" ],
-    "description" : "Eh6lfJtaZJbQip",
+    "npiSubjectHeading" : "3wxJHV6vFEcw8ebE",
+    "tags" : [ "tRedVr1CHP" ],
+    "description" : "kJyaNyBmepBPvch82",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JVuLqqEhF8KtAiQLp5G"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CKLvy0j1NiVaLcEv0"
         }
       },
-      "doi" : "https://www.example.com/SvaJnyCB8AZyVkWS",
+      "doi" : "https://www.example.com/oDF0o6hWDda8I",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
-        "related" : [ "https://www.example.com/UMYUz57AhTEPoNG" ],
+        "related" : [ "https://www.example.com/oqyYiZ57gtfa" ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "wAPqBGHIHigq",
-            "end" : "GvQ0bdP41KvDXJXH"
+            "begin" : "ziM6uwwfkM",
+            "end" : "uziYHPIKZ6yi"
           },
-          "pages" : "ckkFpXBBWK80SlAl",
-          "illustrated" : true
+          "pages" : "wxx3JWQ1bFtSQSf",
+          "illustrated" : false
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/gXNR68tgMtCi3Jje",
-    "abstract" : "Ud4ooMy6gRJ0L"
+    "metadataSource" : "https://www.example.com/YOpp3BWJzm2c",
+    "abstract" : "PzNGygHzBBFoxPtHYfb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autut",
-    "name" : "Phdh7sL8XDR8DlKcB",
+    "id" : "https://www.example.org/enimnon",
+    "name" : "Qdz9wkEfWKs",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "5xpn6L3ner7Q1gkRXWx",
-      "id" : "iPRikFnhQlyaWEXEg9m"
+      "source" : "avucgFJBsNGyTrV",
+      "id" : "NEmPiHhcJLnwo7e10t"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "rbBFRyamUHO7khYs"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "qfDvUSIkThhmI8Y"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eaeius" ],
+  "subjects" : [ "https://www.example.org/voluptatemat" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "3OsyivNIIv",
-      "mimeType" : "x21igorPSTAMNw",
-      "size" : 1688612054,
+      "name" : "nXOSrwzNmJ5MB",
+      "mimeType" : "oKbxjOGJms",
+      "size" : 1859161497,
       "license" : {
         "type" : "License",
-        "identifier" : "UUoWcx0gVQn",
+        "identifier" : "Qe5ih5oXiguwz1hkW",
         "labels" : {
-          "PCr01WWZgL" : "rdnVBHeanPgunp"
+          "pN8sbJAmi73xgSOj" : "1j3LbTJbHR8zIB"
         },
-        "link" : "https://www.example.com/fePfVFV4si28zGXuQ"
+        "link" : "https://www.example.com/069NHi9Z74wk4W"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "3OsyivNIIv",
-    "mimeType" : "x21igorPSTAMNw",
-    "size" : 1688612054,
+    "name" : "nXOSrwzNmJ5MB",
+    "mimeType" : "oKbxjOGJms",
+    "size" : 1859161497,
     "license" : {
       "type" : "License",
-      "identifier" : "UUoWcx0gVQn",
+      "identifier" : "Qe5ih5oXiguwz1hkW",
       "labels" : {
-        "PCr01WWZgL" : "rdnVBHeanPgunp"
+        "pN8sbJAmi73xgSOj" : "1j3LbTJbHR8zIB"
       },
-      "link" : "https://www.example.com/fePfVFV4si28zGXuQ"
+      "link" : "https://www.example.com/069NHi9Z74wk4W"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "ceKP6V7ZJYEll",
+  "owner" : "TGlGH5WKp6",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "O7VNSZv0BEjM",
-    "ownerAffiliation" : "https://www.example.org/sedhic"
+    "owner" : "WMzLvmLOOw4KjdavQU",
+    "ownerAffiliation" : "https://www.example.org/etdolores"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quibusdamdoloribus",
+    "id" : "https://www.example.org/inautem",
     "labels" : {
-      "iLJxSwQbMS" : "41xM0UIy4i0Qzr"
+      "w8KZwEhNNiPw" : "gfFuuVjjiahiC6WB1Ta"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consequaturenim",
-  "doi" : "https://doi.org/10.1234/eveniet",
-  "link" : "https://www.example.org/quasiconsequatur",
+  "handle" : "https://www.example.org/recusandaetotam",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/providentsuscipit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2T0ogCCutgfWN",
+    "mainTitle" : "5ONggWuqf783bmMyTa",
     "alternativeTitles" : {
-      "pt" : "gKtYvPKtfIGZf4zR"
+      "it" : "9lDC03CfS5Y8kB9Ir"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Y8FDrSmCU6XV5lhD",
-      "month" : "VFAEw2WsON2Q",
-      "day" : "fvVtQkIoNtAr"
+      "year" : "05LqVwRM0q4Q5VPUyP9",
+      "month" : "ZghsiFUstJK",
+      "day" : "5cfmZ63enE1g30q"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/PtsEQRj2M3M4FZMuhr6",
-        "name" : "pgoXfkLSAsIWH",
+        "id" : "https://www.example.com/KAf8Z7hKmreaPSAuC6",
+        "name" : "PbcT6Ua7YszR",
         "nameType" : "Personal",
-        "orcId" : "i9GKJr5wnvgg8UxmJ"
+        "orcId" : "ThUuNIUErYPDzJ3oj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VLozNzEaxRR",
+        "id" : "https://www.example.com/UANGrbpWAHT",
         "labels" : {
-          "BmsL89JRQR" : "uouftFdVfL"
+          "SgsBv5Vd23UAUakP" : "p2jxWv0C60RHYxwUTmY"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 9,
+      "role" : "InterviewSubject",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7VVHBhmv2Ya3ftX",
-        "name" : "AU9Bi9ckP523",
+        "id" : "https://www.example.com/kWboKKndyboV8iQ",
+        "name" : "FNTfBDPDxeqaLJqnf",
         "nameType" : "Organizational",
-        "orcId" : "mvXBxBsE54"
+        "orcId" : "xXmTLf4OOeIAIIW0BG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/eyt7bKlHKub4Of",
+        "id" : "https://www.example.com/fc132a1xbse6XXvMJXf",
         "labels" : {
-          "RZU7zQFNFXNlht8" : "zEA1aWf2sqkDosDWm"
+          "1pBe2CRMpZburWkOc99" : "YBXGP43HKJsUO2Nsv"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 2,
+      "role" : "SoundDesigner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "4ElGzVji8rM",
-    "tags" : [ "qFnJiukiTUaby" ],
-    "description" : "hSsASfCBNYTW9F3jIL2",
+    "npiSubjectHeading" : "kmaql33NhfR",
+    "tags" : [ "uIypIW3baZZuir" ],
+    "description" : "HPNmIkuMfc9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c2XO8RDRn7RM0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rxpKh3tchGx"
         }
       },
-      "doi" : "https://www.example.com/d8LXd6B6e9D7WisC",
+      "doi" : "https://www.example.com/zD2WYzU6Ql7",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : true,
+        "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "Z94hHsiGNSXhSlsqJLr"
+          "description" : "THVAG3bvAr"
         },
-        "referencedBy" : [ "https://www.example.com/1HdR3fmgsb7pOWt" ],
-        "related" : [ "https://www.example.com/gSaxCmoP1TjsxbZpKXV" ],
-        "compliesWith" : [ "https://www.example.com/AzIwayYcdVjTr" ],
+        "referencedBy" : [ "https://www.example.com/hUhmeeq7MVWdPXg1N" ],
+        "related" : [ "https://www.example.com/8gJrfxEj94" ],
+        "compliesWith" : [ "https://www.example.com/5GhlvjSNPefMioI" ],
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/PcJLr2VMx2GwhGq",
-    "abstract" : "bHsPMe2Xkw4elNQWj"
+    "metadataSource" : "https://www.example.com/7kquqgS8wQq",
+    "abstract" : "icYabYeXvhDA9NWLz9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/culpamollitia",
-    "name" : "1jD7RreYLsjmy",
+    "id" : "https://www.example.org/nihilat",
+    "name" : "SX5ySXesDi",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "B1XlE1ycLF7Rwrt",
-      "id" : "MExABLqbxzTsiEBbu1v"
+      "source" : "zcj052q665MmO",
+      "id" : "TjBYABnFaM"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "u0bAz8QvbtrA"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "764e4t2l16FZTcM9T"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fugiatdoloribus" ],
+  "subjects" : [ "https://www.example.org/architectorecusandae" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "RxCgj4SjaPLhpkt",
-      "mimeType" : "5AIxkKWxEnZo13S",
-      "size" : 358128426,
+      "name" : "vHIoZXF0M9E2Ro5v",
+      "mimeType" : "oxfMaLGMiL",
+      "size" : 1977678765,
       "license" : {
         "type" : "License",
-        "identifier" : "ThfDj6dAxk6TshbCC2K",
+        "identifier" : "56T385Q1B0",
         "labels" : {
-          "FKvxYLbonn5" : "ZDBAdTlY2w"
+          "tXxFylD3Dyq" : "pMqEqWOZQtq"
         },
-        "link" : "https://www.example.com/UQPhdFKWVQqtuaQo4qJ"
+        "link" : "https://www.example.com/txoePEDnPpXGr"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "RxCgj4SjaPLhpkt",
-    "mimeType" : "5AIxkKWxEnZo13S",
-    "size" : 358128426,
+    "name" : "vHIoZXF0M9E2Ro5v",
+    "mimeType" : "oxfMaLGMiL",
+    "size" : 1977678765,
     "license" : {
       "type" : "License",
-      "identifier" : "ThfDj6dAxk6TshbCC2K",
+      "identifier" : "56T385Q1B0",
       "labels" : {
-        "FKvxYLbonn5" : "ZDBAdTlY2w"
+        "tXxFylD3Dyq" : "pMqEqWOZQtq"
       },
-      "link" : "https://www.example.com/UQPhdFKWVQqtuaQo4qJ"
+      "link" : "https://www.example.com/txoePEDnPpXGr"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "O7VNSZv0BEjM",
+  "owner" : "WMzLvmLOOw4KjdavQU",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,145 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "CnC1BG2JdKMMFBL",
-    "ownerAffiliation" : "https://www.example.org/nihilet"
+    "owner" : "H8AiUnaATSOyc1s11kj",
+    "ownerAffiliation" : "https://www.example.org/etprovident"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sitincidunt",
+    "id" : "https://www.example.org/cumqueaut",
     "labels" : {
-      "Iq3yWKUJ06afwVPOEvT" : "X7WWMcYrst3VTKGrb"
+      "CWpovbQHNryKA4PFEN" : "Srx95DdyRtJf0k"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ipsumet",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/aliasatque",
+  "handle" : "https://www.example.org/velvoluptates",
+  "doi" : "https://doi.org/10.1234/exercitationem",
+  "link" : "https://www.example.org/autest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cfYJSnl0cfraQA",
+    "mainTitle" : "FLDowLynt0Nw",
     "alternativeTitles" : {
-      "de" : "aoGqZCbQuU58T1Z"
+      "da" : "xc1YlPiQd3Iqj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Oo4M2VaLZl",
-      "month" : "H21qAk3Gf12B",
-      "day" : "ii2JMHThvjr6Wq"
+      "year" : "PkhUkvx71oGf9M",
+      "month" : "fP9P2qzb4BRl7dT",
+      "day" : "TJyY6taIhv6u5UmmU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/pevpSuoCVYk",
-        "name" : "EEJNw7SrrIHE",
-        "nameType" : "Organizational",
-        "orcId" : "HGzlhrn7C9"
+        "id" : "https://www.example.com/R7xn9flgmaoi4MDv2Z6",
+        "name" : "it33yVDhyGBlUMWBh",
+        "nameType" : "Personal",
+        "orcId" : "Bji1TOvJ4bZpB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7DwPwLNVYl1S",
+        "id" : "https://www.example.com/7ZZigMeX6DJU",
         "labels" : {
-          "tcA6nYG892JgW" : "xav66pYs4MW3ywO5"
+          "uvjdBNT1g8caa0c" : "Irc0tEwneTArndZN"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 3,
+      "role" : "DataCollector",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/B5GIuolVtrgoWi",
-        "name" : "rvC8zqFbfw502",
+        "id" : "https://www.example.com/hkM5CQwBTDTFLQC",
+        "name" : "h0wPFrc6ck9V",
         "nameType" : "Personal",
-        "orcId" : "aCZeQNXRNi479"
+        "orcId" : "js8lg4U8fon4XKI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QrusNdYmiu",
+        "id" : "https://www.example.com/PPAyFmFcO1",
         "labels" : {
-          "gO9rxLP9QTMh" : "rVkTeOHNEXlOK"
+          "1toS22chvRS9Rwh6WQ" : "UCbRAIu2anshejQ"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 0,
+      "role" : "Editor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "DAAuIPaDO3fL1",
-    "tags" : [ "tgzabT04KSA6qdpa4" ],
-    "description" : "lwQATnRJ7R39mGwymf",
+    "npiSubjectHeading" : "cBVlrGFxjRw5HeJu",
+    "tags" : [ "beyu6s95ZH8NLCyB4VC" ],
+    "description" : "XePrZSDh8zJTgRgr",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rtId9ymhllFnvbv7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kV7MA55Cj0tDTkBE"
         }
       },
-      "doi" : "https://www.example.com/oLAC1EvNDSCG",
+      "doi" : "https://www.example.com/YRHhyjHr7K9Ta6p",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : false,
+        "userAgreesToTermsAndConditions" : true,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "9RZuaZp78xkOLmuF"
+          "description" : "yd7QYCkdPD3"
         },
-        "referencedBy" : [ "https://www.example.com/R7CmTwSssw" ],
-        "related" : [ "https://www.example.com/RbrIsiiDrRX2I1cklm" ],
-        "compliesWith" : [ "https://www.example.com/FxheMlt56gosKqX" ],
+        "referencedBy" : [ "https://www.example.com/ok8JbYBcAgsoGiyPO1s" ],
+        "related" : [ "https://www.example.com/QSo0nRntK5cFA2gV" ],
+        "compliesWith" : [ "https://www.example.com/Pp8EWHuhtLU" ],
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Dh08SPJpEB6AdzG",
-    "abstract" : "CrwP4eAlXe"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "UK0eCfTTW6UaR0uH1X0",
-      "mimeType" : "O9D2f6UP4VzCqxZ",
-      "size" : 634132404,
-      "license" : {
-        "type" : "License",
-        "identifier" : "mUXFtctsbLyYS9",
-        "labels" : {
-          "yP7oICtj38rewSaa3M" : "LdcHZXE9SeVIXtC"
-        },
-        "link" : "https://www.example.com/77AgHz1pp61Z4VlRyNu"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/Og0S1sdmh8Zy1TpjqIZ",
+    "abstract" : "6oEkX0HxhGy8d"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitsimilique",
-    "name" : "ZTcCTlwCQE3aib0iU",
+    "id" : "https://www.example.org/eligendinumquam",
+    "name" : "h3vpBr7CBg3mcU3lAg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "oQH0pzPxJS",
-      "id" : "ex4x4YKjz6llN8MjN7"
+      "source" : "WsV7ZdS0eO0IpjOD",
+      "id" : "QRiIv4TKgsf4G"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "UYYYCrPvnNCTLzcw9IX"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "4cch4fgO3DRuv132"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -147,25 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/repellatconsequatur" ],
+  "subjects" : [ "https://www.example.org/ethic" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "UK0eCfTTW6UaR0uH1X0",
-    "mimeType" : "O9D2f6UP4VzCqxZ",
-    "size" : 634132404,
+    "name" : "d2fcotTOZI",
+    "mimeType" : "w0mnK926Fl",
+    "size" : 1094604549,
     "license" : {
       "type" : "License",
-      "identifier" : "mUXFtctsbLyYS9",
+      "identifier" : "PBAObEC7s7BykPxqDZH",
       "labels" : {
-        "yP7oICtj38rewSaa3M" : "LdcHZXE9SeVIXtC"
+        "9AdNrATPXrdbRNGI5ih" : "TBrTjfTmsbbZ5HOErsz"
       },
-      "link" : "https://www.example.com/77AgHz1pp61Z4VlRyNu"
+      "link" : "https://www.example.com/jbwpBWZawsS"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "CnC1BG2JdKMMFBL"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "d2fcotTOZI",
+      "mimeType" : "w0mnK926Fl",
+      "size" : 1094604549,
+      "license" : {
+        "type" : "License",
+        "identifier" : "PBAObEC7s7BykPxqDZH",
+        "labels" : {
+          "9AdNrATPXrdbRNGI5ih" : "TBrTjfTmsbbZ5HOErsz"
+        },
+        "link" : "https://www.example.com/jbwpBWZawsS"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "H8AiUnaATSOyc1s11kj",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "oH0af2TKppbnRZ",
-    "ownerAffiliation" : "https://www.example.org/quiscum"
+    "owner" : "O7VNSZv0BEjM",
+    "ownerAffiliation" : "https://www.example.org/sedhic"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/magnirerum",
+    "id" : "https://www.example.org/quibusdamdoloribus",
     "labels" : {
-      "oK3VGyVwLLHSHUN4Y" : "Hi6x6jOf5N1g8ktEzhy"
+      "iLJxSwQbMS" : "41xM0UIy4i0Qzr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sintaut",
-  "doi" : "https://doi.org/10.1234/adipisci",
-  "link" : "https://www.example.org/suntcum",
+  "handle" : "https://www.example.org/consequaturenim",
+  "doi" : "https://doi.org/10.1234/eveniet",
+  "link" : "https://www.example.org/quasiconsequatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "etLsZYh1gaEOdb9f",
+    "mainTitle" : "2T0ogCCutgfWN",
     "alternativeTitles" : {
-      "fi" : "WULXLJJT03ZEAsswCAh"
+      "pt" : "gKtYvPKtfIGZf4zR"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Wv6J39jrd0",
-      "month" : "vJOr9xIfWZmdv3806",
-      "day" : "yXrfwKenSCJfRD4gELu"
+      "year" : "Y8FDrSmCU6XV5lhD",
+      "month" : "VFAEw2WsON2Q",
+      "day" : "fvVtQkIoNtAr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0T4Cmo0zDjdHPOOZsAZ",
-        "name" : "XlN4zCnQaQYoUv",
+        "id" : "https://www.example.com/PtsEQRj2M3M4FZMuhr6",
+        "name" : "pgoXfkLSAsIWH",
         "nameType" : "Personal",
-        "orcId" : "hdzgNwFHnMVxbHnYSL7"
+        "orcId" : "i9GKJr5wnvgg8UxmJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/kiKlIMt3VCpxg",
+        "id" : "https://www.example.com/VLozNzEaxRR",
         "labels" : {
-          "ub2NTxPNUW6c7oWa" : "gbLjniuWwX69OWKZI"
+          "BmsL89JRQR" : "uouftFdVfL"
         }
       } ],
-      "role" : "Composer",
-      "sequence" : 3,
+      "role" : "ArtisticDirector",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DOS8MDS2Y7ICmHF",
-        "name" : "3ApPjgSwuDXKWy",
+        "id" : "https://www.example.com/7VVHBhmv2Ya3ftX",
+        "name" : "AU9Bi9ckP523",
         "nameType" : "Organizational",
-        "orcId" : "RbTyAicp14YujwSC"
+        "orcId" : "mvXBxBsE54"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XVJCv1a7zU7",
+        "id" : "https://www.example.com/eyt7bKlHKub4Of",
         "labels" : {
-          "wSlw9nP7GzhQJWbTV" : "rFLlyTALqG742Z6aZYv"
+          "RZU7zQFNFXNlht8" : "zEA1aWf2sqkDosDWm"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 5,
+      "role" : "Creator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Hgrrned5kSeKuq",
-    "tags" : [ "0otXWLBFIreBeeq4d" ],
-    "description" : "ATNPfRWyfG44",
+    "npiSubjectHeading" : "4ElGzVji8rM",
+    "tags" : [ "qFnJiukiTUaby" ],
+    "description" : "hSsASfCBNYTW9F3jIL2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OTmtRTvjd5zpYQ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c2XO8RDRn7RM0"
         }
       },
-      "doi" : "https://www.example.com/L1KY0cZG9N",
+      "doi" : "https://www.example.com/d8LXd6B6e9D7WisC",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : false,
+        "userAgreesToTermsAndConditions" : true,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "rur6kPHKfEy"
+          "description" : "Z94hHsiGNSXhSlsqJLr"
         },
-        "referencedBy" : [ "https://www.example.com/sJo23bETk83ZTj" ],
-        "related" : [ "https://www.example.com/5GTG9gTQOzMGw40lg" ],
-        "compliesWith" : [ "https://www.example.com/KPNvcU1k6GXp" ],
+        "referencedBy" : [ "https://www.example.com/1HdR3fmgsb7pOWt" ],
+        "related" : [ "https://www.example.com/gSaxCmoP1TjsxbZpKXV" ],
+        "compliesWith" : [ "https://www.example.com/AzIwayYcdVjTr" ],
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0A2nUSBNs7I",
-    "abstract" : "FztEt1lfqYFgIE"
+    "metadataSource" : "https://www.example.com/PcJLr2VMx2GwhGq",
+    "abstract" : "bHsPMe2Xkw4elNQWj"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nihilimpedit",
-    "name" : "ehb7ipyneD",
+    "id" : "https://www.example.org/culpamollitia",
+    "name" : "1jD7RreYLsjmy",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "lmePS8kVouVxgE1",
-      "id" : "N1eltN00u1E"
+      "source" : "B1XlE1ycLF7Rwrt",
+      "id" : "MExABLqbxzTsiEBbu1v"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Y34rbzZRcDNao"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "u0bAz8QvbtrA"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,22 +126,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/laudantiumvoluptatem" ],
+  "subjects" : [ "https://www.example.org/fugiatdoloribus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "aqJqqdzzXv",
-      "mimeType" : "31bBVSoAzOYoaYbzd0",
-      "size" : 682763073,
+      "name" : "RxCgj4SjaPLhpkt",
+      "mimeType" : "5AIxkKWxEnZo13S",
+      "size" : 358128426,
       "license" : {
         "type" : "License",
-        "identifier" : "oqSQpFF785Kg9eP",
+        "identifier" : "ThfDj6dAxk6TshbCC2K",
         "labels" : {
-          "NDa4lCtPUZ2" : "m1ToeUksDqN1T"
+          "FKvxYLbonn5" : "ZDBAdTlY2w"
         },
-        "link" : "https://www.example.com/3HTkjGmerM"
+        "link" : "https://www.example.com/UQPhdFKWVQqtuaQo4qJ"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -151,21 +151,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "aqJqqdzzXv",
-    "mimeType" : "31bBVSoAzOYoaYbzd0",
-    "size" : 682763073,
+    "name" : "RxCgj4SjaPLhpkt",
+    "mimeType" : "5AIxkKWxEnZo13S",
+    "size" : 358128426,
     "license" : {
       "type" : "License",
-      "identifier" : "oqSQpFF785Kg9eP",
+      "identifier" : "ThfDj6dAxk6TshbCC2K",
       "labels" : {
-        "NDa4lCtPUZ2" : "m1ToeUksDqN1T"
+        "FKvxYLbonn5" : "ZDBAdTlY2w"
       },
-      "link" : "https://www.example.com/3HTkjGmerM"
+      "link" : "https://www.example.com/UQPhdFKWVQqtuaQo4qJ"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "oH0af2TKppbnRZ",
+  "owner" : "O7VNSZv0BEjM",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "H8AiUnaATSOyc1s11kj",
-    "ownerAffiliation" : "https://www.example.org/etprovident"
+    "owner" : "oH0af2TKppbnRZ",
+    "ownerAffiliation" : "https://www.example.org/quiscum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cumqueaut",
+    "id" : "https://www.example.org/magnirerum",
     "labels" : {
-      "CWpovbQHNryKA4PFEN" : "Srx95DdyRtJf0k"
+      "oK3VGyVwLLHSHUN4Y" : "Hi6x6jOf5N1g8ktEzhy"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velvoluptates",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/autest",
+  "handle" : "https://www.example.org/sintaut",
+  "doi" : "https://doi.org/10.1234/adipisci",
+  "link" : "https://www.example.org/suntcum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FLDowLynt0Nw",
+    "mainTitle" : "etLsZYh1gaEOdb9f",
     "alternativeTitles" : {
-      "da" : "xc1YlPiQd3Iqj"
+      "fi" : "WULXLJJT03ZEAsswCAh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "PkhUkvx71oGf9M",
-      "month" : "fP9P2qzb4BRl7dT",
-      "day" : "TJyY6taIhv6u5UmmU"
+      "year" : "Wv6J39jrd0",
+      "month" : "vJOr9xIfWZmdv3806",
+      "day" : "yXrfwKenSCJfRD4gELu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/R7xn9flgmaoi4MDv2Z6",
-        "name" : "it33yVDhyGBlUMWBh",
+        "id" : "https://www.example.com/0T4Cmo0zDjdHPOOZsAZ",
+        "name" : "XlN4zCnQaQYoUv",
         "nameType" : "Personal",
-        "orcId" : "Bji1TOvJ4bZpB"
+        "orcId" : "hdzgNwFHnMVxbHnYSL7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7ZZigMeX6DJU",
+        "id" : "https://www.example.com/kiKlIMt3VCpxg",
         "labels" : {
-          "uvjdBNT1g8caa0c" : "Irc0tEwneTArndZN"
+          "ub2NTxPNUW6c7oWa" : "gbLjniuWwX69OWKZI"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 1,
+      "role" : "Composer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hkM5CQwBTDTFLQC",
-        "name" : "h0wPFrc6ck9V",
-        "nameType" : "Personal",
-        "orcId" : "js8lg4U8fon4XKI"
+        "id" : "https://www.example.com/DOS8MDS2Y7ICmHF",
+        "name" : "3ApPjgSwuDXKWy",
+        "nameType" : "Organizational",
+        "orcId" : "RbTyAicp14YujwSC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PPAyFmFcO1",
+        "id" : "https://www.example.com/XVJCv1a7zU7",
         "labels" : {
-          "1toS22chvRS9Rwh6WQ" : "UCbRAIu2anshejQ"
+          "wSlw9nP7GzhQJWbTV" : "rFLlyTALqG742Z6aZYv"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 3,
+      "role" : "ProjectLeader",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cBVlrGFxjRw5HeJu",
-    "tags" : [ "beyu6s95ZH8NLCyB4VC" ],
-    "description" : "XePrZSDh8zJTgRgr",
+    "npiSubjectHeading" : "Hgrrned5kSeKuq",
+    "tags" : [ "0otXWLBFIreBeeq4d" ],
+    "description" : "ATNPfRWyfG44",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kV7MA55Cj0tDTkBE"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OTmtRTvjd5zpYQ"
         }
       },
-      "doi" : "https://www.example.com/YRHhyjHr7K9Ta6p",
+      "doi" : "https://www.example.com/L1KY0cZG9N",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : true,
+        "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "yd7QYCkdPD3"
+          "description" : "rur6kPHKfEy"
         },
-        "referencedBy" : [ "https://www.example.com/ok8JbYBcAgsoGiyPO1s" ],
-        "related" : [ "https://www.example.com/QSo0nRntK5cFA2gV" ],
-        "compliesWith" : [ "https://www.example.com/Pp8EWHuhtLU" ],
+        "referencedBy" : [ "https://www.example.com/sJo23bETk83ZTj" ],
+        "related" : [ "https://www.example.com/5GTG9gTQOzMGw40lg" ],
+        "compliesWith" : [ "https://www.example.com/KPNvcU1k6GXp" ],
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Og0S1sdmh8Zy1TpjqIZ",
-    "abstract" : "6oEkX0HxhGy8d"
+    "metadataSource" : "https://www.example.com/0A2nUSBNs7I",
+    "abstract" : "FztEt1lfqYFgIE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eligendinumquam",
-    "name" : "h3vpBr7CBg3mcU3lAg",
+    "id" : "https://www.example.org/nihilimpedit",
+    "name" : "ehb7ipyneD",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "WsV7ZdS0eO0IpjOD",
-      "id" : "QRiIv4TKgsf4G"
+      "source" : "lmePS8kVouVxgE1",
+      "id" : "N1eltN00u1E"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "4cch4fgO3DRuv132"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Y34rbzZRcDNao"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ethic" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "d2fcotTOZI",
-    "mimeType" : "w0mnK926Fl",
-    "size" : 1094604549,
-    "license" : {
-      "type" : "License",
-      "identifier" : "PBAObEC7s7BykPxqDZH",
-      "labels" : {
-        "9AdNrATPXrdbRNGI5ih" : "TBrTjfTmsbbZ5HOErsz"
-      },
-      "link" : "https://www.example.com/jbwpBWZawsS"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/laudantiumvoluptatem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "d2fcotTOZI",
-      "mimeType" : "w0mnK926Fl",
-      "size" : 1094604549,
+      "name" : "aqJqqdzzXv",
+      "mimeType" : "31bBVSoAzOYoaYbzd0",
+      "size" : 682763073,
       "license" : {
         "type" : "License",
-        "identifier" : "PBAObEC7s7BykPxqDZH",
+        "identifier" : "oqSQpFF785Kg9eP",
         "labels" : {
-          "9AdNrATPXrdbRNGI5ih" : "TBrTjfTmsbbZ5HOErsz"
+          "NDa4lCtPUZ2" : "m1ToeUksDqN1T"
         },
-        "link" : "https://www.example.com/jbwpBWZawsS"
+        "link" : "https://www.example.com/3HTkjGmerM"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "H8AiUnaATSOyc1s11kj",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "aqJqqdzzXv",
+    "mimeType" : "31bBVSoAzOYoaYbzd0",
+    "size" : 682763073,
+    "license" : {
+      "type" : "License",
+      "identifier" : "oqSQpFF785Kg9eP",
+      "labels" : {
+        "NDa4lCtPUZ2" : "m1ToeUksDqN1T"
+      },
+      "link" : "https://www.example.com/3HTkjGmerM"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "oH0af2TKppbnRZ",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "rDD199CI96WScb",
-    "ownerAffiliation" : "https://www.example.org/quomagnam"
+    "owner" : "jx8TAK8DAjbgHKIXRa8",
+    "ownerAffiliation" : "https://www.example.org/inalias"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/necessitatibusofficiis",
+    "id" : "https://www.example.org/aperiamquisquam",
     "labels" : {
-      "E6Eb0HTASJOyV" : "SIxKuILjSsQ"
+      "71KlE9g0bZu7yreZc" : "pMy9NzSyQw"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/porroratione",
-  "doi" : "https://doi.org/10.1234/corrupti",
-  "link" : "https://www.example.org/dolorumeius",
+  "handle" : "https://www.example.org/etrerum",
+  "doi" : "https://doi.org/10.1234/dolores",
+  "link" : "https://www.example.org/nostrumet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "87GP9DYvQZNo",
+    "mainTitle" : "pZl8W5e79cygU",
     "alternativeTitles" : {
-      "is" : "7rGxSgaGWy"
+      "af" : "uAdHzxHfnIAzormkyQ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "P5PHncsG4xIZ",
-      "month" : "cE6frhO6kgCfPypc3C",
-      "day" : "UN0SnQ8eFZrjNo8s4X"
+      "year" : "AFUcc9fZBHIwKlRg6",
+      "month" : "BLNKCXtL1T8QhN53",
+      "day" : "A3nuD4xuVIL4pWK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/qPF7q3Qgk2hZPN8a",
-        "name" : "9CM6PDehVoz",
-        "nameType" : "Personal",
-        "orcId" : "YYfBc18C5SvM37FgfZ"
+        "id" : "https://www.example.com/jX7ld5p34BRJ",
+        "name" : "lhiVX2ikGeg",
+        "nameType" : "Organizational",
+        "orcId" : "KEAr8aeKDLCXzHhgxo9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tfCeEuaIaGmevjN",
+        "id" : "https://www.example.com/FNxmljDut3eT",
         "labels" : {
-          "1AqLZxtza8Z5KO" : "ZPLlbRbBod"
+          "7p8aqvUwgkf" : "0f03PxAR0RN0"
         }
       } ],
-      "role" : "Photographer",
-      "sequence" : 1,
+      "role" : "ArtisticDirector",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rzibspEMptMWXoN",
-        "name" : "Jb5P9Ho64RAWvM5",
+        "id" : "https://www.example.com/OFDnZPzyZS81yC",
+        "name" : "EuWciH3crtvS",
         "nameType" : "Organizational",
-        "orcId" : "LBIRJH6oOyl"
+        "orcId" : "7EjrFTAqosDid3duya"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ksePQaKAk1x",
+        "id" : "https://www.example.com/271RGXIPRrQiYxXCs1",
         "labels" : {
-          "XyRLmVriD7Lp" : "H1vfFNt5j1D"
+          "A6LBcLioYwVnEHd49eL" : "uV53kbblsMvkQw"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 6,
+      "role" : "WorkPackageLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "C9EJVJgYYoEgM4L66q",
-    "tags" : [ "6OyZgIJhdYRnutD" ],
-    "description" : "HhTarogwCs",
+    "npiSubjectHeading" : "tyZi0BvSArUU2A",
+    "tags" : [ "k1i9dmmh9wW" ],
+    "description" : "g3HYlQXmQPJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zIyrM9HUGkKWJdlJH17"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EzqWJAmBb1cDzztVm7y"
         },
-        "seriesNumber" : "ja7QVtOKxa3yJFb1RUL",
+        "seriesNumber" : "il1ZWND6eqqSRrur4",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SgoBVyBveesVk"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OBmy6RTCnTwLO3pKT"
         },
-        "isbnList" : [ "9781015844278" ]
+        "isbnList" : [ "9780905240466" ]
       },
-      "doi" : "https://www.example.com/cpdQWHIK50",
+      "doi" : "https://www.example.com/7sRqoHCV4uhtFEhRXo",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "4rrx3WzePHMG",
-          "month" : "r2CASXvmlnLcF",
-          "day" : "FSfvFvkzSC"
+          "year" : "oUfbetHXoKVevxS7MU9",
+          "month" : "vAFsvrOg2nqK",
+          "day" : "wNqT0v1tdfhi"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "gvI7Q9TWf3C",
-            "end" : "OQecZhslicuUT4"
+            "begin" : "vouWcNjE8K",
+            "end" : "3yiL72DA2KOgd"
           },
-          "pages" : "EesOpuH85HTFr",
+          "pages" : "FcKtqqvn6raFX1uU",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/A7NAkCsGOj",
-    "abstract" : "KALGTjoUP5pbrbb"
+    "metadataSource" : "https://www.example.com/lBIVrz6zjXU0V",
+    "abstract" : "t1NIr9GJ4pBsHm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nequedistinctio",
-    "name" : "AtVGQ5Hitu8I8b3",
+    "id" : "https://www.example.org/providenteos",
+    "name" : "EsM16XOKoqvHk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2AgZS0YXt6vCZ0",
-      "id" : "TU6F4O04Hn"
+      "source" : "es3FTYIVV9nulENbJyM",
+      "id" : "MOGWMZ3umM"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "yvAltnz9YRHPO"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "tQcnG5cmNZBE"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quossit" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "oJsBA6alM8",
-    "mimeType" : "4fRXymLv2hVJy2T",
-    "size" : 1236471501,
-    "license" : {
-      "type" : "License",
-      "identifier" : "k6bKkyS8d5",
-      "labels" : {
-        "s4tAkiLlY3yhgxTwtr" : "0ONBXxdCHEtDC3ci2LY"
-      },
-      "link" : "https://www.example.com/J8iujYe1h3NBaaOfv"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/veritatisoptio" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "oJsBA6alM8",
-      "mimeType" : "4fRXymLv2hVJy2T",
-      "size" : 1236471501,
+      "name" : "bnEpwe2iukapBGlr",
+      "mimeType" : "wny33HWS77ej",
+      "size" : 1482890896,
       "license" : {
         "type" : "License",
-        "identifier" : "k6bKkyS8d5",
+        "identifier" : "2Q29TkciN0JvysGLr",
         "labels" : {
-          "s4tAkiLlY3yhgxTwtr" : "0ONBXxdCHEtDC3ci2LY"
+          "PU3yfCwFs86" : "BD6yX6beJw6"
         },
-        "link" : "https://www.example.com/J8iujYe1h3NBaaOfv"
+        "link" : "https://www.example.com/zGLZLQlpdj8tY"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "rDD199CI96WScb",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "bnEpwe2iukapBGlr",
+    "mimeType" : "wny33HWS77ej",
+    "size" : 1482890896,
+    "license" : {
+      "type" : "License",
+      "identifier" : "2Q29TkciN0JvysGLr",
+      "labels" : {
+        "PU3yfCwFs86" : "BD6yX6beJw6"
+      },
+      "link" : "https://www.example.com/zGLZLQlpdj8tY"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "jx8TAK8DAjbgHKIXRa8",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "jx8TAK8DAjbgHKIXRa8",
-    "ownerAffiliation" : "https://www.example.org/inalias"
+    "owner" : "VLmduDD0yCOdiw5jF",
+    "ownerAffiliation" : "https://www.example.org/etsed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aperiamquisquam",
+    "id" : "https://www.example.org/etdistinctio",
     "labels" : {
-      "71KlE9g0bZu7yreZc" : "pMy9NzSyQw"
+      "uouBj5hgZogWkY" : "sFfdJ7av8i"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etrerum",
-  "doi" : "https://doi.org/10.1234/dolores",
-  "link" : "https://www.example.org/nostrumet",
+  "handle" : "https://www.example.org/inciduntnatus",
+  "doi" : "https://doi.org/10.1234/minus",
+  "link" : "https://www.example.org/fugaearum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pZl8W5e79cygU",
+    "mainTitle" : "IQOUSutaN76IF07pr",
     "alternativeTitles" : {
-      "af" : "uAdHzxHfnIAzormkyQ"
+      "de" : "K03XO4f1mX42"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AFUcc9fZBHIwKlRg6",
-      "month" : "BLNKCXtL1T8QhN53",
-      "day" : "A3nuD4xuVIL4pWK"
+      "year" : "tEXq7zhJfgQ1Ce3gb",
+      "month" : "5WDOBL0TQiIlyJJw",
+      "day" : "9p4GtvvEYJw7zO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jX7ld5p34BRJ",
-        "name" : "lhiVX2ikGeg",
-        "nameType" : "Organizational",
-        "orcId" : "KEAr8aeKDLCXzHhgxo9"
+        "id" : "https://www.example.com/95qGRpEVeb8KAwt9SDS",
+        "name" : "PMUb57I3rfpLb",
+        "nameType" : "Personal",
+        "orcId" : "VImRmSp0We6X3tmKEA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FNxmljDut3eT",
+        "id" : "https://www.example.com/xCo4ci0bWyD6Ftd",
         "labels" : {
-          "7p8aqvUwgkf" : "0f03PxAR0RN0"
+          "GMEM5ab7LEx4qm" : "8eeXK0B05zkJW"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 3,
+      "role" : "ProjectManager",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OFDnZPzyZS81yC",
-        "name" : "EuWciH3crtvS",
+        "id" : "https://www.example.com/gFhkev507aEL298",
+        "name" : "UDcD98JgPO3znm",
         "nameType" : "Organizational",
-        "orcId" : "7EjrFTAqosDid3duya"
+        "orcId" : "tekZXwOtAmnsYtV0"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/271RGXIPRrQiYxXCs1",
+        "id" : "https://www.example.com/chViY1mHoSvvFe",
         "labels" : {
-          "A6LBcLioYwVnEHd49eL" : "uV53kbblsMvkQw"
+          "B39fzUDKjYqW6mTTFn" : "Yos9DDB2sGKJn7oD"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 8,
+      "role" : "Organizer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "tyZi0BvSArUU2A",
-    "tags" : [ "k1i9dmmh9wW" ],
-    "description" : "g3HYlQXmQPJ",
+    "npiSubjectHeading" : "Q1b3ld7MVRdj",
+    "tags" : [ "72onjWNveMD" ],
+    "description" : "7zTnXBIoZMUH5W",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EzqWJAmBb1cDzztVm7y"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/vxq1ke9shH0"
         },
-        "seriesNumber" : "il1ZWND6eqqSRrur4",
+        "seriesNumber" : "kjXylLOPDAP",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OBmy6RTCnTwLO3pKT"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9lG5oSb89d"
         },
-        "isbnList" : [ "9780905240466" ]
+        "isbnList" : [ "9780999749173" ]
       },
-      "doi" : "https://www.example.com/7sRqoHCV4uhtFEhRXo",
+      "doi" : "https://www.example.com/BuDEMFuRkSFAw",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "oUfbetHXoKVevxS7MU9",
-          "month" : "vAFsvrOg2nqK",
-          "day" : "wNqT0v1tdfhi"
+          "year" : "bTaD7S9TPeFbO",
+          "month" : "iVDxTohGqKsSqHc",
+          "day" : "6I2hOq4psYgg"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "vouWcNjE8K",
-            "end" : "3yiL72DA2KOgd"
+            "begin" : "UXCRuBOIpQ2pSAa2Qti",
+            "end" : "RyT8xBeJrZ3ruq"
           },
-          "pages" : "FcKtqqvn6raFX1uU",
+          "pages" : "H5kFYx1JVthreMXV",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/lBIVrz6zjXU0V",
-    "abstract" : "t1NIr9GJ4pBsHm"
+    "metadataSource" : "https://www.example.com/dL8ZcAUC3hQFhpoH",
+    "abstract" : "K7h5VlkgmE28fZwO8y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/providenteos",
-    "name" : "EsM16XOKoqvHk",
+    "id" : "https://www.example.org/aspernaturautem",
+    "name" : "4ZbOz2y1PmQh6t7L",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "es3FTYIVV9nulENbJyM",
-      "id" : "MOGWMZ3umM"
+      "source" : "pesdjunk1rRXr",
+      "id" : "G0CbbLn2kSzZup"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "tQcnG5cmNZBE"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "NzgJTpZ18Gy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veritatisoptio" ],
+  "subjects" : [ "https://www.example.org/consequaturut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bnEpwe2iukapBGlr",
-      "mimeType" : "wny33HWS77ej",
-      "size" : 1482890896,
+      "name" : "wEjG7VtEsAr",
+      "mimeType" : "VBMAMrJAhnjjAOg7",
+      "size" : 645216703,
       "license" : {
         "type" : "License",
-        "identifier" : "2Q29TkciN0JvysGLr",
+        "identifier" : "XmemprEzTLIPPo",
         "labels" : {
-          "PU3yfCwFs86" : "BD6yX6beJw6"
+          "2VFawihOu97m8" : "BD6fbA7cgdT"
         },
-        "link" : "https://www.example.com/zGLZLQlpdj8tY"
+        "link" : "https://www.example.com/l6UrSbOQm9XqLa5dg"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bnEpwe2iukapBGlr",
-    "mimeType" : "wny33HWS77ej",
-    "size" : 1482890896,
+    "name" : "wEjG7VtEsAr",
+    "mimeType" : "VBMAMrJAhnjjAOg7",
+    "size" : 645216703,
     "license" : {
       "type" : "License",
-      "identifier" : "2Q29TkciN0JvysGLr",
+      "identifier" : "XmemprEzTLIPPo",
       "labels" : {
-        "PU3yfCwFs86" : "BD6yX6beJw6"
+        "2VFawihOu97m8" : "BD6fbA7cgdT"
       },
-      "link" : "https://www.example.com/zGLZLQlpdj8tY"
+      "link" : "https://www.example.com/l6UrSbOQm9XqLa5dg"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "jx8TAK8DAjbgHKIXRa8",
+  "owner" : "VLmduDD0yCOdiw5jF",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "VLmduDD0yCOdiw5jF",
-    "ownerAffiliation" : "https://www.example.org/etsed"
+    "owner" : "W3WKintHtX",
+    "ownerAffiliation" : "https://www.example.org/deseruntqui"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etdistinctio",
+    "id" : "https://www.example.org/consequaturreprehenderit",
     "labels" : {
-      "uouBj5hgZogWkY" : "sFfdJ7av8i"
+      "2Hc4HqyfxuQqOS" : "iYNRJIlBrk7"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/inciduntnatus",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/fugaearum",
+  "handle" : "https://www.example.org/perferendissit",
+  "doi" : "https://doi.org/10.1234/iusto",
+  "link" : "https://www.example.org/earepellendus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IQOUSutaN76IF07pr",
+    "mainTitle" : "4frOOAYwwj",
     "alternativeTitles" : {
-      "de" : "K03XO4f1mX42"
+      "no" : "BUBptoWrDUV4sD"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tEXq7zhJfgQ1Ce3gb",
-      "month" : "5WDOBL0TQiIlyJJw",
-      "day" : "9p4GtvvEYJw7zO"
+      "year" : "UOzIaaXQi1QAHu",
+      "month" : "Uk1oeXmRUhrOjK",
+      "day" : "oqZMhexLuV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/95qGRpEVeb8KAwt9SDS",
-        "name" : "PMUb57I3rfpLb",
-        "nameType" : "Personal",
-        "orcId" : "VImRmSp0We6X3tmKEA"
+        "id" : "https://www.example.com/CPT98OmFcnwgWEv",
+        "name" : "fzBlhmAoqwCif0I",
+        "nameType" : "Organizational",
+        "orcId" : "Ag4GfuSwiD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xCo4ci0bWyD6Ftd",
+        "id" : "https://www.example.com/5ezjUWf9R8VXjhU",
         "labels" : {
-          "GMEM5ab7LEx4qm" : "8eeXK0B05zkJW"
+          "49grc9mg8Lczh" : "KSm5gjXyfaTLa9dHh0Z"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 9,
+      "role" : "RegistrationAuthority",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gFhkev507aEL298",
-        "name" : "UDcD98JgPO3znm",
-        "nameType" : "Organizational",
-        "orcId" : "tekZXwOtAmnsYtV0"
+        "id" : "https://www.example.com/Oo6SZCjKCA0",
+        "name" : "dtPzrfxxKy",
+        "nameType" : "Personal",
+        "orcId" : "tETzNHFhoJhfH6vdNFd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/chViY1mHoSvvFe",
+        "id" : "https://www.example.com/52JwuWwLWz",
         "labels" : {
-          "B39fzUDKjYqW6mTTFn" : "Yos9DDB2sGKJn7oD"
+          "KGavbvRQdAKy" : "I1V3obq3PYgRj9"
         }
       } ],
-      "role" : "Organizer",
-      "sequence" : 3,
+      "role" : "CostumeDesigner",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Q1b3ld7MVRdj",
-    "tags" : [ "72onjWNveMD" ],
-    "description" : "7zTnXBIoZMUH5W",
+    "npiSubjectHeading" : "wRtbtwqF6nQ76",
+    "tags" : [ "1zCEZPmNoBah" ],
+    "description" : "S1zzBmuSUvNJHsFhOr",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/vxq1ke9shH0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yUrNxkzJGz"
         },
-        "seriesNumber" : "kjXylLOPDAP",
+        "seriesNumber" : "4w0BjhA1WLT13c1gOO5",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9lG5oSb89d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2smOoY6ihGw7xp"
         },
-        "isbnList" : [ "9780999749173" ]
+        "isbnList" : [ "9790889516303" ]
       },
-      "doi" : "https://www.example.com/BuDEMFuRkSFAw",
+      "doi" : "https://www.example.com/J7yU1RJ90UaUnHPT",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "bTaD7S9TPeFbO",
-          "month" : "iVDxTohGqKsSqHc",
-          "day" : "6I2hOq4psYgg"
+          "year" : "5DcRNlCCE0t2NCoXFU",
+          "month" : "5rtEJLCfbqPy",
+          "day" : "kdbjaL95Dz"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "UXCRuBOIpQ2pSAa2Qti",
-            "end" : "RyT8xBeJrZ3ruq"
+            "begin" : "Ryf2yclLTpO",
+            "end" : "N8hZsmfy7ubRSIu2be"
           },
-          "pages" : "H5kFYx1JVthreMXV",
+          "pages" : "5yQFHrKeIYE",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/dL8ZcAUC3hQFhpoH",
-    "abstract" : "K7h5VlkgmE28fZwO8y"
+    "metadataSource" : "https://www.example.com/t1PxfaivlVFI2UpHa3",
+    "abstract" : "euOEGLJ8NDK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aspernaturautem",
-    "name" : "4ZbOz2y1PmQh6t7L",
+    "id" : "https://www.example.org/nisiminus",
+    "name" : "p73pJ2C7ZR",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "pesdjunk1rRXr",
-      "id" : "G0CbbLn2kSzZup"
+      "source" : "NDgo2Lhm9lYTc",
+      "id" : "e4LMs1s1uXwysbbWK5z"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "NzgJTpZ18Gy"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "kzPTWTBobZkToUHQZU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consequaturut" ],
+  "subjects" : [ "https://www.example.org/hicnon" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wEjG7VtEsAr",
-      "mimeType" : "VBMAMrJAhnjjAOg7",
-      "size" : 645216703,
+      "name" : "hXE8mnFEmM7jlBi4",
+      "mimeType" : "9sBILfnB1D",
+      "size" : 1645720931,
       "license" : {
         "type" : "License",
-        "identifier" : "XmemprEzTLIPPo",
+        "identifier" : "8b0lxAHWb67oPma",
         "labels" : {
-          "2VFawihOu97m8" : "BD6fbA7cgdT"
+          "rYpyryiCi6o" : "AEYvAZFLVmGDQ"
         },
-        "link" : "https://www.example.com/l6UrSbOQm9XqLa5dg"
+        "link" : "https://www.example.com/DRso0KBdLxA2Ek"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "wEjG7VtEsAr",
-    "mimeType" : "VBMAMrJAhnjjAOg7",
-    "size" : 645216703,
+    "name" : "hXE8mnFEmM7jlBi4",
+    "mimeType" : "9sBILfnB1D",
+    "size" : 1645720931,
     "license" : {
       "type" : "License",
-      "identifier" : "XmemprEzTLIPPo",
+      "identifier" : "8b0lxAHWb67oPma",
       "labels" : {
-        "2VFawihOu97m8" : "BD6fbA7cgdT"
+        "rYpyryiCi6o" : "AEYvAZFLVmGDQ"
       },
-      "link" : "https://www.example.com/l6UrSbOQm9XqLa5dg"
+      "link" : "https://www.example.com/DRso0KBdLxA2Ek"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "VLmduDD0yCOdiw5jF",
+  "owner" : "W3WKintHtX",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,156 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "D9FEJIwWIww",
-    "ownerAffiliation" : "https://www.example.org/utvelit"
+    "owner" : "rDD199CI96WScb",
+    "ownerAffiliation" : "https://www.example.org/quomagnam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quaeratut",
+    "id" : "https://www.example.org/necessitatibusofficiis",
     "labels" : {
-      "ctOaATIFvXhsq3EVV" : "lfpOezZMNpzdka6Vg"
+      "E6Eb0HTASJOyV" : "SIxKuILjSsQ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiet",
-  "doi" : "https://doi.org/10.1234/quasi",
-  "link" : "https://www.example.org/fugitsequi",
+  "handle" : "https://www.example.org/porroratione",
+  "doi" : "https://doi.org/10.1234/corrupti",
+  "link" : "https://www.example.org/dolorumeius",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Hhbpg6fmeMyl",
+    "mainTitle" : "87GP9DYvQZNo",
     "alternativeTitles" : {
-      "el" : "wn8l0cwzbqtg9"
+      "is" : "7rGxSgaGWy"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "BjWYa9RJgZAnFuJHBf",
-      "month" : "f9YefMnaFw8yE",
-      "day" : "dHUwuafYD5"
+      "year" : "P5PHncsG4xIZ",
+      "month" : "cE6frhO6kgCfPypc3C",
+      "day" : "UN0SnQ8eFZrjNo8s4X"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SLRMECZFmo",
-        "name" : "937x2J76E9n0",
-        "nameType" : "Organizational",
-        "orcId" : "oNSPLn163AA11n"
+        "id" : "https://www.example.com/qPF7q3Qgk2hZPN8a",
+        "name" : "9CM6PDehVoz",
+        "nameType" : "Personal",
+        "orcId" : "YYfBc18C5SvM37FgfZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YxbenFi8G9RRTGOQkuO",
+        "id" : "https://www.example.com/tfCeEuaIaGmevjN",
         "labels" : {
-          "C9kgFUZ439IoJQYZf" : "gDNAiXVYmqdUYeU"
+          "1AqLZxtza8Z5KO" : "ZPLlbRbBod"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 6,
+      "role" : "Photographer",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/w38wrd1qPycm0tvfn",
-        "name" : "ITQCbMLF87",
-        "nameType" : "Personal",
-        "orcId" : "fq2Tr7qFwjOSwxMLUs"
+        "id" : "https://www.example.com/rzibspEMptMWXoN",
+        "name" : "Jb5P9Ho64RAWvM5",
+        "nameType" : "Organizational",
+        "orcId" : "LBIRJH6oOyl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1JeN3KewOmO",
+        "id" : "https://www.example.com/ksePQaKAk1x",
         "labels" : {
-          "u5M5FEx81x" : "4WjFxknlNp"
+          "XyRLmVriD7Lp" : "H1vfFNt5j1D"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 9,
+      "role" : "Researcher",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rfe5jR04DxIM",
-    "tags" : [ "k2kOH3ueqfhopWTIfTs" ],
-    "description" : "HP1ulq0QhQ8LaacLJ3q",
+    "npiSubjectHeading" : "C9EJVJgYYoEgM4L66q",
+    "tags" : [ "6OyZgIJhdYRnutD" ],
+    "description" : "HhTarogwCs",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/QHY6eDsX1ogiQlVj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zIyrM9HUGkKWJdlJH17"
         },
-        "seriesNumber" : "pz1Eohcsud",
+        "seriesNumber" : "ja7QVtOKxa3yJFb1RUL",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4QRcZwjjV5hcyVkA"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SgoBVyBveesVk"
         },
-        "isbnList" : [ "9780003170825" ]
+        "isbnList" : [ "9781015844278" ]
       },
-      "doi" : "https://www.example.com/xYd7Q7iKR4xhdK8",
+      "doi" : "https://www.example.com/cpdQWHIK50",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "y6tlvGzMhmsfEPodC9",
-          "month" : "rsl4UxvW5zwyheMBu",
-          "day" : "uJ8nLHmqIJHQyO4i1wZ"
+          "year" : "4rrx3WzePHMG",
+          "month" : "r2CASXvmlnLcF",
+          "day" : "FSfvFvkzSC"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "4HaeYYs1HWgj",
-            "end" : "cHXLkoAaNyqxCV"
+            "begin" : "gvI7Q9TWf3C",
+            "end" : "OQecZhslicuUT4"
           },
-          "pages" : "YWCctQkzV2Dq2VW1wD",
-          "illustrated" : true
+          "pages" : "EesOpuH85HTFr",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/hOyDiixdXnm0",
-    "abstract" : "GpAhhFS5W2x1EWW0mxR"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "YfHi7XNstUI",
-      "mimeType" : "P947mSnXtB",
-      "size" : 522038509,
-      "license" : {
-        "type" : "License",
-        "identifier" : "BglunR3X0Oh5x5",
-        "labels" : {
-          "RfOIJoSVx5" : "7Wph4NsmayXngG"
-        },
-        "link" : "https://www.example.com/zddqUbLu4pqZs8X"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/A7NAkCsGOj",
+    "abstract" : "KALGTjoUP5pbrbb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/hicoccaecati",
-    "name" : "PkRT6TLogh",
+    "id" : "https://www.example.org/nequedistinctio",
+    "name" : "AtVGQ5Hitu8I8b3",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Uj3Mw0sMi6ojcoi",
-      "id" : "8lLXnkMKsx9Sd9Gz"
+      "source" : "2AgZS0YXt6vCZ0",
+      "id" : "TU6F4O04Hn"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "2pKdlOE31MWYSO"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "yvAltnz9YRHPO"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,25 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiaet" ],
+  "subjects" : [ "https://www.example.org/quossit" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "YfHi7XNstUI",
-    "mimeType" : "P947mSnXtB",
-    "size" : 522038509,
+    "name" : "oJsBA6alM8",
+    "mimeType" : "4fRXymLv2hVJy2T",
+    "size" : 1236471501,
     "license" : {
       "type" : "License",
-      "identifier" : "BglunR3X0Oh5x5",
+      "identifier" : "k6bKkyS8d5",
       "labels" : {
-        "RfOIJoSVx5" : "7Wph4NsmayXngG"
+        "s4tAkiLlY3yhgxTwtr" : "0ONBXxdCHEtDC3ci2LY"
       },
-      "link" : "https://www.example.com/zddqUbLu4pqZs8X"
+      "link" : "https://www.example.com/J8iujYe1h3NBaaOfv"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "D9FEJIwWIww"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "oJsBA6alM8",
+      "mimeType" : "4fRXymLv2hVJy2T",
+      "size" : 1236471501,
+      "license" : {
+        "type" : "License",
+        "identifier" : "k6bKkyS8d5",
+        "labels" : {
+          "s4tAkiLlY3yhgxTwtr" : "0ONBXxdCHEtDC3ci2LY"
+        },
+        "link" : "https://www.example.com/J8iujYe1h3NBaaOfv"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "rDD199CI96WScb",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "YA93MsGpRLFz",
-    "ownerAffiliation" : "https://www.example.org/atqui"
+    "owner" : "QbWJokQtmcbyCw8A62i",
+    "ownerAffiliation" : "https://www.example.org/quiaoptio"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eteligendi",
+    "id" : "https://www.example.org/praesentiumut",
     "labels" : {
-      "iaPFKCuggQ" : "4MVTkKZw7BQ"
+      "5eYJF7VKHezWZ" : "OhDTiUdDK0"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quisquamdoloribus",
-  "doi" : "https://doi.org/10.1234/assumenda",
-  "link" : "https://www.example.org/impeditdolores",
+  "handle" : "https://www.example.org/esseaut",
+  "doi" : "https://doi.org/10.1234/dicta",
+  "link" : "https://www.example.org/consequunturaliquid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VvNZCTn9lE3FVW0s",
+    "mainTitle" : "0NYYnNfHO7",
     "alternativeTitles" : {
-      "nn" : "GerZ4LKv7rU"
+      "da" : "fEOIUk3dCWaLC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "LAD4GPMCtZ9gdiS",
-      "month" : "7ElTQdBF8oDncEds",
-      "day" : "qqlLczWckX0JWnMRjM"
+      "year" : "aTKmZ7nYgW",
+      "month" : "fJ3vlrqpUl7CZ7xIXwD",
+      "day" : "Doy0cODGUT8"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/K2UqgN5hpuNcu",
-        "name" : "OvfWe4R0Cue7U0qA",
+        "id" : "https://www.example.com/p1xPdPZXEr8BdlI3y",
+        "name" : "TU7Bl5zLkXX5az1",
         "nameType" : "Organizational",
-        "orcId" : "7a0hxqcTZIJW6cMDiW"
+        "orcId" : "qQaxHIQhfJOpLMMRt7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ELPLGC1RFjbnbtL",
+        "id" : "https://www.example.com/dun1AVfEl0Lqs",
         "labels" : {
-          "on0zyzJuEBs" : "7wODkEGOHzjx4"
+          "lllKVgdbQ6RYoil" : "E86dwVGJAD2y9AdC"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 2,
+      "role" : "Creator",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Xn28fjNiY0Z",
-        "name" : "TocOW4w3BJQhdLRbH3Y",
+        "id" : "https://www.example.com/I4ZgGRvpRSuaZ7Cwlr",
+        "name" : "IBNJZFmtZgS",
         "nameType" : "Personal",
-        "orcId" : "uGei13OQW6Zw"
+        "orcId" : "tWgJ1OZS5Rs3aJlUn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/G9TTDsdG780B",
+        "id" : "https://www.example.com/RKX02lHOsLB3Mb2",
         "labels" : {
-          "YexEV9wxtqNd2" : "CnhZyKTzRmnW5GU"
+          "OvuWdVLHTArEi7c" : "gT9cWNqWf6p9YaWCs"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 7,
+      "role" : "Architect",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1zMRAyIE1rTfiTtykl",
-    "tags" : [ "3GgWG4dM8zo" ],
-    "description" : "1Uqo8CXKZf1QDE6dEV",
+    "npiSubjectHeading" : "hHILFsyHRBygN",
+    "tags" : [ "BW6y2UJtMBIp" ],
+    "description" : "Vgr84vP4nwS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Y4OPqG5PLf3JGvTa"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/uIg4pl9xZtIpc"
         },
-        "seriesNumber" : "kjtOPsStaKmjZ57r",
+        "seriesNumber" : "uF4A60tONSlBL1udW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GQYzDcM5EB"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gXzyQMxswaUWkMB"
         },
-        "isbnList" : [ "9780598595294" ]
+        "isbnList" : [ "9790772176775" ]
       },
-      "doi" : "https://www.example.com/CodJGX5NRSBWzi",
+      "doi" : "https://www.example.com/HxeRXGn0tMSKW2S",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "X3IE9ws57Shk6gZchHu",
-          "month" : "682vt6FdzHJjWK1PT",
-          "day" : "tr0bhL0fP1o8tgdOcp3"
+          "year" : "4EaLmNE1NqRjTsFS",
+          "month" : "O06fjWdY3dUTU7u",
+          "day" : "m8YwQ4IvAWcBfPiLQ"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "HM3SRDZ9oGn",
-            "end" : "z2uwOSm8GUu0BCeDKBV"
+            "begin" : "dLund9YRUx",
+            "end" : "JRQvTnSRR7"
           },
-          "pages" : "Lro3URlhxlCrGBmMU",
-          "illustrated" : false
+          "pages" : "DvtZq52G7JnCg",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/QXos3OPS6k9",
-    "abstract" : "bHFoQ1jmgtE12Gh"
+    "metadataSource" : "https://www.example.com/D25HGSxDcgKPlujZF",
+    "abstract" : "FRdG3Yj5VcEU8txNGW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omnissed",
-    "name" : "q2xeYJSulPCeAPJqaK",
+    "id" : "https://www.example.org/voluptatessit",
+    "name" : "PzaCIU9Sy8yE",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "4vzy5jPSAKi8",
-      "id" : "jqihl9ravD4"
+      "source" : "m4lMkZXmlMQPJz1ry6L",
+      "id" : "OVTa2qNq2kZWXp"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "8GcoRGjAe3oqvg3"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "6xzZO1K1bi9M"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiquidem" ],
+  "subjects" : [ "https://www.example.org/etaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "M6kDo8C0BbcPZw",
-      "mimeType" : "x4p12j7mxjOBk9Lms",
-      "size" : 1971078581,
+      "name" : "57H3PLFLUW9GHBsnlGu",
+      "mimeType" : "1MKyHNzKHTVR",
+      "size" : 2104496334,
       "license" : {
         "type" : "License",
-        "identifier" : "A6AVHazuxOywuYUBva",
+        "identifier" : "Fe3LzRe2BqJ",
         "labels" : {
-          "prTDovVECajASlpUfwU" : "W0G4VepslN2Q"
+          "HxKuK9yZuDKM" : "qW2oQC1cTJd6fe"
         },
-        "link" : "https://www.example.com/N0tgiwwmgDf2j9qYW"
+        "link" : "https://www.example.com/AKnoOcGfkd9mlnNGvYN"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "M6kDo8C0BbcPZw",
-    "mimeType" : "x4p12j7mxjOBk9Lms",
-    "size" : 1971078581,
+    "name" : "57H3PLFLUW9GHBsnlGu",
+    "mimeType" : "1MKyHNzKHTVR",
+    "size" : 2104496334,
     "license" : {
       "type" : "License",
-      "identifier" : "A6AVHazuxOywuYUBva",
+      "identifier" : "Fe3LzRe2BqJ",
       "labels" : {
-        "prTDovVECajASlpUfwU" : "W0G4VepslN2Q"
+        "HxKuK9yZuDKM" : "qW2oQC1cTJd6fe"
       },
-      "link" : "https://www.example.com/N0tgiwwmgDf2j9qYW"
+      "link" : "https://www.example.com/AKnoOcGfkd9mlnNGvYN"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "YA93MsGpRLFz",
+  "owner" : "QbWJokQtmcbyCw8A62i",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -3,154 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "AJnVuQ06E3mK",
-    "ownerAffiliation" : "https://www.example.org/solutaducimus"
+    "owner" : "hGwKp2H5LWjzu22",
+    "ownerAffiliation" : "https://www.example.org/iddolor"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/animivoluptatum",
+    "id" : "https://www.example.org/oditatque",
     "labels" : {
-      "VtSLlm0GpLUHhGCaMwo" : "BmHXw0GhsT541"
+      "IKCdgxoiSFXfYVPoD0" : "el8IDzptRNndH26jpY"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/cupiditateadipisci",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/velsimilique",
+  "handle" : "https://www.example.org/quodicta",
+  "doi" : "https://doi.org/10.1234/quae",
+  "link" : "https://www.example.org/velitdoloribus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "g1e6R3QiIePdNf8",
+    "mainTitle" : "GDSsBwwY7itf6y",
     "alternativeTitles" : {
-      "zh" : "pWfY7qrYUrmH1NBzzR"
+      "is" : "NVfUB38TaZ559FfaJq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "5L5k57bl17",
-      "month" : "IclfoGN4qE6as",
-      "day" : "K2SvShTLq5"
+      "year" : "HvlQjHdayO",
+      "month" : "QOhHxulMD0EjzMe",
+      "day" : "erCS2YEXO9XL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Frf4ArcPjLN8HhoiC",
-        "name" : "52KePi7Bcdx",
-        "nameType" : "Organizational",
-        "orcId" : "f5MHwBscZZ7"
+        "id" : "https://www.example.com/8JqxRC3DStt1W",
+        "name" : "lZZifk0LHMg2vKdh",
+        "nameType" : "Personal",
+        "orcId" : "AQOZx09LhUl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/sJB4JPKlheQxS2OC",
+        "id" : "https://www.example.com/hIDk5OSJcVMU7oCD",
         "labels" : {
-          "vAoO4T5ZpEPmy58nvI" : "czRkhqisZZoPdkzd"
+          "8V4X7inxtdDoxfSoJJ" : "jN29Q4z8Kl6ncnxU"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 9,
+      "role" : "Dancer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/PAkojPhJYJNeoeL7MEj",
-        "name" : "1HNWqu92QGtEAVk256j",
-        "nameType" : "Organizational",
-        "orcId" : "zMrMa5feiWZvcPSP5Yq"
+        "id" : "https://www.example.com/IkOcvt3xSyXHu08fqbW",
+        "name" : "NHMgOKNQgTbG0NcS",
+        "nameType" : "Personal",
+        "orcId" : "3REDXfOED0pkY7gkHM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Tloej5Kp5dujmv2tzc",
+        "id" : "https://www.example.com/EcHcrLpP7B",
         "labels" : {
-          "zIpxnJLy1gpOOzXNR" : "FLnvK3n07qTuTF6g"
+          "btCpF3xeSgEEtbbsB" : "TdkqTkyGr2UeiIfF"
         }
       } ],
-      "role" : "VideoEditor",
-      "sequence" : 2,
+      "role" : "Creator",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "F6cUA6sIsZdPeCL9kGb",
-    "tags" : [ "BjaQFgWt5iFqVzM" ],
-    "description" : "7owHwsO1vFEpQiyv4",
+    "npiSubjectHeading" : "Y8TUdXkhQa",
+    "tags" : [ "QvGZoIZeDgzjp" ],
+    "description" : "Ifnvv3pPv316W2VPI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CfXK2WBoIFzB4w5qKP"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CzbcALHm5ZT"
         },
-        "seriesNumber" : "EJ6SSAeBWr8ii0",
+        "seriesNumber" : "S8DfhW2aAQSzgz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/86etJk3fyfYzVHfad"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/WVigHlhgnpQ"
         },
-        "isbnList" : [ "9790857908857" ]
+        "isbnList" : [ "9791805463015" ]
       },
-      "doi" : "https://www.example.com/CKvC1dySmpL35Q5Ei7",
+      "doi" : "https://www.example.com/OTZmgmfn1HUj6",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "w81Ua9jgRbW",
-          "month" : "e9x85DQKx7hkqbuuf",
-          "day" : "daT1jEC1Pev7"
+          "year" : "XE9co793qZsz37IoJ1h",
+          "month" : "PX5o64D5XE",
+          "day" : "P5luDc6pGZRTj"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "RNdd7bbvIO0",
-            "end" : "SzeBCSPzxS"
+            "begin" : "F5rpILfVwCq8ldUl",
+            "end" : "zbpsa9UJrZSrojG"
           },
-          "pages" : "uTtRhqk4rYu6esCWeH",
-          "illustrated" : false
+          "pages" : "G8h0uUzrWfWN",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/1IhdH4n8Gu",
-    "abstract" : "DGJkXCzIWMB"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "pZQqByrYo4uy",
-      "mimeType" : "05UtOcTb9gt",
-      "size" : 2046455639,
-      "license" : {
-        "type" : "License",
-        "identifier" : "mOOp1TcQR9HTpE0aNH0",
-        "labels" : {
-          "SjvuHXPh7p8vI4j" : "1PF5142gVuqAJCbY0O"
-        },
-        "link" : "https://www.example.com/1iwZKSDSdW"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/6MLLbRNZeRj",
+    "abstract" : "lTEYYoffCJ2Ng9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estrerum",
-    "name" : "6P2uH9w97L0AYA",
+    "id" : "https://www.example.org/istenon",
+    "name" : "0QF0vnL3xUdnEUfTArv",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "mlbVzKTE5OiIM",
-      "id" : "XDsaHozP7icFYFE"
+      "source" : "Uel7BcZ1ZXB564",
+      "id" : "HEHDuA7iOOAth"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "mAsmoiML02"
+      "applicationCode" : "UDKSue0G1Ak"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,25 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/estet" ],
+  "subjects" : [ "https://www.example.org/utdebitis" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "pZQqByrYo4uy",
-    "mimeType" : "05UtOcTb9gt",
-    "size" : 2046455639,
+    "name" : "MikdOdV5sGPmb5H2BR",
+    "mimeType" : "UFlB9MPs05NG1kBj",
+    "size" : 1915504213,
     "license" : {
       "type" : "License",
-      "identifier" : "mOOp1TcQR9HTpE0aNH0",
+      "identifier" : "VKT4yaJJNlm",
       "labels" : {
-        "SjvuHXPh7p8vI4j" : "1PF5142gVuqAJCbY0O"
+        "yc0GUeXHaxZyu" : "oomDrXSBVl"
       },
-      "link" : "https://www.example.com/1iwZKSDSdW"
+      "link" : "https://www.example.com/TeEInJkor4"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "AJnVuQ06E3mK"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "MikdOdV5sGPmb5H2BR",
+      "mimeType" : "UFlB9MPs05NG1kBj",
+      "size" : 1915504213,
+      "license" : {
+        "type" : "License",
+        "identifier" : "VKT4yaJJNlm",
+        "labels" : {
+          "yc0GUeXHaxZyu" : "oomDrXSBVl"
+        },
+        "link" : "https://www.example.com/TeEInJkor4"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "hGwKp2H5LWjzu22",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -3,133 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "hGwKp2H5LWjzu22",
-    "ownerAffiliation" : "https://www.example.org/iddolor"
+    "owner" : "1wlHW3qbWRlUiH",
+    "ownerAffiliation" : "https://www.example.org/cupiditateullam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/oditatque",
+    "id" : "https://www.example.org/harumomnis",
     "labels" : {
-      "IKCdgxoiSFXfYVPoD0" : "el8IDzptRNndH26jpY"
+      "H3C9Mimlwul4RAevJ" : "2BMR28naz4tEbje"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quodicta",
-  "doi" : "https://doi.org/10.1234/quae",
-  "link" : "https://www.example.org/velitdoloribus",
+  "handle" : "https://www.example.org/acommodi",
+  "doi" : "https://doi.org/10.1234/dolorem",
+  "link" : "https://www.example.org/consequunturqui",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GDSsBwwY7itf6y",
+    "mainTitle" : "2hEBpkAtfa6xNlLyRUf",
     "alternativeTitles" : {
-      "is" : "NVfUB38TaZ559FfaJq"
+      "sv" : "Mgkljkt0RP1KeaxgP"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "HvlQjHdayO",
-      "month" : "QOhHxulMD0EjzMe",
-      "day" : "erCS2YEXO9XL"
+      "year" : "7O2eMU2T8dihmSSLX8",
+      "month" : "aeIEyhumBeH5oR1Y",
+      "day" : "5v7J0ujZO9HAv1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8JqxRC3DStt1W",
-        "name" : "lZZifk0LHMg2vKdh",
+        "id" : "https://www.example.com/UT8IhTCOCZepVl0cQ8",
+        "name" : "uc9uEZyANinfMI",
         "nameType" : "Personal",
-        "orcId" : "AQOZx09LhUl"
+        "orcId" : "t4KWPDqoHQzV5yVW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hIDk5OSJcVMU7oCD",
+        "id" : "https://www.example.com/zZL0cYM37wag1IKo",
         "labels" : {
-          "8V4X7inxtdDoxfSoJJ" : "jN29Q4z8Kl6ncnxU"
+          "DqFPQMWzlknVtZOE6OI" : "p94nIqlDio9fq"
         }
       } ],
-      "role" : "Dancer",
-      "sequence" : 4,
+      "role" : "DataCurator",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IkOcvt3xSyXHu08fqbW",
-        "name" : "NHMgOKNQgTbG0NcS",
+        "id" : "https://www.example.com/WYKBdWIEAvYd8Oj8isq",
+        "name" : "s4zusQCIxft5KAcN",
         "nameType" : "Personal",
-        "orcId" : "3REDXfOED0pkY7gkHM"
+        "orcId" : "aZngBI3z8BSM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/EcHcrLpP7B",
+        "id" : "https://www.example.com/QE4Vc2Ag9wDaU",
         "labels" : {
-          "btCpF3xeSgEEtbbsB" : "TdkqTkyGr2UeiIfF"
+          "1qP6fdn1ESB" : "DrFqevliWJ7Ywa1Nr6v"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 6,
+      "role" : "SoundDesigner",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "Y8TUdXkhQa",
-    "tags" : [ "QvGZoIZeDgzjp" ],
-    "description" : "Ifnvv3pPv316W2VPI",
+    "npiSubjectHeading" : "JmPReUhc7d3",
+    "tags" : [ "QhBWoffcYH3hokZnSq" ],
+    "description" : "Y9N6bzFpsFxu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/CzbcALHm5ZT"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8EAQMCo2TzfJVwrr"
         },
-        "seriesNumber" : "S8DfhW2aAQSzgz",
+        "seriesNumber" : "iVNdXJ52cIvPn6",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/WVigHlhgnpQ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EnZ1ulvez89TO"
         },
-        "isbnList" : [ "9791805463015" ]
+        "isbnList" : [ "9790964338721" ]
       },
-      "doi" : "https://www.example.com/OTZmgmfn1HUj6",
+      "doi" : "https://www.example.com/z4bxQ8ncCn64",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "XE9co793qZsz37IoJ1h",
-          "month" : "PX5o64D5XE",
-          "day" : "P5luDc6pGZRTj"
+          "year" : "NtnfbBNrk0dgm7TCeq",
+          "month" : "8L1RaQE5Wnsb58dT5fb",
+          "day" : "kEtig5rYyDKKv8"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "F5rpILfVwCq8ldUl",
-            "end" : "zbpsa9UJrZSrojG"
+            "begin" : "NCQtjCdrRcMgP36R",
+            "end" : "xSl9pm2V0p6S1"
           },
-          "pages" : "G8h0uUzrWfWN",
+          "pages" : "MfCTE4Rd3H5tR",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/6MLLbRNZeRj",
-    "abstract" : "lTEYYoffCJ2Ng9"
+    "metadataSource" : "https://www.example.com/Z6ye3GNOS89X",
+    "abstract" : "wk2WirEtb2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/istenon",
-    "name" : "0QF0vnL3xUdnEUfTArv",
+    "id" : "https://www.example.org/voluptatumad",
+    "name" : "bu1OFmNu6FmKTgBtkV4",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Uel7BcZ1ZXB564",
-      "id" : "HEHDuA7iOOAth"
+      "source" : "HiBOHcDG7hQvf",
+      "id" : "TvMOq7bINtoYw"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "UDKSue0G1Ak"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "GcI31PjXb1h7FXThR"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/utdebitis" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "MikdOdV5sGPmb5H2BR",
-    "mimeType" : "UFlB9MPs05NG1kBj",
-    "size" : 1915504213,
-    "license" : {
-      "type" : "License",
-      "identifier" : "VKT4yaJJNlm",
-      "labels" : {
-        "yc0GUeXHaxZyu" : "oomDrXSBVl"
-      },
-      "link" : "https://www.example.com/TeEInJkor4"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/minuslaborum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "MikdOdV5sGPmb5H2BR",
-      "mimeType" : "UFlB9MPs05NG1kBj",
-      "size" : 1915504213,
+      "name" : "uBpk1UGlCLx",
+      "mimeType" : "IIkS6xbP0HGRNhxt2",
+      "size" : 1421813653,
       "license" : {
         "type" : "License",
-        "identifier" : "VKT4yaJJNlm",
+        "identifier" : "jPDkrIQumPt3rVViNB4",
         "labels" : {
-          "yc0GUeXHaxZyu" : "oomDrXSBVl"
+          "6jNVIj3BlQajG" : "mlIPFJyI74m3OwerVH"
         },
-        "link" : "https://www.example.com/TeEInJkor4"
+        "link" : "https://www.example.com/fZPpee7OI1ehy"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "hGwKp2H5LWjzu22",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "uBpk1UGlCLx",
+    "mimeType" : "IIkS6xbP0HGRNhxt2",
+    "size" : 1421813653,
+    "license" : {
+      "type" : "License",
+      "identifier" : "jPDkrIQumPt3rVViNB4",
+      "labels" : {
+        "6jNVIj3BlQajG" : "mlIPFJyI74m3OwerVH"
+      },
+      "link" : "https://www.example.com/fZPpee7OI1ehy"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "1wlHW3qbWRlUiH",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "1wlHW3qbWRlUiH",
-    "ownerAffiliation" : "https://www.example.org/cupiditateullam"
+    "owner" : "YA93MsGpRLFz",
+    "ownerAffiliation" : "https://www.example.org/atqui"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/harumomnis",
+    "id" : "https://www.example.org/eteligendi",
     "labels" : {
-      "H3C9Mimlwul4RAevJ" : "2BMR28naz4tEbje"
+      "iaPFKCuggQ" : "4MVTkKZw7BQ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/acommodi",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/consequunturqui",
+  "handle" : "https://www.example.org/quisquamdoloribus",
+  "doi" : "https://doi.org/10.1234/assumenda",
+  "link" : "https://www.example.org/impeditdolores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2hEBpkAtfa6xNlLyRUf",
+    "mainTitle" : "VvNZCTn9lE3FVW0s",
     "alternativeTitles" : {
-      "sv" : "Mgkljkt0RP1KeaxgP"
+      "nn" : "GerZ4LKv7rU"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "7O2eMU2T8dihmSSLX8",
-      "month" : "aeIEyhumBeH5oR1Y",
-      "day" : "5v7J0ujZO9HAv1"
+      "year" : "LAD4GPMCtZ9gdiS",
+      "month" : "7ElTQdBF8oDncEds",
+      "day" : "qqlLczWckX0JWnMRjM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UT8IhTCOCZepVl0cQ8",
-        "name" : "uc9uEZyANinfMI",
-        "nameType" : "Personal",
-        "orcId" : "t4KWPDqoHQzV5yVW"
+        "id" : "https://www.example.com/K2UqgN5hpuNcu",
+        "name" : "OvfWe4R0Cue7U0qA",
+        "nameType" : "Organizational",
+        "orcId" : "7a0hxqcTZIJW6cMDiW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zZL0cYM37wag1IKo",
+        "id" : "https://www.example.com/ELPLGC1RFjbnbtL",
         "labels" : {
-          "DqFPQMWzlknVtZOE6OI" : "p94nIqlDio9fq"
+          "on0zyzJuEBs" : "7wODkEGOHzjx4"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 0,
+      "role" : "Architect",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WYKBdWIEAvYd8Oj8isq",
-        "name" : "s4zusQCIxft5KAcN",
+        "id" : "https://www.example.com/Xn28fjNiY0Z",
+        "name" : "TocOW4w3BJQhdLRbH3Y",
         "nameType" : "Personal",
-        "orcId" : "aZngBI3z8BSM"
+        "orcId" : "uGei13OQW6Zw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QE4Vc2Ag9wDaU",
+        "id" : "https://www.example.com/G9TTDsdG780B",
         "labels" : {
-          "1qP6fdn1ESB" : "DrFqevliWJ7Ywa1Nr6v"
+          "YexEV9wxtqNd2" : "CnhZyKTzRmnW5GU"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 5,
+      "role" : "Producer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "JmPReUhc7d3",
-    "tags" : [ "QhBWoffcYH3hokZnSq" ],
-    "description" : "Y9N6bzFpsFxu",
+    "npiSubjectHeading" : "1zMRAyIE1rTfiTtykl",
+    "tags" : [ "3GgWG4dM8zo" ],
+    "description" : "1Uqo8CXKZf1QDE6dEV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8EAQMCo2TzfJVwrr"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Y4OPqG5PLf3JGvTa"
         },
-        "seriesNumber" : "iVNdXJ52cIvPn6",
+        "seriesNumber" : "kjtOPsStaKmjZ57r",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EnZ1ulvez89TO"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GQYzDcM5EB"
         },
-        "isbnList" : [ "9790964338721" ]
+        "isbnList" : [ "9780598595294" ]
       },
-      "doi" : "https://www.example.com/z4bxQ8ncCn64",
+      "doi" : "https://www.example.com/CodJGX5NRSBWzi",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "NtnfbBNrk0dgm7TCeq",
-          "month" : "8L1RaQE5Wnsb58dT5fb",
-          "day" : "kEtig5rYyDKKv8"
+          "year" : "X3IE9ws57Shk6gZchHu",
+          "month" : "682vt6FdzHJjWK1PT",
+          "day" : "tr0bhL0fP1o8tgdOcp3"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "NCQtjCdrRcMgP36R",
-            "end" : "xSl9pm2V0p6S1"
+            "begin" : "HM3SRDZ9oGn",
+            "end" : "z2uwOSm8GUu0BCeDKBV"
           },
-          "pages" : "MfCTE4Rd3H5tR",
-          "illustrated" : true
+          "pages" : "Lro3URlhxlCrGBmMU",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Z6ye3GNOS89X",
-    "abstract" : "wk2WirEtb2"
+    "metadataSource" : "https://www.example.com/QXos3OPS6k9",
+    "abstract" : "bHFoQ1jmgtE12Gh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatumad",
-    "name" : "bu1OFmNu6FmKTgBtkV4",
+    "id" : "https://www.example.org/omnissed",
+    "name" : "q2xeYJSulPCeAPJqaK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "HiBOHcDG7hQvf",
-      "id" : "TvMOq7bINtoYw"
+      "source" : "4vzy5jPSAKi8",
+      "id" : "jqihl9ravD4"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "GcI31PjXb1h7FXThR"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "8GcoRGjAe3oqvg3"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/minuslaborum" ],
+  "subjects" : [ "https://www.example.org/quiquidem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "uBpk1UGlCLx",
-      "mimeType" : "IIkS6xbP0HGRNhxt2",
-      "size" : 1421813653,
+      "name" : "M6kDo8C0BbcPZw",
+      "mimeType" : "x4p12j7mxjOBk9Lms",
+      "size" : 1971078581,
       "license" : {
         "type" : "License",
-        "identifier" : "jPDkrIQumPt3rVViNB4",
+        "identifier" : "A6AVHazuxOywuYUBva",
         "labels" : {
-          "6jNVIj3BlQajG" : "mlIPFJyI74m3OwerVH"
+          "prTDovVECajASlpUfwU" : "W0G4VepslN2Q"
         },
-        "link" : "https://www.example.com/fZPpee7OI1ehy"
+        "link" : "https://www.example.com/N0tgiwwmgDf2j9qYW"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "uBpk1UGlCLx",
-    "mimeType" : "IIkS6xbP0HGRNhxt2",
-    "size" : 1421813653,
+    "name" : "M6kDo8C0BbcPZw",
+    "mimeType" : "x4p12j7mxjOBk9Lms",
+    "size" : 1971078581,
     "license" : {
       "type" : "License",
-      "identifier" : "jPDkrIQumPt3rVViNB4",
+      "identifier" : "A6AVHazuxOywuYUBva",
       "labels" : {
-        "6jNVIj3BlQajG" : "mlIPFJyI74m3OwerVH"
+        "prTDovVECajASlpUfwU" : "W0G4VepslN2Q"
       },
-      "link" : "https://www.example.com/fZPpee7OI1ehy"
+      "link" : "https://www.example.com/N0tgiwwmgDf2j9qYW"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "1wlHW3qbWRlUiH",
+  "owner" : "YA93MsGpRLFz",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "F4RVNOP5s3kazT7RRY2",
-    "ownerAffiliation" : "https://www.example.org/molestiaeut"
+    "owner" : "VJ6h7zlN8Dlt",
+    "ownerAffiliation" : "https://www.example.org/eumreiciendis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eligendiet",
+    "id" : "https://www.example.org/delectusoccaecati",
     "labels" : {
-      "Cmrp7EQsrn7GD" : "gZ3dr62voZqL7cmAW"
+      "FOowF2Rh5zV" : "8IbP1DJMRS6mNGu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/iurequi",
-  "doi" : "https://doi.org/10.1234/dolore",
-  "link" : "https://www.example.org/quoratione",
+  "handle" : "https://www.example.org/etofficiis",
+  "doi" : "https://doi.org/10.1234/alias",
+  "link" : "https://www.example.org/veniamab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uVTlt8xOQ3Fc",
+    "mainTitle" : "eNDCqFc9rcVgW30FkG",
     "alternativeTitles" : {
-      "ca" : "gAZsNyLcrUpEAY5"
+      "pl" : "SLWePr2ufD4FzbCT"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "5aHyuMFzKq2P6j",
-      "month" : "HgRm6Gk1R0v2",
-      "day" : "L3buRkTfuZ"
+      "year" : "3hXpDoArGAz3h",
+      "month" : "7Pe1d0K4fCq48AzwmEg",
+      "day" : "UwdOLlY9fiK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FB2I4ZRlgPBp3",
-        "name" : "bqEbLocDsjdNk3Z9kr",
+        "id" : "https://www.example.com/XUjtRcrVoeA7JhP",
+        "name" : "2jj9j2gfnUUOsJiE7",
         "nameType" : "Organizational",
-        "orcId" : "Ts5mXNCGdyxeS"
+        "orcId" : "Zmn74wE6eeOzYbsEt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oPuD9jRoKp0q3o4Ga",
+        "id" : "https://www.example.com/irxBDagyclo22s",
         "labels" : {
-          "WWgPBLZvQhd" : "di5vvPbWJEGJmpmt"
+          "xpaP7gtHeX" : "CislQ6q9Sqyh8RZVW0"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 3,
+      "role" : "ProjectLeader",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fvEBTJrtVPk",
-        "name" : "K6h5kpgi0yXXu",
+        "id" : "https://www.example.com/XJ7XFcIKaM2",
+        "name" : "yEVrgiLBo6w8CRK1",
         "nameType" : "Organizational",
-        "orcId" : "Cix84dptc6X3Hrga"
+        "orcId" : "bJg7uLokneS9Dh6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/N0M36i17fBpWkhzxkeF",
+        "id" : "https://www.example.com/KdpsuVtG57",
         "labels" : {
-          "kKLeM4rMYfMc" : "iK6WbV0D0Yy"
+          "RCBAiPIbNCQtGdlyF" : "rN3yUj8CE4qPHRANEq"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 0,
+      "role" : "HostingInstitution",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1PyZmRrLJgkEY",
-    "tags" : [ "WIFnDbGJPc" ],
-    "description" : "aw3N078wI6q",
+    "npiSubjectHeading" : "HYDU5rtGN4i5p",
+    "tags" : [ "3DYLCIX9YQuL1" ],
+    "description" : "kG7NxuzxZxTbgVsHL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wCIynYqBb7hcYXaIxNX"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/NA8TULbQN5qIa"
         },
-        "seriesNumber" : "njTMhyWCdr",
+        "seriesNumber" : "Gy8lq1dHRz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8CasEbbITFDY2yCR"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3Lpb4TZx4S0clo1M8jY"
         },
-        "isbnList" : [ "9780779904419" ]
+        "isbnList" : [ "9781983115660" ]
       },
-      "doi" : "https://www.example.com/GIcrCZokRZaEf",
+      "doi" : "https://www.example.com/1wZCbroPFWnWaU6BqQ",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "tNy0Zs2Qlzl2j6x0",
-          "month" : "KBeoJGDhnlNr",
-          "day" : "mghr3Y9LJeujLcQV0"
+          "year" : "J8SHXSzQHSUZdq",
+          "month" : "dvCWEMPR6UnB",
+          "day" : "0uV88uEg8Udls9N"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "cMJ1L1xU5yOYn4hqw",
-            "end" : "Ep47rgO68HM2akNSzjM"
+            "begin" : "NLxHNCJMDJHUtbdT",
+            "end" : "O6lrEZRn3wq"
           },
-          "pages" : "9gl1HrfTLM2NMVF6B",
+          "pages" : "yrSeKtopnmFxEusR0P",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/RC0PxePRNgFBx4I6jsG",
-    "abstract" : "BMy01AtxYKoeNm5Y"
+    "metadataSource" : "https://www.example.com/Kygk0z9JCbDT018I9uN",
+    "abstract" : "SM3fXrEw80"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/errormaxime",
-    "name" : "9aqo7Dqzz6VbC",
+    "id" : "https://www.example.org/accusamusconsequatur",
+    "name" : "5gHNryTjIxP",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "vE5Xm99Lsv",
-      "id" : "Vp5jB28wawJ"
+      "source" : "qDOLKmmLRcjwFa",
+      "id" : "7mE5kVluPDZBcpDi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "cJjHI0BgyMXqXUeJ0a"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "zROc6tX2ofHByV4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/minimanisi" ],
+  "subjects" : [ "https://www.example.org/quidemsed" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "QwxcB3vojtolh",
-      "mimeType" : "U5zy1wardHjm7S",
-      "size" : 966822007,
+      "name" : "8XHcSNED0NYYsdVC2",
+      "mimeType" : "VrNWmb94Ona8Y128cd",
+      "size" : 426806521,
       "license" : {
         "type" : "License",
-        "identifier" : "FItXzSKRe3Cj",
+        "identifier" : "80yyBRp4pvcS",
         "labels" : {
-          "MTzW8Bbvw62a2qZ" : "d1FdfHQqCy"
+          "OVqJVq7HvMBiG5QLlC" : "Fq2T4O9M9ZGcBdjA0"
         },
-        "link" : "https://www.example.com/7avz5Q3H3IBzEb4im"
+        "link" : "https://www.example.com/DS4FEhkprmH1yCaqPO"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "QwxcB3vojtolh",
-    "mimeType" : "U5zy1wardHjm7S",
-    "size" : 966822007,
+    "name" : "8XHcSNED0NYYsdVC2",
+    "mimeType" : "VrNWmb94Ona8Y128cd",
+    "size" : 426806521,
     "license" : {
       "type" : "License",
-      "identifier" : "FItXzSKRe3Cj",
+      "identifier" : "80yyBRp4pvcS",
       "labels" : {
-        "MTzW8Bbvw62a2qZ" : "d1FdfHQqCy"
+        "OVqJVq7HvMBiG5QLlC" : "Fq2T4O9M9ZGcBdjA0"
       },
-      "link" : "https://www.example.com/7avz5Q3H3IBzEb4im"
+      "link" : "https://www.example.com/DS4FEhkprmH1yCaqPO"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "F4RVNOP5s3kazT7RRY2",
+  "owner" : "VJ6h7zlN8Dlt",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -3,133 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "HCGHLppLRC",
-    "ownerAffiliation" : "https://www.example.org/etasperiores"
+    "owner" : "F4RVNOP5s3kazT7RRY2",
+    "ownerAffiliation" : "https://www.example.org/molestiaeut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiasit",
+    "id" : "https://www.example.org/eligendiet",
     "labels" : {
-      "Qoj3ZAINKD0JZERyIVJ" : "kxRDewYdf97Fh"
+      "Cmrp7EQsrn7GD" : "gZ3dr62voZqL7cmAW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/voluptatumnam",
-  "doi" : "https://doi.org/10.1234/reiciendis",
-  "link" : "https://www.example.org/providentaliquam",
+  "handle" : "https://www.example.org/iurequi",
+  "doi" : "https://doi.org/10.1234/dolore",
+  "link" : "https://www.example.org/quoratione",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eBWoA5p7X6eZta",
+    "mainTitle" : "uVTlt8xOQ3Fc",
     "alternativeTitles" : {
-      "es" : "UxVtERGM3qFkt3uD8k"
+      "ca" : "gAZsNyLcrUpEAY5"
     },
     "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Om4mRsZkm4FHe0rFs",
-      "month" : "wfiH0Gz71Jrs2VhMW2W",
-      "day" : "ts17ns1QkbNd"
+      "year" : "5aHyuMFzKq2P6j",
+      "month" : "HgRm6Gk1R0v2",
+      "day" : "L3buRkTfuZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Z4Pa89w2sxTPuwwM8",
-        "name" : "pdvphAQRj3",
+        "id" : "https://www.example.com/FB2I4ZRlgPBp3",
+        "name" : "bqEbLocDsjdNk3Z9kr",
         "nameType" : "Organizational",
-        "orcId" : "58y3mc3Ibksb"
+        "orcId" : "Ts5mXNCGdyxeS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vhZ4zh8HzSyjGU65b",
+        "id" : "https://www.example.com/oPuD9jRoKp0q3o4Ga",
         "labels" : {
-          "iWZpcTw3Ob5Wyp" : "rGmGDIuxIdwDzvAasp"
+          "WWgPBLZvQhd" : "di5vvPbWJEGJmpmt"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 1,
+      "role" : "Writer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XJIJtRSXLnRkpT",
-        "name" : "cM13GskuSVSp1ix",
+        "id" : "https://www.example.com/fvEBTJrtVPk",
+        "name" : "K6h5kpgi0yXXu",
         "nameType" : "Organizational",
-        "orcId" : "RkdlqZYre9S4ms6HoTA"
+        "orcId" : "Cix84dptc6X3Hrga"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hZL1dRE6KJUxQxQDju",
+        "id" : "https://www.example.com/N0M36i17fBpWkhzxkeF",
         "labels" : {
-          "6Rb72q96H0m" : "Z2N6mBlUKu"
+          "kKLeM4rMYfMc" : "iK6WbV0D0Yy"
         }
       } ],
-      "role" : "CuratorOrganizer",
+      "role" : "DataCollector",
       "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "iakTYb8RNxDmePZ9wgW",
-    "tags" : [ "xrkEd4tPtyKN" ],
-    "description" : "v30ixgWHdqJ5Yz8",
+    "npiSubjectHeading" : "1PyZmRrLJgkEY",
+    "tags" : [ "WIFnDbGJPc" ],
+    "description" : "aw3N078wI6q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/261mNX059Y"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wCIynYqBb7hcYXaIxNX"
         },
-        "seriesNumber" : "FaMoKOIiebjBUt",
+        "seriesNumber" : "njTMhyWCdr",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OwnnpQw6BNvbE3JbqN"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8CasEbbITFDY2yCR"
         },
-        "isbnList" : [ "9791966194209" ]
+        "isbnList" : [ "9780779904419" ]
       },
-      "doi" : "https://www.example.com/uxT35PbnHj",
+      "doi" : "https://www.example.com/GIcrCZokRZaEf",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "YEDKqXJi8yq",
-          "month" : "HVya1wIKvB4rKAgV",
-          "day" : "TuRSAURxObJlye"
+          "year" : "tNy0Zs2Qlzl2j6x0",
+          "month" : "KBeoJGDhnlNr",
+          "day" : "mghr3Y9LJeujLcQV0"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "FK2hiPvCdTeUZa",
-            "end" : "KFE2VPKG6KgRoRc9ck"
+            "begin" : "cMJ1L1xU5yOYn4hqw",
+            "end" : "Ep47rgO68HM2akNSzjM"
           },
-          "pages" : "M43QofXqqOQS8yz5y",
+          "pages" : "9gl1HrfTLM2NMVF6B",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/DngOBf7EPHBX",
-    "abstract" : "CZgFFpZLDbhEFSx"
+    "metadataSource" : "https://www.example.com/RC0PxePRNgFBx4I6jsG",
+    "abstract" : "BMy01AtxYKoeNm5Y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/perspiciatisnihil",
-    "name" : "5hAbQGVVyw",
+    "id" : "https://www.example.org/errormaxime",
+    "name" : "9aqo7Dqzz6VbC",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "RknaQ57Jdansq",
-      "id" : "nb3TMpNOJqES"
+      "source" : "vE5Xm99Lsv",
+      "id" : "Vp5jB28wawJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "h5u3V26rtVfJ"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "cJjHI0BgyMXqXUeJ0a"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/impeditsunt" ],
+  "subjects" : [ "https://www.example.org/minimanisi" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "njUHaQx2N2Q",
-      "mimeType" : "BhE8Cq8aq1",
-      "size" : 564238946,
+      "name" : "QwxcB3vojtolh",
+      "mimeType" : "U5zy1wardHjm7S",
+      "size" : 966822007,
       "license" : {
         "type" : "License",
-        "identifier" : "zJUWX3RXOzCvwdBxyV",
+        "identifier" : "FItXzSKRe3Cj",
         "labels" : {
-          "PBcKBUBgVl2J" : "Zka8apO52omv4"
+          "MTzW8Bbvw62a2qZ" : "d1FdfHQqCy"
         },
-        "link" : "https://www.example.com/qOIRhJ3izf6OjnD"
+        "link" : "https://www.example.com/7avz5Q3H3IBzEb4im"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "njUHaQx2N2Q",
-    "mimeType" : "BhE8Cq8aq1",
-    "size" : 564238946,
+    "name" : "QwxcB3vojtolh",
+    "mimeType" : "U5zy1wardHjm7S",
+    "size" : 966822007,
     "license" : {
       "type" : "License",
-      "identifier" : "zJUWX3RXOzCvwdBxyV",
+      "identifier" : "FItXzSKRe3Cj",
       "labels" : {
-        "PBcKBUBgVl2J" : "Zka8apO52omv4"
+        "MTzW8Bbvw62a2qZ" : "d1FdfHQqCy"
       },
-      "link" : "https://www.example.com/qOIRhJ3izf6OjnD"
+      "link" : "https://www.example.com/7avz5Q3H3IBzEb4im"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "HCGHLppLRC",
+  "owner" : "F4RVNOP5s3kazT7RRY2",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -3,154 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "4mnAyyjng30GQTyu",
-    "ownerAffiliation" : "https://www.example.org/nesciuntprovident"
+    "owner" : "4u3CrssJuON",
+    "ownerAffiliation" : "https://www.example.org/similiqueaperiam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/undevoluptate",
+    "id" : "https://www.example.org/rerumvoluptatem",
     "labels" : {
-      "AWGckr1QhFyL" : "bpON5yJNqCMB0njE0"
+      "YQ6STjiPb4CLK0" : "uD9MGyiH0t"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/minimahic",
-  "doi" : "https://doi.org/10.1234/ad",
-  "link" : "https://www.example.org/eosofficiis",
+  "handle" : "https://www.example.org/facilisoptio",
+  "doi" : "https://doi.org/10.1234/pariatur",
+  "link" : "https://www.example.org/laborequi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5tjcKvtOUvKkOMW",
+    "mainTitle" : "uC8YlFARIPZp7in",
     "alternativeTitles" : {
-      "af" : "9WuPnI3rV9uJ"
+      "ca" : "myVALqQMOuFZ3YM59X"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "cYPHRHoIAb",
-      "month" : "bq7dulPErY",
-      "day" : "PpemCt1tQHO575"
+      "year" : "O3dS4UmkwYf",
+      "month" : "Bi6b2w0fheBu0c",
+      "day" : "qI4pP9mdhSoEck"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jECCsnfAjgvLE",
-        "name" : "i1Wdvgv57p3miEWhol",
+        "id" : "https://www.example.com/E5KEJMxHEb",
+        "name" : "x3VZcj2976IfFhaamz",
         "nameType" : "Organizational",
-        "orcId" : "4gEetYhRAOYhqKiYS"
+        "orcId" : "GO7hVtqbWRChwIa"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CUpSItkdrf",
+        "id" : "https://www.example.com/Q7q4ZIC2TfmrosOQ4",
         "labels" : {
-          "kz0Z2ZEk5Hh28QC" : "BNJxJSahP4SoMnc"
+          "wmLIOoiteB" : "UbIihumGOIG4bEly"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 4,
+      "role" : "Advisor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/19mJ5oOTDu",
-        "name" : "G4vzW4hbsntwHMEhc",
-        "nameType" : "Personal",
-        "orcId" : "imYa5t7cbdie5PJJLR"
+        "id" : "https://www.example.com/uFBksz2SKp85mr0M",
+        "name" : "dRl6bNi0QPwfyJ2um",
+        "nameType" : "Organizational",
+        "orcId" : "l5a0TQNG8HjV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3zHarqPkcb870TLEmj",
+        "id" : "https://www.example.com/slkEc3TXTPyWKQ",
         "labels" : {
-          "68BwGka5DOac7" : "a1E0fUEvoOJ"
+          "DmOx0SXDkOQ9du4R" : "xvJz61acaPyN0RNE"
         }
       } ],
-      "role" : "Researcher",
-      "sequence" : 5,
+      "role" : "WorkPackageLeader",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "COL4HNEfaoi",
-    "tags" : [ "ir2aFb0JyWwxc2" ],
-    "description" : "z8hbf90u0x",
+    "npiSubjectHeading" : "CzAJFSnLQTBvWVvk",
+    "tags" : [ "aU2RJmqC0pMbkE" ],
+    "description" : "37xHPBvzkcDA6GUB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6F1BgV2Z37BZfef"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hPF6FnA8HbZjBeR"
         },
-        "seriesNumber" : "dRwPxgjTxSHItLy3",
+        "seriesNumber" : "y86QlVU9KG",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/L6uNy7r3udzP8mhj"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OFCVb4vZXTmi7"
         },
-        "isbnList" : [ "9781824376182" ]
+        "isbnList" : [ "9781861926494" ]
       },
-      "doi" : "https://www.example.com/LRb9Hq3gO0Eu",
+      "doi" : "https://www.example.com/rCqadL46R3h92ONR",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "bNvp7jBz2Xgz",
-          "month" : "P5kAAnc0eGiI6jsqxs",
-          "day" : "WASOzGN2My0f5pWU84"
+          "year" : "IpAZglYIhLO",
+          "month" : "ujMPaFLat1VYy0Xs",
+          "day" : "uHn1KY36GjBKaYsuO"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "FUu8aU4XSZWO3vkfIT0",
-            "end" : "FurMKns3rO1IjO"
+            "begin" : "1wzNdoBaIPTpn0",
+            "end" : "IsHLjB6XiF60O5"
           },
-          "pages" : "GiAMIfBna3FIfu4xpkK",
+          "pages" : "mWamhsyN03",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/9987tsVeQX54",
-    "abstract" : "71v8CrPLbnsny"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "VAU31CnCFwsP",
-      "mimeType" : "vq54y7Bd1IPix",
-      "size" : 2139409346,
-      "license" : {
-        "type" : "License",
-        "identifier" : "OI8XSlNAFCLV",
-        "labels" : {
-          "4MoXOhrb8uJ3ho0nAT0" : "Sn6BGBJpBjr7LVUxbr"
-        },
-        "link" : "https://www.example.com/pABQdrkhMOgMW"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/qsz2gXayLUn",
+    "abstract" : "u9QUmW133PZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omnislaudantium",
-    "name" : "iPskmxVnRQbz",
+    "id" : "https://www.example.org/minusaccusantium",
+    "name" : "N13hSxwdMl8A",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "x9N62cgaDPUX",
-      "id" : "bQihY4NANst"
+      "source" : "7VQDtlgUGhmC",
+      "id" : "I9oj8ZWmOsLzrJ4PY"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "MV6dlViRjg"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "1L6Ld6mMuDrkTf4G"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,25 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dictalibero" ],
+  "subjects" : [ "https://www.example.org/temporibusdoloremque" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "VAU31CnCFwsP",
-    "mimeType" : "vq54y7Bd1IPix",
-    "size" : 2139409346,
+    "name" : "qXVs3baW8Gzwl",
+    "mimeType" : "y4IFkrDPshAB5BG",
+    "size" : 1406913603,
     "license" : {
       "type" : "License",
-      "identifier" : "OI8XSlNAFCLV",
+      "identifier" : "tHoBVORZnJi0z4",
       "labels" : {
-        "4MoXOhrb8uJ3ho0nAT0" : "Sn6BGBJpBjr7LVUxbr"
+        "7BHBqibRk8AIxD3h" : "D6PTx6MfKLUxh8FuDv"
       },
-      "link" : "https://www.example.com/pABQdrkhMOgMW"
+      "link" : "https://www.example.com/hAdPfHtHmItGHfnHUw"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "4mnAyyjng30GQTyu"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "qXVs3baW8Gzwl",
+      "mimeType" : "y4IFkrDPshAB5BG",
+      "size" : 1406913603,
+      "license" : {
+        "type" : "License",
+        "identifier" : "tHoBVORZnJi0z4",
+        "labels" : {
+          "7BHBqibRk8AIxD3h" : "D6PTx6MfKLUxh8FuDv"
+        },
+        "link" : "https://www.example.com/hAdPfHtHmItGHfnHUw"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "4u3CrssJuON",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -3,133 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "4u3CrssJuON",
-    "ownerAffiliation" : "https://www.example.org/similiqueaperiam"
+    "owner" : "HCGHLppLRC",
+    "ownerAffiliation" : "https://www.example.org/etasperiores"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rerumvoluptatem",
+    "id" : "https://www.example.org/quiasit",
     "labels" : {
-      "YQ6STjiPb4CLK0" : "uD9MGyiH0t"
+      "Qoj3ZAINKD0JZERyIVJ" : "kxRDewYdf97Fh"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/facilisoptio",
-  "doi" : "https://doi.org/10.1234/pariatur",
-  "link" : "https://www.example.org/laborequi",
+  "handle" : "https://www.example.org/voluptatumnam",
+  "doi" : "https://doi.org/10.1234/reiciendis",
+  "link" : "https://www.example.org/providentaliquam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uC8YlFARIPZp7in",
+    "mainTitle" : "eBWoA5p7X6eZta",
     "alternativeTitles" : {
-      "ca" : "myVALqQMOuFZ3YM59X"
+      "es" : "UxVtERGM3qFkt3uD8k"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "O3dS4UmkwYf",
-      "month" : "Bi6b2w0fheBu0c",
-      "day" : "qI4pP9mdhSoEck"
+      "year" : "Om4mRsZkm4FHe0rFs",
+      "month" : "wfiH0Gz71Jrs2VhMW2W",
+      "day" : "ts17ns1QkbNd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/E5KEJMxHEb",
-        "name" : "x3VZcj2976IfFhaamz",
+        "id" : "https://www.example.com/Z4Pa89w2sxTPuwwM8",
+        "name" : "pdvphAQRj3",
         "nameType" : "Organizational",
-        "orcId" : "GO7hVtqbWRChwIa"
+        "orcId" : "58y3mc3Ibksb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Q7q4ZIC2TfmrosOQ4",
+        "id" : "https://www.example.com/vhZ4zh8HzSyjGU65b",
         "labels" : {
-          "wmLIOoiteB" : "UbIihumGOIG4bEly"
+          "iWZpcTw3Ob5Wyp" : "rGmGDIuxIdwDzvAasp"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 5,
+      "role" : "InterviewSubject",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uFBksz2SKp85mr0M",
-        "name" : "dRl6bNi0QPwfyJ2um",
+        "id" : "https://www.example.com/XJIJtRSXLnRkpT",
+        "name" : "cM13GskuSVSp1ix",
         "nameType" : "Organizational",
-        "orcId" : "l5a0TQNG8HjV"
+        "orcId" : "RkdlqZYre9S4ms6HoTA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/slkEc3TXTPyWKQ",
+        "id" : "https://www.example.com/hZL1dRE6KJUxQxQDju",
         "labels" : {
-          "DmOx0SXDkOQ9du4R" : "xvJz61acaPyN0RNE"
+          "6Rb72q96H0m" : "Z2N6mBlUKu"
         }
       } ],
-      "role" : "WorkPackageLeader",
+      "role" : "CuratorOrganizer",
       "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "CzAJFSnLQTBvWVvk",
-    "tags" : [ "aU2RJmqC0pMbkE" ],
-    "description" : "37xHPBvzkcDA6GUB",
+    "npiSubjectHeading" : "iakTYb8RNxDmePZ9wgW",
+    "tags" : [ "xrkEd4tPtyKN" ],
+    "description" : "v30ixgWHdqJ5Yz8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hPF6FnA8HbZjBeR"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/261mNX059Y"
         },
-        "seriesNumber" : "y86QlVU9KG",
+        "seriesNumber" : "FaMoKOIiebjBUt",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OFCVb4vZXTmi7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OwnnpQw6BNvbE3JbqN"
         },
-        "isbnList" : [ "9781861926494" ]
+        "isbnList" : [ "9791966194209" ]
       },
-      "doi" : "https://www.example.com/rCqadL46R3h92ONR",
+      "doi" : "https://www.example.com/uxT35PbnHj",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "IpAZglYIhLO",
-          "month" : "ujMPaFLat1VYy0Xs",
-          "day" : "uHn1KY36GjBKaYsuO"
+          "year" : "YEDKqXJi8yq",
+          "month" : "HVya1wIKvB4rKAgV",
+          "day" : "TuRSAURxObJlye"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "1wzNdoBaIPTpn0",
-            "end" : "IsHLjB6XiF60O5"
+            "begin" : "FK2hiPvCdTeUZa",
+            "end" : "KFE2VPKG6KgRoRc9ck"
           },
-          "pages" : "mWamhsyN03",
+          "pages" : "M43QofXqqOQS8yz5y",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/qsz2gXayLUn",
-    "abstract" : "u9QUmW133PZ"
+    "metadataSource" : "https://www.example.com/DngOBf7EPHBX",
+    "abstract" : "CZgFFpZLDbhEFSx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/minusaccusantium",
-    "name" : "N13hSxwdMl8A",
+    "id" : "https://www.example.org/perspiciatisnihil",
+    "name" : "5hAbQGVVyw",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "7VQDtlgUGhmC",
-      "id" : "I9oj8ZWmOsLzrJ4PY"
+      "source" : "RknaQ57Jdansq",
+      "id" : "nb3TMpNOJqES"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "1L6Ld6mMuDrkTf4G"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "h5u3V26rtVfJ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporibusdoloremque" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "qXVs3baW8Gzwl",
-    "mimeType" : "y4IFkrDPshAB5BG",
-    "size" : 1406913603,
-    "license" : {
-      "type" : "License",
-      "identifier" : "tHoBVORZnJi0z4",
-      "labels" : {
-        "7BHBqibRk8AIxD3h" : "D6PTx6MfKLUxh8FuDv"
-      },
-      "link" : "https://www.example.com/hAdPfHtHmItGHfnHUw"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/impeditsunt" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "qXVs3baW8Gzwl",
-      "mimeType" : "y4IFkrDPshAB5BG",
-      "size" : 1406913603,
+      "name" : "njUHaQx2N2Q",
+      "mimeType" : "BhE8Cq8aq1",
+      "size" : 564238946,
       "license" : {
         "type" : "License",
-        "identifier" : "tHoBVORZnJi0z4",
+        "identifier" : "zJUWX3RXOzCvwdBxyV",
         "labels" : {
-          "7BHBqibRk8AIxD3h" : "D6PTx6MfKLUxh8FuDv"
+          "PBcKBUBgVl2J" : "Zka8apO52omv4"
         },
-        "link" : "https://www.example.com/hAdPfHtHmItGHfnHUw"
+        "link" : "https://www.example.com/qOIRhJ3izf6OjnD"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "4u3CrssJuON",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "njUHaQx2N2Q",
+    "mimeType" : "BhE8Cq8aq1",
+    "size" : 564238946,
+    "license" : {
+      "type" : "License",
+      "identifier" : "zJUWX3RXOzCvwdBxyV",
+      "labels" : {
+        "PBcKBUBgVl2J" : "Zka8apO52omv4"
+      },
+      "link" : "https://www.example.com/qOIRhJ3izf6OjnD"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "HCGHLppLRC",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "alpgkyptyVUdAG6",
-    "ownerAffiliation" : "https://www.example.org/quimolestiae"
+    "owner" : "mTLCVrAqLSdQHMRzx0f",
+    "ownerAffiliation" : "https://www.example.org/architectodicta"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quinemo",
+    "id" : "https://www.example.org/quodolorem",
     "labels" : {
-      "hVTwsw5ppWsdvwVC" : "4bTf1DRxIoLl"
+      "RgcwYYlZofy7arJfVIF" : "klNRist9Q9d"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/evenietnihil",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/quasvoluptas",
+  "handle" : "https://www.example.org/seddeleniti",
+  "doi" : "https://doi.org/10.1234/facilis",
+  "link" : "https://www.example.org/nequequis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "A8LvlybrIxa",
+    "mainTitle" : "NGwdgIddr2HoSaRvvb",
     "alternativeTitles" : {
-      "af" : "2uGSfJ3F4T7y"
+      "nl" : "BnEwARSiOHYEAEKz3P9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "zKJIXmW8EhipV",
-      "month" : "uIJive4WMq7Cm9s7X",
-      "day" : "SE3Ppv1GLiWpxSuodN"
+      "year" : "C0wL5aTKoRy3vy",
+      "month" : "KsPqwS8fX2lXujXs",
+      "day" : "aSKVLKilcdKPHeGTl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/otGLGSmJHqVLgn",
-        "name" : "aFcEJjjzBR3E",
-        "nameType" : "Organizational",
-        "orcId" : "mDxQya42sdoHeHR"
+        "id" : "https://www.example.com/hB6qSKFOEX0ZMmt",
+        "name" : "philJeBDoXzQNBFS5eb",
+        "nameType" : "Personal",
+        "orcId" : "tKomlrk7WW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/NnQOGl61HAl",
+        "id" : "https://www.example.com/MynvojgzCASpBXAHnqP",
         "labels" : {
-          "uipdVOrFYSznGF8" : "B93np4DOJJLT3"
+          "0cA3OGkUCr5nyEUfMI6" : "TwDi9pBLpcR"
         }
       } ],
-      "role" : "Soloist",
+      "role" : "ProjectManager",
       "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BvaZuyE4Oi8qCga1rGX",
-        "name" : "5xvJnDtdigG9",
-        "nameType" : "Organizational",
-        "orcId" : "gTqwQh36JpN3bVXs"
+        "id" : "https://www.example.com/rwVVjxJLcg",
+        "name" : "RaSzSbziQ1",
+        "nameType" : "Personal",
+        "orcId" : "g2Zpb9JBEl7vRbs8h"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0TLA8PGwhXfCs",
+        "id" : "https://www.example.com/4zm9nB9nRA9lgc",
         "labels" : {
-          "7ThwQCUttH1qsOydzt" : "0WO8Vsa9sKB7OTY"
+          "MH4RF5s9JVWYryn63" : "n7123hZYJFjWE"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 3,
+      "role" : "Creator",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "C6MfPzcLLY",
-    "tags" : [ "ptmyY7Er9ccmAGfkl" ],
-    "description" : "0me0Y7CNzKmlmq2K",
+    "npiSubjectHeading" : "y3MCHwZhHFZVObX15ph",
+    "tags" : [ "PqHsyW37X30" ],
+    "description" : "WvjPVcIm7cTYW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/g1KCqVRATTByiyiYm"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/T72GUlMTXWCeQ"
         },
-        "seriesNumber" : "xN2li7vWNqxbx",
+        "seriesNumber" : "hqxIk8Rsgd",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jIfZcniBXjFQwXEYcLA"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6owIAovcanS3"
         },
-        "isbnList" : [ "9791470393235" ]
+        "isbnList" : [ "9780953412723" ]
       },
-      "doi" : "https://www.example.com/fkcohNlZpAzdy5FaV",
+      "doi" : "https://www.example.com/9IIhHdji1g7pI9uQ",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "Hu8IKmCh9jCxgd",
-          "month" : "7z6b6tDBQqTE",
-          "day" : "WU8ingJlX5"
+          "year" : "Odw0hN4Mc8Y2omNANk",
+          "month" : "OmIjazF7WkiFMzaSgRb",
+          "day" : "6EzWjSuSgwccpF"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "AkqRr39Bm7",
-            "end" : "ZIWuKo1OOA"
+            "begin" : "8j2Mui2PCwcZQbkt",
+            "end" : "eROwe4rBvsC"
           },
-          "pages" : "EqePr5Ri37PwHnEVd3",
-          "illustrated" : false
+          "pages" : "po1J3cmoJaPv7cmUfUf",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/vmeNUBiLFc5",
-    "abstract" : "TvMk1z3VnVPi4ao9E"
+    "metadataSource" : "https://www.example.com/YK1eVCKF03w7VcO8en",
+    "abstract" : "9ey57NYTg9riCn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quaeratperferendis",
-    "name" : "iyjaBtIcATsMv",
+    "id" : "https://www.example.org/illoquos",
+    "name" : "tHz6TP1qDNxjs0EBy",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "S8T2f4em6X5zVagQ",
-      "id" : "KCNsbnjdYsesEFF"
+      "source" : "nR2KTXHcq3I",
+      "id" : "BWo6qchIin"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "WhZ68mEiND"
+      "applicationCode" : "LlB7N9L7m3shSl"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nihilnihil" ],
+  "subjects" : [ "https://www.example.org/voluptatemet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "JS3a8G1e0QcV",
-      "mimeType" : "O7cNE4yjTJntESO9L",
-      "size" : 200643406,
+      "name" : "LIHXIHPyuUHyrFm",
+      "mimeType" : "tmd1Nea2H465fV",
+      "size" : 1610410822,
       "license" : {
         "type" : "License",
-        "identifier" : "VOivHT5laKL",
+        "identifier" : "mcd6JU1ahpFzfnDoy8U",
         "labels" : {
-          "PsNNJJdmndRn5v" : "rj3e02vZbF"
+          "1w2XroLgBBFL48DmaM" : "6SkNRePI71zOWVaG"
         },
-        "link" : "https://www.example.com/UB6MAfnHBSs9"
+        "link" : "https://www.example.com/JZTVhD4K7eBxBjOs"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "JS3a8G1e0QcV",
-    "mimeType" : "O7cNE4yjTJntESO9L",
-    "size" : 200643406,
+    "name" : "LIHXIHPyuUHyrFm",
+    "mimeType" : "tmd1Nea2H465fV",
+    "size" : 1610410822,
     "license" : {
       "type" : "License",
-      "identifier" : "VOivHT5laKL",
+      "identifier" : "mcd6JU1ahpFzfnDoy8U",
       "labels" : {
-        "PsNNJJdmndRn5v" : "rj3e02vZbF"
+        "1w2XroLgBBFL48DmaM" : "6SkNRePI71zOWVaG"
       },
-      "link" : "https://www.example.com/UB6MAfnHBSs9"
+      "link" : "https://www.example.com/JZTVhD4K7eBxBjOs"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "alpgkyptyVUdAG6",
+  "owner" : "mTLCVrAqLSdQHMRzx0f",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,156 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "wIOR2ssu8kuWa",
-    "ownerAffiliation" : "https://www.example.org/remquibusdam"
+    "owner" : "iZsEJ8Ty3mfg2sQ",
+    "ownerAffiliation" : "https://www.example.org/culpanihil"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/praesentiumeligendi",
+    "id" : "https://www.example.org/eosdolor",
     "labels" : {
-      "6IIlEjsxoeOR" : "gTugR9GpMPUzefV"
+      "czuu2o4u3HFm6H" : "eVliouynus1w50j4I3"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/officiissint",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/accusantiumexplicabo",
+  "handle" : "https://www.example.org/veniamut",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/voluptatemunde",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eBlMIOO2a8LJDKsOh",
+    "mainTitle" : "BBDRnPVFQ0PyXb",
     "alternativeTitles" : {
-      "no" : "UmGAsQkiy90RpNZ3"
+      "el" : "F8COr5u6Idvtv55"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TPVakDSWkQChfl07U8w",
-      "month" : "E8KSLXwSpUgmZvdjchH",
-      "day" : "w6bBOGWsB6JyiQEXKQY"
+      "year" : "zzK56apBxjAtUyZqL",
+      "month" : "isVERxOociHZyLGgbc4",
+      "day" : "pcv5WIxhB8I0oa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ujXT4qPB74NKQ726q",
-        "name" : "aNzddpMHxZTsc6L",
+        "id" : "https://www.example.com/eYonBmJHsSJ",
+        "name" : "OJ1xye9hLbkv5nic99",
         "nameType" : "Personal",
-        "orcId" : "B5Tiob19357SMDVWo"
+        "orcId" : "Q3uqhxqlCcfNtudV"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/L5zwmOo5Qrk9J3wSoyM",
+        "id" : "https://www.example.com/Q0rVb0KoxR47lb",
         "labels" : {
-          "jSPGxAY9bgX7i3QwSvp" : "AUG4wSLHLM4E2PdQM3y"
+          "ZuHPnkTtRt4RFmh7" : "oSKYZn55M3n6Up"
         }
       } ],
-      "role" : "VfxSupervisor",
-      "sequence" : 2,
+      "role" : "DataCollector",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lcpO7K1zg4aZR6jU",
-        "name" : "17vIEELM3G6tkZBOH0c",
-        "nameType" : "Organizational",
-        "orcId" : "x761ifBSQ0e"
+        "id" : "https://www.example.com/KRRddXswd9RcEp",
+        "name" : "EJg2Dploc4f4t2j",
+        "nameType" : "Personal",
+        "orcId" : "5IDyZ1trRFKAsuHHqO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yfbIjhHPEH",
+        "id" : "https://www.example.com/xZoeUXpU2gP8HK",
         "labels" : {
-          "A09rCALm6yXAPuDYpN" : "hdMVHpb2NX"
+          "7SsvvxPbzvvkfF" : "BRuf1sgJLAKb"
         }
       } ],
-      "role" : "ResearchGroup",
+      "role" : "Other",
       "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5zf987Sjf2",
-    "tags" : [ "gPHiWBXcVrt" ],
-    "description" : "rMkWSE7OYvg5xqdEnYU",
+    "npiSubjectHeading" : "1N3anz9H5mlND3ZAS4",
+    "tags" : [ "JUrAY9lwNEILTvwaL" ],
+    "description" : "3hfK2PmO6OD8ZviZu3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/IUzFUaFLM5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bGLXpWXMbjpZmRYV"
         },
-        "seriesNumber" : "7hPqC1KTExaZaDQEvE",
+        "seriesNumber" : "UDhC0IZPJE",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/t0qiqtM8668moC5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Wv6sUKtCSa9I"
         },
-        "isbnList" : [ "9780331333800" ]
+        "isbnList" : [ "9781881808947" ]
       },
-      "doi" : "https://www.example.com/qMutlJAks2LRIH",
+      "doi" : "https://www.example.com/tIPcKod8QR",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "jvrUHqIonkCSCh",
-          "month" : "s5HIL2oq4Br1UP",
-          "day" : "E19obfFjKTZD72"
+          "year" : "Frx7z23AM0frRCPq",
+          "month" : "r0cAcDSLjOh4rA6",
+          "day" : "VwoQW7CBqwX"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ph9XubQnh3UQz",
-            "end" : "0Sa27ufxuZEES"
+            "begin" : "De9YWnIgw5L9yai",
+            "end" : "ZNgyUN6CNv"
           },
-          "pages" : "Kv7ju2GdMV2Fnc5G5A",
-          "illustrated" : false
+          "pages" : "1iVvn0oa9wxc1jGMhe",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/2JoaLtTGylf7WEI",
-    "abstract" : "PmLup05rwXSe"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "zIWgguKYtWRmv",
-      "mimeType" : "cj7Qr2SdNyenKCFR",
-      "size" : 1590398700,
-      "license" : {
-        "type" : "License",
-        "identifier" : "vgzgumuNtArxoSk0Y",
-        "labels" : {
-          "jeDGnES4Jly2inL" : "wMgHEQoK9J0D"
-        },
-        "link" : "https://www.example.com/U9IT16zrm74h2mEgIi"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/WCcYSPRguN",
+    "abstract" : "G92NYbgmhwIH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/abet",
-    "name" : "tCMZjHxtjGXhTE",
+    "id" : "https://www.example.org/natusautem",
+    "name" : "nGpzaaWsboiKilAwq7",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Pp7ZWUOxMB",
-      "id" : "ORvcFxUoTChMk"
+      "source" : "AO015rBnmZUEp",
+      "id" : "p2839XEEfpn"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Cz6Ou6wAXWPGUhMjo"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ALrG2Fn22J"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,25 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiaasperiores" ],
+  "subjects" : [ "https://www.example.org/dolorema" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "zIWgguKYtWRmv",
-    "mimeType" : "cj7Qr2SdNyenKCFR",
-    "size" : 1590398700,
+    "name" : "ZFXzLMZEvsD",
+    "mimeType" : "Fa5LYufXxZLeOGb",
+    "size" : 1551241194,
     "license" : {
       "type" : "License",
-      "identifier" : "vgzgumuNtArxoSk0Y",
+      "identifier" : "CURE4kuK0tv",
       "labels" : {
-        "jeDGnES4Jly2inL" : "wMgHEQoK9J0D"
+        "CLHhle6Grbw3PEIEV" : "RNA5a2EHYL6xnAc2tiY"
       },
-      "link" : "https://www.example.com/U9IT16zrm74h2mEgIi"
+      "link" : "https://www.example.com/Rvk4VPEE6lSt8k6"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "wIOR2ssu8kuWa"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "ZFXzLMZEvsD",
+      "mimeType" : "Fa5LYufXxZLeOGb",
+      "size" : 1551241194,
+      "license" : {
+        "type" : "License",
+        "identifier" : "CURE4kuK0tv",
+        "labels" : {
+          "CLHhle6Grbw3PEIEV" : "RNA5a2EHYL6xnAc2tiY"
+        },
+        "link" : "https://www.example.com/Rvk4VPEE6lSt8k6"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "iZsEJ8Ty3mfg2sQ",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "iZsEJ8Ty3mfg2sQ",
-    "ownerAffiliation" : "https://www.example.org/culpanihil"
+    "owner" : "jGsmLgi7R9dS7v",
+    "ownerAffiliation" : "https://www.example.org/quaeratillum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eosdolor",
+    "id" : "https://www.example.org/rerumhic",
     "labels" : {
-      "czuu2o4u3HFm6H" : "eVliouynus1w50j4I3"
+      "CUm9LUWW0LCq" : "l0EGBB2OwZNYRO"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/veniamut",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/voluptatemunde",
+  "handle" : "https://www.example.org/etdolores",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/atnihil",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BBDRnPVFQ0PyXb",
+    "mainTitle" : "fUTv7WtORxMZ",
     "alternativeTitles" : {
-      "el" : "F8COr5u6Idvtv55"
+      "fr" : "vpw88cAcIlJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "zzK56apBxjAtUyZqL",
-      "month" : "isVERxOociHZyLGgbc4",
-      "day" : "pcv5WIxhB8I0oa"
+      "year" : "DX5hzasRkZzU7XOODs",
+      "month" : "bIqBeTnsHlsmo1Aum",
+      "day" : "GRXPFR80aq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/eYonBmJHsSJ",
-        "name" : "OJ1xye9hLbkv5nic99",
+        "id" : "https://www.example.com/gkaH717AHPi",
+        "name" : "dSmjJBPk9YZ8RFfs9",
         "nameType" : "Personal",
-        "orcId" : "Q3uqhxqlCcfNtudV"
+        "orcId" : "RzeYmMBQHMBtNu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Q0rVb0KoxR47lb",
+        "id" : "https://www.example.com/7gqIAqgiyPFeC",
         "labels" : {
-          "ZuHPnkTtRt4RFmh7" : "oSKYZn55M3n6Up"
+          "KeZteNrZ3cKEXdNieJk" : "XIbU5AzDlSjaA7ypE"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 1,
+      "role" : "ProductionDesigner",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KRRddXswd9RcEp",
-        "name" : "EJg2Dploc4f4t2j",
+        "id" : "https://www.example.com/AcJTgtvPgdgaUZIe",
+        "name" : "MllfY6nZymQBGiKA",
         "nameType" : "Personal",
-        "orcId" : "5IDyZ1trRFKAsuHHqO"
+        "orcId" : "kvgZEEF0naG6"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xZoeUXpU2gP8HK",
+        "id" : "https://www.example.com/OPtAL2SXGW",
         "labels" : {
-          "7SsvvxPbzvvkfF" : "BRuf1sgJLAKb"
+          "055fmXZHgyL7yoVIN" : "PcV2S3dsX8XhOCbdh"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 7,
+      "role" : "WorkPackageLeader",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1N3anz9H5mlND3ZAS4",
-    "tags" : [ "JUrAY9lwNEILTvwaL" ],
-    "description" : "3hfK2PmO6OD8ZviZu3",
+    "npiSubjectHeading" : "NdBgBgVwIHHJ0ezx1",
+    "tags" : [ "eUJGAMhuclVDGymmOI" ],
+    "description" : "wQ4gyCHfMcfHaK6N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bGLXpWXMbjpZmRYV"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Jfoi4WypihQg5INZIi"
         },
-        "seriesNumber" : "UDhC0IZPJE",
+        "seriesNumber" : "XATXjpKlL91JZvM7L",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Wv6sUKtCSa9I"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5un3hIalsX8"
         },
-        "isbnList" : [ "9781881808947" ]
+        "isbnList" : [ "9781054487962" ]
       },
-      "doi" : "https://www.example.com/tIPcKod8QR",
+      "doi" : "https://www.example.com/1xt5EdPONyiyZW",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "Frx7z23AM0frRCPq",
-          "month" : "r0cAcDSLjOh4rA6",
-          "day" : "VwoQW7CBqwX"
+          "year" : "MWaOtrRCJ6Zr",
+          "month" : "7D0s7sFhh3OQN",
+          "day" : "wAiApEWZ8QNS66Jisu"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "De9YWnIgw5L9yai",
-            "end" : "ZNgyUN6CNv"
+            "begin" : "qUy1IBC12neZp",
+            "end" : "RD2YQBKxFntf2t"
           },
-          "pages" : "1iVvn0oa9wxc1jGMhe",
+          "pages" : "JD8gVw7ANzd28r",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/WCcYSPRguN",
-    "abstract" : "G92NYbgmhwIH"
+    "metadataSource" : "https://www.example.com/zbNxE9XFVTJnR69",
+    "abstract" : "qn6YdP69uyGC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/natusautem",
-    "name" : "nGpzaaWsboiKilAwq7",
+    "id" : "https://www.example.org/voluptatemet",
+    "name" : "UIsY7AcdJZra",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "AO015rBnmZUEp",
-      "id" : "p2839XEEfpn"
+      "source" : "jIOUlfoExK",
+      "id" : "0ux3afMRgJBHKYV2s5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "ALrG2Fn22J"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "avXkOW5d7BmdVGwFr3"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dolorema" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ZFXzLMZEvsD",
-    "mimeType" : "Fa5LYufXxZLeOGb",
-    "size" : 1551241194,
-    "license" : {
-      "type" : "License",
-      "identifier" : "CURE4kuK0tv",
-      "labels" : {
-        "CLHhle6Grbw3PEIEV" : "RNA5a2EHYL6xnAc2tiY"
-      },
-      "link" : "https://www.example.com/Rvk4VPEE6lSt8k6"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/enimut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZFXzLMZEvsD",
-      "mimeType" : "Fa5LYufXxZLeOGb",
-      "size" : 1551241194,
+      "name" : "5qY94zFMHFs9F",
+      "mimeType" : "jkv2GsCbM9ycRE",
+      "size" : 1793540883,
       "license" : {
         "type" : "License",
-        "identifier" : "CURE4kuK0tv",
+        "identifier" : "PxebrTtJeKFE5",
         "labels" : {
-          "CLHhle6Grbw3PEIEV" : "RNA5a2EHYL6xnAc2tiY"
+          "jyleBEBCjLBjTu" : "27whhMQOIULffYmtv"
         },
-        "link" : "https://www.example.com/Rvk4VPEE6lSt8k6"
+        "link" : "https://www.example.com/8a07NLJupQUF"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "iZsEJ8Ty3mfg2sQ",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "5qY94zFMHFs9F",
+    "mimeType" : "jkv2GsCbM9ycRE",
+    "size" : 1793540883,
+    "license" : {
+      "type" : "License",
+      "identifier" : "PxebrTtJeKFE5",
+      "labels" : {
+        "jyleBEBCjLBjTu" : "27whhMQOIULffYmtv"
+      },
+      "link" : "https://www.example.com/8a07NLJupQUF"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "jGsmLgi7R9dS7v",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -3,133 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "jGsmLgi7R9dS7v",
-    "ownerAffiliation" : "https://www.example.org/quaeratillum"
+    "owner" : "alpgkyptyVUdAG6",
+    "ownerAffiliation" : "https://www.example.org/quimolestiae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rerumhic",
+    "id" : "https://www.example.org/quinemo",
     "labels" : {
-      "CUm9LUWW0LCq" : "l0EGBB2OwZNYRO"
+      "hVTwsw5ppWsdvwVC" : "4bTf1DRxIoLl"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etdolores",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/atnihil",
+  "handle" : "https://www.example.org/evenietnihil",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/quasvoluptas",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fUTv7WtORxMZ",
+    "mainTitle" : "A8LvlybrIxa",
     "alternativeTitles" : {
-      "fr" : "vpw88cAcIlJ"
+      "af" : "2uGSfJ3F4T7y"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "DX5hzasRkZzU7XOODs",
-      "month" : "bIqBeTnsHlsmo1Aum",
-      "day" : "GRXPFR80aq"
+      "year" : "zKJIXmW8EhipV",
+      "month" : "uIJive4WMq7Cm9s7X",
+      "day" : "SE3Ppv1GLiWpxSuodN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gkaH717AHPi",
-        "name" : "dSmjJBPk9YZ8RFfs9",
-        "nameType" : "Personal",
-        "orcId" : "RzeYmMBQHMBtNu"
+        "id" : "https://www.example.com/otGLGSmJHqVLgn",
+        "name" : "aFcEJjjzBR3E",
+        "nameType" : "Organizational",
+        "orcId" : "mDxQya42sdoHeHR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7gqIAqgiyPFeC",
+        "id" : "https://www.example.com/NnQOGl61HAl",
         "labels" : {
-          "KeZteNrZ3cKEXdNieJk" : "XIbU5AzDlSjaA7ypE"
+          "uipdVOrFYSznGF8" : "B93np4DOJJLT3"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 5,
+      "role" : "Soloist",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AcJTgtvPgdgaUZIe",
-        "name" : "MllfY6nZymQBGiKA",
-        "nameType" : "Personal",
-        "orcId" : "kvgZEEF0naG6"
+        "id" : "https://www.example.com/BvaZuyE4Oi8qCga1rGX",
+        "name" : "5xvJnDtdigG9",
+        "nameType" : "Organizational",
+        "orcId" : "gTqwQh36JpN3bVXs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OPtAL2SXGW",
+        "id" : "https://www.example.com/0TLA8PGwhXfCs",
         "labels" : {
-          "055fmXZHgyL7yoVIN" : "PcV2S3dsX8XhOCbdh"
+          "7ThwQCUttH1qsOydzt" : "0WO8Vsa9sKB7OTY"
         }
       } ],
-      "role" : "WorkPackageLeader",
+      "role" : "Supervisor",
       "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NdBgBgVwIHHJ0ezx1",
-    "tags" : [ "eUJGAMhuclVDGymmOI" ],
-    "description" : "wQ4gyCHfMcfHaK6N",
+    "npiSubjectHeading" : "C6MfPzcLLY",
+    "tags" : [ "ptmyY7Er9ccmAGfkl" ],
+    "description" : "0me0Y7CNzKmlmq2K",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2Jfoi4WypihQg5INZIi"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/g1KCqVRATTByiyiYm"
         },
-        "seriesNumber" : "XATXjpKlL91JZvM7L",
+        "seriesNumber" : "xN2li7vWNqxbx",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5un3hIalsX8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jIfZcniBXjFQwXEYcLA"
         },
-        "isbnList" : [ "9781054487962" ]
+        "isbnList" : [ "9791470393235" ]
       },
-      "doi" : "https://www.example.com/1xt5EdPONyiyZW",
+      "doi" : "https://www.example.com/fkcohNlZpAzdy5FaV",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "MWaOtrRCJ6Zr",
-          "month" : "7D0s7sFhh3OQN",
-          "day" : "wAiApEWZ8QNS66Jisu"
+          "year" : "Hu8IKmCh9jCxgd",
+          "month" : "7z6b6tDBQqTE",
+          "day" : "WU8ingJlX5"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "qUy1IBC12neZp",
-            "end" : "RD2YQBKxFntf2t"
+            "begin" : "AkqRr39Bm7",
+            "end" : "ZIWuKo1OOA"
           },
-          "pages" : "JD8gVw7ANzd28r",
-          "illustrated" : true
+          "pages" : "EqePr5Ri37PwHnEVd3",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/zbNxE9XFVTJnR69",
-    "abstract" : "qn6YdP69uyGC"
+    "metadataSource" : "https://www.example.com/vmeNUBiLFc5",
+    "abstract" : "TvMk1z3VnVPi4ao9E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemet",
-    "name" : "UIsY7AcdJZra",
+    "id" : "https://www.example.org/quaeratperferendis",
+    "name" : "iyjaBtIcATsMv",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "jIOUlfoExK",
-      "id" : "0ux3afMRgJBHKYV2s5"
+      "source" : "S8T2f4em6X5zVagQ",
+      "id" : "KCNsbnjdYsesEFF"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "avXkOW5d7BmdVGwFr3"
+      "applicationCode" : "WhZ68mEiND"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/enimut" ],
+  "subjects" : [ "https://www.example.org/nihilnihil" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "5qY94zFMHFs9F",
-      "mimeType" : "jkv2GsCbM9ycRE",
-      "size" : 1793540883,
+      "name" : "JS3a8G1e0QcV",
+      "mimeType" : "O7cNE4yjTJntESO9L",
+      "size" : 200643406,
       "license" : {
         "type" : "License",
-        "identifier" : "PxebrTtJeKFE5",
+        "identifier" : "VOivHT5laKL",
         "labels" : {
-          "jyleBEBCjLBjTu" : "27whhMQOIULffYmtv"
+          "PsNNJJdmndRn5v" : "rj3e02vZbF"
         },
-        "link" : "https://www.example.com/8a07NLJupQUF"
+        "link" : "https://www.example.com/UB6MAfnHBSs9"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "5qY94zFMHFs9F",
-    "mimeType" : "jkv2GsCbM9ycRE",
-    "size" : 1793540883,
+    "name" : "JS3a8G1e0QcV",
+    "mimeType" : "O7cNE4yjTJntESO9L",
+    "size" : 200643406,
     "license" : {
       "type" : "License",
-      "identifier" : "PxebrTtJeKFE5",
+      "identifier" : "VOivHT5laKL",
       "labels" : {
-        "jyleBEBCjLBjTu" : "27whhMQOIULffYmtv"
+        "PsNNJJdmndRn5v" : "rj3e02vZbF"
       },
-      "link" : "https://www.example.com/8a07NLJupQUF"
+      "link" : "https://www.example.com/UB6MAfnHBSs9"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "jGsmLgi7R9dS7v",
+  "owner" : "alpgkyptyVUdAG6",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "WvRyPThg6XFZIt",
-    "ownerAffiliation" : "https://www.example.org/reiciendistenetur"
+    "owner" : "GEGDwPxiX9xTr0pD",
+    "ownerAffiliation" : "https://www.example.org/evenietquisquam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quivoluptatem",
+    "id" : "https://www.example.org/autoptio",
     "labels" : {
-      "I8HQeP1fmzn" : "IfpZ4SaGaKE3qAWbG"
+      "rZWxfo3Os529hC" : "h1lXDpePAE5KTJW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/fugiataspernatur",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/etsint",
+  "handle" : "https://www.example.org/facilisfacilis",
+  "doi" : "https://doi.org/10.1234/harum",
+  "link" : "https://www.example.org/quiaadipisci",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uwZEY5sNGghipCeY",
+    "mainTitle" : "sic7JAUho8wVN7nxx",
     "alternativeTitles" : {
-      "cs" : "570YROMx3HtFv"
+      "pl" : "C5OAhbramJs"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "I1DtP47ltI",
-      "month" : "iB5ARthvkeBADvyw",
-      "day" : "RJ1t5HooIOxzaClB"
+      "year" : "qt9QwlKJ5ahTYyx",
+      "month" : "aNe8WOsiN9r1pRD1",
+      "day" : "864b3mrGnLYBWVQc1kI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3YZ1Z4pPLhla3XXL",
-        "name" : "ODxYxUyp1IMUon",
+        "id" : "https://www.example.com/p4uizAwL7bZtxUK",
+        "name" : "UWRJnsTlI1dW",
         "nameType" : "Organizational",
-        "orcId" : "Cuh7GtPJGq"
+        "orcId" : "mtqFPMcdtkvLPt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LkOeeTQsyd",
+        "id" : "https://www.example.com/iHHnY0AeYmrB",
         "labels" : {
-          "Mc3EZolOyH" : "MDVPsyxaZfXGf"
+          "diaXI8vwDQEv" : "g2vuHiXoxrpXv"
         }
       } ],
-      "role" : "Organizer",
-      "sequence" : 3,
+      "role" : "Photographer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ggTG3SFmpDWq",
-        "name" : "fkpcuwjWuMKQ43",
+        "id" : "https://www.example.com/nLQRA3ZW69nBqFYMBbV",
+        "name" : "7kRjG0ycqH4",
         "nameType" : "Organizational",
-        "orcId" : "fE8CuxC7GFt"
+        "orcId" : "RVYTDq6C6mpqEUzQ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DCTaV9820VPi7G",
+        "id" : "https://www.example.com/4wVImTa9g6HaPi",
         "labels" : {
-          "JdqxBkJvyTkJjfEiQV" : "YKDKN7Oj4Y470"
+          "3d5u38DcXE" : "FA38lsd8VrFl4mfWpL"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 2,
+      "role" : "VideoEditor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rkb9mgB0TM59Ci",
-    "tags" : [ "wXbySKg6Sl8UotYNt" ],
-    "description" : "3aGcEDANV2",
+    "npiSubjectHeading" : "9Z9E7jqy8iLO",
+    "tags" : [ "GxZ7eDeUChkx7k" ],
+    "description" : "RX9eqjfXxb4VAjGyjk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yqF9fEQQ3lzC6y0j"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/k7R4VENMvhC1rEeKQyw"
       },
-      "doi" : "https://www.example.com/7P5YNnSqCPDE",
+      "doi" : "https://www.example.com/4Hj5GZiL4thC",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "4wjSwCXDGlEt8",
-        "issue" : "34x9lBLtXo4m48il",
-        "articleNumber" : "d5HMgUm5fha9Vqwu",
+        "volume" : "Y8Gw6OUpshiJAwYFlR",
+        "issue" : "sQxw5jCJK83gHFaVW",
+        "articleNumber" : "GuxNwa26TZGQ8oz5qHX",
         "pages" : {
           "type" : "Range",
-          "begin" : "wesvbFPCEH35EJNptH",
-          "end" : "415kVqDW2boh3"
+          "begin" : "XnOer36bumV",
+          "end" : "Nz5iGl2nFnyF"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/mM36pFitYyXyds0292",
-    "abstract" : "uBTcqHY84XyZ0To"
+    "metadataSource" : "https://www.example.com/LIbatY7TSJ",
+    "abstract" : "MpjosadsDgsexIt"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quaeratvoluptatum",
-    "name" : "zzcMgy2ZeAfr",
+    "id" : "https://www.example.org/consequaturharum",
+    "name" : "AIfUDcF64tm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "pvJv5A7riAX",
-      "id" : "XBNBHlS7BTrfD"
+      "source" : "nRdDYOdeQz3wkfOej",
+      "id" : "ld7whiXcDv1V3tXI"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "SVtmZd8I07FH3eB"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "9fCn7BBpEa9kQbWx7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delectusveniam" ],
+  "subjects" : [ "https://www.example.org/aliquidquas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "seKQGM0E0HzY",
-      "mimeType" : "4M6Li8CXFfrk0",
-      "size" : 153973386,
+      "name" : "iKfhSoRbVZmI",
+      "mimeType" : "jpPUS3jFfW",
+      "size" : 397704093,
       "license" : {
         "type" : "License",
-        "identifier" : "7UW6OMVQ2UFaS7bYnAC",
+        "identifier" : "bSIXAQiJhFC",
         "labels" : {
-          "zbkDqKRgloiGvW" : "LnaWp3vQopGMkuBo"
+          "XhibFdP3RsPM" : "rJF5kExbsTlGLc"
         },
-        "link" : "https://www.example.com/kyKcWK9V9o6u"
+        "link" : "https://www.example.com/dyUDMrELsiYRE"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "seKQGM0E0HzY",
-    "mimeType" : "4M6Li8CXFfrk0",
-    "size" : 153973386,
+    "name" : "iKfhSoRbVZmI",
+    "mimeType" : "jpPUS3jFfW",
+    "size" : 397704093,
     "license" : {
       "type" : "License",
-      "identifier" : "7UW6OMVQ2UFaS7bYnAC",
+      "identifier" : "bSIXAQiJhFC",
       "labels" : {
-        "zbkDqKRgloiGvW" : "LnaWp3vQopGMkuBo"
+        "XhibFdP3RsPM" : "rJF5kExbsTlGLc"
       },
-      "link" : "https://www.example.com/kyKcWK9V9o6u"
+      "link" : "https://www.example.com/dyUDMrELsiYRE"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "WvRyPThg6XFZIt",
+  "owner" : "GEGDwPxiX9xTr0pD",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "GEGDwPxiX9xTr0pD",
-    "ownerAffiliation" : "https://www.example.org/evenietquisquam"
+    "owner" : "JcCb3PLhTZ",
+    "ownerAffiliation" : "https://www.example.org/aspernaturconsequatur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autoptio",
+    "id" : "https://www.example.org/voluptatibusvoluptas",
     "labels" : {
-      "rZWxfo3Os529hC" : "h1lXDpePAE5KTJW"
+      "qPuxmHAKThf4ETS" : "3yWpdD4L0N5CRpFS"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/facilisfacilis",
-  "doi" : "https://doi.org/10.1234/harum",
-  "link" : "https://www.example.org/quiaadipisci",
+  "handle" : "https://www.example.org/rerumrerum",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/laborererum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sic7JAUho8wVN7nxx",
+    "mainTitle" : "jN3reiUtuo40ceBs1",
     "alternativeTitles" : {
-      "pl" : "C5OAhbramJs"
+      "fi" : "7iLEr8zkh2TtHa"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "qt9QwlKJ5ahTYyx",
-      "month" : "aNe8WOsiN9r1pRD1",
-      "day" : "864b3mrGnLYBWVQc1kI"
+      "year" : "ZDw1u0F3nQAVpJRZZAb",
+      "month" : "hWSgmTU23jQbRS9uf",
+      "day" : "cWiO00XZuVX5Yl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/p4uizAwL7bZtxUK",
-        "name" : "UWRJnsTlI1dW",
-        "nameType" : "Organizational",
-        "orcId" : "mtqFPMcdtkvLPt"
+        "id" : "https://www.example.com/UkkvJTlLFGMR",
+        "name" : "SGc3pNZoDyGpEssb",
+        "nameType" : "Personal",
+        "orcId" : "wEQa9kcTTWNyZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iHHnY0AeYmrB",
+        "id" : "https://www.example.com/vPrIFVanaGjhoF2a",
         "labels" : {
-          "diaXI8vwDQEv" : "g2vuHiXoxrpXv"
+          "SSbYcwC1q9" : "NctDPQgYugUIoGTt3DS"
         }
       } ],
-      "role" : "Photographer",
-      "sequence" : 2,
+      "role" : "Director",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/nLQRA3ZW69nBqFYMBbV",
-        "name" : "7kRjG0ycqH4",
+        "id" : "https://www.example.com/miUR5cfalm",
+        "name" : "9XX5JVFKLYj1ioY",
         "nameType" : "Organizational",
-        "orcId" : "RVYTDq6C6mpqEUzQ"
+        "orcId" : "cwyv2mlRdJERwWrFg2l"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4wVImTa9g6HaPi",
+        "id" : "https://www.example.com/pOCq9IP0XAvmub8",
         "labels" : {
-          "3d5u38DcXE" : "FA38lsd8VrFl4mfWpL"
+          "I3NlKAmk4HMpDmQRP9" : "5dVJybsb05MtEf4"
         }
       } ],
-      "role" : "VideoEditor",
-      "sequence" : 8,
+      "role" : "Editor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9Z9E7jqy8iLO",
-    "tags" : [ "GxZ7eDeUChkx7k" ],
-    "description" : "RX9eqjfXxb4VAjGyjk",
+    "npiSubjectHeading" : "gt0h7G6OC4WIEa5W5",
+    "tags" : [ "RJKfTcEHAX2MFAMmEyw" ],
+    "description" : "kwhUv1C2yyzO1dATj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/k7R4VENMvhC1rEeKQyw"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/g26hEKc4tPVhK3eXx"
       },
-      "doi" : "https://www.example.com/4Hj5GZiL4thC",
+      "doi" : "https://www.example.com/AQ7f2Lyumd4JW6n",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "Y8Gw6OUpshiJAwYFlR",
-        "issue" : "sQxw5jCJK83gHFaVW",
-        "articleNumber" : "GuxNwa26TZGQ8oz5qHX",
+        "volume" : "gQtt29dYU9NdtVKqzxO",
+        "issue" : "y9OPIqBFuxLvJWz",
+        "articleNumber" : "RYK79VEwjV",
         "pages" : {
           "type" : "Range",
-          "begin" : "XnOer36bumV",
-          "end" : "Nz5iGl2nFnyF"
+          "begin" : "ZrM98l5ei3cS5YTM8",
+          "end" : "YED02wrdBZ"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/LIbatY7TSJ",
-    "abstract" : "MpjosadsDgsexIt"
+    "metadataSource" : "https://www.example.com/PL0kmwZdiuUuJJ",
+    "abstract" : "2zPRi3Wsahe"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequaturharum",
-    "name" : "AIfUDcF64tm",
+    "id" : "https://www.example.org/idcum",
+    "name" : "JC6wyNeIv9HdVQeuh",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "nRdDYOdeQz3wkfOej",
-      "id" : "ld7whiXcDv1V3tXI"
+      "source" : "qFQKW1MN4PPgsT",
+      "id" : "89ArIRUGsli"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "9fCn7BBpEa9kQbWx7"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "VCYkYCvTpj9L9UkLt"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliquidquas" ],
+  "subjects" : [ "https://www.example.org/ettempora" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "iKfhSoRbVZmI",
-      "mimeType" : "jpPUS3jFfW",
-      "size" : 397704093,
+      "name" : "6vu9qvzCGNM0Ocy4bfF",
+      "mimeType" : "S8qgJRr6fZv3Mm9M",
+      "size" : 165478144,
       "license" : {
         "type" : "License",
-        "identifier" : "bSIXAQiJhFC",
+        "identifier" : "gs4XAhkaIkDeMqX5",
         "labels" : {
-          "XhibFdP3RsPM" : "rJF5kExbsTlGLc"
+          "jWwin0kkRORh" : "3dcoQjdNkfQs"
         },
-        "link" : "https://www.example.com/dyUDMrELsiYRE"
+        "link" : "https://www.example.com/Zp7ndOD7q4bwe8C5"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "iKfhSoRbVZmI",
-    "mimeType" : "jpPUS3jFfW",
-    "size" : 397704093,
+    "name" : "6vu9qvzCGNM0Ocy4bfF",
+    "mimeType" : "S8qgJRr6fZv3Mm9M",
+    "size" : 165478144,
     "license" : {
       "type" : "License",
-      "identifier" : "bSIXAQiJhFC",
+      "identifier" : "gs4XAhkaIkDeMqX5",
       "labels" : {
-        "XhibFdP3RsPM" : "rJF5kExbsTlGLc"
+        "jWwin0kkRORh" : "3dcoQjdNkfQs"
       },
-      "link" : "https://www.example.com/dyUDMrELsiYRE"
+      "link" : "https://www.example.com/Zp7ndOD7q4bwe8C5"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "GEGDwPxiX9xTr0pD",
+  "owner" : "JcCb3PLhTZ",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "cXjpZpLFkPc6",
-    "ownerAffiliation" : "https://www.example.org/autincidunt"
+    "owner" : "PcRxOoz8cW59mvU",
+    "ownerAffiliation" : "https://www.example.org/maximeipsam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemad",
+    "id" : "https://www.example.org/adipisciratione",
     "labels" : {
-      "PJ7K9bCI1EmPBQ6" : "yzxfmJRCb3U92xS"
+      "vJauVTXy1yU" : "gENqYepU11atRvHz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/namaliquam",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/doloreset",
+  "handle" : "https://www.example.org/rationeaccusamus",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/deserunteos",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YfbcZjFlrkmuNxKnna",
+    "mainTitle" : "7ewyBYT8lrUnFRv89",
     "alternativeTitles" : {
-      "nn" : "NPwvQMJXE7"
+      "it" : "0JbHj82hb4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "0GJxRULMLT8CMha",
-      "month" : "xFQwV2obxMMc",
-      "day" : "PaKxsEXqFyx8F5GBoQ"
+      "year" : "44hR0Gh0348DH",
+      "month" : "AqPZ6Qo2ATMgOFv",
+      "day" : "y4X8ireJfA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sxL7OuZ3GU1UhcIxgh",
-        "name" : "gd3s2bCtAwH",
+        "id" : "https://www.example.com/1a3btk41D6QzObWCH",
+        "name" : "myeoZQ9aUnLjOsHMEb",
         "nameType" : "Organizational",
-        "orcId" : "Lz8oHHpFaWp"
+        "orcId" : "RSsydnuZeRDsJ5rEvs7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/C8EatzHx994",
+        "id" : "https://www.example.com/7yqhTnaO1VIa",
         "labels" : {
-          "P5v6FmZt0Gsp8KYfm" : "pVAzb3hUlqs"
+          "mnYMOmLBYdQ4pBbIoS6" : "fb3Qbi47pW30uCE"
         }
       } ],
-      "role" : "Photographer",
-      "sequence" : 0,
+      "role" : "Writer",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9hfI4RRQpB0",
-        "name" : "SEKBppVGlX0ooV0pDNg",
+        "id" : "https://www.example.com/Smb2dvh6h1Xecoivl",
+        "name" : "NRHSageEk3YT991AjJ",
         "nameType" : "Organizational",
-        "orcId" : "LtMlzCwfHZ"
+        "orcId" : "IBkL0ccWgYcIC4y1e"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UydByct9zwnATMGXT",
+        "id" : "https://www.example.com/3OIRsrzQmIrnr3lph",
         "labels" : {
-          "YDdzYykvUrlN" : "BvuU8xrTFQQxDe7"
+          "qUsHUexH2XlAOQRsh" : "c7RfK1VnOmSxBSe9m"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 7,
+      "role" : "Screenwriter",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "mnwZAVqqRxLwxb",
-    "tags" : [ "JeQ5GBBH2RZbGTxMqUy" ],
-    "description" : "81A9tVweYXTUlseg",
+    "npiSubjectHeading" : "7AQ8NbxCNvtRggy",
+    "tags" : [ "eSPjes7VK4c49mDf" ],
+    "description" : "Cm5n6FJE0F",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BZuPu3Oyx9en2il"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/qmgu5mrV3kWm"
       },
-      "doi" : "https://www.example.com/c0yIbwVrLoei",
+      "doi" : "https://www.example.com/Mnubzb9BbDmcgEy2m",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "NiVzEDziUjhw1gz",
-        "issue" : "xy7aoaAhDUsoskGz",
-        "articleNumber" : "v4SxgSG3BV3Xx",
+        "volume" : "ZmOebgV27iUXBIrS",
+        "issue" : "yVhy6PIzTa6v",
+        "articleNumber" : "rC3Pva60vye21dsphY",
         "pages" : {
           "type" : "Range",
-          "begin" : "uo72eRjXMkU1P",
-          "end" : "zhYZKYqgrn"
+          "begin" : "EPWEZnps4JdZP987",
+          "end" : "cy2HVcChiII"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/9Itk2fY81duU4bJsr",
-    "abstract" : "OA8rPo5O93hRvoSBSjJ"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LbGM7tlkLb52V",
-      "mimeType" : "NXptkeqvT413193rti",
-      "size" : 1103043597,
-      "license" : {
-        "type" : "License",
-        "identifier" : "ZoADbdMVVPP7E2AtQ",
-        "labels" : {
-          "VC8shAZeI5N" : "iw617xkHYIk7"
-        },
-        "link" : "https://www.example.com/cgQxWS6W43"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/s6CIp60g7T17QBp",
+    "abstract" : "Dd3RBxPTPH9Pf"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemab",
-    "name" : "XcZYH7LpLSy00x",
+    "id" : "https://www.example.org/etmodi",
+    "name" : "dbNrZmofmExDJ4g",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "0mArCBocPqf",
-      "id" : "oIi8oRa9miJaUmYw"
+      "source" : "4x245u3Lt7cy76",
+      "id" : "VGpNbiyUaB9bX2r"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Cf1GzD37mF6XeHqhhA"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "cGQIpcvSyNV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/officiaitaque" ],
+  "subjects" : [ "https://www.example.org/quasporro" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LbGM7tlkLb52V",
-    "mimeType" : "NXptkeqvT413193rti",
-    "size" : 1103043597,
+    "name" : "rEfKd2iW8iwamYOX5",
+    "mimeType" : "9JN9QhOM6GZTl",
+    "size" : 465372817,
     "license" : {
       "type" : "License",
-      "identifier" : "ZoADbdMVVPP7E2AtQ",
+      "identifier" : "p5TNyRN2yZALQ",
       "labels" : {
-        "VC8shAZeI5N" : "iw617xkHYIk7"
+        "wfZlNZJVM4G0QC" : "zn1Wn5OsHjZMvS9Hl"
       },
-      "link" : "https://www.example.com/cgQxWS6W43"
+      "link" : "https://www.example.com/5TyYdIipd9iK"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "cXjpZpLFkPc6"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "rEfKd2iW8iwamYOX5",
+      "mimeType" : "9JN9QhOM6GZTl",
+      "size" : 465372817,
+      "license" : {
+        "type" : "License",
+        "identifier" : "p5TNyRN2yZALQ",
+        "labels" : {
+          "wfZlNZJVM4G0QC" : "zn1Wn5OsHjZMvS9Hl"
+        },
+        "link" : "https://www.example.com/5TyYdIipd9iK"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "PcRxOoz8cW59mvU",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/FeatureArticle.json
+++ b/documentation/FeatureArticle.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "PcRxOoz8cW59mvU",
-    "ownerAffiliation" : "https://www.example.org/maximeipsam"
+    "owner" : "WvRyPThg6XFZIt",
+    "ownerAffiliation" : "https://www.example.org/reiciendistenetur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/adipisciratione",
+    "id" : "https://www.example.org/quivoluptatem",
     "labels" : {
-      "vJauVTXy1yU" : "gENqYepU11atRvHz"
+      "I8HQeP1fmzn" : "IfpZ4SaGaKE3qAWbG"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/rationeaccusamus",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/deserunteos",
+  "handle" : "https://www.example.org/fugiataspernatur",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/etsint",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7ewyBYT8lrUnFRv89",
+    "mainTitle" : "uwZEY5sNGghipCeY",
     "alternativeTitles" : {
-      "it" : "0JbHj82hb4"
+      "cs" : "570YROMx3HtFv"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "44hR0Gh0348DH",
-      "month" : "AqPZ6Qo2ATMgOFv",
-      "day" : "y4X8ireJfA"
+      "year" : "I1DtP47ltI",
+      "month" : "iB5ARthvkeBADvyw",
+      "day" : "RJ1t5HooIOxzaClB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/1a3btk41D6QzObWCH",
-        "name" : "myeoZQ9aUnLjOsHMEb",
+        "id" : "https://www.example.com/3YZ1Z4pPLhla3XXL",
+        "name" : "ODxYxUyp1IMUon",
         "nameType" : "Organizational",
-        "orcId" : "RSsydnuZeRDsJ5rEvs7"
+        "orcId" : "Cuh7GtPJGq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7yqhTnaO1VIa",
+        "id" : "https://www.example.com/LkOeeTQsyd",
         "labels" : {
-          "mnYMOmLBYdQ4pBbIoS6" : "fb3Qbi47pW30uCE"
+          "Mc3EZolOyH" : "MDVPsyxaZfXGf"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 1,
+      "role" : "Organizer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Smb2dvh6h1Xecoivl",
-        "name" : "NRHSageEk3YT991AjJ",
+        "id" : "https://www.example.com/ggTG3SFmpDWq",
+        "name" : "fkpcuwjWuMKQ43",
         "nameType" : "Organizational",
-        "orcId" : "IBkL0ccWgYcIC4y1e"
+        "orcId" : "fE8CuxC7GFt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3OIRsrzQmIrnr3lph",
+        "id" : "https://www.example.com/DCTaV9820VPi7G",
         "labels" : {
-          "qUsHUexH2XlAOQRsh" : "c7RfK1VnOmSxBSe9m"
+          "JdqxBkJvyTkJjfEiQV" : "YKDKN7Oj4Y470"
         }
       } ],
-      "role" : "Screenwriter",
-      "sequence" : 3,
+      "role" : "ProjectMember",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "7AQ8NbxCNvtRggy",
-    "tags" : [ "eSPjes7VK4c49mDf" ],
-    "description" : "Cm5n6FJE0F",
+    "npiSubjectHeading" : "rkb9mgB0TM59Ci",
+    "tags" : [ "wXbySKg6Sl8UotYNt" ],
+    "description" : "3aGcEDANV2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/qmgu5mrV3kWm"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yqF9fEQQ3lzC6y0j"
       },
-      "doi" : "https://www.example.com/Mnubzb9BbDmcgEy2m",
+      "doi" : "https://www.example.com/7P5YNnSqCPDE",
       "publicationInstance" : {
         "type" : "FeatureArticle",
-        "volume" : "ZmOebgV27iUXBIrS",
-        "issue" : "yVhy6PIzTa6v",
-        "articleNumber" : "rC3Pva60vye21dsphY",
+        "volume" : "4wjSwCXDGlEt8",
+        "issue" : "34x9lBLtXo4m48il",
+        "articleNumber" : "d5HMgUm5fha9Vqwu",
         "pages" : {
           "type" : "Range",
-          "begin" : "EPWEZnps4JdZP987",
-          "end" : "cy2HVcChiII"
+          "begin" : "wesvbFPCEH35EJNptH",
+          "end" : "415kVqDW2boh3"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/s6CIp60g7T17QBp",
-    "abstract" : "Dd3RBxPTPH9Pf"
+    "metadataSource" : "https://www.example.com/mM36pFitYyXyds0292",
+    "abstract" : "uBTcqHY84XyZ0To"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etmodi",
-    "name" : "dbNrZmofmExDJ4g",
+    "id" : "https://www.example.org/quaeratvoluptatum",
+    "name" : "zzcMgy2ZeAfr",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "4x245u3Lt7cy76",
-      "id" : "VGpNbiyUaB9bX2r"
+      "source" : "pvJv5A7riAX",
+      "id" : "XBNBHlS7BTrfD"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "cGQIpcvSyNV"
+      "applicationCode" : "SVtmZd8I07FH3eB"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quasporro" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "rEfKd2iW8iwamYOX5",
-    "mimeType" : "9JN9QhOM6GZTl",
-    "size" : 465372817,
-    "license" : {
-      "type" : "License",
-      "identifier" : "p5TNyRN2yZALQ",
-      "labels" : {
-        "wfZlNZJVM4G0QC" : "zn1Wn5OsHjZMvS9Hl"
-      },
-      "link" : "https://www.example.com/5TyYdIipd9iK"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/delectusveniam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "rEfKd2iW8iwamYOX5",
-      "mimeType" : "9JN9QhOM6GZTl",
-      "size" : 465372817,
+      "name" : "seKQGM0E0HzY",
+      "mimeType" : "4M6Li8CXFfrk0",
+      "size" : 153973386,
       "license" : {
         "type" : "License",
-        "identifier" : "p5TNyRN2yZALQ",
+        "identifier" : "7UW6OMVQ2UFaS7bYnAC",
         "labels" : {
-          "wfZlNZJVM4G0QC" : "zn1Wn5OsHjZMvS9Hl"
+          "zbkDqKRgloiGvW" : "LnaWp3vQopGMkuBo"
         },
-        "link" : "https://www.example.com/5TyYdIipd9iK"
+        "link" : "https://www.example.com/kyKcWK9V9o6u"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "PcRxOoz8cW59mvU",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "seKQGM0E0HzY",
+    "mimeType" : "4M6Li8CXFfrk0",
+    "size" : 153973386,
+    "license" : {
+      "type" : "License",
+      "identifier" : "7UW6OMVQ2UFaS7bYnAC",
+      "labels" : {
+        "zbkDqKRgloiGvW" : "LnaWp3vQopGMkuBo"
+      },
+      "link" : "https://www.example.com/kyKcWK9V9o6u"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "WvRyPThg6XFZIt",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,120 +1,120 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "FaOZaejbYaO8y3",
-    "ownerAffiliation" : "https://www.example.org/eosatque"
+    "owner" : "EyIa1d6H1z8PpeeTQh",
+    "ownerAffiliation" : "https://www.example.org/quiodio"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/estdolores",
+    "id" : "https://www.example.org/autemautem",
     "labels" : {
-      "ai5VoXXCpwwa" : "JjsPdU3ns66CTsmmdV"
+      "N2mDzQxuhY" : "MT05sOMPPYNOxFK"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiaperferendis",
-  "doi" : "https://doi.org/10.1234/odit",
-  "link" : "https://www.example.org/etaut",
+  "handle" : "https://www.example.org/solutaveritatis",
+  "doi" : "https://doi.org/10.1234/tempore",
+  "link" : "https://www.example.org/officiisreiciendis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VMPZxOfSFh8h2b1A",
+    "mainTitle" : "ZdypO5sh5T8pQI",
     "alternativeTitles" : {
-      "fr" : "LEdKu2Dna3Qf"
+      "pl" : "P9QBAWWZqcfcB"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FlrQHEHRSWUe",
-      "month" : "RIkUlwIpHM",
-      "day" : "2X8uW6iURZ492MSjgF0"
+      "year" : "TAgjtlTKZv9in4iA",
+      "month" : "Luo8m7tSYxunN",
+      "day" : "zIfvJcxLt1UxkEvoE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oX93EzQOM2c",
-        "name" : "YeO4pF8GhB3lby",
-        "nameType" : "Organizational",
-        "orcId" : "WUCAcPC5QG"
+        "id" : "https://www.example.com/IL1mjQ8RV3QSuq",
+        "name" : "4rSylJDUFXsOXh",
+        "nameType" : "Personal",
+        "orcId" : "6jTy3dl3KoyViCctOOM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iVjT0720irfssjq76l",
+        "id" : "https://www.example.com/OBQBbYXHemnYetPBMiG",
         "labels" : {
-          "2bmwhxguw5o03RZh" : "mHvoyIYYxLreY7I0Om"
+          "TZBKv2nb5nld" : "96P7EyVdIJ0xELx7BkA"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 8,
+      "role" : "Designer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/32gGAJwIacQB",
-        "name" : "pjBqLb6BM1Z5T6",
+        "id" : "https://www.example.com/71pgPv6nHiXNS8I",
+        "name" : "WANyT8ukxE9GQ6c",
         "nameType" : "Organizational",
-        "orcId" : "q8a4khK0CbG"
+        "orcId" : "w5SBGpIJbwchU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yF1ylmp1Wv6rkGAqRt",
+        "id" : "https://www.example.com/YqRDz8Vgqrm67sHzJ",
         "labels" : {
-          "malCXDJ6WuYYPQ6mPnc" : "mUNlzAUIMfMIaX"
+          "dwyJFXj36FOy9u9" : "P9D9BbuVb1N20"
         }
       } ],
-      "role" : "Soloist",
+      "role" : "Journalist",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "W3RCj9OgyTPCWT",
-    "tags" : [ "8qu9ba32ijwOmVN" ],
-    "description" : "SBpBqXj3GN55BDtR",
+    "npiSubjectHeading" : "eLnBVV8vEmRxvzu",
+    "tags" : [ "G0PsGrC1czE9al" ],
+    "description" : "Jz23RDIezYp1pFnsYt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5dj5GzvUkZCrfK"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rVi1vWAQfe5N"
       },
-      "doi" : "https://www.example.com/8dm9CNOsnXm6BO",
+      "doi" : "https://www.example.com/sinllY78Ib",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "5lpFrhB0RL",
-        "issue" : "W9e2feHqfzh",
-        "articleNumber" : "YlKjZ3oOYZhr9HhF",
-        "contentType" : "PopularScienceArticle",
-        "peerReviewed" : true,
+        "volume" : "H1ldrOAncDqdjAR7i",
+        "issue" : "UOz5ytUuenK",
+        "articleNumber" : "I6TyVjLapsDMuBA",
+        "contentType" : "AcademicLiteratureReview",
+        "peerReviewed" : false,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "YJEAJ66PFtF",
-          "end" : "RzX5NQT6T8V"
+          "begin" : "lyJnGUE63doMgMRR2",
+          "end" : "5sJpnbXvCsmsd"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/g3F3s964ses1Wa0c",
-    "abstract" : "xHv4xdvpW3"
+    "metadataSource" : "https://www.example.com/DNVwLRwqYSiLsMQkLo",
+    "abstract" : "uIyDldJnTGWutKY1ydE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/abasperiores",
-    "name" : "vglLIZdd4iIeu",
+    "id" : "https://www.example.org/nesciuntducimus",
+    "name" : "fc7AdlLXEk8Cmzo4Er",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ukWvN8todhV1",
-      "id" : "LzcFDFbTeu"
+      "source" : "LWJ1Gs6IiKo",
+      "id" : "XyTBQ8aP9xAO"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "1rqx9DxhVXjEGlV"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "7D9EwBASq8D9DHi"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -122,46 +122,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inventoreaut" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "WjvxdAkDS0Ktro",
-    "mimeType" : "KikzC9qtLdUXQ1",
-    "size" : 1467239217,
-    "license" : {
-      "type" : "License",
-      "identifier" : "evJstZ0Kh1rMSuD",
-      "labels" : {
-        "a618W5YwokpNUCw" : "oiZBOWakc9ut6"
-      },
-      "link" : "https://www.example.com/x7K1GxIKWINqHAA"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/aliquamquidem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "WjvxdAkDS0Ktro",
-      "mimeType" : "KikzC9qtLdUXQ1",
-      "size" : 1467239217,
+      "name" : "d8lc2JVtFCLk",
+      "mimeType" : "CfL9ECX3IGIKmwTJz",
+      "size" : 382845460,
       "license" : {
         "type" : "License",
-        "identifier" : "evJstZ0Kh1rMSuD",
+        "identifier" : "2KJdBFPvpCa",
         "labels" : {
-          "a618W5YwokpNUCw" : "oiZBOWakc9ut6"
+          "HXUpoKHo2MjCw2frIOC" : "YMdQshxZQ6d8SRkBYS"
         },
-        "link" : "https://www.example.com/x7K1GxIKWINqHAA"
+        "link" : "https://www.example.com/XJaZnLTMrh7WMw4"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "FaOZaejbYaO8y3",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "d8lc2JVtFCLk",
+    "mimeType" : "CfL9ECX3IGIKmwTJz",
+    "size" : 382845460,
+    "license" : {
+      "type" : "License",
+      "identifier" : "2KJdBFPvpCa",
+      "labels" : {
+        "HXUpoKHo2MjCw2frIOC" : "YMdQshxZQ6d8SRkBYS"
+      },
+      "link" : "https://www.example.com/XJaZnLTMrh7WMw4"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "EyIa1d6H1z8PpeeTQh",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -3,118 +3,118 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "EyIa1d6H1z8PpeeTQh",
-    "ownerAffiliation" : "https://www.example.org/quiodio"
+    "owner" : "obqxSezy2tnSU",
+    "ownerAffiliation" : "https://www.example.org/doloremqueomnis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemautem",
+    "id" : "https://www.example.org/noniste",
     "labels" : {
-      "N2mDzQxuhY" : "MT05sOMPPYNOxFK"
+      "UbhUyZDySkkqsM" : "gVXl2W4Fjslqh6Jhm"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/solutaveritatis",
-  "doi" : "https://doi.org/10.1234/tempore",
-  "link" : "https://www.example.org/officiisreiciendis",
+  "handle" : "https://www.example.org/autipsam",
+  "doi" : "https://doi.org/10.1234/debitis",
+  "link" : "https://www.example.org/idsint",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZdypO5sh5T8pQI",
+    "mainTitle" : "wmHPSM5o1sLEiFV9",
     "alternativeTitles" : {
-      "pl" : "P9QBAWWZqcfcB"
+      "fi" : "Gt9knbzvvasK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TAgjtlTKZv9in4iA",
-      "month" : "Luo8m7tSYxunN",
-      "day" : "zIfvJcxLt1UxkEvoE"
+      "year" : "ytf1GFLAClvgIE6ch13",
+      "month" : "gV0qoOpA2pu",
+      "day" : "zsuGlZnqEcNJ5U"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IL1mjQ8RV3QSuq",
-        "name" : "4rSylJDUFXsOXh",
+        "id" : "https://www.example.com/GUqjCbvqpYCEnzTHGFI",
+        "name" : "gFzoP3o5kPp",
         "nameType" : "Personal",
-        "orcId" : "6jTy3dl3KoyViCctOOM"
+        "orcId" : "BzTRgM5NFxVZKvIZbnO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OBQBbYXHemnYetPBMiG",
+        "id" : "https://www.example.com/g5MjgCJ2wYd",
         "labels" : {
-          "TZBKv2nb5nld" : "96P7EyVdIJ0xELx7BkA"
+          "STMK8Ru8Uu" : "sMGrmXvO4g9eS0Sh"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 7,
+      "role" : "Photographer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/71pgPv6nHiXNS8I",
-        "name" : "WANyT8ukxE9GQ6c",
-        "nameType" : "Organizational",
-        "orcId" : "w5SBGpIJbwchU"
+        "id" : "https://www.example.com/1pydmBMSxAX",
+        "name" : "pvGSe3gLq9ZTfHIk1",
+        "nameType" : "Personal",
+        "orcId" : "CjRd4a9B9WvLBCl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YqRDz8Vgqrm67sHzJ",
+        "id" : "https://www.example.com/Wiw0Qux8Bul7u4bf",
         "labels" : {
-          "dwyJFXj36FOy9u9" : "P9D9BbuVb1N20"
+          "qvHuaT7rbGL" : "R1Igr9xFjZ"
         }
       } ],
-      "role" : "Journalist",
+      "role" : "ProjectLeader",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "eLnBVV8vEmRxvzu",
-    "tags" : [ "G0PsGrC1czE9al" ],
-    "description" : "Jz23RDIezYp1pFnsYt",
+    "npiSubjectHeading" : "NQnACcq3VwuIRq",
+    "tags" : [ "eKaV1RkRzLYCIV" ],
+    "description" : "p9Xbt3gmlvtI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rVi1vWAQfe5N"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zopDYyRJPdg7X"
       },
-      "doi" : "https://www.example.com/sinllY78Ib",
+      "doi" : "https://www.example.com/JuFJNWsxxprd9NmZ4r",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "H1ldrOAncDqdjAR7i",
-        "issue" : "UOz5ytUuenK",
-        "articleNumber" : "I6TyVjLapsDMuBA",
-        "contentType" : "AcademicLiteratureReview",
-        "peerReviewed" : false,
+        "volume" : "i3UKHP5tHgalp6",
+        "issue" : "QF7u6DvtfaH2gE0LYF",
+        "articleNumber" : "LBeVNFvFIE2gw4z",
+        "contentType" : "ProfessionalArticle",
+        "peerReviewed" : true,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "lyJnGUE63doMgMRR2",
-          "end" : "5sJpnbXvCsmsd"
+          "begin" : "r6gbe4dBQSEKpn9X",
+          "end" : "Xk1JqaMZaN9yX0GrmjL"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/DNVwLRwqYSiLsMQkLo",
-    "abstract" : "uIyDldJnTGWutKY1ydE"
+    "metadataSource" : "https://www.example.com/bxyRVnt4Z8sRbIW5PGN",
+    "abstract" : "KBvdCCYwVAen"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nesciuntducimus",
-    "name" : "fc7AdlLXEk8Cmzo4Er",
+    "id" : "https://www.example.org/earumeaque",
+    "name" : "Ij5Lq1jLBe",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "LWJ1Gs6IiKo",
-      "id" : "XyTBQ8aP9xAO"
+      "source" : "cMmOiNvXlKe6su87j7e",
+      "id" : "6vOdhHrUU6F77UR8"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "7D9EwBASq8D9DHi"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "kUT2p0Qw9BYJU1H6zzj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -122,46 +122,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliquamquidem" ],
+  "subjects" : [ "https://www.example.org/doloroccaecati" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "d8lc2JVtFCLk",
-      "mimeType" : "CfL9ECX3IGIKmwTJz",
-      "size" : 382845460,
+      "name" : "P407k21n8gmZoSPRbF",
+      "mimeType" : "OJEz0l0ekpwTGkA",
+      "size" : 24745926,
       "license" : {
         "type" : "License",
-        "identifier" : "2KJdBFPvpCa",
+        "identifier" : "UUFvfqx1H0m",
         "labels" : {
-          "HXUpoKHo2MjCw2frIOC" : "YMdQshxZQ6d8SRkBYS"
+          "5ey10N7jTbvkSJ0pBT" : "m3I73g780S"
         },
-        "link" : "https://www.example.com/XJaZnLTMrh7WMw4"
+        "link" : "https://www.example.com/D7DZhh79BiPC0WNbB"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "d8lc2JVtFCLk",
-    "mimeType" : "CfL9ECX3IGIKmwTJz",
-    "size" : 382845460,
+    "name" : "P407k21n8gmZoSPRbF",
+    "mimeType" : "OJEz0l0ekpwTGkA",
+    "size" : 24745926,
     "license" : {
       "type" : "License",
-      "identifier" : "2KJdBFPvpCa",
+      "identifier" : "UUFvfqx1H0m",
       "labels" : {
-        "HXUpoKHo2MjCw2frIOC" : "YMdQshxZQ6d8SRkBYS"
+        "5ey10N7jTbvkSJ0pBT" : "m3I73g780S"
       },
-      "link" : "https://www.example.com/XJaZnLTMrh7WMw4"
+      "link" : "https://www.example.com/D7DZhh79BiPC0WNbB"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "EyIa1d6H1z8PpeeTQh",
+  "owner" : "obqxSezy2tnSU",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,120 +1,120 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "obqxSezy2tnSU",
-    "ownerAffiliation" : "https://www.example.org/doloremqueomnis"
+    "owner" : "AHQruRZhuVjqDV5y",
+    "ownerAffiliation" : "https://www.example.org/accusantiumquis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/noniste",
+    "id" : "https://www.example.org/perferendispossimus",
     "labels" : {
-      "UbhUyZDySkkqsM" : "gVXl2W4Fjslqh6Jhm"
+      "BoHEsBsLSv8UMQjs" : "huU6XimquXytxO5vUxJ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/autipsam",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/idsint",
+  "handle" : "https://www.example.org/placeatenim",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/etquia",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "wmHPSM5o1sLEiFV9",
+    "mainTitle" : "TQxj8eTB5srqk7",
     "alternativeTitles" : {
-      "fi" : "Gt9knbzvvasK"
+      "cs" : "pwNUwyMV4Vnbx8dtaH3"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ytf1GFLAClvgIE6ch13",
-      "month" : "gV0qoOpA2pu",
-      "day" : "zsuGlZnqEcNJ5U"
+      "year" : "lowOmzEkDxI7",
+      "month" : "Vc3jcrYDKWcRDX",
+      "day" : "BPirleHPfP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/GUqjCbvqpYCEnzTHGFI",
-        "name" : "gFzoP3o5kPp",
-        "nameType" : "Personal",
-        "orcId" : "BzTRgM5NFxVZKvIZbnO"
+        "id" : "https://www.example.com/xenRwj1jvibfo",
+        "name" : "ZBk2yXWlETOwov3I",
+        "nameType" : "Organizational",
+        "orcId" : "khBF4Od2nA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/g5MjgCJ2wYd",
+        "id" : "https://www.example.com/zhFidb4PPae",
         "labels" : {
-          "STMK8Ru8Uu" : "sMGrmXvO4g9eS0Sh"
+          "PfN8F8EeP9QwO9rGZ" : "3OkhquPDmDwHSh"
         }
       } ],
       "role" : "Photographer",
-      "sequence" : 5,
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/1pydmBMSxAX",
-        "name" : "pvGSe3gLq9ZTfHIk1",
-        "nameType" : "Personal",
-        "orcId" : "CjRd4a9B9WvLBCl"
+        "id" : "https://www.example.com/kLkk51uYf7Jl2",
+        "name" : "loHSYyrgiwubeeZSOv2",
+        "nameType" : "Organizational",
+        "orcId" : "rydtMNoVWN461hz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Wiw0Qux8Bul7u4bf",
+        "id" : "https://www.example.com/rRM6ftoUZxnRziW",
         "labels" : {
-          "qvHuaT7rbGL" : "R1Igr9xFjZ"
+          "QfRrvC9Ccdi7wQ7N0T5" : "GbItXuOli2B"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 4,
+      "role" : "Writer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NQnACcq3VwuIRq",
-    "tags" : [ "eKaV1RkRzLYCIV" ],
-    "description" : "p9Xbt3gmlvtI",
+    "npiSubjectHeading" : "ZFlpMKqmMh",
+    "tags" : [ "fW7K1rcnvJPS" ],
+    "description" : "wsw0H0CIhNILI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zopDYyRJPdg7X"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/QbxqQ7RQ2BMxArx5sB"
       },
-      "doi" : "https://www.example.com/JuFJNWsxxprd9NmZ4r",
+      "doi" : "https://www.example.com/4pC8kKZWfuH",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "i3UKHP5tHgalp6",
-        "issue" : "QF7u6DvtfaH2gE0LYF",
-        "articleNumber" : "LBeVNFvFIE2gw4z",
-        "contentType" : "ProfessionalArticle",
+        "volume" : "ICZ73bvwKLrwKlShP9K",
+        "issue" : "KdxSFkZdHtvVx9",
+        "articleNumber" : "MdxfL12zoGbXaMfK9",
+        "contentType" : "PopularScienceArticle",
         "peerReviewed" : true,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "r6gbe4dBQSEKpn9X",
-          "end" : "Xk1JqaMZaN9yX0GrmjL"
+          "begin" : "Ue0izxTAqAfF",
+          "end" : "Nonxz5A2qAvoWzYIf4u"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/bxyRVnt4Z8sRbIW5PGN",
-    "abstract" : "KBvdCCYwVAen"
+    "metadataSource" : "https://www.example.com/EW60Nr6IS4Rl6",
+    "abstract" : "ijRWIovhdLwSTaTtcx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/earumeaque",
-    "name" : "Ij5Lq1jLBe",
+    "id" : "https://www.example.org/rerumaliquam",
+    "name" : "0gzIipu72sBLtXQ31SZ",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "cMmOiNvXlKe6su87j7e",
-      "id" : "6vOdhHrUU6F77UR8"
+      "source" : "4Z6JcFElaeEvgowJs",
+      "id" : "zV9vpGtz5OzsHGiJ7C"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "kUT2p0Qw9BYJU1H6zzj"
+      "applicationCode" : "n1Ki7Jd0jH9B8F"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -122,22 +122,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloroccaecati" ],
+  "subjects" : [ "https://www.example.org/incidunteum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "P407k21n8gmZoSPRbF",
-      "mimeType" : "OJEz0l0ekpwTGkA",
-      "size" : 24745926,
+      "name" : "eOZzq47i1oyNXQH",
+      "mimeType" : "gqw0QDsNUq1aBm8ZYmE",
+      "size" : 1011823273,
       "license" : {
         "type" : "License",
-        "identifier" : "UUFvfqx1H0m",
+        "identifier" : "aT4RfeJXTMQfeoeJoL",
         "labels" : {
-          "5ey10N7jTbvkSJ0pBT" : "m3I73g780S"
+          "b7SpCPLzINDuJYN" : "LxCm8WlSvBNw"
         },
-        "link" : "https://www.example.com/D7DZhh79BiPC0WNbB"
+        "link" : "https://www.example.com/VkNeEZEU1L"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -147,21 +147,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "P407k21n8gmZoSPRbF",
-    "mimeType" : "OJEz0l0ekpwTGkA",
-    "size" : 24745926,
+    "name" : "eOZzq47i1oyNXQH",
+    "mimeType" : "gqw0QDsNUq1aBm8ZYmE",
+    "size" : 1011823273,
     "license" : {
       "type" : "License",
-      "identifier" : "UUFvfqx1H0m",
+      "identifier" : "aT4RfeJXTMQfeoeJoL",
       "labels" : {
-        "5ey10N7jTbvkSJ0pBT" : "m3I73g780S"
+        "b7SpCPLzINDuJYN" : "LxCm8WlSvBNw"
       },
-      "link" : "https://www.example.com/D7DZhh79BiPC0WNbB"
+      "link" : "https://www.example.com/VkNeEZEU1L"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "obqxSezy2tnSU",
+  "owner" : "AHQruRZhuVjqDV5y",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalArticle.json
+++ b/documentation/JournalArticle.json
@@ -1,141 +1,120 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "uAcS6LyPQRCGspp",
-    "ownerAffiliation" : "https://www.example.org/dictafacilis"
+    "owner" : "FaOZaejbYaO8y3",
+    "ownerAffiliation" : "https://www.example.org/eosatque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/reiciendiseum",
+    "id" : "https://www.example.org/estdolores",
     "labels" : {
-      "zf3X5IyzVQ12" : "nytxF88FPWWke6S"
+      "ai5VoXXCpwwa" : "JjsPdU3ns66CTsmmdV"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eiusquibusdam",
-  "doi" : "https://doi.org/10.1234/architecto",
-  "link" : "https://www.example.org/teneturanimi",
+  "handle" : "https://www.example.org/quiaperferendis",
+  "doi" : "https://doi.org/10.1234/odit",
+  "link" : "https://www.example.org/etaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "plAZSlRvbfUKUV",
+    "mainTitle" : "VMPZxOfSFh8h2b1A",
     "alternativeTitles" : {
-      "it" : "jv1ZUtAkhkS"
+      "fr" : "LEdKu2Dna3Qf"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "pNw45R6a75mCs1",
-      "month" : "lZVYcsGEVEQ",
-      "day" : "pHIEgOQLV43i"
+      "year" : "FlrQHEHRSWUe",
+      "month" : "RIkUlwIpHM",
+      "day" : "2X8uW6iURZ492MSjgF0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WPhwQ9naPlntdK0",
-        "name" : "FB8hkPn1XaY",
-        "nameType" : "Personal",
-        "orcId" : "TaQHnVcoTvQ4"
+        "id" : "https://www.example.com/oX93EzQOM2c",
+        "name" : "YeO4pF8GhB3lby",
+        "nameType" : "Organizational",
+        "orcId" : "WUCAcPC5QG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ZPe0ahRNcIPVSnsH",
+        "id" : "https://www.example.com/iVjT0720irfssjq76l",
         "labels" : {
-          "stpmUUWfM3SIqyiv8L" : "zC1ntBIAxGJQNL"
+          "2bmwhxguw5o03RZh" : "mHvoyIYYxLreY7I0Om"
         }
       } ],
       "role" : "Sponsor",
-      "sequence" : 0,
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/G8y6QIZeB8JzoY",
-        "name" : "LUCeJ8pkqNhzu",
+        "id" : "https://www.example.com/32gGAJwIacQB",
+        "name" : "pjBqLb6BM1Z5T6",
         "nameType" : "Organizational",
-        "orcId" : "B09iPKHNa9Dzga"
+        "orcId" : "q8a4khK0CbG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/SdW32DyXi5MtaFsGdGM",
+        "id" : "https://www.example.com/yF1ylmp1Wv6rkGAqRt",
         "labels" : {
-          "q3Ur2mCwiPw" : "P4WoD9MwEhC"
+          "malCXDJ6WuYYPQ6mPnc" : "mUNlzAUIMfMIaX"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 1,
+      "role" : "Soloist",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "mBUJe1CJPGbivFpvm3q",
-    "tags" : [ "lR3mDhZsYAtpybfiK" ],
-    "description" : "mRsZM40JfZ4",
+    "npiSubjectHeading" : "W3RCj9OgyTPCWT",
+    "tags" : [ "8qu9ba32ijwOmVN" ],
+    "description" : "SBpBqXj3GN55BDtR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Zt5budou8xw24Q"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5dj5GzvUkZCrfK"
       },
-      "doi" : "https://www.example.com/e4YelfzXTomm8ylhikP",
+      "doi" : "https://www.example.com/8dm9CNOsnXm6BO",
       "publicationInstance" : {
         "type" : "JournalArticle",
-        "volume" : "UPDymJ5ra1GzTq3",
-        "issue" : "PBBR9xaayuexzM",
-        "articleNumber" : "z3Pty6g8u4L",
-        "contentType" : "StudyProtocol",
-        "peerReviewed" : false,
+        "volume" : "5lpFrhB0RL",
+        "issue" : "W9e2feHqfzh",
+        "articleNumber" : "YlKjZ3oOYZhr9HhF",
+        "contentType" : "PopularScienceArticle",
+        "peerReviewed" : true,
         "originalResearch" : false,
         "pages" : {
           "type" : "Range",
-          "begin" : "3YfQkzuoY9tLP",
-          "end" : "pSvKB3TtSZ"
+          "begin" : "YJEAJ66PFtF",
+          "end" : "RzX5NQT6T8V"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/TGpjgxdEu2QcF8n1Y",
-    "abstract" : "QvSBbbYaNgMJhtFt"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "QyIb2W2lBg",
-      "mimeType" : "diOixclN94Ya0dt",
-      "size" : 1020047340,
-      "license" : {
-        "type" : "License",
-        "identifier" : "1SEGuEndIY",
-        "labels" : {
-          "IZz6XB6PNipVt" : "QZeWXAZTmTrkiFw6c"
-        },
-        "link" : "https://www.example.com/yTTfirD6GAHTCKvSCh"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/g3F3s964ses1Wa0c",
+    "abstract" : "xHv4xdvpW3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitrecusandae",
-    "name" : "wIZIgECoA2",
+    "id" : "https://www.example.org/abasperiores",
+    "name" : "vglLIZdd4iIeu",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6HzE5xZIvClAbDMd0NX",
-      "id" : "e68jJXw4N2Zw6Tmrsq"
+      "source" : "ukWvN8todhV1",
+      "id" : "LzcFDFbTeu"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "nhK7uTHqO6ebxMKb"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "1rqx9DxhVXjEGlV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -143,25 +122,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veniamquia" ],
+  "subjects" : [ "https://www.example.org/inventoreaut" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "QyIb2W2lBg",
-    "mimeType" : "diOixclN94Ya0dt",
-    "size" : 1020047340,
+    "name" : "WjvxdAkDS0Ktro",
+    "mimeType" : "KikzC9qtLdUXQ1",
+    "size" : 1467239217,
     "license" : {
       "type" : "License",
-      "identifier" : "1SEGuEndIY",
+      "identifier" : "evJstZ0Kh1rMSuD",
       "labels" : {
-        "IZz6XB6PNipVt" : "QZeWXAZTmTrkiFw6c"
+        "a618W5YwokpNUCw" : "oiZBOWakc9ut6"
       },
-      "link" : "https://www.example.com/yTTfirD6GAHTCKvSCh"
+      "link" : "https://www.example.com/x7K1GxIKWINqHAA"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "uAcS6LyPQRCGspp"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "WjvxdAkDS0Ktro",
+      "mimeType" : "KikzC9qtLdUXQ1",
+      "size" : 1467239217,
+      "license" : {
+        "type" : "License",
+        "identifier" : "evJstZ0Kh1rMSuD",
+        "labels" : {
+          "a618W5YwokpNUCw" : "oiZBOWakc9ut6"
+        },
+        "link" : "https://www.example.com/x7K1GxIKWINqHAA"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "FaOZaejbYaO8y3",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,119 +1,119 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "c9W5iSwdxr",
-    "ownerAffiliation" : "https://www.example.org/laudantiumeius"
+    "owner" : "wIEAm0l2ktO0Gim",
+    "ownerAffiliation" : "https://www.example.org/suscipitmaxime"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quonesciunt",
+    "id" : "https://www.example.org/autemfacilis",
     "labels" : {
-      "VlLMG8G1oFfusU6l2ye" : "5jtSAJXQP45oaPEJdh"
+      "2qyw4iNU4gz" : "nlT4G7FP8BGYJ3Kp"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolorequos",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/asperioresaliquid",
+  "handle" : "https://www.example.org/molestiaedeserunt",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/ipsumpariatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3UkFNnAfQZYpMt",
+    "mainTitle" : "XU2dIIrU9JJu",
     "alternativeTitles" : {
-      "pt" : "mGuxMXQgt8"
+      "fi" : "ErP9hS9onJiXW"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "6L6IfD6656",
-      "month" : "RnDCwo1SuGPlkaxch5l",
-      "day" : "xzaNUvzGpFwQoDBHp"
+      "year" : "N296Rq3XRP",
+      "month" : "qtdnNFAh87NiN",
+      "day" : "UkL2k2jgi8M"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gFhDhu2xMr4UcKNp",
-        "name" : "XkJhm8X5UreqH9QprYb",
+        "id" : "https://www.example.com/cFug181IE6",
+        "name" : "rTby4zq1aV0bZc",
         "nameType" : "Organizational",
-        "orcId" : "nZuTI6kk4bVeweg"
+        "orcId" : "8DLfGI7zsyg055W"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/fVMw0rjImbN",
+        "id" : "https://www.example.com/uPcMxT9YiKEXMtY7",
         "labels" : {
-          "jNpZJq0Leu" : "q4aSr2qwPw070SUNOYJ"
+          "2HD8KYjzcKBi9" : "RV0yr8dhK1cyNnXt"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 3,
+      "role" : "Musician",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7CA8p5627iT4t",
-        "name" : "QZXKN6mSMvM",
-        "nameType" : "Personal",
-        "orcId" : "NuCyUHSMEHQ3"
+        "id" : "https://www.example.com/SojLO9QtXF",
+        "name" : "tCQG7aJ9FQGlP",
+        "nameType" : "Organizational",
+        "orcId" : "eF5f0HXW1W"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zxIaqCaDQ0cH",
+        "id" : "https://www.example.com/6G6PD3qMVXj5NJX",
         "labels" : {
-          "F4H0E0F1BCud8" : "lyNQOLh4INPxfMh"
+          "H8pckHU4TTdxWYlm" : "dSLQKrIP9XiGx2iIZ"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 4,
+      "role" : "CuratorOrganizer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "jxKYCvUtnYVxOEWu",
-    "tags" : [ "4Vrs4uFNENMa1gxtN" ],
-    "description" : "WMbZNpkBXwrBX4JthPm",
+    "npiSubjectHeading" : "LOE3WQeAMQIl1IRfou",
+    "tags" : [ "VUriAvHS9e" ],
+    "description" : "8jYQcut7bvxcK98tE1q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mSP3Wz6ULtSHc07gu"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8MLsXCBN7Zbg"
       },
-      "doi" : "https://www.example.com/TQjWjBqiqFgcwMreKzo",
+      "doi" : "https://www.example.com/HdFhP2QY2QII3",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "JaLEF0ods0LxBNGf",
-        "issue" : "CiVx0cG1DvXwHMpQXL",
-        "articleNumber" : "jyjBAbstybU6iUXnF",
+        "volume" : "DA2EIuZxYW8zawvS",
+        "issue" : "Ex4zSX01l94l8vx",
+        "articleNumber" : "Iua892VpgsG7Gg",
         "pages" : {
           "type" : "Range",
-          "begin" : "tZ5nvSoBwWrRoL",
-          "end" : "63ZG5L0DsqrwOp0WkUC"
+          "begin" : "1ZNSKsCJsvn",
+          "end" : "3EhTj2VFcSa0ov"
         },
-        "corrigendumFor" : "https://www.example.com/lDIaxXZHqXivzie9E",
+        "corrigendumFor" : "https://www.example.com/29fTwvRU9qd",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/lPPOqQhFeup",
-    "abstract" : "AyZ1kdxdICqc"
+    "metadataSource" : "https://www.example.com/EmQnpmpzHge6sscYJh",
+    "abstract" : "FCrujb07lk66v"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/itaqueeaque",
-    "name" : "seaRWLie1H74",
+    "id" : "https://www.example.org/autmolestias",
+    "name" : "zPkhsHRuVMOiB1Krk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "9iomPVhabZ5eiYxj",
-      "id" : "LSIAtR02ccP4L"
+      "source" : "ZdhDYVLHBtp",
+      "id" : "9NeWJHHElxCzO"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "hjS6HJ5cRt"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "jiW4mbZIJ6HQunQy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -121,46 +121,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/odioaspernatur" ],
+  "subjects" : [ "https://www.example.org/quodvoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "p5OeU24M0ecJjWy",
-      "mimeType" : "MkU8zzqWWGl",
-      "size" : 662027926,
+      "name" : "bulC3Y9LHQP1Jp",
+      "mimeType" : "Y1XoClP61NIM",
+      "size" : 767739680,
       "license" : {
         "type" : "License",
-        "identifier" : "uNYM4GrUZPF88HgnHu",
+        "identifier" : "n5S0T312ETUJzuw60",
         "labels" : {
-          "hqhonR71KlJleBA" : "Egf3octGFkcJ"
+          "X0ugufaGHouACdFrm" : "UxykIgQG8vRr8kY"
         },
-        "link" : "https://www.example.com/ohRt0ZN64E1w"
+        "link" : "https://www.example.com/oaEMfp7f8XlKHACKNG"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "p5OeU24M0ecJjWy",
-    "mimeType" : "MkU8zzqWWGl",
-    "size" : 662027926,
+    "name" : "bulC3Y9LHQP1Jp",
+    "mimeType" : "Y1XoClP61NIM",
+    "size" : 767739680,
     "license" : {
       "type" : "License",
-      "identifier" : "uNYM4GrUZPF88HgnHu",
+      "identifier" : "n5S0T312ETUJzuw60",
       "labels" : {
-        "hqhonR71KlJleBA" : "Egf3octGFkcJ"
+        "X0ugufaGHouACdFrm" : "UxykIgQG8vRr8kY"
       },
-      "link" : "https://www.example.com/ohRt0ZN64E1w"
+      "link" : "https://www.example.com/oaEMfp7f8XlKHACKNG"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "c9W5iSwdxr",
+  "owner" : "wIEAm0l2ktO0Gim",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -3,138 +3,117 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "jer8tqE4umk",
-    "ownerAffiliation" : "https://www.example.org/inventoreomnis"
+    "owner" : "aGmlCSH7gnvoW",
+    "ownerAffiliation" : "https://www.example.org/quamsed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiaducimus",
+    "id" : "https://www.example.org/estquia",
     "labels" : {
-      "ctyuAfUmIAEt" : "s3rFKIQSmBGAC"
+      "GUI6aRIGJt4W6" : "9dQWuxqtFD59"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consequatursit",
-  "doi" : "https://doi.org/10.1234/itaque",
-  "link" : "https://www.example.org/nobistemporibus",
+  "handle" : "https://www.example.org/modivero",
+  "doi" : "https://doi.org/10.1234/blanditiis",
+  "link" : "https://www.example.org/modiquo",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DnZynHAholb4",
+    "mainTitle" : "IXPFHW0qjOY5gIu",
     "alternativeTitles" : {
-      "nl" : "CpPsK1Fn3FTslZ8"
+      "nb" : "mBCK7PBybhFHIv"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "D2Hx0HRpIpd",
-      "month" : "ZA32uQFvK8plkxuZ",
-      "day" : "WJtyyfhSias3dGP6Yfw"
+      "year" : "PX7nMLLf99VFTLA",
+      "month" : "TS9jXtCMEjiXRg8dB",
+      "day" : "4fbCaISqIogjwpU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/QE8sEIQKMkhmaU",
-        "name" : "cM5qbRQA9CccibnnVb9",
-        "nameType" : "Organizational",
-        "orcId" : "HDBXMVhikHxh"
+        "id" : "https://www.example.com/Qb1DPmQkng7",
+        "name" : "pxDwRVE8V4WpLn",
+        "nameType" : "Personal",
+        "orcId" : "tPFZExqA31yUAt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/D1rA5k17HQ",
+        "id" : "https://www.example.com/Kbj0wTe5BgQk8Oj2tal",
         "labels" : {
-          "zScgiTSUgEDcOEx71" : "QffWPh7NE8g6a6DM"
+          "3oSFaH9leIGUeIdPM90" : "3733rnF3xmpzUfl"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 0,
+      "role" : "ArtisticDirector",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DELKnqHUm7Nax",
-        "name" : "C2RpqLORfnZ4ujzxRx",
-        "nameType" : "Organizational",
-        "orcId" : "7T1UrCc9smy3in9"
+        "id" : "https://www.example.com/NWlsCOpUlntCjMYzPU",
+        "name" : "3jSWODOlQMEksb7xEqo",
+        "nameType" : "Personal",
+        "orcId" : "ZJVUmgp0sHQAgliO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/HWKXsNPK2w5EXtF50jg",
+        "id" : "https://www.example.com/1dWu6DCkAA3H9N",
         "labels" : {
-          "1trg3SHjmQyuV" : "RVeIaYaezVXGYHKc"
+          "Y5isiyb6xAvFqIN" : "83FiHaIYMOmT5YGfl"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 2,
+      "role" : "Choreographer",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YKNbFy4aew",
-    "tags" : [ "iJxGNbdbiw70cWYhy" ],
-    "description" : "xVma0Mkogh7rktLFEQx",
+    "npiSubjectHeading" : "rTVLYMDIoFC43yXjO3W",
+    "tags" : [ "wpgvYHFC99l2gNVfkD" ],
+    "description" : "HUETW8XvB2rwJKPjDlI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/tqHj2CSH7iZdL"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/IyMABAhrMZcOTZ90T"
       },
-      "doi" : "https://www.example.com/N65RiRig9wWKvLv",
+      "doi" : "https://www.example.com/DohOo3kzVAC9zbotlGg",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "R9C6aZUSrNZ",
-        "issue" : "ENsDi8Y26sgb5YubE",
-        "articleNumber" : "eD6HB3W3V2",
+        "volume" : "lLlp13aeaa6FEkgJd",
+        "issue" : "VOBIiOAwyxg8",
+        "articleNumber" : "cAvGIWZpWW9wAcMgH",
         "pages" : {
           "type" : "Range",
-          "begin" : "NK2kYVFq7Pik5g",
-          "end" : "YItsN6zPhN8QP6f9b"
+          "begin" : "L9NUaYL8rHL2QVks",
+          "end" : "wgTZ6OO8I3"
         },
-        "corrigendumFor" : "https://www.example.com/bkBlXc9tHx7",
+        "corrigendumFor" : "https://www.example.com/WyzYPo13fGAy0tkEJ4",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/gJvVks2cbQdNK1R5Y",
-    "abstract" : "RlDOa3Mc0pzX"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "jXCWCIlCynbSTwQ3UAy",
-      "mimeType" : "eEs32egHYFNHiNgTp1N",
-      "size" : 1097191637,
-      "license" : {
-        "type" : "License",
-        "identifier" : "w6G2s7EcyYtUjdY3",
-        "labels" : {
-          "L1WUsjw4UPxejawyTS" : "iDNv3isA7tOr"
-        },
-        "link" : "https://www.example.com/oibPB73Y13exMtJ1zm"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/YzymG6c0Rw3B9NQ6",
+    "abstract" : "nJ2kxGjCoP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estaut",
-    "name" : "Jk0uewcAF4C226Y2",
+    "id" : "https://www.example.org/omnislibero",
+    "name" : "plSOYA1YYZ9Dm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "mmytf5bSfgi",
-      "id" : "hSU4RjPd7E53nBXkr3"
+      "source" : "P8GxC58zczWNt",
+      "id" : "oNCtyBbHxGBZVi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "efHpb4zKXXBdO"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "HhIUVuCpBLyxgwq"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -142,25 +121,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sapientevel" ],
+  "subjects" : [ "https://www.example.org/doloreslibero" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "jXCWCIlCynbSTwQ3UAy",
-    "mimeType" : "eEs32egHYFNHiNgTp1N",
-    "size" : 1097191637,
+    "name" : "yyizJ0eDZG1RDY",
+    "mimeType" : "efPtKuDmqpF",
+    "size" : 1605905471,
     "license" : {
       "type" : "License",
-      "identifier" : "w6G2s7EcyYtUjdY3",
+      "identifier" : "mmn1weEELGb",
       "labels" : {
-        "L1WUsjw4UPxejawyTS" : "iDNv3isA7tOr"
+        "RArjL4E8M2htUvt6Unv" : "s79J9gLqZBwgoU"
       },
-      "link" : "https://www.example.com/oibPB73Y13exMtJ1zm"
+      "link" : "https://www.example.com/pAeiu8Oca1N"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "jer8tqE4umk"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "yyizJ0eDZG1RDY",
+      "mimeType" : "efPtKuDmqpF",
+      "size" : 1605905471,
+      "license" : {
+        "type" : "License",
+        "identifier" : "mmn1weEELGb",
+        "labels" : {
+          "RArjL4E8M2htUvt6Unv" : "s79J9gLqZBwgoU"
+        },
+        "link" : "https://www.example.com/pAeiu8Oca1N"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "aGmlCSH7gnvoW",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,119 +1,119 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "aGmlCSH7gnvoW",
-    "ownerAffiliation" : "https://www.example.org/quamsed"
+    "owner" : "c9W5iSwdxr",
+    "ownerAffiliation" : "https://www.example.org/laudantiumeius"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/estquia",
+    "id" : "https://www.example.org/quonesciunt",
     "labels" : {
-      "GUI6aRIGJt4W6" : "9dQWuxqtFD59"
+      "VlLMG8G1oFfusU6l2ye" : "5jtSAJXQP45oaPEJdh"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/modivero",
-  "doi" : "https://doi.org/10.1234/blanditiis",
-  "link" : "https://www.example.org/modiquo",
+  "handle" : "https://www.example.org/dolorequos",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/asperioresaliquid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IXPFHW0qjOY5gIu",
+    "mainTitle" : "3UkFNnAfQZYpMt",
     "alternativeTitles" : {
-      "nb" : "mBCK7PBybhFHIv"
+      "pt" : "mGuxMXQgt8"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "PX7nMLLf99VFTLA",
-      "month" : "TS9jXtCMEjiXRg8dB",
-      "day" : "4fbCaISqIogjwpU"
+      "year" : "6L6IfD6656",
+      "month" : "RnDCwo1SuGPlkaxch5l",
+      "day" : "xzaNUvzGpFwQoDBHp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Qb1DPmQkng7",
-        "name" : "pxDwRVE8V4WpLn",
-        "nameType" : "Personal",
-        "orcId" : "tPFZExqA31yUAt"
+        "id" : "https://www.example.com/gFhDhu2xMr4UcKNp",
+        "name" : "XkJhm8X5UreqH9QprYb",
+        "nameType" : "Organizational",
+        "orcId" : "nZuTI6kk4bVeweg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Kbj0wTe5BgQk8Oj2tal",
+        "id" : "https://www.example.com/fVMw0rjImbN",
         "labels" : {
-          "3oSFaH9leIGUeIdPM90" : "3733rnF3xmpzUfl"
+          "jNpZJq0Leu" : "q4aSr2qwPw070SUNOYJ"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 8,
+      "role" : "DataCurator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/NWlsCOpUlntCjMYzPU",
-        "name" : "3jSWODOlQMEksb7xEqo",
+        "id" : "https://www.example.com/7CA8p5627iT4t",
+        "name" : "QZXKN6mSMvM",
         "nameType" : "Personal",
-        "orcId" : "ZJVUmgp0sHQAgliO"
+        "orcId" : "NuCyUHSMEHQ3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1dWu6DCkAA3H9N",
+        "id" : "https://www.example.com/zxIaqCaDQ0cH",
         "labels" : {
-          "Y5isiyb6xAvFqIN" : "83FiHaIYMOmT5YGfl"
+          "F4H0E0F1BCud8" : "lyNQOLh4INPxfMh"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 8,
+      "role" : "AcademicCoordinator",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rTVLYMDIoFC43yXjO3W",
-    "tags" : [ "wpgvYHFC99l2gNVfkD" ],
-    "description" : "HUETW8XvB2rwJKPjDlI",
+    "npiSubjectHeading" : "jxKYCvUtnYVxOEWu",
+    "tags" : [ "4Vrs4uFNENMa1gxtN" ],
+    "description" : "WMbZNpkBXwrBX4JthPm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/IyMABAhrMZcOTZ90T"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/mSP3Wz6ULtSHc07gu"
       },
-      "doi" : "https://www.example.com/DohOo3kzVAC9zbotlGg",
+      "doi" : "https://www.example.com/TQjWjBqiqFgcwMreKzo",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "lLlp13aeaa6FEkgJd",
-        "issue" : "VOBIiOAwyxg8",
-        "articleNumber" : "cAvGIWZpWW9wAcMgH",
+        "volume" : "JaLEF0ods0LxBNGf",
+        "issue" : "CiVx0cG1DvXwHMpQXL",
+        "articleNumber" : "jyjBAbstybU6iUXnF",
         "pages" : {
           "type" : "Range",
-          "begin" : "L9NUaYL8rHL2QVks",
-          "end" : "wgTZ6OO8I3"
+          "begin" : "tZ5nvSoBwWrRoL",
+          "end" : "63ZG5L0DsqrwOp0WkUC"
         },
-        "corrigendumFor" : "https://www.example.com/WyzYPo13fGAy0tkEJ4",
+        "corrigendumFor" : "https://www.example.com/lDIaxXZHqXivzie9E",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/YzymG6c0Rw3B9NQ6",
-    "abstract" : "nJ2kxGjCoP"
+    "metadataSource" : "https://www.example.com/lPPOqQhFeup",
+    "abstract" : "AyZ1kdxdICqc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/omnislibero",
-    "name" : "plSOYA1YYZ9Dm",
+    "id" : "https://www.example.org/itaqueeaque",
+    "name" : "seaRWLie1H74",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "P8GxC58zczWNt",
-      "id" : "oNCtyBbHxGBZVi"
+      "source" : "9iomPVhabZ5eiYxj",
+      "id" : "LSIAtR02ccP4L"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "HhIUVuCpBLyxgwq"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "hjS6HJ5cRt"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -121,46 +121,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloreslibero" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "yyizJ0eDZG1RDY",
-    "mimeType" : "efPtKuDmqpF",
-    "size" : 1605905471,
-    "license" : {
-      "type" : "License",
-      "identifier" : "mmn1weEELGb",
-      "labels" : {
-        "RArjL4E8M2htUvt6Unv" : "s79J9gLqZBwgoU"
-      },
-      "link" : "https://www.example.com/pAeiu8Oca1N"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/odioaspernatur" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yyizJ0eDZG1RDY",
-      "mimeType" : "efPtKuDmqpF",
-      "size" : 1605905471,
+      "name" : "p5OeU24M0ecJjWy",
+      "mimeType" : "MkU8zzqWWGl",
+      "size" : 662027926,
       "license" : {
         "type" : "License",
-        "identifier" : "mmn1weEELGb",
+        "identifier" : "uNYM4GrUZPF88HgnHu",
         "labels" : {
-          "RArjL4E8M2htUvt6Unv" : "s79J9gLqZBwgoU"
+          "hqhonR71KlJleBA" : "Egf3octGFkcJ"
         },
-        "link" : "https://www.example.com/pAeiu8Oca1N"
+        "link" : "https://www.example.com/ohRt0ZN64E1w"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "aGmlCSH7gnvoW",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "p5OeU24M0ecJjWy",
+    "mimeType" : "MkU8zzqWWGl",
+    "size" : 662027926,
+    "license" : {
+      "type" : "License",
+      "identifier" : "uNYM4GrUZPF88HgnHu",
+      "labels" : {
+        "hqhonR71KlJleBA" : "Egf3octGFkcJ"
+      },
+      "link" : "https://www.example.com/ohRt0ZN64E1w"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "c9W5iSwdxr",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,119 +1,119 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "wIEAm0l2ktO0Gim",
-    "ownerAffiliation" : "https://www.example.org/suscipitmaxime"
+    "owner" : "xs5tkBOZD3XIPi",
+    "ownerAffiliation" : "https://www.example.org/estquibusdam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemfacilis",
+    "id" : "https://www.example.org/sedest",
     "labels" : {
-      "2qyw4iNU4gz" : "nlT4G7FP8BGYJ3Kp"
+      "wOHPKWzxzJBRVnP" : "f2DJHq5HIFpN0Scx"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/molestiaedeserunt",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/ipsumpariatur",
+  "handle" : "https://www.example.org/quoseligendi",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/omnisfugit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XU2dIIrU9JJu",
+    "mainTitle" : "kOhGhoiOvjnHfXi",
     "alternativeTitles" : {
-      "fi" : "ErP9hS9onJiXW"
+      "nn" : "MAlfpR2NyzI5FBa0"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "N296Rq3XRP",
-      "month" : "qtdnNFAh87NiN",
-      "day" : "UkL2k2jgi8M"
+      "year" : "QceLz5qyfBNdN8MNW",
+      "month" : "EDevTyXyAGbzyNfAVkO",
+      "day" : "0Tw3D2MwcwIzc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cFug181IE6",
-        "name" : "rTby4zq1aV0bZc",
+        "id" : "https://www.example.com/yuVpOWmFGD0cLeym",
+        "name" : "75kEadN66oPHCn0Zv",
         "nameType" : "Organizational",
-        "orcId" : "8DLfGI7zsyg055W"
+        "orcId" : "j4at73LEJaUar9tc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uPcMxT9YiKEXMtY7",
+        "id" : "https://www.example.com/iHAOXZiD6PWvco",
         "labels" : {
-          "2HD8KYjzcKBi9" : "RV0yr8dhK1cyNnXt"
+          "ZXkk76cC0VwwIdLal" : "nX0lvSXeSX2ltZh51e"
         }
       } ],
-      "role" : "Musician",
-      "sequence" : 6,
+      "role" : "Dramaturge",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SojLO9QtXF",
-        "name" : "tCQG7aJ9FQGlP",
+        "id" : "https://www.example.com/7fyXSoke97kqceY5SoP",
+        "name" : "bVJMKB6RAqZ",
         "nameType" : "Organizational",
-        "orcId" : "eF5f0HXW1W"
+        "orcId" : "O3Hl2wQHyx2iHfOnQ8n"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6G6PD3qMVXj5NJX",
+        "id" : "https://www.example.com/jWqEPk3RNFj",
         "labels" : {
-          "H8pckHU4TTdxWYlm" : "dSLQKrIP9XiGx2iIZ"
+          "8KOWdTv9r8lk6" : "ThhYBsksvElU2oOV0ad"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 5,
+      "role" : "ContactPerson",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "LOE3WQeAMQIl1IRfou",
-    "tags" : [ "VUriAvHS9e" ],
-    "description" : "8jYQcut7bvxcK98tE1q",
+    "npiSubjectHeading" : "GwJaNSleVqw8E",
+    "tags" : [ "5ofWensndvK" ],
+    "description" : "ux75Mdu5KZyZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8MLsXCBN7Zbg"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/GyIJo4JeDADpnhZPDSK"
       },
-      "doi" : "https://www.example.com/HdFhP2QY2QII3",
+      "doi" : "https://www.example.com/UA26Q2yQuV2VuE",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "DA2EIuZxYW8zawvS",
-        "issue" : "Ex4zSX01l94l8vx",
-        "articleNumber" : "Iua892VpgsG7Gg",
+        "volume" : "ScvWzqjjBWcCXcFLc4",
+        "issue" : "VmslCwLAaatm",
+        "articleNumber" : "MFHDm0pbcp",
         "pages" : {
           "type" : "Range",
-          "begin" : "1ZNSKsCJsvn",
-          "end" : "3EhTj2VFcSa0ov"
+          "begin" : "gqEF4zcSWm",
+          "end" : "wwYXrvjoFULCkO"
         },
-        "corrigendumFor" : "https://www.example.com/29fTwvRU9qd",
+        "corrigendumFor" : "https://www.example.com/visCehV44kh6WVyMhp6",
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/EmQnpmpzHge6sscYJh",
-    "abstract" : "FCrujb07lk66v"
+    "metadataSource" : "https://www.example.com/FqjHsUeIDT",
+    "abstract" : "2SCLfsZfYyKU7Yq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autmolestias",
-    "name" : "zPkhsHRuVMOiB1Krk",
+    "id" : "https://www.example.org/doloratque",
+    "name" : "OgPnCqt6e6",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZdhDYVLHBtp",
-      "id" : "9NeWJHHElxCzO"
+      "source" : "6oszO5hEQt2iuj4LLLU",
+      "id" : "QAreandWbgQ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "jiW4mbZIJ6HQunQy"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "Oy8Bl4mOvbdkfq4e2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -121,46 +121,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quodvoluptas" ],
+  "subjects" : [ "https://www.example.org/dolorumnon" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bulC3Y9LHQP1Jp",
-      "mimeType" : "Y1XoClP61NIM",
-      "size" : 767739680,
+      "name" : "MUfiU8IOEsLZ7BtE",
+      "mimeType" : "9vzsoxzlwEcRtvCmx",
+      "size" : 1827175626,
       "license" : {
         "type" : "License",
-        "identifier" : "n5S0T312ETUJzuw60",
+        "identifier" : "yROg0tCKDKa",
         "labels" : {
-          "X0ugufaGHouACdFrm" : "UxykIgQG8vRr8kY"
+          "PdKbVF9lZOP" : "CVwCIqHFio36XC8O"
         },
-        "link" : "https://www.example.com/oaEMfp7f8XlKHACKNG"
+        "link" : "https://www.example.com/HRGfFvQHJCZ9DW"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bulC3Y9LHQP1Jp",
-    "mimeType" : "Y1XoClP61NIM",
-    "size" : 767739680,
+    "name" : "MUfiU8IOEsLZ7BtE",
+    "mimeType" : "9vzsoxzlwEcRtvCmx",
+    "size" : 1827175626,
     "license" : {
       "type" : "License",
-      "identifier" : "n5S0T312ETUJzuw60",
+      "identifier" : "yROg0tCKDKa",
       "labels" : {
-        "X0ugufaGHouACdFrm" : "UxykIgQG8vRr8kY"
+        "PdKbVF9lZOP" : "CVwCIqHFio36XC8O"
       },
-      "link" : "https://www.example.com/oaEMfp7f8XlKHACKNG"
+      "link" : "https://www.example.com/HRGfFvQHJCZ9DW"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "wIEAm0l2ktO0Gim",
+  "owner" : "xs5tkBOZD3XIPi",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "bBXiXYykCSSafG",
-    "ownerAffiliation" : "https://www.example.org/deserunttemporibus"
+    "owner" : "8cok6tR0aG4CTwvz",
+    "ownerAffiliation" : "https://www.example.org/fugittenetur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quisquamconsequatur",
+    "id" : "https://www.example.org/rerumexercitationem",
     "labels" : {
-      "ft9ilEgbeB" : "YmwKth8MPaV9Zkg"
+      "2DmTDHMhuEH7k0" : "Yy9zpaJOQ7n"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/aliquidat",
-  "doi" : "https://doi.org/10.1234/quae",
-  "link" : "https://www.example.org/suntsequi",
+  "handle" : "https://www.example.org/eavelit",
+  "doi" : "https://doi.org/10.1234/necessitatibus",
+  "link" : "https://www.example.org/quiavoluptate",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9OC9l4mW4QST",
+    "mainTitle" : "442bGNUjUSXyjjWw",
     "alternativeTitles" : {
-      "zh" : "y24MYsZXXt"
+      "af" : "wWU4zx9nYavHXaK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "UYvmwkWFnueKLr",
-      "month" : "fgiMuu4xKpBjgC",
-      "day" : "4ZRtC82isc"
+      "year" : "FsTAil3xNE2ilF",
+      "month" : "L8zkV3L8ymqSPd",
+      "day" : "u7J7OHYFsqdSUo4OBe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SFnXrokhcw1sq3",
-        "name" : "qqu3GLeiRFYk9AY7C",
+        "id" : "https://www.example.com/ydZlUow61hy",
+        "name" : "spijAxAFEy",
         "nameType" : "Personal",
-        "orcId" : "Qg2CkFkWSv2TFCzW"
+        "orcId" : "Pw2H7ZD7AwTiG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vFCjXXN25hIq7Zil7",
+        "id" : "https://www.example.com/neZV4pR8qenJb2mqLK",
         "labels" : {
-          "jwa9MhVk1LG2jePTW" : "A2TCY07Ii9"
+          "xpHVRJYrKHYHjOla5" : "mzgZISsTJ9tvGFjodo"
         }
       } ],
-      "role" : "InteriorArchitect",
-      "sequence" : 8,
+      "role" : "Other",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xrnI463oKimf",
-        "name" : "Cya6V5wZBdNM7N",
+        "id" : "https://www.example.com/V9lQVTniCHhxb6Psasv",
+        "name" : "XcwoOx2TJ5GFXz",
         "nameType" : "Personal",
-        "orcId" : "4osQKKcfHfPM"
+        "orcId" : "jk1mJAcUojARN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hlUqRGoir8ATndF",
+        "id" : "https://www.example.com/COKPOL6zKQYeJhX",
         "labels" : {
-          "vvESCUNZ8nfBQ" : "1tmktAWWtKDlGU"
+          "3HmRrQBPHhuCjkwEE" : "PFvXvUw6l3j8"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 1,
+      "role" : "ProductionDesigner",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "yO1pyffsxYK",
-    "tags" : [ "uvAEcJZMGiC0ydIl" ],
-    "description" : "1BMix59U3l6m",
+    "npiSubjectHeading" : "QFYMDRho51LE65PZbRm",
+    "tags" : [ "YMyBsp1vZLqn" ],
+    "description" : "NEL1ni1FatqV3Zp3X4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HL8MkIEAue6m70"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BdIVbxMroS"
       },
-      "doi" : "https://www.example.com/ecC2u2B27fYA",
+      "doi" : "https://www.example.com/lmF41pScrdzCu",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "qOW28agneqMvS",
-        "issue" : "bh2Zc4Wkj509Hxx",
-        "articleNumber" : "Mx8La6KVRiiyX",
+        "volume" : "kn0noVbEUj0TsUJW",
+        "issue" : "Ew1tyl4luADdN0j9V",
+        "articleNumber" : "7ofgag4bCWVTeGgvEf",
         "pages" : {
           "type" : "Range",
-          "begin" : "x6eTMUQ0QQiPCZLO",
-          "end" : "haSXrGkJKgwF"
+          "begin" : "faxjJV6dZxS7IZfPgH",
+          "end" : "ocDmuAl9nDl"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/WfrpOjVq5eUmwK2Eq",
-    "abstract" : "m2lGtCbVXO"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lSxnvy3kd9h1gN",
-      "mimeType" : "A4aROlVRNT7lo",
-      "size" : 1929237326,
-      "license" : {
-        "type" : "License",
-        "identifier" : "nzBXGWCQi3nR4n",
-        "labels" : {
-          "98Im9j3eXHb7" : "n3V5Z8oa7zHF3"
-        },
-        "link" : "https://www.example.com/3CjIssDCUj97"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/BUpTA35Pu5VdiLV",
+    "abstract" : "rBoRa13mAk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utquidem",
-    "name" : "VHzRCBTfJnG8pr089l",
+    "id" : "https://www.example.org/exporro",
+    "name" : "rwfVkxjwh7",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Yw1gjQC0NNZxPQdVK49",
-      "id" : "erp67xXqiSl6A"
+      "source" : "xMyGHgXfIqPyoqawPvP",
+      "id" : "dPnxBE1Ys9F4lSLJapm"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "VsWjL07kQt5lRLBxTFe"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "u0gOMUutlC"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/possimusmodi" ],
+  "subjects" : [ "https://www.example.org/cupiditatevel" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lSxnvy3kd9h1gN",
-    "mimeType" : "A4aROlVRNT7lo",
-    "size" : 1929237326,
+    "name" : "ksFnmCMBPBJ",
+    "mimeType" : "KZf0dQsCAV",
+    "size" : 486043704,
     "license" : {
       "type" : "License",
-      "identifier" : "nzBXGWCQi3nR4n",
+      "identifier" : "xEgPwlYbZUEgpufygq1",
       "labels" : {
-        "98Im9j3eXHb7" : "n3V5Z8oa7zHF3"
+        "kNU6F3lreV46NQEbA4C" : "QF2Ehxp8Vaz4q92nAYe"
       },
-      "link" : "https://www.example.com/3CjIssDCUj97"
+      "link" : "https://www.example.com/SwKaPuc2BHFqHeu"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "bBXiXYykCSSafG"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "ksFnmCMBPBJ",
+      "mimeType" : "KZf0dQsCAV",
+      "size" : 486043704,
+      "license" : {
+        "type" : "License",
+        "identifier" : "xEgPwlYbZUEgpufygq1",
+        "labels" : {
+          "kNU6F3lreV46NQEbA4C" : "QF2Ehxp8Vaz4q92nAYe"
+        },
+        "link" : "https://www.example.com/SwKaPuc2BHFqHeu"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "8cok6tR0aG4CTwvz",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "8cok6tR0aG4CTwvz",
-    "ownerAffiliation" : "https://www.example.org/fugittenetur"
+    "owner" : "HoJxQd6MO3IkY7IWi",
+    "ownerAffiliation" : "https://www.example.org/autmaiores"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rerumexercitationem",
+    "id" : "https://www.example.org/advoluptatem",
     "labels" : {
-      "2DmTDHMhuEH7k0" : "Yy9zpaJOQ7n"
+      "rPM9zrEUw3" : "fYRGCfQJYNu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eavelit",
+  "handle" : "https://www.example.org/doloremamet",
   "doi" : "https://doi.org/10.1234/necessitatibus",
-  "link" : "https://www.example.org/quiavoluptate",
+  "link" : "https://www.example.org/utsit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "442bGNUjUSXyjjWw",
+    "mainTitle" : "FRRGwKkQw3ND",
     "alternativeTitles" : {
-      "af" : "wWU4zx9nYavHXaK"
+      "bg" : "Z4bsyF0O7pgKDQ6"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FsTAil3xNE2ilF",
-      "month" : "L8zkV3L8ymqSPd",
-      "day" : "u7J7OHYFsqdSUo4OBe"
+      "year" : "99okhZg1CU",
+      "month" : "tu6k8FvyOXPc",
+      "day" : "lyN8AFxGx99165NJGXG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ydZlUow61hy",
-        "name" : "spijAxAFEy",
-        "nameType" : "Personal",
-        "orcId" : "Pw2H7ZD7AwTiG"
+        "id" : "https://www.example.com/Alk3TxkkxF",
+        "name" : "o8Jguu5S8AeyM",
+        "nameType" : "Organizational",
+        "orcId" : "2CeMEC8prtQofKG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/neZV4pR8qenJb2mqLK",
+        "id" : "https://www.example.com/q0L65SLVezH",
         "labels" : {
-          "xpHVRJYrKHYHjOla5" : "mzgZISsTJ9tvGFjodo"
+          "NqLYAqKShF49VUZTxU" : "pVa13V38lL"
         }
       } ],
       "role" : "Other",
-      "sequence" : 9,
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/V9lQVTniCHhxb6Psasv",
-        "name" : "XcwoOx2TJ5GFXz",
+        "id" : "https://www.example.com/sVvVKBEZdEfh",
+        "name" : "xAE55bn6zk9ChAPyd",
         "nameType" : "Personal",
-        "orcId" : "jk1mJAcUojARN"
+        "orcId" : "G3dbFMorTkgB5Tc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/COKPOL6zKQYeJhX",
+        "id" : "https://www.example.com/PZ8HuoCwACAFej8rXPE",
         "labels" : {
-          "3HmRrQBPHhuCjkwEE" : "PFvXvUw6l3j8"
+          "hEmqGr9yYY" : "97MOVD1MTyK"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 3,
+      "role" : "Consultant",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "QFYMDRho51LE65PZbRm",
-    "tags" : [ "YMyBsp1vZLqn" ],
-    "description" : "NEL1ni1FatqV3Zp3X4",
+    "npiSubjectHeading" : "tUFw00p2OXq",
+    "tags" : [ "hkZX7BuMcqadnAIK" ],
+    "description" : "fsPdpfrxxTp4p",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BdIVbxMroS"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TxVboGFVuwYH8K7XTN"
       },
-      "doi" : "https://www.example.com/lmF41pScrdzCu",
+      "doi" : "https://www.example.com/Hvcmo3Kym8R8nZ",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "kn0noVbEUj0TsUJW",
-        "issue" : "Ew1tyl4luADdN0j9V",
-        "articleNumber" : "7ofgag4bCWVTeGgvEf",
+        "volume" : "TFfnwJZ0mgvriUg",
+        "issue" : "0ZpfKzh58tAopP",
+        "articleNumber" : "becAzsX4hnlrXXXTsq",
         "pages" : {
           "type" : "Range",
-          "begin" : "faxjJV6dZxS7IZfPgH",
-          "end" : "ocDmuAl9nDl"
+          "begin" : "oKN726pfuA05EAQ7o",
+          "end" : "kUlxLoNRIXwczCKK0"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/BUpTA35Pu5VdiLV",
-    "abstract" : "rBoRa13mAk"
+    "metadataSource" : "https://www.example.com/WbnZGh7AFw3SCr2srOY",
+    "abstract" : "giu1xr7OKMP4RP1bxJ1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/exporro",
-    "name" : "rwfVkxjwh7",
+    "id" : "https://www.example.org/beataeconsequatur",
+    "name" : "mRsoqaA58sNCwV0dv",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "xMyGHgXfIqPyoqawPvP",
-      "id" : "dPnxBE1Ys9F4lSLJapm"
+      "source" : "mI2ae47cFMcrW2DWs",
+      "id" : "O1zw5Y5QFo"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "u0gOMUutlC"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "7kisXn7PtjgGxL"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cupiditatevel" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ksFnmCMBPBJ",
-    "mimeType" : "KZf0dQsCAV",
-    "size" : 486043704,
-    "license" : {
-      "type" : "License",
-      "identifier" : "xEgPwlYbZUEgpufygq1",
-      "labels" : {
-        "kNU6F3lreV46NQEbA4C" : "QF2Ehxp8Vaz4q92nAYe"
-      },
-      "link" : "https://www.example.com/SwKaPuc2BHFqHeu"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/architectovoluptatem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ksFnmCMBPBJ",
-      "mimeType" : "KZf0dQsCAV",
-      "size" : 486043704,
+      "name" : "iAFnX1m4TE1yNZ0i",
+      "mimeType" : "Aq1M7ODVtieP0oXafd",
+      "size" : 1727526930,
       "license" : {
         "type" : "License",
-        "identifier" : "xEgPwlYbZUEgpufygq1",
+        "identifier" : "beqdHSIzxVTlFcWglV",
         "labels" : {
-          "kNU6F3lreV46NQEbA4C" : "QF2Ehxp8Vaz4q92nAYe"
+          "BorRwChotqmbuLF" : "n7jPSEjxLO7eVPDhi3"
         },
-        "link" : "https://www.example.com/SwKaPuc2BHFqHeu"
+        "link" : "https://www.example.com/Qvp2ZQoR00IHkrMRjt"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "8cok6tR0aG4CTwvz",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "iAFnX1m4TE1yNZ0i",
+    "mimeType" : "Aq1M7ODVtieP0oXafd",
+    "size" : 1727526930,
+    "license" : {
+      "type" : "License",
+      "identifier" : "beqdHSIzxVTlFcWglV",
+      "labels" : {
+        "BorRwChotqmbuLF" : "n7jPSEjxLO7eVPDhi3"
+      },
+      "link" : "https://www.example.com/Qvp2ZQoR00IHkrMRjt"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "HoJxQd6MO3IkY7IWi",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "chEg3QAjPqUXd2Ih",
-    "ownerAffiliation" : "https://www.example.org/occaecatifugiat"
+    "owner" : "OI33roZdhubqDAPEqd3",
+    "ownerAffiliation" : "https://www.example.org/modiaccusamus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/isteomnis",
+    "id" : "https://www.example.org/facilissed",
     "labels" : {
-      "x6VpUYepwY" : "BjU3lMc1coCfs"
+      "j45kG3mrl2qNegdQkv" : "ZHkgJHjHoOeUo"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/verodoloremque",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/rerumdolor",
+  "handle" : "https://www.example.org/voluptasexplicabo",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/harumquidem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Ub0KPruEEuCpKEk9",
+    "mainTitle" : "VIQtPUNaWkS6N22fR",
     "alternativeTitles" : {
-      "pl" : "RdwBrBM8eM7Re"
+      "pt" : "Fpc38e9RQxCgw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "5iUcnBFNHPJvQ5HBI00",
-      "month" : "0s37uYnWTSjdVBG",
-      "day" : "yx7vV8vKUc9b"
+      "year" : "npaB5v2nF1TXCU",
+      "month" : "LotHwIrYON90",
+      "day" : "QJdyZQZRN0Tz6LjpwXB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/vjd5B14NFJB",
-        "name" : "WTSXidJQ51hxU",
-        "nameType" : "Personal",
-        "orcId" : "zuXfKd0jvA"
+        "id" : "https://www.example.com/nW1lFkypZHrpw6KA",
+        "name" : "xhgDpMKYsxeVL80DK2",
+        "nameType" : "Organizational",
+        "orcId" : "vZ12pAB5UvSPC5Qpq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mXlemuJhnl",
+        "id" : "https://www.example.com/0lOXripPzQiaU",
         "labels" : {
-          "HOol5fi8bcsWZeTMSL" : "aYxUeRFQhGZlIoGN7"
+          "86eBrSMBzdMS0" : "pFXlymtg2vLR44OD5y"
         }
       } ],
-      "role" : "Director",
-      "sequence" : 4,
+      "role" : "Scenographer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AyNaidxbipiRS",
-        "name" : "1nlPgpabmn",
+        "id" : "https://www.example.com/WSBJ7anQ7uGx3t",
+        "name" : "k3czWBArfIBk",
         "nameType" : "Personal",
-        "orcId" : "sLb3v9iTIip"
+        "orcId" : "82xaovHLUNjdiyD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/NtrmZlO37eHo2hTS",
+        "id" : "https://www.example.com/bb73ls1yAIR27fm",
         "labels" : {
-          "0Be1Bt3WEH" : "mDEJYyk1pgexh38la"
+          "hwKMQYZfoZfJLAc" : "sC9d8Oyc41"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 2,
+      "role" : "Conductor",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "hawDs2RQyyI0ousBRw",
-    "tags" : [ "yDgTIMlZ48jZeo59D" ],
-    "description" : "jt3fMR01C9Dc4",
+    "npiSubjectHeading" : "ldyblawt8S",
+    "tags" : [ "0B8kmDkPyX7gKJCad54" ],
+    "description" : "7sivuvZ2UpN2rCps1fe",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OZU6Ivz37xL"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/kxhsk8vHuQzMzEtL8"
       },
-      "doi" : "https://www.example.com/R6BCxKAD8dK",
+      "doi" : "https://www.example.com/rUQDuq89W4c",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "hviG5izQtj5JQHd",
-        "issue" : "WCJpbWsgJN",
-        "articleNumber" : "lrkiKHzGkogk",
+        "volume" : "imXpcXSSG4",
+        "issue" : "ZOFoX7NDfop",
+        "articleNumber" : "zNtCsTFGcOq3l",
         "pages" : {
           "type" : "Range",
-          "begin" : "DdhogzcuiYO9",
-          "end" : "yVIJvw3DwBL2a"
+          "begin" : "ivcv09Wkp99UwYDGMy9",
+          "end" : "Iz0uAtKHSQkJXjT"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/DScGl3Uq27ET8zRD9f",
-    "abstract" : "j2MdhDY9h10gV"
+    "metadataSource" : "https://www.example.com/ZIydnGw7X3sUqhn",
+    "abstract" : "vMvUBmIzA15GWb5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cumqueconsequatur",
-    "name" : "ALZ2f9kmmuNw7Yw",
+    "id" : "https://www.example.org/ipsaquasi",
+    "name" : "dEd1ziw1cJgd1v",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "gvanAnKXiOjp",
-      "id" : "1UIIOkCFpX8"
+      "source" : "og1V4EKVTw",
+      "id" : "s6hkzOFfhH30xO"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "SkKnNRuKLx8VcnZV"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "2ArlTijmg7lXN"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,22 +120,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloremsint" ],
+  "subjects" : [ "https://www.example.org/teneturipsam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "XnK8sin7H69qeNjkDgT",
-      "mimeType" : "UfPolh8FijQq",
-      "size" : 1417768344,
+      "name" : "z1KhIcOpBrE8C",
+      "mimeType" : "v0nxUMol6wz",
+      "size" : 1983782443,
       "license" : {
         "type" : "License",
-        "identifier" : "qkunSkFpoDjhfvBj",
+        "identifier" : "maF7YNUtH6cxpx",
         "labels" : {
-          "fLuqtJeU9urq" : "LFLVxE1gqIgnK8Ug"
+          "oTXRAGxKjP9xF1fkU" : "6MGv9fxV6PpM1TiRC"
         },
-        "link" : "https://www.example.com/jNMwlQ0OFwc9GGb"
+        "link" : "https://www.example.com/xu1gqdrCRBKN"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -145,21 +145,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "XnK8sin7H69qeNjkDgT",
-    "mimeType" : "UfPolh8FijQq",
-    "size" : 1417768344,
+    "name" : "z1KhIcOpBrE8C",
+    "mimeType" : "v0nxUMol6wz",
+    "size" : 1983782443,
     "license" : {
       "type" : "License",
-      "identifier" : "qkunSkFpoDjhfvBj",
+      "identifier" : "maF7YNUtH6cxpx",
       "labels" : {
-        "fLuqtJeU9urq" : "LFLVxE1gqIgnK8Ug"
+        "oTXRAGxKjP9xF1fkU" : "6MGv9fxV6PpM1TiRC"
       },
-      "link" : "https://www.example.com/jNMwlQ0OFwc9GGb"
+      "link" : "https://www.example.com/xu1gqdrCRBKN"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "chEg3QAjPqUXd2Ih",
+  "owner" : "OI33roZdhubqDAPEqd3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalInterview.json
+++ b/documentation/JournalInterview.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "HoJxQd6MO3IkY7IWi",
-    "ownerAffiliation" : "https://www.example.org/autmaiores"
+    "owner" : "chEg3QAjPqUXd2Ih",
+    "ownerAffiliation" : "https://www.example.org/occaecatifugiat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/advoluptatem",
+    "id" : "https://www.example.org/isteomnis",
     "labels" : {
-      "rPM9zrEUw3" : "fYRGCfQJYNu"
+      "x6VpUYepwY" : "BjU3lMc1coCfs"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/doloremamet",
-  "doi" : "https://doi.org/10.1234/necessitatibus",
-  "link" : "https://www.example.org/utsit",
+  "handle" : "https://www.example.org/verodoloremque",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/rerumdolor",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FRRGwKkQw3ND",
+    "mainTitle" : "Ub0KPruEEuCpKEk9",
     "alternativeTitles" : {
-      "bg" : "Z4bsyF0O7pgKDQ6"
+      "pl" : "RdwBrBM8eM7Re"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "99okhZg1CU",
-      "month" : "tu6k8FvyOXPc",
-      "day" : "lyN8AFxGx99165NJGXG"
+      "year" : "5iUcnBFNHPJvQ5HBI00",
+      "month" : "0s37uYnWTSjdVBG",
+      "day" : "yx7vV8vKUc9b"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Alk3TxkkxF",
-        "name" : "o8Jguu5S8AeyM",
-        "nameType" : "Organizational",
-        "orcId" : "2CeMEC8prtQofKG"
+        "id" : "https://www.example.com/vjd5B14NFJB",
+        "name" : "WTSXidJQ51hxU",
+        "nameType" : "Personal",
+        "orcId" : "zuXfKd0jvA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/q0L65SLVezH",
+        "id" : "https://www.example.com/mXlemuJhnl",
         "labels" : {
-          "NqLYAqKShF49VUZTxU" : "pVa13V38lL"
+          "HOol5fi8bcsWZeTMSL" : "aYxUeRFQhGZlIoGN7"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 1,
+      "role" : "Director",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sVvVKBEZdEfh",
-        "name" : "xAE55bn6zk9ChAPyd",
+        "id" : "https://www.example.com/AyNaidxbipiRS",
+        "name" : "1nlPgpabmn",
         "nameType" : "Personal",
-        "orcId" : "G3dbFMorTkgB5Tc"
+        "orcId" : "sLb3v9iTIip"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PZ8HuoCwACAFej8rXPE",
+        "id" : "https://www.example.com/NtrmZlO37eHo2hTS",
         "labels" : {
-          "hEmqGr9yYY" : "97MOVD1MTyK"
+          "0Be1Bt3WEH" : "mDEJYyk1pgexh38la"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 5,
+      "role" : "Distributor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "tUFw00p2OXq",
-    "tags" : [ "hkZX7BuMcqadnAIK" ],
-    "description" : "fsPdpfrxxTp4p",
+    "npiSubjectHeading" : "hawDs2RQyyI0ousBRw",
+    "tags" : [ "yDgTIMlZ48jZeo59D" ],
+    "description" : "jt3fMR01C9Dc4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TxVboGFVuwYH8K7XTN"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OZU6Ivz37xL"
       },
-      "doi" : "https://www.example.com/Hvcmo3Kym8R8nZ",
+      "doi" : "https://www.example.com/R6BCxKAD8dK",
       "publicationInstance" : {
         "type" : "JournalInterview",
-        "volume" : "TFfnwJZ0mgvriUg",
-        "issue" : "0ZpfKzh58tAopP",
-        "articleNumber" : "becAzsX4hnlrXXXTsq",
+        "volume" : "hviG5izQtj5JQHd",
+        "issue" : "WCJpbWsgJN",
+        "articleNumber" : "lrkiKHzGkogk",
         "pages" : {
           "type" : "Range",
-          "begin" : "oKN726pfuA05EAQ7o",
-          "end" : "kUlxLoNRIXwczCKK0"
+          "begin" : "DdhogzcuiYO9",
+          "end" : "yVIJvw3DwBL2a"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/WbnZGh7AFw3SCr2srOY",
-    "abstract" : "giu1xr7OKMP4RP1bxJ1"
+    "metadataSource" : "https://www.example.com/DScGl3Uq27ET8zRD9f",
+    "abstract" : "j2MdhDY9h10gV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/beataeconsequatur",
-    "name" : "mRsoqaA58sNCwV0dv",
+    "id" : "https://www.example.org/cumqueconsequatur",
+    "name" : "ALZ2f9kmmuNw7Yw",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "mI2ae47cFMcrW2DWs",
-      "id" : "O1zw5Y5QFo"
+      "source" : "gvanAnKXiOjp",
+      "id" : "1UIIOkCFpX8"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "7kisXn7PtjgGxL"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "SkKnNRuKLx8VcnZV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/architectovoluptatem" ],
+  "subjects" : [ "https://www.example.org/doloremsint" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "iAFnX1m4TE1yNZ0i",
-      "mimeType" : "Aq1M7ODVtieP0oXafd",
-      "size" : 1727526930,
+      "name" : "XnK8sin7H69qeNjkDgT",
+      "mimeType" : "UfPolh8FijQq",
+      "size" : 1417768344,
       "license" : {
         "type" : "License",
-        "identifier" : "beqdHSIzxVTlFcWglV",
+        "identifier" : "qkunSkFpoDjhfvBj",
         "labels" : {
-          "BorRwChotqmbuLF" : "n7jPSEjxLO7eVPDhi3"
+          "fLuqtJeU9urq" : "LFLVxE1gqIgnK8Ug"
         },
-        "link" : "https://www.example.com/Qvp2ZQoR00IHkrMRjt"
+        "link" : "https://www.example.com/jNMwlQ0OFwc9GGb"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "iAFnX1m4TE1yNZ0i",
-    "mimeType" : "Aq1M7ODVtieP0oXafd",
-    "size" : 1727526930,
+    "name" : "XnK8sin7H69qeNjkDgT",
+    "mimeType" : "UfPolh8FijQq",
+    "size" : 1417768344,
     "license" : {
       "type" : "License",
-      "identifier" : "beqdHSIzxVTlFcWglV",
+      "identifier" : "qkunSkFpoDjhfvBj",
       "labels" : {
-        "BorRwChotqmbuLF" : "n7jPSEjxLO7eVPDhi3"
+        "fLuqtJeU9urq" : "LFLVxE1gqIgnK8Ug"
       },
-      "link" : "https://www.example.com/Qvp2ZQoR00IHkrMRjt"
+      "link" : "https://www.example.com/jNMwlQ0OFwc9GGb"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "HoJxQd6MO3IkY7IWi",
+  "owner" : "chEg3QAjPqUXd2Ih",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "cDNaJd8o1GLhB6rmzu",
-    "ownerAffiliation" : "https://www.example.org/fugiatcorrupti"
+    "owner" : "Hbs5bYukDhI9ad3qV",
+    "ownerAffiliation" : "https://www.example.org/nesciuntdistinctio"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laboreofficiis",
+    "id" : "https://www.example.org/quasipraesentium",
     "labels" : {
-      "O2d3drLnUtNg6B1k4Sc" : "MJQ4xr4GU72j2Qm"
+      "jQcVTYuPvuVXDKr0I7K" : "7R0zLVgMJZrPiLPC"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suntveritatis",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/estaut",
+  "handle" : "https://www.example.org/voluptatibusa",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/uteum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7AyBl22UjPe",
+    "mainTitle" : "68UZnTj8IbbAL",
     "alternativeTitles" : {
-      "ru" : "eG48RPONLqtI"
+      "da" : "1TcOwHx5JC7X"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "FlCtIIMFLgyMklRGY",
-      "month" : "55r1Y24D59Ffcht3",
-      "day" : "CWagpNoYdo"
+      "year" : "mJ9xsxVoR8oI4nECM",
+      "month" : "l5tJ7EgnAVotb1uRg1K",
+      "day" : "KemFzxQzYyCJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uttDv2a5HuwafPjF",
-        "name" : "KW1V8wHIMVjo0mR",
-        "nameType" : "Personal",
-        "orcId" : "vVCdfgQsBgM5ug"
+        "id" : "https://www.example.com/znLaek70LK",
+        "name" : "rrMveeURt4nN1Gh",
+        "nameType" : "Organizational",
+        "orcId" : "331ilkBvuYUDqMuDT"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/pqar3D4n7rfli1ICQUW",
+        "id" : "https://www.example.com/7uU8w1jhELMb7v54gb",
         "labels" : {
-          "M9JreIpDbEy3YVOY" : "dDZanwZeH98BiYm"
+          "FdosiN0KggK5t2b" : "xxYYKgBjCCz2knM2hGB"
         }
       } ],
-      "role" : "Director",
-      "sequence" : 3,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/NYtP3Mi5ylWmvG8",
-        "name" : "0kw1S0Ue1dJyXBjXZ",
-        "nameType" : "Personal",
-        "orcId" : "BSaVvtoNOqAbBuJc"
+        "id" : "https://www.example.com/fdPX7LYhwojj",
+        "name" : "UGRzsECJgLM5M0P",
+        "nameType" : "Organizational",
+        "orcId" : "njHWdwRVJxD14Impu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DcWe8vNIJR0",
+        "id" : "https://www.example.com/Ig7SXEwXFI8",
         "labels" : {
-          "QkLvV2kMTkq" : "LBup5L1To1QW40SWc1l"
+          "f9QzNSBxD71CDXS" : "6A1dqUT1YnuPPgC"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 7,
+      "role" : "Journalist",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YWwkeFpHhGbBaiKHv",
-    "tags" : [ "rChdlKVVBS4TQfQrRx" ],
-    "description" : "lY5geteORBoKPwnM2k",
+    "npiSubjectHeading" : "vFaxclsmMU",
+    "tags" : [ "595JwmH0RuDs4" ],
+    "description" : "hBRQN63ObZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/VlVdxoHAyD"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2rpLaBCZddbgmT"
       },
-      "doi" : "https://www.example.com/ibJU4tfLgEfGm",
+      "doi" : "https://www.example.com/LEm95M7DdPe",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "s6VGMPZ5sO",
-        "issue" : "1yaFXjyOoE3VZd",
-        "articleNumber" : "lCc9Vps2EhKKJ",
+        "volume" : "ExqWkAavWQHBieXM6W6",
+        "issue" : "9jqTB36LJ2",
+        "articleNumber" : "YedV2X5y3fbIBk0Wso",
         "pages" : {
           "type" : "Range",
-          "begin" : "WwfxFpxF2t4LZ",
-          "end" : "ilEuaOA6Kb"
+          "begin" : "VAMM9KS11D2CthD3N",
+          "end" : "xuSbo23Lc4xf5"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/L0aHqdow0X",
-    "abstract" : "vd0zMBxVNsvM"
+    "metadataSource" : "https://www.example.com/W4OmcGK1x3xflIX",
+    "abstract" : "HFpTotteBEORsRaCP8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/impeditipsam",
-    "name" : "Do8ei0LkbbPr47",
+    "id" : "https://www.example.org/eosrerum",
+    "name" : "Yweg0Ht8ZWojg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ShM7Tac50jvoL0tDQxa",
-      "id" : "T9zXWidxs9nqJM"
+      "source" : "LLKmeGRlCeEjfc",
+      "id" : "MliKQu2tR7iUGa"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "NHnzlNabGveFsMGZ4"
+      "applicationCode" : "Z6Hf1O7iE1sp"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliquidest" ],
+  "subjects" : [ "https://www.example.org/ducimuseveniet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "SWqDjjm7LtZJx",
-      "mimeType" : "mSlm3ZpGSl",
-      "size" : 790287759,
+      "name" : "N7vKNGpLs6mFI",
+      "mimeType" : "iAm6ZcwIbeotyMCMYWT",
+      "size" : 2108496216,
       "license" : {
         "type" : "License",
-        "identifier" : "XCKhJQYIbD05",
+        "identifier" : "QJ0iVvEekRrCUNXI",
         "labels" : {
-          "B10U7c0hnA79ilJ" : "wkQUTfy3aqKNI"
+          "vqPK2HdmJLbUNxQ" : "yq9EjkekSfKeWDuTov"
         },
-        "link" : "https://www.example.com/D2U3LDTP6n4Y"
+        "link" : "https://www.example.com/oKh2sU5gxR"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "SWqDjjm7LtZJx",
-    "mimeType" : "mSlm3ZpGSl",
-    "size" : 790287759,
+    "name" : "N7vKNGpLs6mFI",
+    "mimeType" : "iAm6ZcwIbeotyMCMYWT",
+    "size" : 2108496216,
     "license" : {
       "type" : "License",
-      "identifier" : "XCKhJQYIbD05",
+      "identifier" : "QJ0iVvEekRrCUNXI",
       "labels" : {
-        "B10U7c0hnA79ilJ" : "wkQUTfy3aqKNI"
+        "vqPK2HdmJLbUNxQ" : "yq9EjkekSfKeWDuTov"
       },
-      "link" : "https://www.example.com/D2U3LDTP6n4Y"
+      "link" : "https://www.example.com/oKh2sU5gxR"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "cDNaJd8o1GLhB6rmzu",
+  "owner" : "Hbs5bYukDhI9ad3qV",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "pnYWKdEcT7",
-    "ownerAffiliation" : "https://www.example.org/necessitatibusnumquam"
+    "owner" : "gc3d0rfuXlyf7w",
+    "ownerAffiliation" : "https://www.example.org/isteiusto"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiaeaperiam",
+    "id" : "https://www.example.org/velitenim",
     "labels" : {
-      "08Nfm9RwpGF3Dx1" : "aJ9yW3XIw8j"
+      "jZ8t3mSdf4HvAjYaZQc" : "mxpZhWqvkdUl0IW6Y6U"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/cumqueoptio",
-  "doi" : "https://doi.org/10.1234/reprehenderit",
-  "link" : "https://www.example.org/laborumquibusdam",
+  "handle" : "https://www.example.org/veroducimus",
+  "doi" : "https://doi.org/10.1234/modi",
+  "link" : "https://www.example.org/estab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VOLI8LxiUCZY",
+    "mainTitle" : "0Qb6EnvirZie",
     "alternativeTitles" : {
-      "it" : "OHBajROT1FLOaARI63z"
+      "de" : "0rK64qH2ySt"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "lI1ZsTlIpcd2I2N",
-      "month" : "QFBPJMqV4DRlQ6",
-      "day" : "7al2vTPqKgtsaBH"
+      "year" : "BTKklXVukiLch9w",
+      "month" : "0yU8CVtJzg",
+      "day" : "eGhwmnWZCxDSErawdJr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/h40o9V5ge15",
-        "name" : "UStWCjHElbXKf6",
+        "id" : "https://www.example.com/gxXmGrEaRu6K",
+        "name" : "b3q5NGLFrLHBhrxo",
         "nameType" : "Organizational",
-        "orcId" : "1TdlvKt8GBcxAa"
+        "orcId" : "6GaAHESEnrLJZ6LF"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/jwyOI6z6jrF2hwc",
+        "id" : "https://www.example.com/rqJgOpSjUBOVKKkBE",
         "labels" : {
-          "F9hlgwQIwH" : "deVaazBA6tbbhb"
+          "wlVpiKWFe3Qdi62p" : "HYjc6U9ULaCgdOIjhz"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 8,
+      "role" : "Dancer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IOB832fkdnJHngp",
-        "name" : "Fiq6h1LFTef",
+        "id" : "https://www.example.com/7PTfMGTz9Na3B",
+        "name" : "DyC8Iwdh3b",
         "nameType" : "Organizational",
-        "orcId" : "XG1xyzX2QOM4kBFcw"
+        "orcId" : "L9RaD3Vf7tdSpMP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/TLcJ3Z7TyorZHapk4",
+        "id" : "https://www.example.com/bE2J9oY1aj2SucTgj",
         "labels" : {
-          "vPgcXAaFEYvZVWD" : "0K5iXh6cTZ4"
+          "5Ec60d1xbmk0RgCkpg" : "A0xVa5oN33WZL0DCd9d"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 6,
+      "role" : "DataCollector",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5fwOw2OD8WLKTX0oG",
-    "tags" : [ "f1kIdbf3eohC" ],
-    "description" : "tRIqgncPIV0Da2lCYsW",
+    "npiSubjectHeading" : "ZFTpidP7UjTWuD7",
+    "tags" : [ "EPN55Lyz2gAaabLKasH" ],
+    "description" : "fhzUa8CsKxa7LZ7Oky",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1ZaChM3DUbVaAPEsyl"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/VgBCI7Ft5BQb0cVsrxH"
       },
-      "doi" : "https://www.example.com/7WYaCePg9tnTMdF3",
+      "doi" : "https://www.example.com/1ETlNH0wqnrtW",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "eUmafrJpykmUva",
-        "issue" : "Tq3EnGbM0Lsgt5",
-        "articleNumber" : "Yoq8DkJh2t3tePFS",
+        "volume" : "2dFA4ebMpzVitiLAN5s",
+        "issue" : "wIwnALU5k0D",
+        "articleNumber" : "d7FlblNjrALHuU",
         "pages" : {
           "type" : "Range",
-          "begin" : "On6yUnHaDHqaqjN",
-          "end" : "JcyhAJuTgseysPBoK"
+          "begin" : "9hWlgbGDIF",
+          "end" : "FhhtMiOusD"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/3KqDQozwU9I",
-    "abstract" : "dJoHyx8pdT"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "7YUVasdyVRXWyM3up3K",
-      "mimeType" : "Uf4XuhtnyJ6I7slvGD",
-      "size" : 1152249916,
-      "license" : {
-        "type" : "License",
-        "identifier" : "UmI79IauqCm",
-        "labels" : {
-          "3eu21zhOOXN" : "vq8OrsTuznNGEuGcmxX"
-        },
-        "link" : "https://www.example.com/IJ8k2GLj6khIGLO"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/Hm0ePVw2H0iXVqLz",
+    "abstract" : "HCYMud1ajBdUHfY7Q"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/adarchitecto",
-    "name" : "BNCFC1nhitRBE",
+    "id" : "https://www.example.org/dignissimosest",
+    "name" : "lG5VuWJGDzwm2OT",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "rywoKDKO4NdmKNNs",
-      "id" : "yomEze8uFUhT8p0Ai"
+      "source" : "15C7PqQ7QPGadHs1F",
+      "id" : "RTAdSZkjIbkoS9Y"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "M81r1PYC5Ym"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Ci04sMj6syVO"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delenitiomnis" ],
+  "subjects" : [ "https://www.example.org/atab" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "7YUVasdyVRXWyM3up3K",
-    "mimeType" : "Uf4XuhtnyJ6I7slvGD",
-    "size" : 1152249916,
+    "name" : "Lf9JV0aYqkFqS7D",
+    "mimeType" : "EAXqmu8P5sr2PWZ",
+    "size" : 789611404,
     "license" : {
       "type" : "License",
-      "identifier" : "UmI79IauqCm",
+      "identifier" : "hRqFGQZ0aRrAZngK",
       "labels" : {
-        "3eu21zhOOXN" : "vq8OrsTuznNGEuGcmxX"
+        "1wAu0i30hWFRL" : "P7HdRQdgLvFc"
       },
-      "link" : "https://www.example.com/IJ8k2GLj6khIGLO"
+      "link" : "https://www.example.com/WjFgpHhHUB7v"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "pnYWKdEcT7"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "Lf9JV0aYqkFqS7D",
+      "mimeType" : "EAXqmu8P5sr2PWZ",
+      "size" : 789611404,
+      "license" : {
+        "type" : "License",
+        "identifier" : "hRqFGQZ0aRrAZngK",
+        "labels" : {
+          "1wAu0i30hWFRL" : "P7HdRQdgLvFc"
+        },
+        "link" : "https://www.example.com/WjFgpHhHUB7v"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "gc3d0rfuXlyf7w",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "gc3d0rfuXlyf7w",
-    "ownerAffiliation" : "https://www.example.org/isteiusto"
+    "owner" : "cDNaJd8o1GLhB6rmzu",
+    "ownerAffiliation" : "https://www.example.org/fugiatcorrupti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/velitenim",
+    "id" : "https://www.example.org/laboreofficiis",
     "labels" : {
-      "jZ8t3mSdf4HvAjYaZQc" : "mxpZhWqvkdUl0IW6Y6U"
+      "O2d3drLnUtNg6B1k4Sc" : "MJQ4xr4GU72j2Qm"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/veroducimus",
-  "doi" : "https://doi.org/10.1234/modi",
-  "link" : "https://www.example.org/estab",
+  "handle" : "https://www.example.org/suntveritatis",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/estaut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0Qb6EnvirZie",
+    "mainTitle" : "7AyBl22UjPe",
     "alternativeTitles" : {
-      "de" : "0rK64qH2ySt"
+      "ru" : "eG48RPONLqtI"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "BTKklXVukiLch9w",
-      "month" : "0yU8CVtJzg",
-      "day" : "eGhwmnWZCxDSErawdJr"
+      "year" : "FlCtIIMFLgyMklRGY",
+      "month" : "55r1Y24D59Ffcht3",
+      "day" : "CWagpNoYdo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gxXmGrEaRu6K",
-        "name" : "b3q5NGLFrLHBhrxo",
-        "nameType" : "Organizational",
-        "orcId" : "6GaAHESEnrLJZ6LF"
+        "id" : "https://www.example.com/uttDv2a5HuwafPjF",
+        "name" : "KW1V8wHIMVjo0mR",
+        "nameType" : "Personal",
+        "orcId" : "vVCdfgQsBgM5ug"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/rqJgOpSjUBOVKKkBE",
+        "id" : "https://www.example.com/pqar3D4n7rfli1ICQUW",
         "labels" : {
-          "wlVpiKWFe3Qdi62p" : "HYjc6U9ULaCgdOIjhz"
+          "M9JreIpDbEy3YVOY" : "dDZanwZeH98BiYm"
         }
       } ],
-      "role" : "Dancer",
-      "sequence" : 0,
+      "role" : "Director",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7PTfMGTz9Na3B",
-        "name" : "DyC8Iwdh3b",
-        "nameType" : "Organizational",
-        "orcId" : "L9RaD3Vf7tdSpMP"
+        "id" : "https://www.example.com/NYtP3Mi5ylWmvG8",
+        "name" : "0kw1S0Ue1dJyXBjXZ",
+        "nameType" : "Personal",
+        "orcId" : "BSaVvtoNOqAbBuJc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bE2J9oY1aj2SucTgj",
+        "id" : "https://www.example.com/DcWe8vNIJR0",
         "labels" : {
-          "5Ec60d1xbmk0RgCkpg" : "A0xVa5oN33WZL0DCd9d"
+          "QkLvV2kMTkq" : "LBup5L1To1QW40SWc1l"
         }
       } ],
-      "role" : "DataCollector",
-      "sequence" : 5,
+      "role" : "DataManager",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ZFTpidP7UjTWuD7",
-    "tags" : [ "EPN55Lyz2gAaabLKasH" ],
-    "description" : "fhzUa8CsKxa7LZ7Oky",
+    "npiSubjectHeading" : "YWwkeFpHhGbBaiKHv",
+    "tags" : [ "rChdlKVVBS4TQfQrRx" ],
+    "description" : "lY5geteORBoKPwnM2k",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/VgBCI7Ft5BQb0cVsrxH"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/VlVdxoHAyD"
       },
-      "doi" : "https://www.example.com/1ETlNH0wqnrtW",
+      "doi" : "https://www.example.com/ibJU4tfLgEfGm",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "2dFA4ebMpzVitiLAN5s",
-        "issue" : "wIwnALU5k0D",
-        "articleNumber" : "d7FlblNjrALHuU",
+        "volume" : "s6VGMPZ5sO",
+        "issue" : "1yaFXjyOoE3VZd",
+        "articleNumber" : "lCc9Vps2EhKKJ",
         "pages" : {
           "type" : "Range",
-          "begin" : "9hWlgbGDIF",
-          "end" : "FhhtMiOusD"
+          "begin" : "WwfxFpxF2t4LZ",
+          "end" : "ilEuaOA6Kb"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Hm0ePVw2H0iXVqLz",
-    "abstract" : "HCYMud1ajBdUHfY7Q"
+    "metadataSource" : "https://www.example.com/L0aHqdow0X",
+    "abstract" : "vd0zMBxVNsvM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dignissimosest",
-    "name" : "lG5VuWJGDzwm2OT",
+    "id" : "https://www.example.org/impeditipsam",
+    "name" : "Do8ei0LkbbPr47",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "15C7PqQ7QPGadHs1F",
-      "id" : "RTAdSZkjIbkoS9Y"
+      "source" : "ShM7Tac50jvoL0tDQxa",
+      "id" : "T9zXWidxs9nqJM"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Ci04sMj6syVO"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "NHnzlNabGveFsMGZ4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/atab" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "Lf9JV0aYqkFqS7D",
-    "mimeType" : "EAXqmu8P5sr2PWZ",
-    "size" : 789611404,
-    "license" : {
-      "type" : "License",
-      "identifier" : "hRqFGQZ0aRrAZngK",
-      "labels" : {
-        "1wAu0i30hWFRL" : "P7HdRQdgLvFc"
-      },
-      "link" : "https://www.example.com/WjFgpHhHUB7v"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/aliquidest" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Lf9JV0aYqkFqS7D",
-      "mimeType" : "EAXqmu8P5sr2PWZ",
-      "size" : 789611404,
+      "name" : "SWqDjjm7LtZJx",
+      "mimeType" : "mSlm3ZpGSl",
+      "size" : 790287759,
       "license" : {
         "type" : "License",
-        "identifier" : "hRqFGQZ0aRrAZngK",
+        "identifier" : "XCKhJQYIbD05",
         "labels" : {
-          "1wAu0i30hWFRL" : "P7HdRQdgLvFc"
+          "B10U7c0hnA79ilJ" : "wkQUTfy3aqKNI"
         },
-        "link" : "https://www.example.com/WjFgpHhHUB7v"
+        "link" : "https://www.example.com/D2U3LDTP6n4Y"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "gc3d0rfuXlyf7w",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "SWqDjjm7LtZJx",
+    "mimeType" : "mSlm3ZpGSl",
+    "size" : 790287759,
+    "license" : {
+      "type" : "License",
+      "identifier" : "XCKhJQYIbD05",
+      "labels" : {
+        "B10U7c0hnA79ilJ" : "wkQUTfy3aqKNI"
+      },
+      "link" : "https://www.example.com/D2U3LDTP6n4Y"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "cDNaJd8o1GLhB6rmzu",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Hbs5bYukDhI9ad3qV",
-    "ownerAffiliation" : "https://www.example.org/nesciuntdistinctio"
+    "owner" : "p3Efu2IWZygz7w",
+    "ownerAffiliation" : "https://www.example.org/delectusprovident"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quasipraesentium",
+    "id" : "https://www.example.org/velvoluptas",
     "labels" : {
-      "jQcVTYuPvuVXDKr0I7K" : "7R0zLVgMJZrPiLPC"
+      "9iydEB6bI4" : "dxFwjmWYHD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/voluptatibusa",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/uteum",
+  "handle" : "https://www.example.org/eligendiet",
+  "doi" : "https://doi.org/10.1234/architecto",
+  "link" : "https://www.example.org/arepellat",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "68UZnTj8IbbAL",
+    "mainTitle" : "Mhry2UWn2bd8vx8gzn",
     "alternativeTitles" : {
-      "da" : "1TcOwHx5JC7X"
+      "nb" : "4BxhqsAvUAOGKZX"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "mJ9xsxVoR8oI4nECM",
-      "month" : "l5tJ7EgnAVotb1uRg1K",
-      "day" : "KemFzxQzYyCJ"
+      "year" : "THXD5Na9ZBG1bANx6",
+      "month" : "WMTECy9PUwYCod",
+      "day" : "tYXTkgXz7YU97e4mI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/znLaek70LK",
-        "name" : "rrMveeURt4nN1Gh",
+        "id" : "https://www.example.com/DbFoMqlk7pECZlx1",
+        "name" : "JgViL6iBtyZ",
         "nameType" : "Organizational",
-        "orcId" : "331ilkBvuYUDqMuDT"
+        "orcId" : "cLn6miQY6vqPhhUks"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7uU8w1jhELMb7v54gb",
+        "id" : "https://www.example.com/ZoNGW5cLMibJ9IQ",
         "labels" : {
-          "FdosiN0KggK5t2b" : "xxYYKgBjCCz2knM2hGB"
+          "hO0CFjuL1Zzg8aly" : "mrckXFItjTY1o174RU"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 5,
+      "role" : "Choreographer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fdPX7LYhwojj",
-        "name" : "UGRzsECJgLM5M0P",
+        "id" : "https://www.example.com/Yq31Ga170inT0nnF7d",
+        "name" : "bmewEj4ahX1t11tgLV",
         "nameType" : "Organizational",
-        "orcId" : "njHWdwRVJxD14Impu"
+        "orcId" : "l8gQzxSeqkhK5u8"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Ig7SXEwXFI8",
+        "id" : "https://www.example.com/eWm9raUcSoAVmKeh",
         "labels" : {
-          "f9QzNSBxD71CDXS" : "6A1dqUT1YnuPPgC"
+          "b4RpsRCdqJh1Ky" : "KZTYYtfu8CN7FFK"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 8,
+      "role" : "RelatedPerson",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "vFaxclsmMU",
-    "tags" : [ "595JwmH0RuDs4" ],
-    "description" : "hBRQN63ObZ",
+    "npiSubjectHeading" : "Ni1BbNxmmj1h8Qq",
+    "tags" : [ "DDdpanayak6j8PUU" ],
+    "description" : "QBl5IHraM3PiH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2rpLaBCZddbgmT"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YjAXrZLkzlLXA"
       },
-      "doi" : "https://www.example.com/LEm95M7DdPe",
+      "doi" : "https://www.example.com/O65zbTkUC1",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "ExqWkAavWQHBieXM6W6",
-        "issue" : "9jqTB36LJ2",
-        "articleNumber" : "YedV2X5y3fbIBk0Wso",
+        "volume" : "ESuFi2gIA6SkCzqZ",
+        "issue" : "Id23RgvHY2uzB",
+        "articleNumber" : "4YSL1OhI3W7",
         "pages" : {
           "type" : "Range",
-          "begin" : "VAMM9KS11D2CthD3N",
-          "end" : "xuSbo23Lc4xf5"
+          "begin" : "nqdQeXKV1WdaZixF",
+          "end" : "SBlpVGm8xeQkehKcsK"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/W4OmcGK1x3xflIX",
-    "abstract" : "HFpTotteBEORsRaCP8"
+    "metadataSource" : "https://www.example.com/CZbRLIImxUZSV4z",
+    "abstract" : "jcLnoX6hMADmTwWd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eosrerum",
-    "name" : "Yweg0Ht8ZWojg",
+    "id" : "https://www.example.org/occaecatilaborum",
+    "name" : "MoUJOohJlnHST",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "LLKmeGRlCeEjfc",
-      "id" : "MliKQu2tR7iUGa"
+      "source" : "halj5iz70SkchYPJ",
+      "id" : "5mgRMpdHsna"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Z6Hf1O7iE1sp"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "GnmTt7AN5nSjKOS3N1"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ducimuseveniet" ],
+  "subjects" : [ "https://www.example.org/teneturexplicabo" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "N7vKNGpLs6mFI",
-      "mimeType" : "iAm6ZcwIbeotyMCMYWT",
-      "size" : 2108496216,
+      "name" : "tO7YoEOIDl",
+      "mimeType" : "ARU0Us3u4qqa1",
+      "size" : 149248788,
       "license" : {
         "type" : "License",
-        "identifier" : "QJ0iVvEekRrCUNXI",
+        "identifier" : "3A2K1BjkQeF1",
         "labels" : {
-          "vqPK2HdmJLbUNxQ" : "yq9EjkekSfKeWDuTov"
+          "e03AzYUXB5Eg3ToESU" : "kRy7DzFOREQV"
         },
-        "link" : "https://www.example.com/oKh2sU5gxR"
+        "link" : "https://www.example.com/crDFADgvWy1E4Qj"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "N7vKNGpLs6mFI",
-    "mimeType" : "iAm6ZcwIbeotyMCMYWT",
-    "size" : 2108496216,
+    "name" : "tO7YoEOIDl",
+    "mimeType" : "ARU0Us3u4qqa1",
+    "size" : 149248788,
     "license" : {
       "type" : "License",
-      "identifier" : "QJ0iVvEekRrCUNXI",
+      "identifier" : "3A2K1BjkQeF1",
       "labels" : {
-        "vqPK2HdmJLbUNxQ" : "yq9EjkekSfKeWDuTov"
+        "e03AzYUXB5Eg3ToESU" : "kRy7DzFOREQV"
       },
-      "link" : "https://www.example.com/oKh2sU5gxR"
+      "link" : "https://www.example.com/crDFADgvWy1E4Qj"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "Hbs5bYukDhI9ad3qV",
+  "owner" : "p3Efu2IWZygz7w",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "dHXO25aaIBr",
-    "ownerAffiliation" : "https://www.example.org/dolorumvoluptas"
+    "owner" : "2tY5bUWT0YFOaKesl0",
+    "ownerAffiliation" : "https://www.example.org/facilisfugit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autemfugiat",
+    "id" : "https://www.example.org/temporavoluptatem",
     "labels" : {
-      "TTH1Y4XfMIJT" : "5dpIQm6hhYFuV"
+      "xeBkm9JcUBNp96w8m1" : "bkwf385363Cj7"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nobismodi",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/cupiditateconsequatur",
+  "handle" : "https://www.example.org/autet",
+  "doi" : "https://doi.org/10.1234/saepe",
+  "link" : "https://www.example.org/quiofficiis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TvwKsttOpsiT8k5R",
+    "mainTitle" : "gKdHIolnxwbw",
     "alternativeTitles" : {
-      "nb" : "9RaUTiltnv31F5uVg"
+      "bg" : "rXTzyIPpcitAy"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "3ZhOuHloAi",
-      "month" : "IByyhJI9VNB1bOzM9",
-      "day" : "5ago2G9OfgrecK"
+      "year" : "fVm7RYMKyr2Hy6mVh3I",
+      "month" : "TCT52EFhtGqvO",
+      "day" : "wgzEbxDQ4bZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AQI8Tq9vMggcxNBb",
-        "name" : "Yfen60zrQ3d",
+        "id" : "https://www.example.com/5GdaaRuoFhw948",
+        "name" : "iaT81A986eun",
         "nameType" : "Personal",
-        "orcId" : "jYYj1mqMnoeX50RhP"
+        "orcId" : "DdNiEeuEWg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Nw5UxrHk6ApstTK79pm",
+        "id" : "https://www.example.com/ArYL1Zibwezb7S",
         "labels" : {
-          "767cfqaz0C32B" : "OeRdWvQvhG6xG1b"
+          "Ms4HkyRj5nVzpx4NR" : "nbTt1mpC1eQ9vD3L"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 7,
+      "role" : "DataCurator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/kyR7RsrbNbad7cfw",
-        "name" : "FA8xbrOLHs3S0P",
+        "id" : "https://www.example.com/JKgiLy0LYxnOiI",
+        "name" : "ayXvLNQUouWWmQKKTl",
         "nameType" : "Organizational",
-        "orcId" : "dbYHsEDsAKDTU"
+        "orcId" : "XXuNW3Vr3ncUEIjmR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/synOKD89WKMQYF",
+        "id" : "https://www.example.com/BKvIAdWvepc8NVuDFP",
         "labels" : {
-          "08kobbguIUBrF" : "O0GPAbdEtaOFmrhTskd"
+          "h6ZDAVbSxIgU3Tt" : "x4KSFo5ci04gKUFEFJ"
         }
       } ],
       "role" : "Dancer",
-      "sequence" : 2,
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "6PX4bMvCUSQdIfs",
-    "tags" : [ "y1Yn12scmtGV73r" ],
-    "description" : "oQJ2IXEZ1CxtEQjBB",
+    "npiSubjectHeading" : "dhru5Nx4Be9Gh",
+    "tags" : [ "lCrD0EdWu1" ],
+    "description" : "zyx1qy5CYdkquoBwbW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XsNfGtEKpzC"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7ttDBy5vWYD"
       },
-      "doi" : "https://www.example.com/b4FpdO9Z2vlc7M9",
+      "doi" : "https://www.example.com/Kbc6Nw2BkXR",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "tMuSeiYo6h1hSN",
-        "issue" : "eeEy8J4sGuh",
-        "articleNumber" : "ZDiSA8df32suQzuMs9",
+        "volume" : "EZHsM3L4AQm7dh",
+        "issue" : "F9IrNwfVLOY",
+        "articleNumber" : "BkRcpJ01ZkIMmKjqnz",
         "pages" : {
           "type" : "Range",
-          "begin" : "vP2mCmYjnZonhRYZv",
-          "end" : "tkrctqCD0Oa9KR4x5"
+          "begin" : "NiDXNmoSLEngo",
+          "end" : "b8o2gbzNZb8"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/Rt2oZL4c9oBxhDD",
-    "abstract" : "t9Hy9U0RAInA4l7yY"
+    "metadataSource" : "https://www.example.com/Al9OztWKqpbCA",
+    "abstract" : "b0kK43Xow4FMbBjD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nesciuntcum",
-    "name" : "dfsijeaAPEH",
+    "id" : "https://www.example.org/voluptatemsed",
+    "name" : "lb0eCp8jB2dbl5yw2Yi",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "kxMUpFEEwWyX",
-      "id" : "ebK4suHSl701OuGX"
+      "source" : "a5uzvzNtJQbtXO29",
+      "id" : "NCLKVqecqg"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Pfdha3qYWPWj"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "mPsF4MfIqlJVgwr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nullablanditiis" ],
+  "subjects" : [ "https://www.example.org/autdolor" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "b2hikX8xezqtpgMDU9R",
-      "mimeType" : "9UU8yaGAFLqAIXCIM1",
-      "size" : 1952357956,
+      "name" : "seStNFT8QgJE6DkK",
+      "mimeType" : "jMWgip0TTEBtQJj0",
+      "size" : 924755661,
       "license" : {
         "type" : "License",
-        "identifier" : "7Kc69ZQHpqR0fE4",
+        "identifier" : "QwJsmqO8B5hwf573RFM",
         "labels" : {
-          "YtCP8RV7OZ3GYr" : "5eV5FOI5zdw"
+          "inK4qSrhlMLFfFLI" : "095FKxpmkL1"
         },
-        "link" : "https://www.example.com/UG6Q8d91WmN"
+        "link" : "https://www.example.com/qjXOG9Jy17s00p"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "b2hikX8xezqtpgMDU9R",
-    "mimeType" : "9UU8yaGAFLqAIXCIM1",
-    "size" : 1952357956,
+    "name" : "seStNFT8QgJE6DkK",
+    "mimeType" : "jMWgip0TTEBtQJj0",
+    "size" : 924755661,
     "license" : {
       "type" : "License",
-      "identifier" : "7Kc69ZQHpqR0fE4",
+      "identifier" : "QwJsmqO8B5hwf573RFM",
       "labels" : {
-        "YtCP8RV7OZ3GYr" : "5eV5FOI5zdw"
+        "inK4qSrhlMLFfFLI" : "095FKxpmkL1"
       },
-      "link" : "https://www.example.com/UG6Q8d91WmN"
+      "link" : "https://www.example.com/qjXOG9Jy17s00p"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "dHXO25aaIBr",
+  "owner" : "2tY5bUWT0YFOaKesl0",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "vuzeSMDUIZ",
-    "ownerAffiliation" : "https://www.example.org/sedquia"
+    "owner" : "SkEw6714iYpMa9Xa",
+    "ownerAffiliation" : "https://www.example.org/quasidicta"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/minimaitaque",
+    "id" : "https://www.example.org/teneturut",
     "labels" : {
-      "jpQqWYNZeaMfy8S" : "DeukuhLIai9W"
+      "oFm2B3Aql1IRu4dh" : "0WerOlvhmF3EIk"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quasidelectus",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/sedquisquam",
+  "handle" : "https://www.example.org/fugavoluptate",
+  "doi" : "https://doi.org/10.1234/commodi",
+  "link" : "https://www.example.org/uttemporibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "q2mcTfh71j",
+    "mainTitle" : "KeiNcnb7qCd",
     "alternativeTitles" : {
-      "nl" : "Jh8uneokQobiIb"
+      "cs" : "QMOjMam2tbetIb"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ZIxiWztG6pGYj",
-      "month" : "3Q9NQoHuS9C",
-      "day" : "zOoXBtgQq4fqYMdSy"
+      "year" : "8GbfmywGtP0",
+      "month" : "yvVlJkom8gm2Dct5U",
+      "day" : "vcvP9rjPQo3VZEN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oJq67z0i4Wd",
-        "name" : "3PacNbf7g8hBak0y2Pw",
-        "nameType" : "Organizational",
-        "orcId" : "2v71CeUba1f2e7"
+        "id" : "https://www.example.com/zv9q4LuKDhND",
+        "name" : "ytfcc9OFVKZSXi",
+        "nameType" : "Personal",
+        "orcId" : "BcJWd7faLCCpk"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/satutzCDUONmp73R3qO",
+        "id" : "https://www.example.com/YyGTvQOiZLIkOloQy",
         "labels" : {
-          "va47dsPFlCxW7a" : "bY8oFzdDXyyzuSgtaLW"
+          "1TFvlZ0zMp" : "QeF6c6lPgRVF3wY"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 2,
+      "role" : "AcademicCoordinator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/AHDWV2kf7lN2M8MpzV",
-        "name" : "kViHttG2FU",
-        "nameType" : "Personal",
-        "orcId" : "8BOEAPCOWnNljzY5SS"
+        "id" : "https://www.example.com/aJktgFKVx2Fj",
+        "name" : "iVtN7orF7IrA25DP",
+        "nameType" : "Organizational",
+        "orcId" : "Awd0MMXN8Tshyf"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cRqwztJ5BdSXOmYhOpj",
+        "id" : "https://www.example.com/BnFBndP7u5IeQ6",
         "labels" : {
-          "lDhy4yWrC89D42" : "NgYEcTHXTf5TMniKk"
+          "djUKjothwgrq" : "8EPAWQv2DuDkt"
         }
       } ],
-      "role" : "Composer",
-      "sequence" : 1,
+      "role" : "SoundDesigner",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "AP7mSyUnca5Ksl2U",
-    "tags" : [ "Q1D32wV6SBvbwKp" ],
-    "description" : "80IgCsIMb6oWU2eLyF",
+    "npiSubjectHeading" : "TUeygRbyvyd",
+    "tags" : [ "7rbSTLCVrKsn0" ],
+    "description" : "r8Teyt5B8vHkUZEHF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hNUeppTgyPzxsvYr"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9ZQ4x43XGp"
       },
-      "doi" : "https://www.example.com/HY3huiaZ5UwvRVR8",
+      "doi" : "https://www.example.com/bg6u0W7VmVY",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "ZWOOCCU8ZIVKBGI",
-        "issue" : "dbU9tcI6kJB378",
-        "articleNumber" : "LLNIuwIQOiUtuC",
+        "volume" : "yhBuppST27S6",
+        "issue" : "VpKVq5qFmVdbXf",
+        "articleNumber" : "PHEgM0Thclat",
         "pages" : {
           "type" : "Range",
-          "begin" : "oSJtHt5nXvR9GE",
-          "end" : "sCmDs8oAbdbweYmB"
+          "begin" : "HNe0rg4ZliPc5qR",
+          "end" : "AhHcZQM8QS"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/xcyKDFGAXU3jkAk0A",
-    "abstract" : "wRnr3kwN2bhHm3"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "npvrFc4G1fI7",
-      "mimeType" : "N3d7v42B8vN1sN",
-      "size" : 448300250,
-      "license" : {
-        "type" : "License",
-        "identifier" : "B7Jan33oytH8u",
-        "labels" : {
-          "69XwPpQETUVcwAw" : "uZaIeCLbAfqt5ghxf"
-        },
-        "link" : "https://www.example.com/refvMmIPyMg9QpW24ib"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/9LJcBaXZiiyEEC3",
+    "abstract" : "w9wD82aPOPCb2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/adipiscideserunt",
-    "name" : "1hva8XLommRQA3Xe7",
+    "id" : "https://www.example.org/quiquas",
+    "name" : "KSbd55cbGI2Izvnubj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "9D25li3EbXTLGiqak",
-      "id" : "4pwnCdTIFzge"
+      "source" : "Mcro7yF0cSjjuypq",
+      "id" : "26nnhzMoLI5SUw"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "sIXAIovzYHebu"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "mAoFWgO8XThma7HTd5I"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/excepturiut" ],
+  "subjects" : [ "https://www.example.org/quinam" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "npvrFc4G1fI7",
-    "mimeType" : "N3d7v42B8vN1sN",
-    "size" : 448300250,
+    "name" : "rMwlLlvZBddNw",
+    "mimeType" : "5cGaEB4e6ebu77",
+    "size" : 1824822451,
     "license" : {
       "type" : "License",
-      "identifier" : "B7Jan33oytH8u",
+      "identifier" : "AODCVFUQW1r",
       "labels" : {
-        "69XwPpQETUVcwAw" : "uZaIeCLbAfqt5ghxf"
+        "lqFfWg1ED2wk" : "Jy57j8e5kaw"
       },
-      "link" : "https://www.example.com/refvMmIPyMg9QpW24ib"
+      "link" : "https://www.example.com/g5qYngrVEq3PC7iJhEV"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "vuzeSMDUIZ"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "rMwlLlvZBddNw",
+      "mimeType" : "5cGaEB4e6ebu77",
+      "size" : 1824822451,
+      "license" : {
+        "type" : "License",
+        "identifier" : "AODCVFUQW1r",
+        "labels" : {
+          "lqFfWg1ED2wk" : "Jy57j8e5kaw"
+        },
+        "link" : "https://www.example.com/g5qYngrVEq3PC7iJhEV"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "SkEw6714iYpMa9Xa",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "SkEw6714iYpMa9Xa",
-    "ownerAffiliation" : "https://www.example.org/quasidicta"
+    "owner" : "IaqRihKux6",
+    "ownerAffiliation" : "https://www.example.org/autemculpa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/teneturut",
+    "id" : "https://www.example.org/dolorperferendis",
     "labels" : {
-      "oFm2B3Aql1IRu4dh" : "0WerOlvhmF3EIk"
+      "NWOgXXkNe6rQ2lQM" : "QMqvHarZnTbE0E"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/fugavoluptate",
-  "doi" : "https://doi.org/10.1234/commodi",
-  "link" : "https://www.example.org/uttemporibus",
+  "handle" : "https://www.example.org/laboretotam",
+  "doi" : "https://doi.org/10.1234/libero",
+  "link" : "https://www.example.org/saepenon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KeiNcnb7qCd",
+    "mainTitle" : "hSu0gfQ3PO",
     "alternativeTitles" : {
-      "cs" : "QMOjMam2tbetIb"
+      "en" : "NGIVa19I6YKflGMpm7"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/por",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "8GbfmywGtP0",
-      "month" : "yvVlJkom8gm2Dct5U",
-      "day" : "vcvP9rjPQo3VZEN"
+      "year" : "j5JYwSZe5hZbn",
+      "month" : "yoUhcuql69uff",
+      "day" : "op7G6LCge9SGLWxdpLQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/zv9q4LuKDhND",
-        "name" : "ytfcc9OFVKZSXi",
-        "nameType" : "Personal",
-        "orcId" : "BcJWd7faLCCpk"
+        "id" : "https://www.example.com/X3jXm4mbhlmUMBoe",
+        "name" : "oBjfSFV5TO5DAqgQA",
+        "nameType" : "Organizational",
+        "orcId" : "8SBrMgBX2So"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YyGTvQOiZLIkOloQy",
+        "id" : "https://www.example.com/gwhrI76ABFN1fd",
         "labels" : {
-          "1TFvlZ0zMp" : "QeF6c6lPgRVF3wY"
+          "4W5SqCsr79zeM0biDQ" : "v0g7sdb5qn18XcZhk"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 3,
+      "role" : "Architect",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aJktgFKVx2Fj",
-        "name" : "iVtN7orF7IrA25DP",
+        "id" : "https://www.example.com/8IGhULRJyyBD7EgKZ",
+        "name" : "brCJGR8ZKa",
         "nameType" : "Organizational",
-        "orcId" : "Awd0MMXN8Tshyf"
+        "orcId" : "DvpmAo8rSWv8f"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/BnFBndP7u5IeQ6",
+        "id" : "https://www.example.com/uuh9KgR3CrKs9DxUpV",
         "labels" : {
-          "djUKjothwgrq" : "8EPAWQv2DuDkt"
+          "Uz1HiwWLoNB3fYK" : "cE0uHzez10pvl8AhiRc"
         }
       } ],
       "role" : "SoundDesigner",
-      "sequence" : 7,
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "TUeygRbyvyd",
-    "tags" : [ "7rbSTLCVrKsn0" ],
-    "description" : "r8Teyt5B8vHkUZEHF",
+    "npiSubjectHeading" : "UFZcjUv5Me1saDa",
+    "tags" : [ "u4RRoOAdpChZzeJ" ],
+    "description" : "66kAVUh6nd4RJoEsJYi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9ZQ4x43XGp"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JNIIq0r3f52o"
       },
-      "doi" : "https://www.example.com/bg6u0W7VmVY",
+      "doi" : "https://www.example.com/a7FUduqKByYNFuo3a",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "yhBuppST27S6",
-        "issue" : "VpKVq5qFmVdbXf",
-        "articleNumber" : "PHEgM0Thclat",
+        "volume" : "lla13lKI4yog1s",
+        "issue" : "3YZFlYjPUjHG",
+        "articleNumber" : "jjW24vFTDrLEZFSOyxj",
         "pages" : {
           "type" : "Range",
-          "begin" : "HNe0rg4ZliPc5qR",
-          "end" : "AhHcZQM8QS"
+          "begin" : "ZnOuHQsn9GWjFIr",
+          "end" : "ipHPzkjJijlNHu2syV"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/9LJcBaXZiiyEEC3",
-    "abstract" : "w9wD82aPOPCb2"
+    "metadataSource" : "https://www.example.com/ihknrjb4Ue33ti3SkpK",
+    "abstract" : "7m14ATuH6i811VdVVO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiquas",
-    "name" : "KSbd55cbGI2Izvnubj",
+    "id" : "https://www.example.org/minusaut",
+    "name" : "UOSavky4gkS0ZTD",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Mcro7yF0cSjjuypq",
-      "id" : "26nnhzMoLI5SUw"
+      "source" : "e61IG0CB8El44hhk0T",
+      "id" : "x7shuF9Caf"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "mAoFWgO8XThma7HTd5I"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "UdUpHTPefDXJ0h"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quinam" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "rMwlLlvZBddNw",
-    "mimeType" : "5cGaEB4e6ebu77",
-    "size" : 1824822451,
-    "license" : {
-      "type" : "License",
-      "identifier" : "AODCVFUQW1r",
-      "labels" : {
-        "lqFfWg1ED2wk" : "Jy57j8e5kaw"
-      },
-      "link" : "https://www.example.com/g5qYngrVEq3PC7iJhEV"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/providenteum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "rMwlLlvZBddNw",
-      "mimeType" : "5cGaEB4e6ebu77",
-      "size" : 1824822451,
+      "name" : "XWNLZxWiOGeBYFdbDT",
+      "mimeType" : "mF5pKhNHlnyQx",
+      "size" : 1500470925,
       "license" : {
         "type" : "License",
-        "identifier" : "AODCVFUQW1r",
+        "identifier" : "tvyJPclBOYlN",
         "labels" : {
-          "lqFfWg1ED2wk" : "Jy57j8e5kaw"
+          "EeXy7KcF9aQNeQjU" : "MTEk8ssZ8RPva7tE2hX"
         },
-        "link" : "https://www.example.com/g5qYngrVEq3PC7iJhEV"
+        "link" : "https://www.example.com/9U37lEhHPUjY"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "SkEw6714iYpMa9Xa",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "XWNLZxWiOGeBYFdbDT",
+    "mimeType" : "mF5pKhNHlnyQx",
+    "size" : 1500470925,
+    "license" : {
+      "type" : "License",
+      "identifier" : "tvyJPclBOYlN",
+      "labels" : {
+        "EeXy7KcF9aQNeQjU" : "MTEk8ssZ8RPva7tE2hX"
+      },
+      "link" : "https://www.example.com/9U37lEhHPUjY"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "IaqRihKux6",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "IaqRihKux6",
-    "ownerAffiliation" : "https://www.example.org/autemculpa"
+    "owner" : "dHXO25aaIBr",
+    "ownerAffiliation" : "https://www.example.org/dolorumvoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorperferendis",
+    "id" : "https://www.example.org/autemfugiat",
     "labels" : {
-      "NWOgXXkNe6rQ2lQM" : "QMqvHarZnTbE0E"
+      "TTH1Y4XfMIJT" : "5dpIQm6hhYFuV"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/laboretotam",
-  "doi" : "https://doi.org/10.1234/libero",
-  "link" : "https://www.example.org/saepenon",
+  "handle" : "https://www.example.org/nobismodi",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/cupiditateconsequatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hSu0gfQ3PO",
+    "mainTitle" : "TvwKsttOpsiT8k5R",
     "alternativeTitles" : {
-      "en" : "NGIVa19I6YKflGMpm7"
+      "nb" : "9RaUTiltnv31F5uVg"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "j5JYwSZe5hZbn",
-      "month" : "yoUhcuql69uff",
-      "day" : "op7G6LCge9SGLWxdpLQ"
+      "year" : "3ZhOuHloAi",
+      "month" : "IByyhJI9VNB1bOzM9",
+      "day" : "5ago2G9OfgrecK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/X3jXm4mbhlmUMBoe",
-        "name" : "oBjfSFV5TO5DAqgQA",
-        "nameType" : "Organizational",
-        "orcId" : "8SBrMgBX2So"
+        "id" : "https://www.example.com/AQI8Tq9vMggcxNBb",
+        "name" : "Yfen60zrQ3d",
+        "nameType" : "Personal",
+        "orcId" : "jYYj1mqMnoeX50RhP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/gwhrI76ABFN1fd",
+        "id" : "https://www.example.com/Nw5UxrHk6ApstTK79pm",
         "labels" : {
-          "4W5SqCsr79zeM0biDQ" : "v0g7sdb5qn18XcZhk"
+          "767cfqaz0C32B" : "OeRdWvQvhG6xG1b"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 1,
+      "role" : "Writer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8IGhULRJyyBD7EgKZ",
-        "name" : "brCJGR8ZKa",
+        "id" : "https://www.example.com/kyR7RsrbNbad7cfw",
+        "name" : "FA8xbrOLHs3S0P",
         "nameType" : "Organizational",
-        "orcId" : "DvpmAo8rSWv8f"
+        "orcId" : "dbYHsEDsAKDTU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uuh9KgR3CrKs9DxUpV",
+        "id" : "https://www.example.com/synOKD89WKMQYF",
         "labels" : {
-          "Uz1HiwWLoNB3fYK" : "cE0uHzez10pvl8AhiRc"
+          "08kobbguIUBrF" : "O0GPAbdEtaOFmrhTskd"
         }
       } ],
-      "role" : "SoundDesigner",
+      "role" : "Dancer",
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "UFZcjUv5Me1saDa",
-    "tags" : [ "u4RRoOAdpChZzeJ" ],
-    "description" : "66kAVUh6nd4RJoEsJYi",
+    "npiSubjectHeading" : "6PX4bMvCUSQdIfs",
+    "tags" : [ "y1Yn12scmtGV73r" ],
+    "description" : "oQJ2IXEZ1CxtEQjBB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/JNIIq0r3f52o"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/XsNfGtEKpzC"
       },
-      "doi" : "https://www.example.com/a7FUduqKByYNFuo3a",
+      "doi" : "https://www.example.com/b4FpdO9Z2vlc7M9",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "lla13lKI4yog1s",
-        "issue" : "3YZFlYjPUjHG",
-        "articleNumber" : "jjW24vFTDrLEZFSOyxj",
+        "volume" : "tMuSeiYo6h1hSN",
+        "issue" : "eeEy8J4sGuh",
+        "articleNumber" : "ZDiSA8df32suQzuMs9",
         "pages" : {
           "type" : "Range",
-          "begin" : "ZnOuHQsn9GWjFIr",
-          "end" : "ipHPzkjJijlNHu2syV"
+          "begin" : "vP2mCmYjnZonhRYZv",
+          "end" : "tkrctqCD0Oa9KR4x5"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/ihknrjb4Ue33ti3SkpK",
-    "abstract" : "7m14ATuH6i811VdVVO"
+    "metadataSource" : "https://www.example.com/Rt2oZL4c9oBxhDD",
+    "abstract" : "t9Hy9U0RAInA4l7yY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/minusaut",
-    "name" : "UOSavky4gkS0ZTD",
+    "id" : "https://www.example.org/nesciuntcum",
+    "name" : "dfsijeaAPEH",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "e61IG0CB8El44hhk0T",
-      "id" : "x7shuF9Caf"
+      "source" : "kxMUpFEEwWyX",
+      "id" : "ebK4suHSl701OuGX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "UdUpHTPefDXJ0h"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Pfdha3qYWPWj"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,22 +120,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/providenteum" ],
+  "subjects" : [ "https://www.example.org/nullablanditiis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "XWNLZxWiOGeBYFdbDT",
-      "mimeType" : "mF5pKhNHlnyQx",
-      "size" : 1500470925,
+      "name" : "b2hikX8xezqtpgMDU9R",
+      "mimeType" : "9UU8yaGAFLqAIXCIM1",
+      "size" : 1952357956,
       "license" : {
         "type" : "License",
-        "identifier" : "tvyJPclBOYlN",
+        "identifier" : "7Kc69ZQHpqR0fE4",
         "labels" : {
-          "EeXy7KcF9aQNeQjU" : "MTEk8ssZ8RPva7tE2hX"
+          "YtCP8RV7OZ3GYr" : "5eV5FOI5zdw"
         },
-        "link" : "https://www.example.com/9U37lEhHPUjY"
+        "link" : "https://www.example.com/UG6Q8d91WmN"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -145,21 +145,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "XWNLZxWiOGeBYFdbDT",
-    "mimeType" : "mF5pKhNHlnyQx",
-    "size" : 1500470925,
+    "name" : "b2hikX8xezqtpgMDU9R",
+    "mimeType" : "9UU8yaGAFLqAIXCIM1",
+    "size" : 1952357956,
     "license" : {
       "type" : "License",
-      "identifier" : "tvyJPclBOYlN",
+      "identifier" : "7Kc69ZQHpqR0fE4",
       "labels" : {
-        "EeXy7KcF9aQNeQjU" : "MTEk8ssZ8RPva7tE2hX"
+        "YtCP8RV7OZ3GYr" : "5eV5FOI5zdw"
       },
-      "link" : "https://www.example.com/9U37lEhHPUjY"
+      "link" : "https://www.example.com/UG6Q8d91WmN"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "IaqRihKux6",
+  "owner" : "dHXO25aaIBr",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Vvkk9wnAmCxFbTWSAki",
-    "ownerAffiliation" : "https://www.example.org/quamnemo"
+    "owner" : "pwf25SAHj0YZ",
+    "ownerAffiliation" : "https://www.example.org/estaccusantium"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quoddeleniti",
+    "id" : "https://www.example.org/quiaaut",
     "labels" : {
-      "Zj8KVy2GTw4f64d" : "kRspCXnwQ0rTct"
+      "errs96guINiuj" : "IdrxAS4bcZV7B"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eavoluptatem",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/liberoqui",
+  "handle" : "https://www.example.org/nequemollitia",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/harumex",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tAppyT3MUpvwUZ",
+    "mainTitle" : "l2o3Yx8ZmQnq",
     "alternativeTitles" : {
-      "ru" : "vxaSio4oS7Duntdx"
+      "bg" : "KyQ5gcbGMF6vgajE"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tFp5JJSf42jLUt",
-      "month" : "QpB0iIgTUF0aXj",
-      "day" : "rPP0sf9FbLPaq3ysVg"
+      "year" : "bRFHsqsUJs39nES",
+      "month" : "tbZhONI3U5wtN2avw8",
+      "day" : "rkYbl4ozmsOgsTRcqtv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UKHwnJY9PY",
-        "name" : "ZrkKcnZUykba4",
+        "id" : "https://www.example.com/hT1TaSZdVvw",
+        "name" : "NtHmMmeLHYmcLP7y",
         "nameType" : "Personal",
-        "orcId" : "Mo2aKTUGcxyczSbDV4L"
+        "orcId" : "gkXPtJSrxYc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/K3M6H0Nrimw6vj",
+        "id" : "https://www.example.com/6W7Aap0oQSv3XKVOb",
         "labels" : {
-          "oJG4eOmk1B3Cji6eCwV" : "NGzBzohK1Or9AKeW9sH"
+          "XPOvUKekycP" : "1FBGFKe3LWwiVw"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 0,
+      "role" : "EditorialBoardMember",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WPgXTzzvz5ArGp",
-        "name" : "KIplU7S0jZxwL0ZGU",
+        "id" : "https://www.example.com/D0FbwksDjPLG",
+        "name" : "hPWXXkCSK4rfsZ",
         "nameType" : "Personal",
-        "orcId" : "YGESf8y7rDY7L"
+        "orcId" : "NjklcX0dXsB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bumpW8vvkN",
+        "id" : "https://www.example.com/M6Oyiqb8nGknFewC",
         "labels" : {
-          "sQUOjBaMSYE" : "jrt3yDfMvpqQKZkN"
+          "jmkljp7siZUGAl5r" : "7Oya1Tu4FEXkfg6Vv"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 0,
+      "role" : "Funder",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "hJLLb5jMeq9u2Ru",
-    "tags" : [ "o9MpdqGLoe73Q" ],
-    "description" : "jtR6pufmNLqxVb2y",
+    "npiSubjectHeading" : "5CGzzzYk76zWB2tHos",
+    "tags" : [ "KMaOEtWbQjWcReJdKjR" ],
+    "description" : "YhNNCabdQ0ELc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/VzrdihsdgAZ"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EDcBwsyclCe"
       },
-      "doi" : "https://www.example.com/or3kWTIDLFGDHTBEAS",
+      "doi" : "https://www.example.com/g8SuuDjZ8dN",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "9td627dmXKd2i",
-        "issue" : "dGVhO9zhJp",
-        "articleNumber" : "TDdl0XfwCvHT",
+        "volume" : "8RdSUQRLJyR2vq",
+        "issue" : "TUMWqS1EGAQ",
+        "articleNumber" : "Rof4Np78IgMVfz9M",
         "pages" : {
           "type" : "Range",
-          "begin" : "Q0Ubl1PLMbssIAAsO",
-          "end" : "Q2pGu5oXyoFCmbsiBG"
+          "begin" : "L103p676cRcA",
+          "end" : "tswpldKuQqN4CPRVXX"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/JQCMe4zhl7NYFH",
-    "abstract" : "0omziQywxNKk9QeAn"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LKeDnmqbsbgbBZRnXh",
-      "mimeType" : "pUQh6Izyrhzqay",
-      "size" : 1645188556,
-      "license" : {
-        "type" : "License",
-        "identifier" : "4FOlu1hhmUM3s",
-        "labels" : {
-          "DgQQMVaYDhQs" : "PN8SVJMnkYOET4K0B"
-        },
-        "link" : "https://www.example.com/5G1xpcb4dPjXl22hUr"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/H7e3oCd5qak4I",
+    "abstract" : "SlrvFKF0ZKW9Znqd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etautem",
-    "name" : "eTqJpk7YXM9Jx",
+    "id" : "https://www.example.org/sitsint",
+    "name" : "eXv4XtKDw2AXiASP",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "TCTNEZvYsWXvx48z",
-      "id" : "45bcoqwP6SAl"
+      "source" : "OLUkH3BKN8",
+      "id" : "2ZhSaUlgh3JdQIk"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "gyGSX4o8pl2T"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "LwAcqBYAUSK"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aperiamarchitecto" ],
+  "subjects" : [ "https://www.example.org/porroquaerat" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LKeDnmqbsbgbBZRnXh",
-    "mimeType" : "pUQh6Izyrhzqay",
-    "size" : 1645188556,
+    "name" : "Idvg4lEQLj",
+    "mimeType" : "VPGVVp6SMRP3glRs9e",
+    "size" : 953254324,
     "license" : {
       "type" : "License",
-      "identifier" : "4FOlu1hhmUM3s",
+      "identifier" : "rLXdTDpEmft5D5m",
       "labels" : {
-        "DgQQMVaYDhQs" : "PN8SVJMnkYOET4K0B"
+        "7QR1sWS5aSw" : "rHfJQo5AbcTnooRyA"
       },
-      "link" : "https://www.example.com/5G1xpcb4dPjXl22hUr"
+      "link" : "https://www.example.com/RoPfME3EOii"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "Vvkk9wnAmCxFbTWSAki"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "Idvg4lEQLj",
+      "mimeType" : "VPGVVp6SMRP3glRs9e",
+      "size" : 953254324,
+      "license" : {
+        "type" : "License",
+        "identifier" : "rLXdTDpEmft5D5m",
+        "labels" : {
+          "7QR1sWS5aSw" : "rHfJQo5AbcTnooRyA"
+        },
+        "link" : "https://www.example.com/RoPfME3EOii"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "pwf25SAHj0YZ",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "1UfhyW3q6Hb78Ssf9",
-    "ownerAffiliation" : "https://www.example.org/molestiaequi"
+    "owner" : "WC7Nj69G4htyO3",
+    "ownerAffiliation" : "https://www.example.org/automnis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemnecessitatibus",
+    "id" : "https://www.example.org/aperiamneque",
     "labels" : {
-      "mj1mtKmv65fk3q" : "kosfzE9UCf8"
+      "OfMmyTpYP1ATz5oeOY" : "Gab13MOiwU5"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etcum",
-  "doi" : "https://doi.org/10.1234/quibusdam",
-  "link" : "https://www.example.org/voluptatesquo",
+  "handle" : "https://www.example.org/exercitationemvoluptas",
+  "doi" : "https://doi.org/10.1234/inventore",
+  "link" : "https://www.example.org/undemagnam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pEwaWrsNcRfMzvKVK",
+    "mainTitle" : "LMqzZnHSF38UhmC",
     "alternativeTitles" : {
-      "is" : "MHsI3iksFxu91sQ"
+      "hu" : "ddHP9scjeXsVk4xj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "BioFtIhP71",
-      "month" : "kxXbJrYE7Uo",
-      "day" : "OeTub83k6FX9I3a6ci"
+      "year" : "0dEuWQhyQTumJM",
+      "month" : "zSR8TZKdrLI8KH",
+      "day" : "miMX0JYk0l4nfhRmne"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aoPI6Ab57HcvZFMiF",
-        "name" : "1euT9udye6",
-        "nameType" : "Organizational",
-        "orcId" : "lXxGSV6BXJc"
+        "id" : "https://www.example.com/eaW5Jqb1PFI",
+        "name" : "6JiSJiZ5WObkh9AQB",
+        "nameType" : "Personal",
+        "orcId" : "xzclncnKiZhhJaYH9I"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ftbysxpfj8jiJ5uXk",
+        "id" : "https://www.example.com/9hbmguL62tfPG",
         "labels" : {
-          "7LfZouXUvRpZMT" : "ATK0pCAOqdI2R"
+          "rpF3Ryts2ODTr8G" : "hz7SDuJZ42Q"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 3,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rTY7qZlPK3RUSE7SDz",
-        "name" : "ZlQZixBQjbAXi1rK0fZ",
+        "id" : "https://www.example.com/MAuqxyNUxbVERyLSIPR",
+        "name" : "35YTBjtp629",
         "nameType" : "Organizational",
-        "orcId" : "3laCV8wFLK23RAyu"
+        "orcId" : "CDZETR0GwVGtPu8sy7R"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/o9oTFdyBTV",
+        "id" : "https://www.example.com/aF5Vcn9Nxkfb7",
         "labels" : {
-          "4bKEFewHm9" : "1B6vGwpvkyhHR3goc"
+          "b1azqXP5Wdk3LcV" : "7W4NA7JQ3Yak"
         }
       } ],
-      "role" : "Organizer",
-      "sequence" : 2,
+      "role" : "Sponsor",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "iTpSZW6qG2zZ7GHM",
-    "tags" : [ "WqAv6Pq4EZ" ],
-    "description" : "0Z1Md2dZQqrnH",
+    "npiSubjectHeading" : "dqrAXLFAGQ9T",
+    "tags" : [ "ilm3YQ7snh4Xkfj" ],
+    "description" : "dWmR6EmkvgsInJR0B",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TuPWYPdOoW4"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FfxeVFLoHvzwnHpC1oD"
       },
-      "doi" : "https://www.example.com/j1AXtc7il9",
+      "doi" : "https://www.example.com/KRHlsiMHYo9EnBh7",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "fbvhcvkrNRG",
-        "issue" : "us8dSEtZxKZEo",
-        "articleNumber" : "Nl1t0jrZDqcOvC42uP0",
+        "volume" : "IdObGC91aFpH8B0",
+        "issue" : "I43fRQmrFyd2sjCG",
+        "articleNumber" : "2nbJF8uS9M7ffF",
         "pages" : {
           "type" : "Range",
-          "begin" : "SX2Qh0IsUSlk",
-          "end" : "3cjNJtdXsjgb6"
+          "begin" : "A2yqDt3sgM",
+          "end" : "roinJYGjn6PUcHIRU"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/4MKQYywMrM4yf9U7",
-    "abstract" : "ZLYjd7Nqli"
+    "metadataSource" : "https://www.example.com/9oJ5HD3zxvKfM5",
+    "abstract" : "83OEIeyPlZiqdrR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitsuscipit",
-    "name" : "lrJNWkxiy28F6Fgr",
+    "id" : "https://www.example.org/quidemin",
+    "name" : "XXMFUsoMX8kdm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "eDZkr1W3Wsg",
-      "id" : "PkKeC4q5mQg0Nq"
+      "source" : "SaLB0n9dlTVn4",
+      "id" : "7IXwwnSMKr1MJuSe1S"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Kx1uGfpeZu"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "zSQZo83vMUP6mHo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/atqueneque" ],
+  "subjects" : [ "https://www.example.org/errornon" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "2rbmaikyuiOgZiqmj",
-      "mimeType" : "q6qvx6sUCPXIPk0wIY",
-      "size" : 434539486,
+      "name" : "jbhINVRkfVt",
+      "mimeType" : "lFz4Oo2R3xEEyBCvGb",
+      "size" : 676999821,
       "license" : {
         "type" : "License",
-        "identifier" : "Tqs3fqVzDGgrqHLz1",
+        "identifier" : "9Woq5i5SH4",
         "labels" : {
-          "IqludFkISpxi2tI" : "r1RP4Dac8e"
+          "wOFLjDjRaPJ5K1yixf" : "AxggpvCNjaF"
         },
-        "link" : "https://www.example.com/vFhAU5qAJqOTioCR"
+        "link" : "https://www.example.com/VyhljhverJxnabiQfOg"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "2rbmaikyuiOgZiqmj",
-    "mimeType" : "q6qvx6sUCPXIPk0wIY",
-    "size" : 434539486,
+    "name" : "jbhINVRkfVt",
+    "mimeType" : "lFz4Oo2R3xEEyBCvGb",
+    "size" : 676999821,
     "license" : {
       "type" : "License",
-      "identifier" : "Tqs3fqVzDGgrqHLz1",
+      "identifier" : "9Woq5i5SH4",
       "labels" : {
-        "IqludFkISpxi2tI" : "r1RP4Dac8e"
+        "wOFLjDjRaPJ5K1yixf" : "AxggpvCNjaF"
       },
-      "link" : "https://www.example.com/vFhAU5qAJqOTioCR"
+      "link" : "https://www.example.com/VyhljhverJxnabiQfOg"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "1UfhyW3q6Hb78Ssf9",
+  "owner" : "WC7Nj69G4htyO3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "WC7Nj69G4htyO3",
-    "ownerAffiliation" : "https://www.example.org/automnis"
+    "owner" : "ROi5Mlw4PHor2N9EKHI",
+    "ownerAffiliation" : "https://www.example.org/dolorumquo"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aperiamneque",
+    "id" : "https://www.example.org/aliquamsunt",
     "labels" : {
-      "OfMmyTpYP1ATz5oeOY" : "Gab13MOiwU5"
+      "TEg1RuKun0Jls55t" : "OMYABj8v704cAeXWmD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/exercitationemvoluptas",
-  "doi" : "https://doi.org/10.1234/inventore",
-  "link" : "https://www.example.org/undemagnam",
+  "handle" : "https://www.example.org/distinctioipsum",
+  "doi" : "https://doi.org/10.1234/cum",
+  "link" : "https://www.example.org/iddelectus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LMqzZnHSF38UhmC",
+    "mainTitle" : "n2izUwwbc8tLh0U",
     "alternativeTitles" : {
-      "hu" : "ddHP9scjeXsVk4xj"
+      "es" : "m8j3RYVeIFAnXEJtJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "0dEuWQhyQTumJM",
-      "month" : "zSR8TZKdrLI8KH",
-      "day" : "miMX0JYk0l4nfhRmne"
+      "year" : "26K5MuQblQ3M",
+      "month" : "XOHaY6WgFxf",
+      "day" : "tllSwElVgWj5It"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/eaW5Jqb1PFI",
-        "name" : "6JiSJiZ5WObkh9AQB",
-        "nameType" : "Personal",
-        "orcId" : "xzclncnKiZhhJaYH9I"
+        "id" : "https://www.example.com/b8kuITFIeNFXiwFiY",
+        "name" : "RPTjdKwWYSLswa3XeE6",
+        "nameType" : "Organizational",
+        "orcId" : "fn9bOG5p8PBu3VoE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9hbmguL62tfPG",
+        "id" : "https://www.example.com/46eRE7mDf5hV57xsQ",
         "labels" : {
-          "rpF3Ryts2ODTr8G" : "hz7SDuJZ42Q"
+          "X4H7biUWDUfYM" : "6fEv9FNqzu4"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 6,
+      "role" : "CuratorOrganizer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MAuqxyNUxbVERyLSIPR",
-        "name" : "35YTBjtp629",
-        "nameType" : "Organizational",
-        "orcId" : "CDZETR0GwVGtPu8sy7R"
+        "id" : "https://www.example.com/Np2P6MbsDTWK6m5v",
+        "name" : "44Goq6DsQhGhZh",
+        "nameType" : "Personal",
+        "orcId" : "RB555bLB62vnn"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aF5Vcn9Nxkfb7",
+        "id" : "https://www.example.com/Oq5fs5W0OU21WPZu",
         "labels" : {
-          "b1azqXP5Wdk3LcV" : "7W4NA7JQ3Yak"
+          "g07DOJRORkmCkjSjXKp" : "PAqRODi8JyYPPi"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 1,
+      "role" : "ArchitecturalPlanner",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "dqrAXLFAGQ9T",
-    "tags" : [ "ilm3YQ7snh4Xkfj" ],
-    "description" : "dWmR6EmkvgsInJR0B",
+    "npiSubjectHeading" : "5tIIilRPBnYAUyqI4O",
+    "tags" : [ "cZ0KOQhwrkJ7Y2zV" ],
+    "description" : "HXDY9bOjoBIawWshtfR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/FfxeVFLoHvzwnHpC1oD"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/T5RNDSaJM1ceY"
       },
-      "doi" : "https://www.example.com/KRHlsiMHYo9EnBh7",
+      "doi" : "https://www.example.com/rmuDG5zqTGAj",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "IdObGC91aFpH8B0",
-        "issue" : "I43fRQmrFyd2sjCG",
-        "articleNumber" : "2nbJF8uS9M7ffF",
+        "volume" : "0tgP385KvmjaaL",
+        "issue" : "jsZ0XvjfsTV56qypwju",
+        "articleNumber" : "iZHtliR0W7j8S4u0cD",
         "pages" : {
           "type" : "Range",
-          "begin" : "A2yqDt3sgM",
-          "end" : "roinJYGjn6PUcHIRU"
+          "begin" : "tQC4clYX3dC28Rfj",
+          "end" : "ARuBwJW9Ek73c6"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/9oJ5HD3zxvKfM5",
-    "abstract" : "83OEIeyPlZiqdrR"
+    "metadataSource" : "https://www.example.com/bvPOEsQ4kP5R1RQ",
+    "abstract" : "dzPF8MPI2mt6phO0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quidemin",
-    "name" : "XXMFUsoMX8kdm",
+    "id" : "https://www.example.org/veritatiscorporis",
+    "name" : "hvov1DJ42OtBKzzmR",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "SaLB0n9dlTVn4",
-      "id" : "7IXwwnSMKr1MJuSe1S"
+      "source" : "RHHC5zKln59j5Sc",
+      "id" : "iYnjNtI9XSL16RIr"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zSQZo83vMUP6mHo"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "FjNzGa6yDbT"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,22 +120,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/errornon" ],
+  "subjects" : [ "https://www.example.org/solutaeum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "jbhINVRkfVt",
-      "mimeType" : "lFz4Oo2R3xEEyBCvGb",
-      "size" : 676999821,
+      "name" : "ZUQdniy8StcW",
+      "mimeType" : "obrZMFUqHn3sR",
+      "size" : 442134118,
       "license" : {
         "type" : "License",
-        "identifier" : "9Woq5i5SH4",
+        "identifier" : "YGRuTtGdIxymp9",
         "labels" : {
-          "wOFLjDjRaPJ5K1yixf" : "AxggpvCNjaF"
+          "j2kub8Xs1oUsfFAum3" : "PgPFs339AXBdIYWxt"
         },
-        "link" : "https://www.example.com/VyhljhverJxnabiQfOg"
+        "link" : "https://www.example.com/NUc4YxZKh5GtJhln"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -145,21 +145,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "jbhINVRkfVt",
-    "mimeType" : "lFz4Oo2R3xEEyBCvGb",
-    "size" : 676999821,
+    "name" : "ZUQdniy8StcW",
+    "mimeType" : "obrZMFUqHn3sR",
+    "size" : 442134118,
     "license" : {
       "type" : "License",
-      "identifier" : "9Woq5i5SH4",
+      "identifier" : "YGRuTtGdIxymp9",
       "labels" : {
-        "wOFLjDjRaPJ5K1yixf" : "AxggpvCNjaF"
+        "j2kub8Xs1oUsfFAum3" : "PgPFs339AXBdIYWxt"
       },
-      "link" : "https://www.example.com/VyhljhverJxnabiQfOg"
+      "link" : "https://www.example.com/NUc4YxZKh5GtJhln"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "WC7Nj69G4htyO3",
+  "owner" : "ROi5Mlw4PHor2N9EKHI",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "pwf25SAHj0YZ",
-    "ownerAffiliation" : "https://www.example.org/estaccusantium"
+    "owner" : "1UfhyW3q6Hb78Ssf9",
+    "ownerAffiliation" : "https://www.example.org/molestiaequi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiaaut",
+    "id" : "https://www.example.org/voluptatemnecessitatibus",
     "labels" : {
-      "errs96guINiuj" : "IdrxAS4bcZV7B"
+      "mj1mtKmv65fk3q" : "kosfzE9UCf8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nequemollitia",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/harumex",
+  "handle" : "https://www.example.org/etcum",
+  "doi" : "https://doi.org/10.1234/quibusdam",
+  "link" : "https://www.example.org/voluptatesquo",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "l2o3Yx8ZmQnq",
+    "mainTitle" : "pEwaWrsNcRfMzvKVK",
     "alternativeTitles" : {
-      "bg" : "KyQ5gcbGMF6vgajE"
+      "is" : "MHsI3iksFxu91sQ"
     },
     "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "bRFHsqsUJs39nES",
-      "month" : "tbZhONI3U5wtN2avw8",
-      "day" : "rkYbl4ozmsOgsTRcqtv"
+      "year" : "BioFtIhP71",
+      "month" : "kxXbJrYE7Uo",
+      "day" : "OeTub83k6FX9I3a6ci"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hT1TaSZdVvw",
-        "name" : "NtHmMmeLHYmcLP7y",
-        "nameType" : "Personal",
-        "orcId" : "gkXPtJSrxYc"
+        "id" : "https://www.example.com/aoPI6Ab57HcvZFMiF",
+        "name" : "1euT9udye6",
+        "nameType" : "Organizational",
+        "orcId" : "lXxGSV6BXJc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6W7Aap0oQSv3XKVOb",
+        "id" : "https://www.example.com/ftbysxpfj8jiJ5uXk",
         "labels" : {
-          "XPOvUKekycP" : "1FBGFKe3LWwiVw"
+          "7LfZouXUvRpZMT" : "ATK0pCAOqdI2R"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 6,
+      "role" : "RegistrationAgency",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/D0FbwksDjPLG",
-        "name" : "hPWXXkCSK4rfsZ",
-        "nameType" : "Personal",
-        "orcId" : "NjklcX0dXsB"
+        "id" : "https://www.example.com/rTY7qZlPK3RUSE7SDz",
+        "name" : "ZlQZixBQjbAXi1rK0fZ",
+        "nameType" : "Organizational",
+        "orcId" : "3laCV8wFLK23RAyu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/M6Oyiqb8nGknFewC",
+        "id" : "https://www.example.com/o9oTFdyBTV",
         "labels" : {
-          "jmkljp7siZUGAl5r" : "7Oya1Tu4FEXkfg6Vv"
+          "4bKEFewHm9" : "1B6vGwpvkyhHR3goc"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 6,
+      "role" : "Organizer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5CGzzzYk76zWB2tHos",
-    "tags" : [ "KMaOEtWbQjWcReJdKjR" ],
-    "description" : "YhNNCabdQ0ELc",
+    "npiSubjectHeading" : "iTpSZW6qG2zZ7GHM",
+    "tags" : [ "WqAv6Pq4EZ" ],
+    "description" : "0Z1Md2dZQqrnH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EDcBwsyclCe"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TuPWYPdOoW4"
       },
-      "doi" : "https://www.example.com/g8SuuDjZ8dN",
+      "doi" : "https://www.example.com/j1AXtc7il9",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "8RdSUQRLJyR2vq",
-        "issue" : "TUMWqS1EGAQ",
-        "articleNumber" : "Rof4Np78IgMVfz9M",
+        "volume" : "fbvhcvkrNRG",
+        "issue" : "us8dSEtZxKZEo",
+        "articleNumber" : "Nl1t0jrZDqcOvC42uP0",
         "pages" : {
           "type" : "Range",
-          "begin" : "L103p676cRcA",
-          "end" : "tswpldKuQqN4CPRVXX"
+          "begin" : "SX2Qh0IsUSlk",
+          "end" : "3cjNJtdXsjgb6"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/H7e3oCd5qak4I",
-    "abstract" : "SlrvFKF0ZKW9Znqd"
+    "metadataSource" : "https://www.example.com/4MKQYywMrM4yf9U7",
+    "abstract" : "ZLYjd7Nqli"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitsint",
-    "name" : "eXv4XtKDw2AXiASP",
+    "id" : "https://www.example.org/sitsuscipit",
+    "name" : "lrJNWkxiy28F6Fgr",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "OLUkH3BKN8",
-      "id" : "2ZhSaUlgh3JdQIk"
+      "source" : "eDZkr1W3Wsg",
+      "id" : "PkKeC4q5mQg0Nq"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "LwAcqBYAUSK"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "Kx1uGfpeZu"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/porroquaerat" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "Idvg4lEQLj",
-    "mimeType" : "VPGVVp6SMRP3glRs9e",
-    "size" : 953254324,
-    "license" : {
-      "type" : "License",
-      "identifier" : "rLXdTDpEmft5D5m",
-      "labels" : {
-        "7QR1sWS5aSw" : "rHfJQo5AbcTnooRyA"
-      },
-      "link" : "https://www.example.com/RoPfME3EOii"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/atqueneque" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Idvg4lEQLj",
-      "mimeType" : "VPGVVp6SMRP3glRs9e",
-      "size" : 953254324,
+      "name" : "2rbmaikyuiOgZiqmj",
+      "mimeType" : "q6qvx6sUCPXIPk0wIY",
+      "size" : 434539486,
       "license" : {
         "type" : "License",
-        "identifier" : "rLXdTDpEmft5D5m",
+        "identifier" : "Tqs3fqVzDGgrqHLz1",
         "labels" : {
-          "7QR1sWS5aSw" : "rHfJQo5AbcTnooRyA"
+          "IqludFkISpxi2tI" : "r1RP4Dac8e"
         },
-        "link" : "https://www.example.com/RoPfME3EOii"
+        "link" : "https://www.example.com/vFhAU5qAJqOTioCR"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "pwf25SAHj0YZ",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "2rbmaikyuiOgZiqmj",
+    "mimeType" : "q6qvx6sUCPXIPk0wIY",
+    "size" : 434539486,
+    "license" : {
+      "type" : "License",
+      "identifier" : "Tqs3fqVzDGgrqHLz1",
+      "labels" : {
+        "IqludFkISpxi2tI" : "r1RP4Dac8e"
+      },
+      "link" : "https://www.example.com/vFhAU5qAJqOTioCR"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "1UfhyW3q6Hb78Ssf9",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "cFaUcj4HZC4pVSkvez",
-    "ownerAffiliation" : "https://www.example.org/aut"
+    "owner" : "auRfZxPLC25PB",
+    "ownerAffiliation" : "https://www.example.org/utculpa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/remea",
+    "id" : "https://www.example.org/nullaeos",
     "labels" : {
-      "rfQ363mHm32I60zR" : "KUXAc0dlXni7DvxtE"
+      "JBZPwgI40ZN" : "AxyAWXNdtq02fXj57"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnisaccusamus",
-  "doi" : "https://doi.org/10.1234/eveniet",
-  "link" : "https://www.example.org/sedoptio",
+  "handle" : "https://www.example.org/namerror",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/maximenulla",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5jPN2hExri2AByh4U",
+    "mainTitle" : "KJqxrkxWaPlAghDh1dH",
     "alternativeTitles" : {
-      "fr" : "UtjRGWdh8HOb8yKpRJ"
+      "hu" : "YiaGYLfWlN0iD5sPUm"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ita",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "skYrzf0cLPFubk2",
-      "month" : "KEQgKDmlvr0eT5Y",
-      "day" : "tAcftvcBhUYLGb"
+      "year" : "XnSvqac4qI",
+      "month" : "c5SPkwMtrQu8",
+      "day" : "pp5TFizSQsyAxXAxi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/o2X2kE6OWsmXfRl",
-        "name" : "EC1jYG51759ah5",
+        "id" : "https://www.example.com/2IRXV2YZs2z",
+        "name" : "tK9U1ppp7NAeN",
         "nameType" : "Personal",
-        "orcId" : "q9D09lgd2dMiqw"
+        "orcId" : "80RUFgjlnXxbOD1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/okyMJJ4m11",
+        "id" : "https://www.example.com/vdYVOdpVtgyFOw1",
         "labels" : {
-          "TMjomgYRi4FwJhO" : "16Kzh5kJFOFF"
+          "0p3fAqjGl3uQDKS8k" : "z0lUnLDUn7"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 2,
+      "role" : "Funder",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sjUlL2qLcTrKz59X",
-        "name" : "3VJqL30DEY",
-        "nameType" : "Organizational",
-        "orcId" : "SYVFrEB3ie"
+        "id" : "https://www.example.com/GiUxKw3EnvC",
+        "name" : "le8gj8Ldw1T1pL",
+        "nameType" : "Personal",
+        "orcId" : "r9d38IX68uZDixFE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/l4oYN5JKFA",
+        "id" : "https://www.example.com/zJTRkMVNumO7uQBAkq",
         "labels" : {
-          "sUcd0w1F1Z8Z" : "gjxVUzv1B9"
+          "NduIJlUVMVT83DA7" : "ORKzH3Uks7Xr7L7"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 3,
+      "role" : "WorkPackageLeader",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "awX6A0XGMeNnC",
-    "tags" : [ "Ts6NOhbX60vlI77BYZO" ],
-    "description" : "SVQKognaKqEaUe3",
+    "npiSubjectHeading" : "oUyb52YNBA0uQXik",
+    "tags" : [ "jsPsXPVFBn" ],
+    "description" : "LSBROy3qhDiTNEOez",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/N01LAcFnDSSw7QqjoOW"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/OTtpTgf1mCe"
       },
-      "doi" : "https://www.example.com/Y1SfN4solBQ",
+      "doi" : "https://www.example.com/tMdMFohliEjnXbE",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "1XROovV4LbW",
-        "issue" : "AoK8J8HtsTapG9V09d",
-        "articleNumber" : "uAHGiIfNZn7os0Ni",
+        "volume" : "bqPmTIhW0YLHBnhamwb",
+        "issue" : "jVf6D6Sr4X2vY",
+        "articleNumber" : "T78FYOtLOKrJ2F5Lw",
         "pages" : {
           "type" : "Range",
-          "begin" : "5eQfvhIplAz5Uv4zkr1",
-          "end" : "OQlpvNtn1cXl4moR"
+          "begin" : "buxMFjWzRGlPaSq",
+          "end" : "FXgqCSzfVJ"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/AiK4qpRC17UvhyEJR0f",
-    "abstract" : "sYXHEm3WeR"
+    "metadataSource" : "https://www.example.com/NsCjRpOuPfUzw",
+    "abstract" : "t97wosThA5wP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/molestiaesit",
-    "name" : "KNcAgk7sAd",
+    "id" : "https://www.example.org/quilaudantium",
+    "name" : "oUK4psG9lqhAz3y4bb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Q2CwIZTpQXk",
-      "id" : "ozwNFdJuazPzu3vuN"
+      "source" : "fBabQj8CzCAyt",
+      "id" : "lnO2D39jIW"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "tzVmGsNY43uRNsryU"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "0XpPqDrOI8x99KET"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,22 +120,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/rerumet" ],
+  "subjects" : [ "https://www.example.org/dignissimosaperiam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "14Gv52kRDLyDl6XQN",
-      "mimeType" : "g2Z3vb7eCpmc",
-      "size" : 458196887,
+      "name" : "CRpOMoTIIJ4keGNH",
+      "mimeType" : "07gGJUKSxbXvoC087m",
+      "size" : 499800788,
       "license" : {
         "type" : "License",
-        "identifier" : "QEjmgZYjk2",
+        "identifier" : "edTC7klVuHz9w8N",
         "labels" : {
-          "Id3Vd6SHijj" : "wKOblXpYDnT6izkpW"
+          "kbfgmEvm24xcI" : "SXcEuHREB99YN"
         },
-        "link" : "https://www.example.com/JAoeeYiPwmFWD"
+        "link" : "https://www.example.com/sLvULpi9pS06ykT2I"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -145,21 +145,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "14Gv52kRDLyDl6XQN",
-    "mimeType" : "g2Z3vb7eCpmc",
-    "size" : 458196887,
+    "name" : "CRpOMoTIIJ4keGNH",
+    "mimeType" : "07gGJUKSxbXvoC087m",
+    "size" : 499800788,
     "license" : {
       "type" : "License",
-      "identifier" : "QEjmgZYjk2",
+      "identifier" : "edTC7klVuHz9w8N",
       "labels" : {
-        "Id3Vd6SHijj" : "wKOblXpYDnT6izkpW"
+        "kbfgmEvm24xcI" : "SXcEuHREB99YN"
       },
-      "link" : "https://www.example.com/JAoeeYiPwmFWD"
+      "link" : "https://www.example.com/sLvULpi9pS06ykT2I"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "cFaUcj4HZC4pVSkvez",
+  "owner" : "auRfZxPLC25PB",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,139 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "9bcBc2kC4K5v3",
-    "ownerAffiliation" : "https://www.example.org/quisunt"
+    "owner" : "Xp8qqU0u9Ji",
+    "ownerAffiliation" : "https://www.example.org/utpraesentium"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiaut",
+    "id" : "https://www.example.org/voluptatetemporibus",
     "labels" : {
-      "uKdPmZ89p12du6LX" : "XaBfzl2emj8r1"
+      "JnOzE0dfqfFb" : "dro5QzBNl4koD5"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/iureexpedita",
-  "doi" : "https://doi.org/10.1234/sit",
-  "link" : "https://www.example.org/assumendablanditiis",
+  "handle" : "https://www.example.org/accusantiumaliquid",
+  "doi" : "https://doi.org/10.1234/aliquam",
+  "link" : "https://www.example.org/sedaspernatur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rdq0m44Q2aFsvNtY7iV",
+    "mainTitle" : "9hSXU8yhLY",
     "alternativeTitles" : {
-      "fi" : "BUNJRd3BiCKbgP"
+      "zh" : "8PFl5shlzJQyF"
     },
     "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "cDsLxvrvmjfH7sh",
-      "month" : "C2wDKVDS9jcUklbXC",
-      "day" : "9CVJYgGAf9eh9SJUcz"
+      "year" : "RAYBSOcArjqHpkuYaC",
+      "month" : "ht9ia3wDaON41GR",
+      "day" : "NVwfLhuTk7JFNa4c"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0aJw6FnQkIOBacAz4EC",
-        "name" : "IKjEhGOl3gCmiW24d",
+        "id" : "https://www.example.com/kNKkEnWtjTpQqGc4B2",
+        "name" : "HPRAoqnTR7",
         "nameType" : "Personal",
-        "orcId" : "aDjEjNJkJ8VRR4skpJh"
+        "orcId" : "B0lRtK9rhKUJucKB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uBRZHrSjHXt",
+        "id" : "https://www.example.com/Qg7ipZtvvK",
         "labels" : {
-          "Mn6W8eavQI" : "dok6QKETKgXA"
+          "MEXrJWde1xA" : "e1WOr6roBlUaglvr"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 9,
+      "role" : "Dancer",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0j6vrXbjL0",
-        "name" : "G1JYYzLOWvQUcmm",
-        "nameType" : "Organizational",
-        "orcId" : "5Nx5LVeqS6oC4"
+        "id" : "https://www.example.com/0k7zoTB4L8C",
+        "name" : "W82UF1kuAjPE7as3",
+        "nameType" : "Personal",
+        "orcId" : "AtEgAO7IJgKllDE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/sD97Q2ScM5gStktDLJ",
+        "id" : "https://www.example.com/J5kBKvrLV4hyTK2",
         "labels" : {
-          "mAU6b9s4JH3eKp" : "FVuGltu9gC9yo2wGXj"
+          "DIUeDlfKISv" : "r1Q1lu6JBWdSUj"
         }
       } ],
-      "role" : "Dancer",
-      "sequence" : 0,
+      "role" : "LightDesigner",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "yQ6gng9DEgZiBSCfuC1",
-    "tags" : [ "To5UcmDbUIH8" ],
-    "description" : "D5jxPr50iIZe7jvcZ",
+    "npiSubjectHeading" : "XT1tCUn9rtfro1",
+    "tags" : [ "OmWRawvTxRM49k12sHO" ],
+    "description" : "cqyVw3VvaNiX4zW1ka",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zbadKsJFsvsJrQm"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zdV519cz8GJ5sUmq"
       },
-      "doi" : "https://www.example.com/SipnAKlsRlNIgaAU",
+      "doi" : "https://www.example.com/j3DbdVmKBLbmg2pv",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "A030crD1GSISHtcXTzS",
-        "issue" : "x7e2ooVBep5sD6",
-        "articleNumber" : "tbiGD8WYYa",
+        "volume" : "F5HjOcN0pCLy",
+        "issue" : "wUD3uGqbrf0",
+        "articleNumber" : "6rJ3HnAcSDZQ6Rp",
         "pages" : {
           "type" : "Range",
-          "begin" : "gcmug59Svd",
-          "end" : "OsuVySy2OZM36byt"
+          "begin" : "o9ci6CLqnE",
+          "end" : "PAklOhJv00U3u"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/MHY2DwS6lnhP3y",
-    "abstract" : "NKjJO1sFeTwfw"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bmszS8iG3tRKaEQ",
-      "mimeType" : "b7xwkMX4lokLXhEA4H3",
-      "size" : 1018656671,
-      "license" : {
-        "type" : "License",
-        "identifier" : "57nDFzEv5PWjLy",
-        "labels" : {
-          "PvqN3xO1TMs5CpeVeQ" : "zmiZhQ37Gqzf"
-        },
-        "link" : "https://www.example.com/ADVfqp2JyAT1yz"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/74qXsZ1MHfA1aLVFLN",
+    "abstract" : "lPaUPAbFgImoio"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloribussuscipit",
-    "name" : "fTEAK594Eezm",
+    "id" : "https://www.example.org/eligendinecessitatibus",
+    "name" : "vnvooTXrljuu1",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "MjSDpPuyQA0",
-      "id" : "IXbzyeLibGgILt4Tk"
+      "source" : "4BD7Y9Rgxsmv",
+      "id" : "DjnkIPngbgeEMdYQJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "MD5ztnvL4M9Gvq8"
+      "applicationCode" : "rlFZ6Vqel3aFTsnJC"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -141,25 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nequeomnis" ],
+  "subjects" : [ "https://www.example.org/etdoloribus" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bmszS8iG3tRKaEQ",
-    "mimeType" : "b7xwkMX4lokLXhEA4H3",
-    "size" : 1018656671,
+    "name" : "QgclIUT8J4yyJGE",
+    "mimeType" : "AHK3jMBA3km",
+    "size" : 805864688,
     "license" : {
       "type" : "License",
-      "identifier" : "57nDFzEv5PWjLy",
+      "identifier" : "JUzpOdCKs7W",
       "labels" : {
-        "PvqN3xO1TMs5CpeVeQ" : "zmiZhQ37Gqzf"
+        "ZVOnYClkiMLysO" : "2DNX3JoQ5D"
       },
-      "link" : "https://www.example.com/ADVfqp2JyAT1yz"
+      "link" : "https://www.example.com/S6ef8WfoWXmG6B"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "9bcBc2kC4K5v3"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "QgclIUT8J4yyJGE",
+      "mimeType" : "AHK3jMBA3km",
+      "size" : 805864688,
+      "license" : {
+        "type" : "License",
+        "identifier" : "JUzpOdCKs7W",
+        "labels" : {
+          "ZVOnYClkiMLysO" : "2DNX3JoQ5D"
+        },
+        "link" : "https://www.example.com/S6ef8WfoWXmG6B"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "Xp8qqU0u9Ji",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -3,116 +3,116 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "usJZfivzCjaDCq6U2i6",
-    "ownerAffiliation" : "https://www.example.org/debitisquis"
+    "owner" : "cFaUcj4HZC4pVSkvez",
+    "ownerAffiliation" : "https://www.example.org/aut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/oditdolores",
+    "id" : "https://www.example.org/remea",
     "labels" : {
-      "9BNgSWsg1gY" : "5eXs2JEa3ogM4"
+      "rfQ363mHm32I60zR" : "KUXAc0dlXni7DvxtE"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/easit",
-  "doi" : "https://doi.org/10.1234/ex",
-  "link" : "https://www.example.org/suntnecessitatibus",
+  "handle" : "https://www.example.org/omnisaccusamus",
+  "doi" : "https://doi.org/10.1234/eveniet",
+  "link" : "https://www.example.org/sedoptio",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GTOY8D8Gfnh",
+    "mainTitle" : "5jPN2hExri2AByh4U",
     "alternativeTitles" : {
-      "bg" : "DqMZt4mBfd"
+      "fr" : "UtjRGWdh8HOb8yKpRJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "N54rzqpKcqYLxSjbkf",
-      "month" : "phiIJh7TyJnwLHLOFd",
-      "day" : "VsyWlL0PTyyJPb"
+      "year" : "skYrzf0cLPFubk2",
+      "month" : "KEQgKDmlvr0eT5Y",
+      "day" : "tAcftvcBhUYLGb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/vlpqH0aymwCAqCAYb6",
-        "name" : "qWQi0SFSCJEiUnwDuVc",
+        "id" : "https://www.example.com/o2X2kE6OWsmXfRl",
+        "name" : "EC1jYG51759ah5",
         "nameType" : "Personal",
-        "orcId" : "IVR6aUU9OHrgXi9l7rS"
+        "orcId" : "q9D09lgd2dMiqw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hmMkwMoenuQtdqe8c",
+        "id" : "https://www.example.com/okyMJJ4m11",
         "labels" : {
-          "Ky1TfxR24uKHfVYRXY" : "dTaC6y6cZghaRND"
+          "TMjomgYRi4FwJhO" : "16Kzh5kJFOFF"
         }
       } ],
-      "role" : "Photographer",
-      "sequence" : 4,
+      "role" : "RelatedPerson",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jF5KyRa8VtHcz",
-        "name" : "sT0CYk4MlX",
+        "id" : "https://www.example.com/sjUlL2qLcTrKz59X",
+        "name" : "3VJqL30DEY",
         "nameType" : "Organizational",
-        "orcId" : "ZNxk97fDbzcGOnrAzh"
+        "orcId" : "SYVFrEB3ie"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/z3OAY0rYKgR2meGnG3e",
+        "id" : "https://www.example.com/l4oYN5JKFA",
         "labels" : {
-          "FCY2vq07RIYbI29" : "rbblxMSICCeSuBreMam"
+          "sUcd0w1F1Z8Z" : "gjxVUzv1B9"
         }
       } ],
-      "role" : "ProgrammeParticipant",
-      "sequence" : 9,
+      "role" : "Sponsor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ZjPd801o8F",
-    "tags" : [ "rIbodskWxbWmZqSB5i" ],
-    "description" : "bFWdSi90lX56nmLDrW",
+    "npiSubjectHeading" : "awX6A0XGMeNnC",
+    "tags" : [ "Ts6NOhbX60vlI77BYZO" ],
+    "description" : "SVQKognaKqEaUe3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/vyQjfCk5DeLNe"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/N01LAcFnDSSw7QqjoOW"
       },
-      "doi" : "https://www.example.com/MXLDRfM8bkeN5W8",
+      "doi" : "https://www.example.com/Y1SfN4solBQ",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "qxfHeolxgcCkwP1T",
-        "issue" : "0WSr0bDYHkhk",
-        "articleNumber" : "sdejW4Bx9Zy9Q",
+        "volume" : "1XROovV4LbW",
+        "issue" : "AoK8J8HtsTapG9V09d",
+        "articleNumber" : "uAHGiIfNZn7os0Ni",
         "pages" : {
           "type" : "Range",
-          "begin" : "RYUovMMDUtDU0s2w3AA",
-          "end" : "naiQhCdK0r9"
+          "begin" : "5eQfvhIplAz5Uv4zkr1",
+          "end" : "OQlpvNtn1cXl4moR"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/okCNjTlDAWqWS7Gt",
-    "abstract" : "z5j6NeyqoaA1"
+    "metadataSource" : "https://www.example.com/AiK4qpRC17UvhyEJR0f",
+    "abstract" : "sYXHEm3WeR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/veroat",
-    "name" : "7j0G2zTN0iR7WtU5Nt",
+    "id" : "https://www.example.org/molestiaesit",
+    "name" : "KNcAgk7sAd",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "E8eW2BAQxJ",
-      "id" : "O93sFHPxhMmUPp71Kc"
+      "source" : "Q2CwIZTpQXk",
+      "id" : "ozwNFdJuazPzu3vuN"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "z998OyUtPSYxq"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "tzVmGsNY43uRNsryU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autemet" ],
+  "subjects" : [ "https://www.example.org/rerumet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "UEUBS9CNaj6",
-      "mimeType" : "yO98Wg6JlBbPd8ksNj",
-      "size" : 462899714,
+      "name" : "14Gv52kRDLyDl6XQN",
+      "mimeType" : "g2Z3vb7eCpmc",
+      "size" : 458196887,
       "license" : {
         "type" : "License",
-        "identifier" : "UOIofB1sQUy",
+        "identifier" : "QEjmgZYjk2",
         "labels" : {
-          "pxhyJQBpjMSxIcq" : "mvqeVKXnX0fERsE9RPA"
+          "Id3Vd6SHijj" : "wKOblXpYDnT6izkpW"
         },
-        "link" : "https://www.example.com/53ShN5lbVkWV"
+        "link" : "https://www.example.com/JAoeeYiPwmFWD"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "UEUBS9CNaj6",
-    "mimeType" : "yO98Wg6JlBbPd8ksNj",
-    "size" : 462899714,
+    "name" : "14Gv52kRDLyDl6XQN",
+    "mimeType" : "g2Z3vb7eCpmc",
+    "size" : 458196887,
     "license" : {
       "type" : "License",
-      "identifier" : "UOIofB1sQUy",
+      "identifier" : "QEjmgZYjk2",
       "labels" : {
-        "pxhyJQBpjMSxIcq" : "mvqeVKXnX0fERsE9RPA"
+        "Id3Vd6SHijj" : "wKOblXpYDnT6izkpW"
       },
-      "link" : "https://www.example.com/53ShN5lbVkWV"
+      "link" : "https://www.example.com/JAoeeYiPwmFWD"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "usJZfivzCjaDCq6U2i6",
+  "owner" : "cFaUcj4HZC4pVSkvez",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,118 +1,118 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Xp8qqU0u9Ji",
-    "ownerAffiliation" : "https://www.example.org/utpraesentium"
+    "owner" : "usJZfivzCjaDCq6U2i6",
+    "ownerAffiliation" : "https://www.example.org/debitisquis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatetemporibus",
+    "id" : "https://www.example.org/oditdolores",
     "labels" : {
-      "JnOzE0dfqfFb" : "dro5QzBNl4koD5"
+      "9BNgSWsg1gY" : "5eXs2JEa3ogM4"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/accusantiumaliquid",
-  "doi" : "https://doi.org/10.1234/aliquam",
-  "link" : "https://www.example.org/sedaspernatur",
+  "handle" : "https://www.example.org/easit",
+  "doi" : "https://doi.org/10.1234/ex",
+  "link" : "https://www.example.org/suntnecessitatibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9hSXU8yhLY",
+    "mainTitle" : "GTOY8D8Gfnh",
     "alternativeTitles" : {
-      "zh" : "8PFl5shlzJQyF"
+      "bg" : "DqMZt4mBfd"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "RAYBSOcArjqHpkuYaC",
-      "month" : "ht9ia3wDaON41GR",
-      "day" : "NVwfLhuTk7JFNa4c"
+      "year" : "N54rzqpKcqYLxSjbkf",
+      "month" : "phiIJh7TyJnwLHLOFd",
+      "day" : "VsyWlL0PTyyJPb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/kNKkEnWtjTpQqGc4B2",
-        "name" : "HPRAoqnTR7",
+        "id" : "https://www.example.com/vlpqH0aymwCAqCAYb6",
+        "name" : "qWQi0SFSCJEiUnwDuVc",
         "nameType" : "Personal",
-        "orcId" : "B0lRtK9rhKUJucKB"
+        "orcId" : "IVR6aUU9OHrgXi9l7rS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Qg7ipZtvvK",
+        "id" : "https://www.example.com/hmMkwMoenuQtdqe8c",
         "labels" : {
-          "MEXrJWde1xA" : "e1WOr6roBlUaglvr"
+          "Ky1TfxR24uKHfVYRXY" : "dTaC6y6cZghaRND"
         }
       } ],
-      "role" : "Dancer",
-      "sequence" : 3,
+      "role" : "Photographer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0k7zoTB4L8C",
-        "name" : "W82UF1kuAjPE7as3",
-        "nameType" : "Personal",
-        "orcId" : "AtEgAO7IJgKllDE"
+        "id" : "https://www.example.com/jF5KyRa8VtHcz",
+        "name" : "sT0CYk4MlX",
+        "nameType" : "Organizational",
+        "orcId" : "ZNxk97fDbzcGOnrAzh"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/J5kBKvrLV4hyTK2",
+        "id" : "https://www.example.com/z3OAY0rYKgR2meGnG3e",
         "labels" : {
-          "DIUeDlfKISv" : "r1Q1lu6JBWdSUj"
+          "FCY2vq07RIYbI29" : "rbblxMSICCeSuBreMam"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 1,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XT1tCUn9rtfro1",
-    "tags" : [ "OmWRawvTxRM49k12sHO" ],
-    "description" : "cqyVw3VvaNiX4zW1ka",
+    "npiSubjectHeading" : "ZjPd801o8F",
+    "tags" : [ "rIbodskWxbWmZqSB5i" ],
+    "description" : "bFWdSi90lX56nmLDrW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/zdV519cz8GJ5sUmq"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/vyQjfCk5DeLNe"
       },
-      "doi" : "https://www.example.com/j3DbdVmKBLbmg2pv",
+      "doi" : "https://www.example.com/MXLDRfM8bkeN5W8",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "F5HjOcN0pCLy",
-        "issue" : "wUD3uGqbrf0",
-        "articleNumber" : "6rJ3HnAcSDZQ6Rp",
+        "volume" : "qxfHeolxgcCkwP1T",
+        "issue" : "0WSr0bDYHkhk",
+        "articleNumber" : "sdejW4Bx9Zy9Q",
         "pages" : {
           "type" : "Range",
-          "begin" : "o9ci6CLqnE",
-          "end" : "PAklOhJv00U3u"
+          "begin" : "RYUovMMDUtDU0s2w3AA",
+          "end" : "naiQhCdK0r9"
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/74qXsZ1MHfA1aLVFLN",
-    "abstract" : "lPaUPAbFgImoio"
+    "metadataSource" : "https://www.example.com/okCNjTlDAWqWS7Gt",
+    "abstract" : "z5j6NeyqoaA1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eligendinecessitatibus",
-    "name" : "vnvooTXrljuu1",
+    "id" : "https://www.example.org/veroat",
+    "name" : "7j0G2zTN0iR7WtU5Nt",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "4BD7Y9Rgxsmv",
-      "id" : "DjnkIPngbgeEMdYQJ"
+      "source" : "E8eW2BAQxJ",
+      "id" : "O93sFHPxhMmUPp71Kc"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "rlFZ6Vqel3aFTsnJC"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "z998OyUtPSYxq"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -120,46 +120,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etdoloribus" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "QgclIUT8J4yyJGE",
-    "mimeType" : "AHK3jMBA3km",
-    "size" : 805864688,
-    "license" : {
-      "type" : "License",
-      "identifier" : "JUzpOdCKs7W",
-      "labels" : {
-        "ZVOnYClkiMLysO" : "2DNX3JoQ5D"
-      },
-      "link" : "https://www.example.com/S6ef8WfoWXmG6B"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/autemet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "QgclIUT8J4yyJGE",
-      "mimeType" : "AHK3jMBA3km",
-      "size" : 805864688,
+      "name" : "UEUBS9CNaj6",
+      "mimeType" : "yO98Wg6JlBbPd8ksNj",
+      "size" : 462899714,
       "license" : {
         "type" : "License",
-        "identifier" : "JUzpOdCKs7W",
+        "identifier" : "UOIofB1sQUy",
         "labels" : {
-          "ZVOnYClkiMLysO" : "2DNX3JoQ5D"
+          "pxhyJQBpjMSxIcq" : "mvqeVKXnX0fERsE9RPA"
         },
-        "link" : "https://www.example.com/S6ef8WfoWXmG6B"
+        "link" : "https://www.example.com/53ShN5lbVkWV"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "Xp8qqU0u9Ji",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "UEUBS9CNaj6",
+    "mimeType" : "yO98Wg6JlBbPd8ksNj",
+    "size" : 462899714,
+    "license" : {
+      "type" : "License",
+      "identifier" : "UOIofB1sQUy",
+      "labels" : {
+        "pxhyJQBpjMSxIcq" : "mvqeVKXnX0fERsE9RPA"
+      },
+      "link" : "https://www.example.com/53ShN5lbVkWV"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "usJZfivzCjaDCq6U2i6",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,104 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "gTKUw90d9L",
-    "ownerAffiliation" : "https://www.example.org/delectusfacilis"
+    "owner" : "9VAc0cLQfH4",
+    "ownerAffiliation" : "https://www.example.org/nonquia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/doloremprovident",
+    "id" : "https://www.example.org/inventoredicta",
     "labels" : {
-      "GzEuvlP8ZIeTnWT" : "605L6MvUKLIlnwy"
+      "7l5qZzXWZoLASm6nuuZ" : "oewTCmsjjT0"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/enimest",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/aliquamdeserunt",
+  "handle" : "https://www.example.org/sitrerum",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/temporibusquasi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8qOm3ogBofr0tV",
+    "mainTitle" : "ZEyRDebiDITgLHS",
     "alternativeTitles" : {
-      "es" : "lr9igH8BuuAD"
+      "da" : "hkuQ9hsU1c9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "iG7GR1H4AyDnjuV5S",
-      "month" : "3vEwkKhmB88Ytkwb3qT",
-      "day" : "cyZsHLeHeoHfBJx"
+      "year" : "aJdExP6cuVsWyxI2wEc",
+      "month" : "Ak2xwI7KFGuGfzh",
+      "day" : "RZgaH4mMw4clEexk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/a2hV1knDRK14",
-        "name" : "dpNaIxciIF8owkBGP5",
+        "id" : "https://www.example.com/n0dQJmbOmtCnL",
+        "name" : "gWqaK8jbh16uR",
         "nameType" : "Organizational",
-        "orcId" : "fuIN4CyHUAY"
+        "orcId" : "RxGbrjku6Ram4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4vV8ElgTpRkyX8kSi",
+        "id" : "https://www.example.com/Ju6l1Zl2N7tfx0",
         "labels" : {
-          "eP7gj6I10F94B1B" : "Rv99LQMe78tokxcDo"
+          "wa04Cbqrcdabn4V" : "1pjdEnPLz69lcFI7ibk"
         }
       } ],
-      "role" : "Director",
+      "role" : "LandscapeArchitect",
       "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hXuOLDXBoL",
-        "name" : "4fErTthm9tuaL",
+        "id" : "https://www.example.com/nr5FbmVznBI6T",
+        "name" : "dp1JfnOl0eI",
         "nameType" : "Personal",
-        "orcId" : "hhH9zXhfNidGnmWn"
+        "orcId" : "ksjY0c8RMug"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oY52fbwTNw",
+        "id" : "https://www.example.com/IC1H3S7zVpgT44ET9j",
         "labels" : {
-          "zobvDW32CZvYGOn" : "LQdWxak8nuqbJ"
+          "pz7iQKYUJhypY" : "6VpCfIzOIIKLrEu8ihc"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 1,
+      "role" : "Soloist",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "8PQGOrrNJ1kV4ppVVc",
-    "tags" : [ "08arwC3ZDUEwqUoN5sx" ],
-    "description" : "eqoFP3eKZefOGx",
+    "npiSubjectHeading" : "MUe3DMWDaDVo5q",
+    "tags" : [ "KAmzBN7xsjppblsb" ],
+    "description" : "hK5duHcsSjgPX9thMby",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "ScqT7Fv7br6AesPF",
+        "label" : "1S4EUumwzx2",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "ybJJ6Axpqt",
-          "country" : "irIEJRUidwFVF33a5L"
+          "label" : "PaVjFthgyl7",
+          "country" : "0wN7W3rMMV9Xf"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/ojjapAMI25kqNKD6",
+          "id" : "https://www.example.com/f04sIFXp1P6YnGTAxZ",
           "labels" : {
-            "cRZqgRk6Ra7Fw667dQc" : "aN4lSBMGvEt"
+            "5sYcbaCQcz" : "Pbi8JpTsMJAHky5xsW"
           }
         },
-        "product" : "https://www.example.com/sdlNBlEymPyFbuCecnr"
+        "product" : "https://www.example.com/kbzbXDuR6Fqig"
       },
-      "doi" : "https://www.example.com/IG1OSZZHK8zGoMXsAm",
+      "doi" : "https://www.example.com/vZSruBYy6cmo3",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -107,45 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/VAeMXOdPLjny1q7qYdF",
-    "abstract" : "U3ygalqbhvUOq"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "cftJX6L57jBu0CZhnjK",
-      "mimeType" : "hJb0jsQCbk",
-      "size" : 1779266329,
-      "license" : {
-        "type" : "License",
-        "identifier" : "4HzL5NLO4f0",
-        "labels" : {
-          "v8M3Y7aV3C0" : "Gft06BKlRN6FkKOa"
-        },
-        "link" : "https://www.example.com/tEaNC38hng2UCIp"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/VItuw8ePEuj5lLD513",
+    "abstract" : "Fw8CqcEIQeE8Xk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequaturvoluptas",
-    "name" : "DnF4NxVQqh1JSB4",
+    "id" : "https://www.example.org/etautem",
+    "name" : "pWqSWoqtQFdy",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "iHc2vt1uT65e",
-      "id" : "gtzQoSyMRoZA36n3c"
+      "source" : "3nYYuoMXzGZ3cXg8mIL",
+      "id" : "t24OEAl1kugDtpKMgqo"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "HYrDvxWxVJJacq3FdG"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "2sAcwkb3ENwI2AO4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/veldolores" ],
+  "subjects" : [ "https://www.example.org/inventorererum" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "cftJX6L57jBu0CZhnjK",
-    "mimeType" : "hJb0jsQCbk",
-    "size" : 1779266329,
+    "name" : "lqHalgpp0B3",
+    "mimeType" : "eCEdQWbkPBO",
+    "size" : 36759435,
     "license" : {
       "type" : "License",
-      "identifier" : "4HzL5NLO4f0",
+      "identifier" : "rZCx8olcQ4tb2",
       "labels" : {
-        "v8M3Y7aV3C0" : "Gft06BKlRN6FkKOa"
+        "2iKky9vGDQJZ3ImLt" : "HdL4mvZ9Rr0oYMAzH"
       },
-      "link" : "https://www.example.com/tEaNC38hng2UCIp"
+      "link" : "https://www.example.com/BjhhBvTwLF8wi90L7YL"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "gTKUw90d9L"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "lqHalgpp0B3",
+      "mimeType" : "eCEdQWbkPBO",
+      "size" : 36759435,
+      "license" : {
+        "type" : "License",
+        "identifier" : "rZCx8olcQ4tb2",
+        "labels" : {
+          "2iKky9vGDQJZ3ImLt" : "HdL4mvZ9Rr0oYMAzH"
+        },
+        "link" : "https://www.example.com/BjhhBvTwLF8wi90L7YL"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "9VAc0cLQfH4",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "9VAc0cLQfH4",
-    "ownerAffiliation" : "https://www.example.org/nonquia"
+    "owner" : "G0fvp6mha8xnNYq",
+    "ownerAffiliation" : "https://www.example.org/commodiipsam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/inventoredicta",
+    "id" : "https://www.example.org/etest",
     "labels" : {
-      "7l5qZzXWZoLASm6nuuZ" : "oewTCmsjjT0"
+      "MGlnrLcK2S5vodOH" : "kBGQVhJizk8jt1v1f"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sitrerum",
-  "doi" : "https://doi.org/10.1234/esse",
-  "link" : "https://www.example.org/temporibusquasi",
+  "handle" : "https://www.example.org/quiinventore",
+  "doi" : "https://doi.org/10.1234/vero",
+  "link" : "https://www.example.org/architectoperspiciatis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZEyRDebiDITgLHS",
+    "mainTitle" : "TcSwjT5CxulQXd0u4dG",
     "alternativeTitles" : {
-      "da" : "hkuQ9hsU1c9"
+      "sv" : "XQFuRY67xCzmtR2W0"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "aJdExP6cuVsWyxI2wEc",
-      "month" : "Ak2xwI7KFGuGfzh",
-      "day" : "RZgaH4mMw4clEexk"
+      "year" : "vnlfa2YkMb0MyKt36zY",
+      "month" : "LYxKO09C6LFeRwDke",
+      "day" : "8pRfqCw2Jt1foxon4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/n0dQJmbOmtCnL",
-        "name" : "gWqaK8jbh16uR",
+        "id" : "https://www.example.com/OylsKAyBsV",
+        "name" : "MowYwYePmI0oDtyc",
         "nameType" : "Organizational",
-        "orcId" : "RxGbrjku6Ram4"
+        "orcId" : "oaNW9K8pt6WL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Ju6l1Zl2N7tfx0",
+        "id" : "https://www.example.com/QBBT872AP2nj",
         "labels" : {
-          "wa04Cbqrcdabn4V" : "1pjdEnPLz69lcFI7ibk"
+          "ZPJWhfOG6SI9Jq8e" : "G5JwcOiJBXX"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 8,
+      "role" : "DataManager",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/nr5FbmVznBI6T",
-        "name" : "dp1JfnOl0eI",
+        "id" : "https://www.example.com/cy0woNuaY8zJAIC",
+        "name" : "xZmoCvffVJymDv6Z",
         "nameType" : "Personal",
-        "orcId" : "ksjY0c8RMug"
+        "orcId" : "a8qqc50Fwpa4w3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/IC1H3S7zVpgT44ET9j",
+        "id" : "https://www.example.com/RYiKA6wn0S37PVpMB",
         "labels" : {
-          "pz7iQKYUJhypY" : "6VpCfIzOIIKLrEu8ihc"
+          "tBpkitZqrzW" : "kDwIrmPtgrbhXAfGZMy"
         }
       } ],
-      "role" : "Soloist",
-      "sequence" : 8,
+      "role" : "ProductionDesigner",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "MUe3DMWDaDVo5q",
-    "tags" : [ "KAmzBN7xsjppblsb" ],
-    "description" : "hK5duHcsSjgPX9thMby",
+    "npiSubjectHeading" : "CSyEUycH7ZRWLozhqnv",
+    "tags" : [ "15tkqnAZdbwCklH4" ],
+    "description" : "YAVfgeJWSdJ0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "1S4EUumwzx2",
+        "label" : "steUReyc0j",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "PaVjFthgyl7",
-          "country" : "0wN7W3rMMV9Xf"
+          "label" : "FIWfxC1RchgIq9gB",
+          "country" : "lJD3hWL739Fwer8t1P"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/f04sIFXp1P6YnGTAxZ",
+          "id" : "https://www.example.com/7L3BGxKMGHIg8r",
           "labels" : {
-            "5sYcbaCQcz" : "Pbi8JpTsMJAHky5xsW"
+            "mIr5II9EKkwol" : "jUwGGCfRah8B85wp"
           }
         },
-        "product" : "https://www.example.com/kbzbXDuR6Fqig"
+        "product" : "https://www.example.com/lreDTZL6IG8BMf3"
       },
-      "doi" : "https://www.example.com/vZSruBYy6cmo3",
+      "doi" : "https://www.example.com/n3pyTZt6IibNW2P",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/VItuw8ePEuj5lLD513",
-    "abstract" : "Fw8CqcEIQeE8Xk"
+    "metadataSource" : "https://www.example.com/hYREKrXcrNQYRUS5i",
+    "abstract" : "4IfBvBmeL7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etautem",
-    "name" : "pWqSWoqtQFdy",
+    "id" : "https://www.example.org/saepesoluta",
+    "name" : "lSL2SCC52zg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "3nYYuoMXzGZ3cXg8mIL",
-      "id" : "t24OEAl1kugDtpKMgqo"
+      "source" : "tJ0ggMuqZpQYB5N87j",
+      "id" : "BJ7u0IbM01CBq2V0s"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "2sAcwkb3ENwI2AO4"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "L1nq1QeTH4AlQTwjo1"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inventorererum" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lqHalgpp0B3",
-    "mimeType" : "eCEdQWbkPBO",
-    "size" : 36759435,
-    "license" : {
-      "type" : "License",
-      "identifier" : "rZCx8olcQ4tb2",
-      "labels" : {
-        "2iKky9vGDQJZ3ImLt" : "HdL4mvZ9Rr0oYMAzH"
-      },
-      "link" : "https://www.example.com/BjhhBvTwLF8wi90L7YL"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/nobisfacere" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lqHalgpp0B3",
-      "mimeType" : "eCEdQWbkPBO",
-      "size" : 36759435,
+      "name" : "HkXXjjd16prn2ZjioA",
+      "mimeType" : "triaRr1KSAi4Hgv",
+      "size" : 538411920,
       "license" : {
         "type" : "License",
-        "identifier" : "rZCx8olcQ4tb2",
+        "identifier" : "nTMasAGURMxK",
         "labels" : {
-          "2iKky9vGDQJZ3ImLt" : "HdL4mvZ9Rr0oYMAzH"
+          "aD67QIs6EuUAeOD" : "ZlAvmNwBvtk6MLVP"
         },
-        "link" : "https://www.example.com/BjhhBvTwLF8wi90L7YL"
+        "link" : "https://www.example.com/FYP4FUzpwl"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "9VAc0cLQfH4",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "HkXXjjd16prn2ZjioA",
+    "mimeType" : "triaRr1KSAi4Hgv",
+    "size" : 538411920,
+    "license" : {
+      "type" : "License",
+      "identifier" : "nTMasAGURMxK",
+      "labels" : {
+        "aD67QIs6EuUAeOD" : "ZlAvmNwBvtk6MLVP"
+      },
+      "link" : "https://www.example.com/FYP4FUzpwl"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "G0fvp6mha8xnNYq",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "G0fvp6mha8xnNYq",
-    "ownerAffiliation" : "https://www.example.org/commodiipsam"
+    "owner" : "tGbG3FQD0H",
+    "ownerAffiliation" : "https://www.example.org/placeatut"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etest",
+    "id" : "https://www.example.org/repellatanimi",
     "labels" : {
-      "MGlnrLcK2S5vodOH" : "kBGQVhJizk8jt1v1f"
+      "E3qaka5P151OeL86" : "xkMaM6ruqaLIYo13"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiinventore",
-  "doi" : "https://doi.org/10.1234/vero",
-  "link" : "https://www.example.org/architectoperspiciatis",
+  "handle" : "https://www.example.org/architectodeserunt",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/cupiditatedolorum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TcSwjT5CxulQXd0u4dG",
+    "mainTitle" : "SxKf4cAGh0fP3C07h",
     "alternativeTitles" : {
-      "sv" : "XQFuRY67xCzmtR2W0"
+      "nn" : "sx7CUky2YJC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "vnlfa2YkMb0MyKt36zY",
-      "month" : "LYxKO09C6LFeRwDke",
-      "day" : "8pRfqCw2Jt1foxon4"
+      "year" : "onYx2vbn0V",
+      "month" : "coF8lOCwcT0",
+      "day" : "kq5UqW8EWsdhlW5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OylsKAyBsV",
-        "name" : "MowYwYePmI0oDtyc",
-        "nameType" : "Organizational",
-        "orcId" : "oaNW9K8pt6WL"
+        "id" : "https://www.example.com/MpGK30EGG6T",
+        "name" : "EzIDk6ALKfO9t",
+        "nameType" : "Personal",
+        "orcId" : "svZy12kc6Zd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QBBT872AP2nj",
+        "id" : "https://www.example.com/JndZfVSCtGgIzm2E5",
         "labels" : {
-          "ZPJWhfOG6SI9Jq8e" : "G5JwcOiJBXX"
+          "endutkMlOunM3" : "MSNuGzjttVe"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 3,
+      "role" : "Journalist",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cy0woNuaY8zJAIC",
-        "name" : "xZmoCvffVJymDv6Z",
+        "id" : "https://www.example.com/naPIwb7CmILCz3",
+        "name" : "K8CLzIQG9gT9Nin2dff",
         "nameType" : "Personal",
-        "orcId" : "a8qqc50Fwpa4w3"
+        "orcId" : "7Lk0qVT2b2yn1ACi9U"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RYiKA6wn0S37PVpMB",
+        "id" : "https://www.example.com/uhLBaK0DjFyE",
         "labels" : {
-          "tBpkitZqrzW" : "kDwIrmPtgrbhXAfGZMy"
+          "3ztAazl5bBAFIx5w" : "eAZkH2uFs7tB1Bquc"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 0,
+      "role" : "Architect",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "CSyEUycH7ZRWLozhqnv",
-    "tags" : [ "15tkqnAZdbwCklH4" ],
-    "description" : "YAVfgeJWSdJ0",
+    "npiSubjectHeading" : "XEnTvhCag48",
+    "tags" : [ "PvdVXUH0yODXHZlic2" ],
+    "description" : "D0fKz2EdrhqqlWYG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "steUReyc0j",
+        "label" : "JakTdTj9K9Q7jZW0if",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "FIWfxC1RchgIq9gB",
-          "country" : "lJD3hWL739Fwer8t1P"
+          "label" : "v8JC6tY09b2jHPSL",
+          "country" : "gJbYsB2pE9MoyFOo"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/7L3BGxKMGHIg8r",
+          "id" : "https://www.example.com/4WQEuQ0IoCWFATBVeA",
           "labels" : {
-            "mIr5II9EKkwol" : "jUwGGCfRah8B85wp"
+            "EWm2MIbP9ZLiu" : "0hLshGxtZZufVNnDlA"
           }
         },
-        "product" : "https://www.example.com/lreDTZL6IG8BMf3"
+        "product" : "https://www.example.com/c2AkT1epndJjY"
       },
-      "doi" : "https://www.example.com/n3pyTZt6IibNW2P",
+      "doi" : "https://www.example.com/XLroPwPiW22Hll",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/hYREKrXcrNQYRUS5i",
-    "abstract" : "4IfBvBmeL7"
+    "metadataSource" : "https://www.example.com/iVnkF0JhE2V",
+    "abstract" : "GemOZXCYTe9jfAFhF7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/saepesoluta",
-    "name" : "lSL2SCC52zg",
+    "id" : "https://www.example.org/nondoloremque",
+    "name" : "zkzEa4U3AV",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "tJ0ggMuqZpQYB5N87j",
-      "id" : "BJ7u0IbM01CBq2V0s"
+      "source" : "boFju3Rri4d0T",
+      "id" : "XaIIsO2TaUHm8PI5m"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "L1nq1QeTH4AlQTwjo1"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "VBHfDCYFjZpgn"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,22 +133,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nobisfacere" ],
+  "subjects" : [ "https://www.example.org/innostrum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "HkXXjjd16prn2ZjioA",
-      "mimeType" : "triaRr1KSAi4Hgv",
-      "size" : 538411920,
+      "name" : "AVTNb2334qeUXbKxnD",
+      "mimeType" : "AhEyADqt8lsnNTsM",
+      "size" : 1406886089,
       "license" : {
         "type" : "License",
-        "identifier" : "nTMasAGURMxK",
+        "identifier" : "VnJhemMom6UQuzbAFK",
         "labels" : {
-          "aD67QIs6EuUAeOD" : "ZlAvmNwBvtk6MLVP"
+          "PmOumQ0KrP" : "eSyTwr38s8SrZb1IT"
         },
-        "link" : "https://www.example.com/FYP4FUzpwl"
+        "link" : "https://www.example.com/xA7p2Shskg6ljk7"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -158,21 +158,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "HkXXjjd16prn2ZjioA",
-    "mimeType" : "triaRr1KSAi4Hgv",
-    "size" : 538411920,
+    "name" : "AVTNb2334qeUXbKxnD",
+    "mimeType" : "AhEyADqt8lsnNTsM",
+    "size" : 1406886089,
     "license" : {
       "type" : "License",
-      "identifier" : "nTMasAGURMxK",
+      "identifier" : "VnJhemMom6UQuzbAFK",
       "labels" : {
-        "aD67QIs6EuUAeOD" : "ZlAvmNwBvtk6MLVP"
+        "PmOumQ0KrP" : "eSyTwr38s8SrZb1IT"
       },
-      "link" : "https://www.example.com/FYP4FUzpwl"
+      "link" : "https://www.example.com/xA7p2Shskg6ljk7"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "G0fvp6mha8xnNYq",
+  "owner" : "tGbG3FQD0H",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -3,87 +3,87 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "tGbG3FQD0H",
-    "ownerAffiliation" : "https://www.example.org/placeatut"
+    "owner" : "u8nnkem0Sn8p6TN3",
+    "ownerAffiliation" : "https://www.example.org/repellendusid"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repellatanimi",
+    "id" : "https://www.example.org/omnisanimi",
     "labels" : {
-      "E3qaka5P151OeL86" : "xkMaM6ruqaLIYo13"
+      "8frM2511dufI3nGlmm" : "uPm3CsG9whc3lnY"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/architectodeserunt",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/cupiditatedolorum",
+  "handle" : "https://www.example.org/eavel",
+  "doi" : "https://doi.org/10.1234/accusamus",
+  "link" : "https://www.example.org/doloremvoluptas",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SxKf4cAGh0fP3C07h",
+    "mainTitle" : "b3WZEHsTDv",
     "alternativeTitles" : {
-      "nn" : "sx7CUky2YJC"
+      "no" : "4EW7Y2VLk8yjqXJ4WBB"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/ita",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "onYx2vbn0V",
-      "month" : "coF8lOCwcT0",
-      "day" : "kq5UqW8EWsdhlW5"
+      "year" : "7a3ELLVs4S",
+      "month" : "qGFWYY4x7ejS",
+      "day" : "g3rPYwkYHTx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MpGK30EGG6T",
-        "name" : "EzIDk6ALKfO9t",
+        "id" : "https://www.example.com/C8SXMrM8kIO8fpiN",
+        "name" : "uwO5xj4wU6jyLhf3",
         "nameType" : "Personal",
-        "orcId" : "svZy12kc6Zd"
+        "orcId" : "SXnITwlBTwXmCOCcIC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/JndZfVSCtGgIzm2E5",
+        "id" : "https://www.example.com/u4XdzZPA3UIL",
         "labels" : {
-          "endutkMlOunM3" : "MSNuGzjttVe"
+          "Ml1M7GaEGsUCSASYU2u" : "4pQaU35yvI3IHM"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 1,
+      "role" : "HostingInstitution",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/naPIwb7CmILCz3",
-        "name" : "K8CLzIQG9gT9Nin2dff",
+        "id" : "https://www.example.com/8SN61RAc0riuJ",
+        "name" : "CV4xtLNHyaK2gt4b6",
         "nameType" : "Personal",
-        "orcId" : "7Lk0qVT2b2yn1ACi9U"
+        "orcId" : "y7OaCIAxsT2Qc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uhLBaK0DjFyE",
+        "id" : "https://www.example.com/bVv0aCzeuXnazpE18Rz",
         "labels" : {
-          "3ztAazl5bBAFIx5w" : "eAZkH2uFs7tB1Bquc"
+          "jmelF919eFRHVTQS" : "uD3KTFon4Mky0"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 7,
+      "role" : "ProgrammeLeader",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XEnTvhCag48",
-    "tags" : [ "PvdVXUH0yODXHZlic2" ],
-    "description" : "D0fKz2EdrhqqlWYG",
+    "npiSubjectHeading" : "kxMFuDHIGrb8fF",
+    "tags" : [ "T17CymzSYxLL" ],
+    "description" : "aSfbKIWqVXk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "JakTdTj9K9Q7jZW0if",
+        "label" : "O0smHC8pHaS0BGbCR",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "v8JC6tY09b2jHPSL",
-          "country" : "gJbYsB2pE9MoyFOo"
+          "label" : "Gi0qSSWsmc",
+          "country" : "oCeoPh3AR6gwcRA"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/4WQEuQ0IoCWFATBVeA",
+          "id" : "https://www.example.com/VIYxeEOB7mW",
           "labels" : {
-            "EWm2MIbP9ZLiu" : "0hLshGxtZZufVNnDlA"
+            "zUu1190h53KykmDMS8" : "MX37ySxuCM"
           }
         },
-        "product" : "https://www.example.com/c2AkT1epndJjY"
+        "product" : "https://www.example.com/j0dHVO7PNg1y"
       },
-      "doi" : "https://www.example.com/XLroPwPiW22Hll",
+      "doi" : "https://www.example.com/gZTtNocGdajIKs",
       "publicationInstance" : {
         "type" : "Lecture",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/iVnkF0JhE2V",
-    "abstract" : "GemOZXCYTe9jfAFhF7"
+    "metadataSource" : "https://www.example.com/l6IkydwIppT",
+    "abstract" : "majduJDxGAhVG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nondoloremque",
-    "name" : "zkzEa4U3AV",
+    "id" : "https://www.example.org/corruptiaspernatur",
+    "name" : "JplELNhiIx6",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "boFju3Rri4d0T",
-      "id" : "XaIIsO2TaUHm8PI5m"
+      "source" : "wF2FY5jm0eq",
+      "id" : "joGOUPccV7z6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "VBHfDCYFjZpgn"
+      "applicationCode" : "9ro5FneBU8p4RqoM6FM"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,22 +133,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/innostrum" ],
+  "subjects" : [ "https://www.example.org/solutasoluta" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "AVTNb2334qeUXbKxnD",
-      "mimeType" : "AhEyADqt8lsnNTsM",
-      "size" : 1406886089,
+      "name" : "9Ro0oSBIUtWG",
+      "mimeType" : "XVsZmEnLbZM9vq",
+      "size" : 2078870005,
       "license" : {
         "type" : "License",
-        "identifier" : "VnJhemMom6UQuzbAFK",
+        "identifier" : "nOgIB4n9b7PBdD",
         "labels" : {
-          "PmOumQ0KrP" : "eSyTwr38s8SrZb1IT"
+          "0Va1mKunqlAMx" : "IImgOrM5KiaUK523p"
         },
-        "link" : "https://www.example.com/xA7p2Shskg6ljk7"
+        "link" : "https://www.example.com/cAE41i9e7sq"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -158,21 +158,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "AVTNb2334qeUXbKxnD",
-    "mimeType" : "AhEyADqt8lsnNTsM",
-    "size" : 1406886089,
+    "name" : "9Ro0oSBIUtWG",
+    "mimeType" : "XVsZmEnLbZM9vq",
+    "size" : 2078870005,
     "license" : {
       "type" : "License",
-      "identifier" : "VnJhemMom6UQuzbAFK",
+      "identifier" : "nOgIB4n9b7PBdD",
       "labels" : {
-        "PmOumQ0KrP" : "eSyTwr38s8SrZb1IT"
+        "0Va1mKunqlAMx" : "IImgOrM5KiaUK523p"
       },
-      "link" : "https://www.example.com/xA7p2Shskg6ljk7"
+      "link" : "https://www.example.com/cAE41i9e7sq"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "tGbG3FQD0H",
+  "owner" : "u8nnkem0Sn8p6TN3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,182 +1,182 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "tBzX2mWzzgLnd",
-    "ownerAffiliation" : "https://www.example.org/vitaevel"
+    "owner" : "6DIXfchM8PiNqQM",
+    "ownerAffiliation" : "https://www.example.org/modianimi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ipsamest",
+    "id" : "https://www.example.org/temporain",
     "labels" : {
-      "1lWt4iM4SuL" : "1MQsm439KxHrgG"
+      "WXsnRwlv5lLURyX" : "EWPyuzw7cwMAcV69j8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/officiaexplicabo",
-  "doi" : "https://doi.org/10.1234/similique",
-  "link" : "https://www.example.org/consequaturdolorem",
+  "handle" : "https://www.example.org/nihilqui",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/nisinostrum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5rFTs96pqWRDNc8dN",
+    "mainTitle" : "jWt5jQCrkdsRYzP1l",
     "alternativeTitles" : {
-      "nn" : "3lB88NdqAd"
+      "da" : "4mcKxRxbn4aeCyjMoUW"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "iHCijYoLWL",
-      "month" : "TXZ4OJYjRBDoK",
-      "day" : "OVXF8eep3M5u1v"
+      "year" : "GYrYPHed5fDhYN",
+      "month" : "Hwyny5Hs05J",
+      "day" : "lSE4aKIXKW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wRRFOHamQ5",
-        "name" : "mMiqXG9xxmGuu2NMv",
+        "id" : "https://www.example.com/htr2un89c24",
+        "name" : "d9ZtXJ3eQu3",
         "nameType" : "Personal",
-        "orcId" : "mt3KAag62cVFNhG28"
+        "orcId" : "Rbo3TSQOEb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6ytbaGHMM1vRZs67wXk",
+        "id" : "https://www.example.com/qjxgKhiuJaaj7Zl",
         "labels" : {
-          "jw4pPpMhbor2ZDdtfc2" : "Ki64ZqyD6ktK"
+          "djvq42YWJVv5jCM" : "gT6kEInfEbPXoVqr"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 4,
+      "role" : "ProjectMember",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9Dym6HbzzAK0V",
-        "name" : "Yd7csmfzP8KCpiPwn",
+        "id" : "https://www.example.com/Mo0m9celITpzK",
+        "name" : "LNfvpTapjKi",
         "nameType" : "Personal",
-        "orcId" : "71VCShA92iPgOvJpmZ"
+        "orcId" : "B7DjzDVDtZs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/KbFAzHei6FTSPX8g",
+        "id" : "https://www.example.com/lCV3EtqCCI0YzSogjH",
         "labels" : {
-          "cSmVuU6yGeJCrwjrwF" : "P8Udc2moMYQJ"
+          "yPpyyQOeUJPhqn38Xa2" : "xlAnaqdZRW6l64vx"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 2,
+      "role" : "ArtisticDirector",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ErAvgpYbtKEGCRdeTS",
-    "tags" : [ "wVVgMW6pamND" ],
-    "description" : "RGKWd2B0wgpmIG",
+    "npiSubjectHeading" : "8mUAdaBGGeLmy1HQ",
+    "tags" : [ "GBzV1GmYXCZ2" ],
+    "description" : "WNtcw3s2fI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/eiw2fXrSEM",
+      "doi" : "https://www.example.com/HGSOrAvLHHMsl",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Play"
+          "type" : "Essay"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "CVRFQEEVmmiO"
+            "name" : "rHWkHeTIO5"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "CevcrRsUiCY8d",
-            "month" : "iInXMJbsVe",
-            "day" : "hlEhGJwP37M8CDq"
+            "year" : "JYo0OeNr2l",
+            "month" : "8rcJCkprSqkPdXCO",
+            "day" : "7eC7e227OfojLH6d"
           },
           "isbn" : "9780099470434",
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "hUTl1NoEue",
-              "end" : "mWw7Ir0SeS0"
+              "begin" : "uRtCNqfXKPhxPPM",
+              "end" : "RPQgcVNqNz"
             },
-            "pages" : "JgFuk1XMGv7VPBtKydB",
+            "pages" : "u5aWVNDZzt6",
             "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
-          "subtype" : "ShortFilm",
+          "subtype" : "Other",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "pcByGYSEJ5g9R"
+            "name" : "GwEHbP8uvB"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "LgOykVaWdO",
-            "month" : "KsqpCGeaGEh3zeqpc",
-            "day" : "IYFO74XH7Oij"
+            "year" : "ds22qvXzkjvl2M65",
+            "month" : "3qXT26ElbcMMUf6",
+            "day" : "P3hei6aP5f2987q"
           },
           "isbn" : "9780099470434",
-          "extent" : 769493257
+          "extent" : 415655474
         }, {
           "type" : "LiteraryArtsPerformance",
-          "subtype" : "Other",
+          "subtype" : "Reading",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Bru7v3ndYRsFV",
-            "country" : "5SA7WqwTH2F3VEYso"
+            "label" : "5dgiR1vgvJXN",
+            "country" : "3P45MJAOt3694e13b7"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "4EXQGW6YIf4",
-            "month" : "AuRxGxBklrbGJ",
-            "day" : "XOPXwzjV7J6LbQx"
+            "year" : "ahSV88EcOtIQPvX",
+            "month" : "gg068uII4Trt",
+            "day" : "MWmcV6FSQfrR"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/G6D1QErPEociQE5",
+          "id" : "https://www.example.com/YCKddg9UhcIS9F",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "W9nKGuZ469Tvp"
+            "name" : "4bpcxWQezBsb"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "74spMlMhfE3",
-            "month" : "d4E6ujbaKC094RU8YHT",
-            "day" : "ri2nf6fJ4WRidqn1"
+            "year" : "vsQ84MVTTkkO6y8",
+            "month" : "UQ3arjT4IKBMpooXDHz",
+            "day" : "OP3GAcby7T"
           }
         } ],
-        "description" : "mYgc3HjQTiGxGD4rfW",
+        "description" : "wD4SjB3Z6y4M58OS4",
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/D3igdRP6Q7s",
-    "abstract" : "UkqKJni6pgp"
+    "metadataSource" : "https://www.example.com/SwCL7WWXfkH1E",
+    "abstract" : "bMbQDulbMB5aYuywE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/praesentiumquia",
-    "name" : "BIkRX4ycDfEI6L",
+    "id" : "https://www.example.org/dolorumquo",
+    "name" : "WhOsGo0NbUU8c",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "CTSn3WoGdMrR",
-      "id" : "zMvgOPuP0AUe4uqjVQ"
+      "source" : "fnwjC58vZ36V",
+      "id" : "FzqEjR5UeLM2UmkLR"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "1m7EPp5Wdg1u2"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ZZ7P4GIK30J"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -184,46 +184,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etoccaecati" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "vcoEoj81HeEYh",
-    "mimeType" : "au5yRGzNdRC",
-    "size" : 1208229541,
-    "license" : {
-      "type" : "License",
-      "identifier" : "7B1WX9vHR2mGPS3Qdki",
-      "labels" : {
-        "EZJCZL7xBS0P" : "m6tk3ZntYNmAmjBpCN"
-      },
-      "link" : "https://www.example.com/lhaIpRSfaV9dV3d"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/optiolaboriosam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "vcoEoj81HeEYh",
-      "mimeType" : "au5yRGzNdRC",
-      "size" : 1208229541,
+      "name" : "yUsmmf8Y6VOKrVDHhm",
+      "mimeType" : "nlH4mnes2S5W",
+      "size" : 541279708,
       "license" : {
         "type" : "License",
-        "identifier" : "7B1WX9vHR2mGPS3Qdki",
+        "identifier" : "WiCUW6pK5jz6",
         "labels" : {
-          "EZJCZL7xBS0P" : "m6tk3ZntYNmAmjBpCN"
+          "hji34MIf0KMZonbLKuM" : "qucO3AQCWLyULz"
         },
-        "link" : "https://www.example.com/lhaIpRSfaV9dV3d"
+        "link" : "https://www.example.com/QOsjto3cNk"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "tBzX2mWzzgLnd",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "yUsmmf8Y6VOKrVDHhm",
+    "mimeType" : "nlH4mnes2S5W",
+    "size" : 541279708,
+    "license" : {
+      "type" : "License",
+      "identifier" : "WiCUW6pK5jz6",
+      "labels" : {
+        "hji34MIf0KMZonbLKuM" : "qucO3AQCWLyULz"
+      },
+      "link" : "https://www.example.com/QOsjto3cNk"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "6DIXfchM8PiNqQM",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,204 +1,182 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "rss27SpUu1OW",
-    "ownerAffiliation" : "https://www.example.org/doloranimi"
+    "owner" : "tBzX2mWzzgLnd",
+    "ownerAffiliation" : "https://www.example.org/vitaevel"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quiaaut",
+    "id" : "https://www.example.org/ipsamest",
     "labels" : {
-      "X2ivSmoPzP6BhUYPFI" : "MdrtT1ZxDb"
+      "1lWt4iM4SuL" : "1MQsm439KxHrgG"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/voluptatemquibusdam",
-  "doi" : "https://doi.org/10.1234/atque",
-  "link" : "https://www.example.org/utsuscipit",
+  "handle" : "https://www.example.org/officiaexplicabo",
+  "doi" : "https://doi.org/10.1234/similique",
+  "link" : "https://www.example.org/consequaturdolorem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "OrMUYg5uwG",
+    "mainTitle" : "5rFTs96pqWRDNc8dN",
     "alternativeTitles" : {
-      "el" : "7sckvUKqyo2bLV"
+      "nn" : "3lB88NdqAd"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "n3xhsQJKaw1IOg9u",
-      "month" : "HDt8keveAVDdoDxY",
-      "day" : "IDbT4qEZswegOlUM"
+      "year" : "iHCijYoLWL",
+      "month" : "TXZ4OJYjRBDoK",
+      "day" : "OVXF8eep3M5u1v"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/neywdcTiI47Ada",
-        "name" : "05W8C9nBPhilZ",
+        "id" : "https://www.example.com/wRRFOHamQ5",
+        "name" : "mMiqXG9xxmGuu2NMv",
         "nameType" : "Personal",
-        "orcId" : "G11DqmNjG2"
+        "orcId" : "mt3KAag62cVFNhG28"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1QfZ4D8dnYCNFXZDa",
+        "id" : "https://www.example.com/6ytbaGHMM1vRZs67wXk",
         "labels" : {
-          "w5sOZ2YuWdQ3Hj" : "Q2nQ6yefYePt"
+          "jw4pPpMhbor2ZDdtfc2" : "Ki64ZqyD6ktK"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 8,
+      "role" : "Choreographer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/XcMW6w40rIeT",
-        "name" : "a3OybM5LiT",
-        "nameType" : "Organizational",
-        "orcId" : "bQQBFB19lR"
+        "id" : "https://www.example.com/9Dym6HbzzAK0V",
+        "name" : "Yd7csmfzP8KCpiPwn",
+        "nameType" : "Personal",
+        "orcId" : "71VCShA92iPgOvJpmZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/O0c6tV7crhBngltr",
+        "id" : "https://www.example.com/KbFAzHei6FTSPX8g",
         "labels" : {
-          "jKdDxYop1eVwXt7P6sG" : "tGiX9Bx1GnMEsGN"
+          "cSmVuU6yGeJCrwjrwF" : "P8Udc2moMYQJ"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 0,
+      "role" : "HostingInstitution",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "j1wSkPABIqCLNb",
-    "tags" : [ "3jpcjkjoPeCeT7" ],
-    "description" : "2jRNuvxAMLW9mDb",
+    "npiSubjectHeading" : "ErAvgpYbtKEGCRdeTS",
+    "tags" : [ "wVVgMW6pamND" ],
+    "description" : "RGKWd2B0wgpmIG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/HfFY2gOGuJfOA",
+      "doi" : "https://www.example.com/eiw2fXrSEM",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Other",
-          "description" : "vB2TEDqns0AsT8Bww1i"
+          "type" : "Play"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Uqta6ICX6wAf"
+            "name" : "CVRFQEEVmmiO"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "CKPzrNncdqOTL",
-            "month" : "RQAKosMnUm1",
-            "day" : "l93hiVbk9fIzo873dx"
+            "year" : "CevcrRsUiCY8d",
+            "month" : "iInXMJbsVe",
+            "day" : "hlEhGJwP37M8CDq"
           },
           "isbn" : "9780099470434",
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "JAs4o21vgQQtWtl",
-              "end" : "heknMvKSyvu2"
+              "begin" : "hUTl1NoEue",
+              "end" : "mWw7Ir0SeS0"
             },
-            "pages" : "vwVlFysNm4",
+            "pages" : "JgFuk1XMGv7VPBtKydB",
             "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
-          "subtype" : "Other",
+          "subtype" : "ShortFilm",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "YEjShnW5uhLxD"
+            "name" : "pcByGYSEJ5g9R"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "MgMIJmRUih",
-            "month" : "paHi6GCqmqh",
-            "day" : "ojb7odVNY5"
+            "year" : "LgOykVaWdO",
+            "month" : "KsqpCGeaGEh3zeqpc",
+            "day" : "IYFO74XH7Oij"
           },
           "isbn" : "9780099470434",
-          "extent" : 457322077
+          "extent" : 769493257
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : "Other",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "orFjmelRwwG0g",
-            "country" : "axhqT3NdmjF8dc"
+            "label" : "Bru7v3ndYRsFV",
+            "country" : "5SA7WqwTH2F3VEYso"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "DaXXAeQhabA9LMEZ9",
-            "month" : "YXxv88vhlgJ",
-            "day" : "Zfbzx0HL5En"
+            "year" : "4EXQGW6YIf4",
+            "month" : "AuRxGxBklrbGJ",
+            "day" : "XOPXwzjV7J6LbQx"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/OAzLh5l1xzpviv",
+          "id" : "https://www.example.com/G6D1QErPEociQE5",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "UijwgNlluwUxDQy"
+            "name" : "W9nKGuZ469Tvp"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "jDgCClCAisXZ",
-            "month" : "JprWiIKDgkki",
-            "day" : "kkURr4aUi8ReJ0h2EdC"
+            "year" : "74spMlMhfE3",
+            "month" : "d4E6ujbaKC094RU8YHT",
+            "day" : "ri2nf6fJ4WRidqn1"
           }
         } ],
-        "description" : "kXJvUHESRmI5JN3IDo4",
+        "description" : "mYgc3HjQTiGxGD4rfW",
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/sJTf1WCHDPQGySVQsr",
-    "abstract" : "jWnno76BvTWGoi"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "FE8QF8NoWvuX9O5W17",
-      "mimeType" : "ORM554lOMvWxjmKIgjb",
-      "size" : 1804017178,
-      "license" : {
-        "type" : "License",
-        "identifier" : "tABailguEhm9CAVhSLs",
-        "labels" : {
-          "c2fCZ4IQ7iINin8r2W" : "B14C2KQfepQGETUEmr"
-        },
-        "link" : "https://www.example.com/hPKLKdUnYs77d157U"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/D3igdRP6Q7s",
+    "abstract" : "UkqKJni6pgp"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nesciuntnecessitatibus",
-    "name" : "8Go3nmLnGA",
+    "id" : "https://www.example.org/praesentiumquia",
+    "name" : "BIkRX4ycDfEI6L",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Billk5IZqrlAwt",
-      "id" : "Jeday596xUrbmO6Lb"
+      "source" : "CTSn3WoGdMrR",
+      "id" : "zMvgOPuP0AUe4uqjVQ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "CRaMCDPFDD"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "1m7EPp5Wdg1u2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -206,25 +184,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/facilisqui" ],
+  "subjects" : [ "https://www.example.org/etoccaecati" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "FE8QF8NoWvuX9O5W17",
-    "mimeType" : "ORM554lOMvWxjmKIgjb",
-    "size" : 1804017178,
+    "name" : "vcoEoj81HeEYh",
+    "mimeType" : "au5yRGzNdRC",
+    "size" : 1208229541,
     "license" : {
       "type" : "License",
-      "identifier" : "tABailguEhm9CAVhSLs",
+      "identifier" : "7B1WX9vHR2mGPS3Qdki",
       "labels" : {
-        "c2fCZ4IQ7iINin8r2W" : "B14C2KQfepQGETUEmr"
+        "EZJCZL7xBS0P" : "m6tk3ZntYNmAmjBpCN"
       },
-      "link" : "https://www.example.com/hPKLKdUnYs77d157U"
+      "link" : "https://www.example.com/lhaIpRSfaV9dV3d"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "rss27SpUu1OW"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "vcoEoj81HeEYh",
+      "mimeType" : "au5yRGzNdRC",
+      "size" : 1208229541,
+      "license" : {
+        "type" : "License",
+        "identifier" : "7B1WX9vHR2mGPS3Qdki",
+        "labels" : {
+          "EZJCZL7xBS0P" : "m6tk3ZntYNmAmjBpCN"
+        },
+        "link" : "https://www.example.com/lhaIpRSfaV9dV3d"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "tBzX2mWzzgLnd",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -3,180 +3,180 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "6DIXfchM8PiNqQM",
-    "ownerAffiliation" : "https://www.example.org/modianimi"
+    "owner" : "neFDeOv5c8xLBX",
+    "ownerAffiliation" : "https://www.example.org/aliquiddoloribus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/temporain",
+    "id" : "https://www.example.org/consequaturad",
     "labels" : {
-      "WXsnRwlv5lLURyX" : "EWPyuzw7cwMAcV69j8"
+      "8zp3MDuUe2k4" : "VwnHYdQxd14BqRmKUBc"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nihilqui",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/nisinostrum",
+  "handle" : "https://www.example.org/enimquis",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/estducimus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jWt5jQCrkdsRYzP1l",
+    "mainTitle" : "lHSUUzRYXk",
     "alternativeTitles" : {
-      "da" : "4mcKxRxbn4aeCyjMoUW"
+      "no" : "0VanO866BI758D"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "GYrYPHed5fDhYN",
-      "month" : "Hwyny5Hs05J",
-      "day" : "lSE4aKIXKW"
+      "year" : "KWDaR8P0epW",
+      "month" : "PXZ29YxJaorRd",
+      "day" : "dMa5THvcQBaVFfQc7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/htr2un89c24",
-        "name" : "d9ZtXJ3eQu3",
+        "id" : "https://www.example.com/rJmENKwzeoSNED",
+        "name" : "2ZOdXsoaBg",
         "nameType" : "Personal",
-        "orcId" : "Rbo3TSQOEb"
+        "orcId" : "s11WSyarVuw0qANo"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qjxgKhiuJaaj7Zl",
+        "id" : "https://www.example.com/jf39WukvL6e67",
         "labels" : {
-          "djvq42YWJVv5jCM" : "gT6kEInfEbPXoVqr"
+          "aRARa8JVCMi" : "G8wtteuUecqMcxzWJu"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 0,
+      "role" : "ProjectManager",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Mo0m9celITpzK",
-        "name" : "LNfvpTapjKi",
+        "id" : "https://www.example.com/Q8MqdTPRa1UJi9Wqd",
+        "name" : "ZgqCNKuDXiDnzyZqdq",
         "nameType" : "Personal",
-        "orcId" : "B7DjzDVDtZs"
+        "orcId" : "glN4nrupse"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lCV3EtqCCI0YzSogjH",
+        "id" : "https://www.example.com/KMYcZtqPWdl9Gn",
         "labels" : {
-          "yPpyyQOeUJPhqn38Xa2" : "xlAnaqdZRW6l64vx"
+          "E6JNYtP23H3Qj6Ma3" : "jd9tnHF0oUqmsHM"
         }
       } ],
-      "role" : "ArtisticDirector",
+      "role" : "Choreographer",
       "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "8mUAdaBGGeLmy1HQ",
-    "tags" : [ "GBzV1GmYXCZ2" ],
-    "description" : "WNtcw3s2fI",
+    "npiSubjectHeading" : "DbXBn4XRmVMOZ4jZVQ",
+    "tags" : [ "pda8DM1CIE" ],
+    "description" : "gnLBBXu2AfqYl59Jw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/HGSOrAvLHHMsl",
+      "doi" : "https://www.example.com/hg4G3kP2P7mJvgJ",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Essay"
+          "type" : "Novel"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "rHWkHeTIO5"
+            "name" : "mpr7r8b9btq"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "JYo0OeNr2l",
-            "month" : "8rcJCkprSqkPdXCO",
-            "day" : "7eC7e227OfojLH6d"
+            "year" : "KiTvJekggHk1Wj",
+            "month" : "J8ZYhvuPeOjeDAo",
+            "day" : "IVicrQsoEKDew"
           },
           "isbn" : "9780099470434",
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "uRtCNqfXKPhxPPM",
-              "end" : "RPQgcVNqNz"
+              "begin" : "ZOVpdClO76EHQwY",
+              "end" : "wQ5NPlFP8Vei8J"
             },
-            "pages" : "u5aWVNDZzt6",
+            "pages" : "4p5FC4VFdoah",
             "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
-          "subtype" : "Other",
+          "subtype" : "RadioPlay",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "GwEHbP8uvB"
+            "name" : "dMOov2s1CP"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "ds22qvXzkjvl2M65",
-            "month" : "3qXT26ElbcMMUf6",
-            "day" : "P3hei6aP5f2987q"
+            "year" : "7eVkAibZU0oFFbq1po",
+            "month" : "0J9mQtkTi6G2mH",
+            "day" : "93EzEPjsSwDS4xIfiHt"
           },
           "isbn" : "9780099470434",
-          "extent" : 415655474
+          "extent" : 1775215167
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : "Reading",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "5dgiR1vgvJXN",
-            "country" : "3P45MJAOt3694e13b7"
+            "label" : "GjjeXKeiTT7",
+            "country" : "7Oa0YcYXRekz"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "ahSV88EcOtIQPvX",
-            "month" : "gg068uII4Trt",
-            "day" : "MWmcV6FSQfrR"
+            "year" : "IHdxoi49trBG9n7Wgp",
+            "month" : "EUTKWIK0VXcuayWcm",
+            "day" : "XDWTGqw2l1KINkRr"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/YCKddg9UhcIS9F",
+          "id" : "https://www.example.com/JGda9xxY1EFOG3cql",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "4bpcxWQezBsb"
+            "name" : "Yqjb4pzRsn0S8ygOtv"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "vsQ84MVTTkkO6y8",
-            "month" : "UQ3arjT4IKBMpooXDHz",
-            "day" : "OP3GAcby7T"
+            "year" : "3pKGkFHYOnIrIAiFX",
+            "month" : "W6nN7elb60jB01O3",
+            "day" : "0wcP5MmOoJP"
           }
         } ],
-        "description" : "wD4SjB3Z6y4M58OS4",
+        "description" : "NWsm5OTT2BddRSns8u",
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/SwCL7WWXfkH1E",
-    "abstract" : "bMbQDulbMB5aYuywE"
+    "metadataSource" : "https://www.example.com/0SzkjoIPNE6W",
+    "abstract" : "JhcLZWYA6Dk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dolorumquo",
-    "name" : "WhOsGo0NbUU8c",
+    "id" : "https://www.example.org/quaeratminima",
+    "name" : "UqI6C7pkm4mn",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "fnwjC58vZ36V",
-      "id" : "FzqEjR5UeLM2UmkLR"
+      "source" : "bP49i0RKwVrC",
+      "id" : "4rs90PqaGVR738MtCs1"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "ZZ7P4GIK30J"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "sc7P4rLet1vzsXE15N"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -184,22 +184,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/optiolaboriosam" ],
+  "subjects" : [ "https://www.example.org/voluptatibusvoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yUsmmf8Y6VOKrVDHhm",
-      "mimeType" : "nlH4mnes2S5W",
-      "size" : 541279708,
+      "name" : "dIcnldEKsMU81Rsyp",
+      "mimeType" : "H0AvgLsVW2145RaAt",
+      "size" : 1428258346,
       "license" : {
         "type" : "License",
-        "identifier" : "WiCUW6pK5jz6",
+        "identifier" : "n7jEiDrrtB",
         "labels" : {
-          "hji34MIf0KMZonbLKuM" : "qucO3AQCWLyULz"
+          "UohICoCXxKjysXfy3n" : "c4VB807r8zA7IY"
         },
-        "link" : "https://www.example.com/QOsjto3cNk"
+        "link" : "https://www.example.com/wG9WSxx5fNSMf"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -209,21 +209,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "yUsmmf8Y6VOKrVDHhm",
-    "mimeType" : "nlH4mnes2S5W",
-    "size" : 541279708,
+    "name" : "dIcnldEKsMU81Rsyp",
+    "mimeType" : "H0AvgLsVW2145RaAt",
+    "size" : 1428258346,
     "license" : {
       "type" : "License",
-      "identifier" : "WiCUW6pK5jz6",
+      "identifier" : "n7jEiDrrtB",
       "labels" : {
-        "hji34MIf0KMZonbLKuM" : "qucO3AQCWLyULz"
+        "UohICoCXxKjysXfy3n" : "c4VB807r8zA7IY"
       },
-      "link" : "https://www.example.com/QOsjto3cNk"
+      "link" : "https://www.example.com/wG9WSxx5fNSMf"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "6DIXfchM8PiNqQM",
+  "owner" : "neFDeOv5c8xLBX",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,182 +1,182 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "neFDeOv5c8xLBX",
-    "ownerAffiliation" : "https://www.example.org/aliquiddoloribus"
+    "owner" : "xPDpptZGX67Cu",
+    "ownerAffiliation" : "https://www.example.org/erroripsum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequaturad",
+    "id" : "https://www.example.org/quiaiure",
     "labels" : {
-      "8zp3MDuUe2k4" : "VwnHYdQxd14BqRmKUBc"
+      "nRQJOHTViSA6olY2" : "BEaQYhL6JV"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/enimquis",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/estducimus",
+  "handle" : "https://www.example.org/vitaetempora",
+  "doi" : "https://doi.org/10.1234/sapiente",
+  "link" : "https://www.example.org/sitperspiciatis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lHSUUzRYXk",
+    "mainTitle" : "89WuCWPKzE",
     "alternativeTitles" : {
-      "no" : "0VanO866BI758D"
+      "pt" : "nUvNMm8dgSXzEwO"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "KWDaR8P0epW",
-      "month" : "PXZ29YxJaorRd",
-      "day" : "dMa5THvcQBaVFfQc7"
+      "year" : "SETWfr4YEgkFD4Vw",
+      "month" : "UWVKvw7dEBvpHmhMbpR",
+      "day" : "WJjevONLY8x"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rJmENKwzeoSNED",
-        "name" : "2ZOdXsoaBg",
-        "nameType" : "Personal",
-        "orcId" : "s11WSyarVuw0qANo"
+        "id" : "https://www.example.com/Fv9NFWw8LYG0wlnQnL",
+        "name" : "Z7qVz8AlpQRbvWN3kk",
+        "nameType" : "Organizational",
+        "orcId" : "Lgwjxh4iK3SsmbDr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/jf39WukvL6e67",
+        "id" : "https://www.example.com/obnie5yWurVCOUMa",
         "labels" : {
-          "aRARa8JVCMi" : "G8wtteuUecqMcxzWJu"
+          "RQPGmQHsKAq7w" : "ZQXoTwy5SA2eR2Nd5U"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 5,
+      "role" : "ProjectMember",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Q8MqdTPRa1UJi9Wqd",
-        "name" : "ZgqCNKuDXiDnzyZqdq",
-        "nameType" : "Personal",
-        "orcId" : "glN4nrupse"
+        "id" : "https://www.example.com/s6Hc2op96TKbJAloBW",
+        "name" : "Gp78RiVBJIA",
+        "nameType" : "Organizational",
+        "orcId" : "n0aD41vqYnX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/KMYcZtqPWdl9Gn",
+        "id" : "https://www.example.com/xlJlbBAUNz8iN3",
         "labels" : {
-          "E6JNYtP23H3Qj6Ma3" : "jd9tnHF0oUqmsHM"
+          "fDqtwUsgloh" : "Tx0AME1z3q33H8zz"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 7,
+      "role" : "LightDesigner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "DbXBn4XRmVMOZ4jZVQ",
-    "tags" : [ "pda8DM1CIE" ],
-    "description" : "gnLBBXu2AfqYl59Jw",
+    "npiSubjectHeading" : "115LSE4wXtEOKJNw5",
+    "tags" : [ "mthrlyw0Nro" ],
+    "description" : "iL35V8to7aDkNq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/hg4G3kP2P7mJvgJ",
+      "doi" : "https://www.example.com/o5BWbzxuCxP",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Novel"
+          "type" : "Retelling"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "mpr7r8b9btq"
+            "name" : "pZ6WMbvdU52vFZP6Jm"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "KiTvJekggHk1Wj",
-            "month" : "J8ZYhvuPeOjeDAo",
-            "day" : "IVicrQsoEKDew"
+            "year" : "ypwJCXIUMIbe17amlAX",
+            "month" : "GBX2xPZVPeWafz",
+            "day" : "vLaLVyXyakWa"
           },
           "isbn" : "9780099470434",
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "ZOVpdClO76EHQwY",
-              "end" : "wQ5NPlFP8Vei8J"
+              "begin" : "S7QCuxM6ui",
+              "end" : "Uvc2Vru90qA"
             },
-            "pages" : "4p5FC4VFdoah",
-            "illustrated" : false
+            "pages" : "aNNg78fzFeMYs",
+            "illustrated" : true
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
-          "subtype" : "RadioPlay",
+          "subtype" : "Other",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "dMOov2s1CP"
+            "name" : "I7sCI9FSpI6wU4"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "7eVkAibZU0oFFbq1po",
-            "month" : "0J9mQtkTi6G2mH",
-            "day" : "93EzEPjsSwDS4xIfiHt"
+            "year" : "JtcodxC95FgupRk",
+            "month" : "ZDzkX8icmZN0pp7",
+            "day" : "LS54oWCqW2HqQ"
           },
           "isbn" : "9780099470434",
-          "extent" : 1775215167
+          "extent" : 1554955195
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : "Reading",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "GjjeXKeiTT7",
-            "country" : "7Oa0YcYXRekz"
+            "label" : "mPpTuNagHK",
+            "country" : "nuHoMKIGyM"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "IHdxoi49trBG9n7Wgp",
-            "month" : "EUTKWIK0VXcuayWcm",
-            "day" : "XDWTGqw2l1KINkRr"
+            "year" : "npsGQb0U3Wx",
+            "month" : "oY12Hl1KryD1",
+            "day" : "W3M8ZwnfdrZVij2y"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/JGda9xxY1EFOG3cql",
+          "id" : "https://www.example.com/k3oNAskJP1RzgVl",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Yqjb4pzRsn0S8ygOtv"
+            "name" : "skRrMGS1AUq1f7kVA"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "3pKGkFHYOnIrIAiFX",
-            "month" : "W6nN7elb60jB01O3",
-            "day" : "0wcP5MmOoJP"
+            "year" : "PhHHR8eIMJHFvSx1d",
+            "month" : "7zmlttp0ct",
+            "day" : "ZzJZJdfjwOG4"
           }
         } ],
-        "description" : "NWsm5OTT2BddRSns8u",
+        "description" : "NH0cUAjV7iPYxL",
         "peerReviewed" : false,
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0SzkjoIPNE6W",
-    "abstract" : "JhcLZWYA6Dk"
+    "metadataSource" : "https://www.example.com/4HSjmFeVEe9G44RPB",
+    "abstract" : "4V3SZWajr3sV3x"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quaeratminima",
-    "name" : "UqI6C7pkm4mn",
+    "id" : "https://www.example.org/hicet",
+    "name" : "pQ666DwlH2iWc",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "bP49i0RKwVrC",
-      "id" : "4rs90PqaGVR738MtCs1"
+      "source" : "URO3ukm3E6U",
+      "id" : "q1totb4Ok49Njdm"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "sc7P4rLet1vzsXE15N"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "UrrGgYxJjNgMzE"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -184,22 +184,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatibusvoluptas" ],
+  "subjects" : [ "https://www.example.org/beataehic" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "dIcnldEKsMU81Rsyp",
-      "mimeType" : "H0AvgLsVW2145RaAt",
-      "size" : 1428258346,
+      "name" : "4gTngmmNAFIhfPWvWZ",
+      "mimeType" : "BQbRwWWQX4bbMB",
+      "size" : 317654149,
       "license" : {
         "type" : "License",
-        "identifier" : "n7jEiDrrtB",
+        "identifier" : "2FvEHn2wq2hDF7",
         "labels" : {
-          "UohICoCXxKjysXfy3n" : "c4VB807r8zA7IY"
+          "oWC30wsfUxfIxYTInRC" : "IADw96T9itKiM"
         },
-        "link" : "https://www.example.com/wG9WSxx5fNSMf"
+        "link" : "https://www.example.com/3jk9kP24EO"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -209,21 +209,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "dIcnldEKsMU81Rsyp",
-    "mimeType" : "H0AvgLsVW2145RaAt",
-    "size" : 1428258346,
+    "name" : "4gTngmmNAFIhfPWvWZ",
+    "mimeType" : "BQbRwWWQX4bbMB",
+    "size" : 317654149,
     "license" : {
       "type" : "License",
-      "identifier" : "n7jEiDrrtB",
+      "identifier" : "2FvEHn2wq2hDF7",
       "labels" : {
-        "UohICoCXxKjysXfy3n" : "c4VB807r8zA7IY"
+        "oWC30wsfUxfIxYTInRC" : "IADw96T9itKiM"
       },
-      "link" : "https://www.example.com/wG9WSxx5fNSMf"
+      "link" : "https://www.example.com/3jk9kP24EO"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "neFDeOv5c8xLBX",
+  "owner" : "xPDpptZGX67Cu",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "GbDxOyumDxjZoG8",
-    "ownerAffiliation" : "https://www.example.org/etnam"
+    "owner" : "4Q9KVSiZmV67m",
+    "ownerAffiliation" : "https://www.example.org/veliteligendi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/maximenam",
+    "id" : "https://www.example.org/exercitationemdolore",
     "labels" : {
-      "JSp9BaSkva" : "0jzfOvbxFChWchrX"
+      "a2jvE3kn0g7nCxppP" : "mzGx74B8ZlQg"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nonnatus",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/nequeiste",
+  "handle" : "https://www.example.org/necessitatibussunt",
+  "doi" : "https://doi.org/10.1234/sunt",
+  "link" : "https://www.example.org/sediste",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mnWx5MIrWXTdrc",
+    "mainTitle" : "w4d8zfTcoOtzuqTDzu0",
     "alternativeTitles" : {
-      "it" : "PiEXIXQuojloMe"
+      "no" : "Ys454rMwYtHbHTSgmbh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "e5Hhkhx95A3q",
-      "month" : "hBUquDpqc3J4J",
-      "day" : "e6qQbPkTlTSASEYo"
+      "year" : "bNS3njAYp7uAC",
+      "month" : "innx4ZIpGgFR",
+      "day" : "KrstwcT2wmdKl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wi5pT87w0ij",
-        "name" : "4zGMmzFakxs",
-        "nameType" : "Organizational",
-        "orcId" : "gDdAK2ZkhLPRsVS"
+        "id" : "https://www.example.com/rdpwaxLNMhhZHJRMmN",
+        "name" : "IgcVBgztoRklilwo",
+        "nameType" : "Personal",
+        "orcId" : "5cmKXaJ28q6jd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RgkxIklih431cnj894I",
+        "id" : "https://www.example.com/IE7SxCI8vdXt5Nf",
         "labels" : {
-          "A02Nq7qU55GZG" : "DjxZf5G1YQU"
+          "aGwik7FbWA1SRck" : "q4ZyXZcNoF8kHLh1"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 9,
+      "role" : "Funder",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/RuuqfzHK48JZUSHUtk3",
-        "name" : "UV6swHKHbZE6OCZ",
+        "id" : "https://www.example.com/wR9zbU3FEOW7x",
+        "name" : "6ArbCHUM3PRL4wHkCF",
         "nameType" : "Organizational",
-        "orcId" : "GIttgpQ3YrppKZsRyIB"
+        "orcId" : "SwHjtnaF8mlbEL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/agnkZ1B67u",
+        "id" : "https://www.example.com/kStzSdcVabIm",
         "labels" : {
-          "22of7MxpbM" : "Ole34GM5Rs4"
+          "DPcB2sur66W9" : "kISjCrkyh67kAcC"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 3,
+      "role" : "Other",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "NbR7W3kWXPwR",
-    "tags" : [ "49eoEpcg6eXsjDus" ],
-    "description" : "tOlYjenctE",
+    "npiSubjectHeading" : "CHTnjGG6tI",
+    "tags" : [ "35Zsg5wsOBwlvs6AG" ],
+    "description" : "Q6dXo9Zw383z8Lz40op",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MDb2pqjnWZW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HSlMvzlAVrj4zMw"
         }
       },
-      "doi" : "https://www.example.com/3sBfR8kp01oxqMVn",
+      "doi" : "https://www.example.com/3GABmO5NcBDKZ3SSsN",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "hlhfQmHukkM3F2",
+        "description" : "L1QflSTEV6R6SpkuQZ",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "bOf4hNaX7DntlV2a45",
-            "end" : "VTpTehqBU610CTt"
+            "begin" : "x4EFcFnFTIFcWhJSIea",
+            "end" : "XnnlEUfluhEFx"
           },
-          "pages" : "fSiBA5QfnPj4HQmf",
-          "illustrated" : false
+          "pages" : "7DEsVT0kNZgq",
+          "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/jRWQjkgZg3oET1",
-    "abstract" : "gVxJZcDKiIe"
+    "metadataSource" : "https://www.example.com/vGDErLovfW9",
+    "abstract" : "O7XLcASeL8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utaliquid",
-    "name" : "8XUcrUxV4CxAAxg",
+    "id" : "https://www.example.org/etnisi",
+    "name" : "ynjEzmwduw2",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "DJedYFLsjO327TMrnP",
-      "id" : "keKlyhPodbLVELxFS4"
+      "source" : "O6OfbL0Jbq8a9YS",
+      "id" : "GZTzkLHtEYe"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "GzKfRjPWce"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "9YyYuXfw3ZPEb"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autemanimi" ],
+  "subjects" : [ "https://www.example.org/doloribusillum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "kRliZ2eibVn5s2Th4X",
-      "mimeType" : "PJk6FetlpbtsY5nKx",
-      "size" : 93402305,
+      "name" : "YkJqML1y4Yb",
+      "mimeType" : "bgMPE2LlyxvI",
+      "size" : 1750600864,
       "license" : {
         "type" : "License",
-        "identifier" : "NAzBXRjdIj6jk9r",
+        "identifier" : "uSYKgdiUHv",
         "labels" : {
-          "rJeJJ9Bf98SNF2HKj" : "ujQ4qiPEGzuab"
+          "tnPtwK7XpDl8Wb" : "wlr2sLZDBUo"
         },
-        "link" : "https://www.example.com/l7RBSSxCzfV80"
+        "link" : "https://www.example.com/8Ho4aRwJKT"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "kRliZ2eibVn5s2Th4X",
-    "mimeType" : "PJk6FetlpbtsY5nKx",
-    "size" : 93402305,
+    "name" : "YkJqML1y4Yb",
+    "mimeType" : "bgMPE2LlyxvI",
+    "size" : 1750600864,
     "license" : {
       "type" : "License",
-      "identifier" : "NAzBXRjdIj6jk9r",
+      "identifier" : "uSYKgdiUHv",
       "labels" : {
-        "rJeJJ9Bf98SNF2HKj" : "ujQ4qiPEGzuab"
+        "tnPtwK7XpDl8Wb" : "wlr2sLZDBUo"
       },
-      "link" : "https://www.example.com/l7RBSSxCzfV80"
+      "link" : "https://www.example.com/8Ho4aRwJKT"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "GbDxOyumDxjZoG8",
+  "owner" : "4Q9KVSiZmV67m",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "8qpG3kTx3c8sAwOWn",
-    "ownerAffiliation" : "https://www.example.org/iureeos"
+    "owner" : "47Dy1RBdG42t8",
+    "ownerAffiliation" : "https://www.example.org/molestiaeodit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/solutavoluptatem",
+    "id" : "https://www.example.org/ametqui",
     "labels" : {
-      "HDpXWoLKu9R3Z" : "jLkIHUAZYbcgWUG0"
+      "kB8u5ipKokHxi" : "WCJeF9HhcwnvM6"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etut",
-  "doi" : "https://doi.org/10.1234/maxime",
-  "link" : "https://www.example.org/possimusin",
+  "handle" : "https://www.example.org/aliasunde",
+  "doi" : "https://doi.org/10.1234/at",
+  "link" : "https://www.example.org/quaeea",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0rnwAAz1dCNA",
+    "mainTitle" : "HtOvQh2jVlUs",
     "alternativeTitles" : {
-      "se" : "tArw3rGar2uQ"
+      "fr" : "w5x0MACJTQN1BSaDFNP"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "AgtYShZjBQz4lQpD",
-      "month" : "3NvxJXIXTZsh92wPdD",
-      "day" : "PO2vlc8GPSnXM6m6"
+      "year" : "YZPOq3CEstZi",
+      "month" : "jMBXZv9UGV7sBT",
+      "day" : "cbWewuRBTGMSkLp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/gZfapnz6PS7RTz",
-        "name" : "7fNu4Gi90u",
-        "nameType" : "Personal",
-        "orcId" : "UYBUqWBmHDlqp"
+        "id" : "https://www.example.com/8mU6rdFyPm1i1Loohu",
+        "name" : "Q6VQetbHoxlY",
+        "nameType" : "Organizational",
+        "orcId" : "UchOe3ATO5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/J0I9mJvjv5",
+        "id" : "https://www.example.com/FD3zFSkuKq",
         "labels" : {
-          "DhKGLCLuMJi0H" : "wyCvWFPGNgUZWSAZMti"
+          "0UOeGol9fzoKMA" : "mjLRbiPfFaCfrAmm5"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 3,
+      "role" : "CuratorOrganizer",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/m8rCRWViQrLcn",
-        "name" : "5QkR4DS76jgw",
+        "id" : "https://www.example.com/qARo7XBZOmm8krPq",
+        "name" : "7AwWYmTt3bNXWXhlJd",
         "nameType" : "Organizational",
-        "orcId" : "tJeGAgTvv1z"
+        "orcId" : "2ReXUXMiVePK2ELl0s"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wpcZ0mZqIXf3",
+        "id" : "https://www.example.com/0e8eAIX3qmlX4",
         "labels" : {
-          "NL9mtbz3wshXrSRCy" : "PK4Lo4AuidQX"
+          "h3VtX2vwJ4tcZNZxjMD" : "7BSpM8Kiri8zGUJ"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 8,
+      "role" : "ProjectMember",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "aKTT1F8wdM6bP3sa",
-    "tags" : [ "Uzmt7PaBbAJRw0N" ],
-    "description" : "BLhO50s2LawZS",
+    "npiSubjectHeading" : "J0IA3gJjinAIoyoC5DA",
+    "tags" : [ "O18bwNCgWzMPa2GFg" ],
+    "description" : "RSU1pPainUvI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Lhf83nzEqxHJMRa"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ceE4fvT2rBlcaMV"
         }
       },
-      "doi" : "https://www.example.com/y2hZTiuE8XSRjH0wm7b",
+      "doi" : "https://www.example.com/JZTbmhmbL3SS",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "QaMXBWuALEWdA6C5RFT",
+        "description" : "5yCuYK9OuxL2v1ms",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "UrKi2muBberLcQqBCb",
-            "end" : "1JdCtsRVHURwc"
+            "begin" : "rkIPivsxn5",
+            "end" : "VwMoc4AeCgdUAYF"
           },
-          "pages" : "FBB9xBRkge98",
+          "pages" : "GLykH0AB8Dd6s",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/jtFyuGM16dBLd0jo9",
-    "abstract" : "DP2m9EGoqVUXTFG2"
+    "metadataSource" : "https://www.example.com/AtK5dbiw5KT",
+    "abstract" : "IrBQWnykU8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autlaboriosam",
-    "name" : "DdnJNyX5Gi9UV42l2",
+    "id" : "https://www.example.org/rationeillo",
+    "name" : "9jNGVGnEY2vJ",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "vnBppbvEfUL",
-      "id" : "ODf2IW6uz7KB"
+      "source" : "XMUwm5dHCMoS22So0b",
+      "id" : "TtD02ITc2SXSGSy2d"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "bFAlFCiupFsFG2HG"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "VIRD3caHs2T"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,46 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/omnisnemo" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "wlGDY2V3hWw",
-    "mimeType" : "2POr69lhGIkjpuEjjHk",
-    "size" : 1816630863,
-    "license" : {
-      "type" : "License",
-      "identifier" : "nsiYMdGGfHque",
-      "labels" : {
-        "CzLpiDmusCks" : "rhiHqCUA1ucsme"
-      },
-      "link" : "https://www.example.com/lAKuguwJCsc"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/commodiet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "wlGDY2V3hWw",
-      "mimeType" : "2POr69lhGIkjpuEjjHk",
-      "size" : 1816630863,
+      "name" : "LLU3vkofNKKpe6jQOC2",
+      "mimeType" : "2F5LLw1538Pwyjl1lA",
+      "size" : 1460242897,
       "license" : {
         "type" : "License",
-        "identifier" : "nsiYMdGGfHque",
+        "identifier" : "rbsPieyR7aPNZJkdMOU",
         "labels" : {
-          "CzLpiDmusCks" : "rhiHqCUA1ucsme"
+          "p9n72uSs0QaAVFIwx" : "xF94D4Vxh3"
         },
-        "link" : "https://www.example.com/lAKuguwJCsc"
+        "link" : "https://www.example.com/n9bDy4xHzh"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "8qpG3kTx3c8sAwOWn",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "LLU3vkofNKKpe6jQOC2",
+    "mimeType" : "2F5LLw1538Pwyjl1lA",
+    "size" : 1460242897,
+    "license" : {
+      "type" : "License",
+      "identifier" : "rbsPieyR7aPNZJkdMOU",
+      "labels" : {
+        "p9n72uSs0QaAVFIwx" : "xF94D4Vxh3"
+      },
+      "link" : "https://www.example.com/n9bDy4xHzh"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "47Dy1RBdG42t8",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,124 +1,124 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "47Dy1RBdG42t8",
-    "ownerAffiliation" : "https://www.example.org/molestiaeodit"
+    "owner" : "GbDxOyumDxjZoG8",
+    "ownerAffiliation" : "https://www.example.org/etnam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ametqui",
+    "id" : "https://www.example.org/maximenam",
     "labels" : {
-      "kB8u5ipKokHxi" : "WCJeF9HhcwnvM6"
+      "JSp9BaSkva" : "0jzfOvbxFChWchrX"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/aliasunde",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/quaeea",
+  "handle" : "https://www.example.org/nonnatus",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/nequeiste",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HtOvQh2jVlUs",
+    "mainTitle" : "mnWx5MIrWXTdrc",
     "alternativeTitles" : {
-      "fr" : "w5x0MACJTQN1BSaDFNP"
+      "it" : "PiEXIXQuojloMe"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "YZPOq3CEstZi",
-      "month" : "jMBXZv9UGV7sBT",
-      "day" : "cbWewuRBTGMSkLp"
+      "year" : "e5Hhkhx95A3q",
+      "month" : "hBUquDpqc3J4J",
+      "day" : "e6qQbPkTlTSASEYo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8mU6rdFyPm1i1Loohu",
-        "name" : "Q6VQetbHoxlY",
+        "id" : "https://www.example.com/wi5pT87w0ij",
+        "name" : "4zGMmzFakxs",
         "nameType" : "Organizational",
-        "orcId" : "UchOe3ATO5"
+        "orcId" : "gDdAK2ZkhLPRsVS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FD3zFSkuKq",
+        "id" : "https://www.example.com/RgkxIklih431cnj894I",
         "labels" : {
-          "0UOeGol9fzoKMA" : "mjLRbiPfFaCfrAmm5"
+          "A02Nq7qU55GZG" : "DjxZf5G1YQU"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 8,
+      "role" : "ContactPerson",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/qARo7XBZOmm8krPq",
-        "name" : "7AwWYmTt3bNXWXhlJd",
+        "id" : "https://www.example.com/RuuqfzHK48JZUSHUtk3",
+        "name" : "UV6swHKHbZE6OCZ",
         "nameType" : "Organizational",
-        "orcId" : "2ReXUXMiVePK2ELl0s"
+        "orcId" : "GIttgpQ3YrppKZsRyIB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0e8eAIX3qmlX4",
+        "id" : "https://www.example.com/agnkZ1B67u",
         "labels" : {
-          "h3VtX2vwJ4tcZNZxjMD" : "7BSpM8Kiri8zGUJ"
+          "22of7MxpbM" : "Ole34GM5Rs4"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 2,
+      "role" : "DataManager",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "J0IA3gJjinAIoyoC5DA",
-    "tags" : [ "O18bwNCgWzMPa2GFg" ],
-    "description" : "RSU1pPainUvI",
+    "npiSubjectHeading" : "NbR7W3kWXPwR",
+    "tags" : [ "49eoEpcg6eXsjDus" ],
+    "description" : "tOlYjenctE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ceE4fvT2rBlcaMV"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MDb2pqjnWZW"
         }
       },
-      "doi" : "https://www.example.com/JZTbmhmbL3SS",
+      "doi" : "https://www.example.com/3sBfR8kp01oxqMVn",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "5yCuYK9OuxL2v1ms",
+        "description" : "hlhfQmHukkM3F2",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rkIPivsxn5",
-            "end" : "VwMoc4AeCgdUAYF"
+            "begin" : "bOf4hNaX7DntlV2a45",
+            "end" : "VTpTehqBU610CTt"
           },
-          "pages" : "GLykH0AB8Dd6s",
-          "illustrated" : true
+          "pages" : "fSiBA5QfnPj4HQmf",
+          "illustrated" : false
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/AtK5dbiw5KT",
-    "abstract" : "IrBQWnykU8"
+    "metadataSource" : "https://www.example.com/jRWQjkgZg3oET1",
+    "abstract" : "gVxJZcDKiIe"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/rationeillo",
-    "name" : "9jNGVGnEY2vJ",
+    "id" : "https://www.example.org/utaliquid",
+    "name" : "8XUcrUxV4CxAAxg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XMUwm5dHCMoS22So0b",
-      "id" : "TtD02ITc2SXSGSy2d"
+      "source" : "DJedYFLsjO327TMrnP",
+      "id" : "keKlyhPodbLVELxFS4"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "VIRD3caHs2T"
+      "applicationCode" : "GzKfRjPWce"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -126,22 +126,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/commodiet" ],
+  "subjects" : [ "https://www.example.org/autemanimi" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LLU3vkofNKKpe6jQOC2",
-      "mimeType" : "2F5LLw1538Pwyjl1lA",
-      "size" : 1460242897,
+      "name" : "kRliZ2eibVn5s2Th4X",
+      "mimeType" : "PJk6FetlpbtsY5nKx",
+      "size" : 93402305,
       "license" : {
         "type" : "License",
-        "identifier" : "rbsPieyR7aPNZJkdMOU",
+        "identifier" : "NAzBXRjdIj6jk9r",
         "labels" : {
-          "p9n72uSs0QaAVFIwx" : "xF94D4Vxh3"
+          "rJeJJ9Bf98SNF2HKj" : "ujQ4qiPEGzuab"
         },
-        "link" : "https://www.example.com/n9bDy4xHzh"
+        "link" : "https://www.example.com/l7RBSSxCzfV80"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -151,21 +151,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LLU3vkofNKKpe6jQOC2",
-    "mimeType" : "2F5LLw1538Pwyjl1lA",
-    "size" : 1460242897,
+    "name" : "kRliZ2eibVn5s2Th4X",
+    "mimeType" : "PJk6FetlpbtsY5nKx",
+    "size" : 93402305,
     "license" : {
       "type" : "License",
-      "identifier" : "rbsPieyR7aPNZJkdMOU",
+      "identifier" : "NAzBXRjdIj6jk9r",
       "labels" : {
-        "p9n72uSs0QaAVFIwx" : "xF94D4Vxh3"
+        "rJeJJ9Bf98SNF2HKj" : "ujQ4qiPEGzuab"
       },
-      "link" : "https://www.example.com/n9bDy4xHzh"
+      "link" : "https://www.example.com/l7RBSSxCzfV80"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "47Dy1RBdG42t8",
+  "owner" : "GbDxOyumDxjZoG8",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -3,143 +3,122 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "9Y0Y340Ihcxs8uRsodt",
-    "ownerAffiliation" : "https://www.example.org/illumenim"
+    "owner" : "8qpG3kTx3c8sAwOWn",
+    "ownerAffiliation" : "https://www.example.org/iureeos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fugalaudantium",
+    "id" : "https://www.example.org/solutavoluptatem",
     "labels" : {
-      "WM4Way1Wtlo3WRtIb" : "ZVzaH80Wgxued"
+      "HDpXWoLKu9R3Z" : "jLkIHUAZYbcgWUG0"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sedvel",
-  "doi" : "https://doi.org/10.1234/nam",
-  "link" : "https://www.example.org/fugiatillum",
+  "handle" : "https://www.example.org/etut",
+  "doi" : "https://doi.org/10.1234/maxime",
+  "link" : "https://www.example.org/possimusin",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6rQScdKZittzLTa",
+    "mainTitle" : "0rnwAAz1dCNA",
     "alternativeTitles" : {
-      "hu" : "gRse7YcOM594HdaPK"
+      "se" : "tArw3rGar2uQ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ofmKqTbmdaeSrABqol",
-      "month" : "Sf2N7JTRxS",
-      "day" : "Jk28fCNiELOuOWV0b"
+      "year" : "AgtYShZjBQz4lQpD",
+      "month" : "3NvxJXIXTZsh92wPdD",
+      "day" : "PO2vlc8GPSnXM6m6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8yHO4C3WgiRs",
-        "name" : "7eLa0r0xvpmXt4MjF",
-        "nameType" : "Organizational",
-        "orcId" : "nGiqkTVDKWKU"
+        "id" : "https://www.example.com/gZfapnz6PS7RTz",
+        "name" : "7fNu4Gi90u",
+        "nameType" : "Personal",
+        "orcId" : "UYBUqWBmHDlqp"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VskCWHDgLbTnNNH",
+        "id" : "https://www.example.com/J0I9mJvjv5",
         "labels" : {
-          "9LYllN3pk4" : "ykwtHmeWYiVpi"
+          "DhKGLCLuMJi0H" : "wyCvWFPGNgUZWSAZMti"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 2,
+      "role" : "Architect",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wqWWBW4n0KMbX",
-        "name" : "ZheG3uM0Djv8rwV",
+        "id" : "https://www.example.com/m8rCRWViQrLcn",
+        "name" : "5QkR4DS76jgw",
         "nameType" : "Organizational",
-        "orcId" : "9Xn6HwqM4EZ"
+        "orcId" : "tJeGAgTvv1z"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9Pv40XnPtJW6WW",
+        "id" : "https://www.example.com/wpcZ0mZqIXf3",
         "labels" : {
-          "GfjJL6z4cBCT" : "108RkY0TuYQg"
+          "NL9mtbz3wshXrSRCy" : "PK4Lo4AuidQX"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 0,
+      "role" : "Funder",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "jXvkIfUPBF2IDiP",
-    "tags" : [ "DnG6PK2KktxnrkZW6" ],
-    "description" : "eL6ElvMyOF6Ovz1PR",
+    "npiSubjectHeading" : "aKTT1F8wdM6bP3sa",
+    "tags" : [ "Uzmt7PaBbAJRw0N" ],
+    "description" : "BLhO50s2LawZS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/SZ8qlS9c8QagC3uR"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Lhf83nzEqxHJMRa"
         }
       },
-      "doi" : "https://www.example.com/PMNyDJIZtz",
+      "doi" : "https://www.example.com/y2hZTiuE8XSRjH0wm7b",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "3DaHkHjod4",
+        "description" : "QaMXBWuALEWdA6C5RFT",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ljio2k7d7x07q",
-            "end" : "uy7zXgwIZDC14wjNp4"
+            "begin" : "UrKi2muBberLcQqBCb",
+            "end" : "1JdCtsRVHURwc"
           },
-          "pages" : "gBLFEEjVvOW",
+          "pages" : "FBB9xBRkge98",
           "illustrated" : true
         },
         "peerReviewed" : false
       }
     },
-    "metadataSource" : "https://www.example.com/xrr4ZRng9kFB31rib",
-    "abstract" : "TrVR0UYhAwFN"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "vMDa0HZNQP",
-      "mimeType" : "Hj1UUhpQQ6RgO",
-      "size" : 1057992107,
-      "license" : {
-        "type" : "License",
-        "identifier" : "kat9aW6hSnawMU",
-        "labels" : {
-          "zwLIqFGzTl1HvoH" : "eXAkr5gzl5JVey7aT"
-        },
-        "link" : "https://www.example.com/ZlIjF1KEovu"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/jtFyuGM16dBLd0jo9",
+    "abstract" : "DP2m9EGoqVUXTFG2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiaeos",
-    "name" : "oJKge72Wyz80",
+    "id" : "https://www.example.org/autlaboriosam",
+    "name" : "DdnJNyX5Gi9UV42l2",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "b5CE9C2702f",
-      "id" : "TnREMMlf4I64UD"
+      "source" : "vnBppbvEfUL",
+      "id" : "ODf2IW6uz7KB"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "SlTrRbN8VcCpMG"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "bFAlFCiupFsFG2HG"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -147,25 +126,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/consecteturest" ],
+  "subjects" : [ "https://www.example.org/omnisnemo" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "vMDa0HZNQP",
-    "mimeType" : "Hj1UUhpQQ6RgO",
-    "size" : 1057992107,
+    "name" : "wlGDY2V3hWw",
+    "mimeType" : "2POr69lhGIkjpuEjjHk",
+    "size" : 1816630863,
     "license" : {
       "type" : "License",
-      "identifier" : "kat9aW6hSnawMU",
+      "identifier" : "nsiYMdGGfHque",
       "labels" : {
-        "zwLIqFGzTl1HvoH" : "eXAkr5gzl5JVey7aT"
+        "CzLpiDmusCks" : "rhiHqCUA1ucsme"
       },
-      "link" : "https://www.example.com/ZlIjF1KEovu"
+      "link" : "https://www.example.com/lAKuguwJCsc"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "9Y0Y340Ihcxs8uRsodt"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "wlGDY2V3hWw",
+      "mimeType" : "2POr69lhGIkjpuEjjHk",
+      "size" : 1816630863,
+      "license" : {
+        "type" : "License",
+        "identifier" : "nsiYMdGGfHque",
+        "labels" : {
+          "CzLpiDmusCks" : "rhiHqCUA1ucsme"
+        },
+        "link" : "https://www.example.com/lAKuguwJCsc"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "8qpG3kTx3c8sAwOWn",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "A2yPmmvMjgpvjgF",
-    "ownerAffiliation" : "https://www.example.org/ullamullam"
+    "owner" : "je7ZfFQz6f",
+    "ownerAffiliation" : "https://www.example.org/recusandaenumquam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequaturdolor",
+    "id" : "https://www.example.org/sitlaudantium",
     "labels" : {
-      "HTJ4fJNBFzGR232ba" : "PAJvgpz57oZ"
+      "LDrHr98dl57uqi" : "bDF63m4DugcRRB7Xiil"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/itaquequi",
-  "doi" : "https://doi.org/10.1234/provident",
-  "link" : "https://www.example.org/possimusat",
+  "handle" : "https://www.example.org/dolorumet",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/temporibusdolorum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bVMRXfQfuNVZG0VJ",
+    "mainTitle" : "lHVMzMZaRA24yVm",
     "alternativeTitles" : {
-      "hu" : "Jg0mzb0elDzCn3MQ9"
+      "el" : "U6GFkSOtGq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "XUjklG04HrjDxuwh5b",
-      "month" : "L0QtJlJbOXv",
-      "day" : "y9JUDC3XgggMYb"
+      "year" : "zo1q5ixfo81qYOB6dS9",
+      "month" : "OnjMKBsIjAk2Ih",
+      "day" : "gTlFzoEtrn"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/FLJqiiujYkGH",
-        "name" : "MbOCje6eCZqQIEQhrdz",
+        "id" : "https://www.example.com/7poyi0xbQo",
+        "name" : "5nlSy6KQ2b0nxLh4m",
         "nameType" : "Personal",
-        "orcId" : "sKxHRq1y80h"
+        "orcId" : "uBww44s2ocBVLdlDJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ju4nmw1b9K3JCtMlMvy",
+        "id" : "https://www.example.com/Qy8IQgEXdyhxF",
         "labels" : {
-          "HvnDqhm4eJuwVFJfKv7" : "VaaYEV4vklb"
+          "U0Wd3EWCX9vDg9Rg" : "wYbSyhVqa03"
         }
       } ],
-      "role" : "RightsHolder",
-      "sequence" : 6,
+      "role" : "Sponsor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hpu4tB1WHte4",
-        "name" : "kt7WG4ct3JUkl73S5V",
+        "id" : "https://www.example.com/cRhK9gPT2bU2Rom",
+        "name" : "dJp4RAuMiU5fgo0V",
         "nameType" : "Organizational",
-        "orcId" : "n0dobGXuPNzjBa9"
+        "orcId" : "rnjuXpLfUmny2rea"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/gUAl9f0IsPeqBN",
+        "id" : "https://www.example.com/LfBww0vZ4i",
         "labels" : {
-          "0Kurh4RTMQZScylwZ" : "MrJI4HoFk4n"
+          "xuvgurzHvF4Nw5H" : "hQGgjqo9phsOt"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 6,
+      "role" : "ContactPerson",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "zO1u4P8YeMo",
-    "tags" : [ "ATC5itE4Zjw" ],
-    "description" : "JC6Rjs380nUET1nnO",
+    "npiSubjectHeading" : "YM7o4bK670ySK",
+    "tags" : [ "8vgOAyB7asBULfy" ],
+    "description" : "uUxMCpZ5WHVJssx",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "TV"
         },
         "format" : "Text",
-        "disseminationChannel" : "AU1Zp8frDFdsLZE5J",
+        "disseminationChannel" : "EfpwBIXbvGOCicjP2K",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "Kan9aCxGB3rMxBmP",
-          "seriesPart" : "qTTNdXSctk0tIAO"
+          "series" : "g3RnImjoLCi9",
+          "seriesPart" : "H0zTpWjfDdYSrY"
         }
       },
-      "doi" : "https://www.example.com/IOPTniqIZFE0r",
+      "doi" : "https://www.example.com/7kRb0jB8q6K",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Gd3VahRrmynv4AXSQKp",
-    "abstract" : "tWNhKcJAbFGMBhu4512"
+    "metadataSource" : "https://www.example.com/myMX1lU5pXVAiu76",
+    "abstract" : "jzCMWwKp7pT1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estvoluptas",
-    "name" : "HttfkaV5s2",
+    "id" : "https://www.example.org/abinventore",
+    "name" : "21SvuJFn67hxMjTDOd",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "YtM80St4QMPDsRa",
-      "id" : "h6Ez9aZJh16X"
+      "source" : "nQd00CWvWtOJVrs",
+      "id" : "iNriafGBCkI3NwT"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "htaflKosTsFoU"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "yRixvmrQT7Ww84A"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,22 +124,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quosest" ],
+  "subjects" : [ "https://www.example.org/undeet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "BwG9cOxLwb5lg",
-      "mimeType" : "2i5sjLsuHAtF",
-      "size" : 955844979,
+      "name" : "C7eHqVaBPbqvKiyu1h",
+      "mimeType" : "a7CUESXeNncHGfnu",
+      "size" : 669381261,
       "license" : {
         "type" : "License",
-        "identifier" : "083pryi7Q7e",
+        "identifier" : "Hsa8Akx8ajvnT",
         "labels" : {
-          "gBWMpiVLAB" : "KY4qkvjh84z"
+          "ERxaQyxzmfy" : "vlLe1iAGcb"
         },
-        "link" : "https://www.example.com/Py7j6TGxZBg9s"
+        "link" : "https://www.example.com/mgMAQoW6t1ZbZ2L"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -149,21 +149,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "BwG9cOxLwb5lg",
-    "mimeType" : "2i5sjLsuHAtF",
-    "size" : 955844979,
+    "name" : "C7eHqVaBPbqvKiyu1h",
+    "mimeType" : "a7CUESXeNncHGfnu",
+    "size" : 669381261,
     "license" : {
       "type" : "License",
-      "identifier" : "083pryi7Q7e",
+      "identifier" : "Hsa8Akx8ajvnT",
       "labels" : {
-        "gBWMpiVLAB" : "KY4qkvjh84z"
+        "ERxaQyxzmfy" : "vlLe1iAGcb"
       },
-      "link" : "https://www.example.com/Py7j6TGxZBg9s"
+      "link" : "https://www.example.com/mgMAQoW6t1ZbZ2L"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "A2yPmmvMjgpvjgF",
+  "owner" : "je7ZfFQz6f",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -3,94 +3,95 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "iepWRy8o4H",
-    "ownerAffiliation" : "https://www.example.org/accusamusrerum"
+    "owner" : "iVFh0CVhJaoGA",
+    "ownerAffiliation" : "https://www.example.org/rerumperferendis"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/delectusquia",
+    "id" : "https://www.example.org/autut",
     "labels" : {
-      "vpbV6Qu2ZsTX" : "GUAM9iggebSlJ2zhnw3"
+      "oP8VeKcxPtTrG20GNlF" : "Z95CVonlBF"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/delectussuscipit",
-  "doi" : "https://doi.org/10.1234/eos",
-  "link" : "https://www.example.org/ipsummollitia",
+  "handle" : "https://www.example.org/delenitiiusto",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/nondeserunt",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mqShfAc3ug",
+    "mainTitle" : "V7mpuFyWDoNCNzLevt",
     "alternativeTitles" : {
-      "se" : "JxM21KfyJq1YlRwF2KW"
+      "bg" : "7F2dK0pvEndZ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Us67WZPVs4MbCtZhyHE",
-      "month" : "poxldTCTbRkxh",
-      "day" : "OHzf32iVtH8nFvGi"
+      "year" : "HMTiWjKsfgZgvfM",
+      "month" : "ZWWCudsSSyo5f",
+      "day" : "G9HAhmJLFMPZrFm2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Gqf3O0U3lTpVxXw",
-        "name" : "CHZWaQh9OhhBgDF",
-        "nameType" : "Organizational",
-        "orcId" : "McPGXotsUa1KyUM3"
+        "id" : "https://www.example.com/ynjLSTmrzcW",
+        "name" : "ULo2oi9lZasN3AjNiS",
+        "nameType" : "Personal",
+        "orcId" : "LHzee7j9I21Ztw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UDGO6jlOVHHdr4W3kmn",
+        "id" : "https://www.example.com/BAErmNXwYLi79",
         "labels" : {
-          "VzmuESzmLYC03q2Itt" : "QDMwYbAYhZhV1l"
+          "TE2Gkxh37M4mJ" : "CrO7jn7JY8mN4"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 4,
+      "role" : "Writer",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/adXw1a6sDUVtifgf",
-        "name" : "JNnXsszsMkTTN",
+        "id" : "https://www.example.com/dK0Cs1IfcK7HKt1hzrD",
+        "name" : "aRf5p6FdO6gxIgOZwa",
         "nameType" : "Personal",
-        "orcId" : "iKEXhhXqRBUwR"
+        "orcId" : "qryAdvBQZVhdKelY4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xoCJQ1vlw9ks0W",
+        "id" : "https://www.example.com/5wXV7DqIOe5",
         "labels" : {
-          "9szWmXM52NMaI" : "sDVvsOg1JcPMbAmf8"
+          "lkCiYGzm4tDuX" : "Q2hSPTMiDsOrw"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 8,
+      "role" : "ProductionDesigner",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "BKaHritZ0Z",
-    "tags" : [ "gC5HXpnEHMXg7phHut" ],
-    "description" : "7Hlro8lyasTxc4NTeb4",
+    "npiSubjectHeading" : "WMd9EB9VpX",
+    "tags" : [ "3K8cH4BPbfXJc" ],
+    "description" : "zCfgFesociaE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Other",
+          "description" : "8Vb10rTB0dkrL2ukO"
         },
-        "format" : "Video",
-        "disseminationChannel" : "91LY4I0tmfVWgl4FKh",
+        "format" : "Text",
+        "disseminationChannel" : "MHfFC5cbtXp",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "r41qT7E5cqUMTvi",
-          "seriesPart" : "GVyQavybqlkcnz"
+          "series" : "2NlRttUfy1ZdQdRfr7G",
+          "seriesPart" : "0ft7qOGZEluXQvJfq"
         }
       },
-      "doi" : "https://www.example.com/uist2Ag9tnvL6FNX",
+      "doi" : "https://www.example.com/udsn0hwRuYMgsMlb8",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "peerReviewed" : false,
@@ -99,45 +100,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/YV5i6S4RXTEgEr",
-    "abstract" : "dVeEbyNQlTisq"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "myPAkZc9SlXvknZvrL8",
-      "mimeType" : "HtjwpcFERps1",
-      "size" : 1127001020,
-      "license" : {
-        "type" : "License",
-        "identifier" : "Hwe2Wjl8U8SbU",
-        "labels" : {
-          "40nSHGPGdun" : "tX3jzT2pDUhUYhXpe1"
-        },
-        "link" : "https://www.example.com/bvyustce8ip2Opnvx"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/IepEAqxJOuRZwywxP",
+    "abstract" : "xr9YIzgiRP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/perferendisdicta",
-    "name" : "INezmPL7XniI4fpVc",
+    "id" : "https://www.example.org/doloremqueplaceat",
+    "name" : "7CRfrkQFOxOo",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "oBscDt7C1yqPdQ",
-      "id" : "qvI0KkfLMEGac"
+      "source" : "1678tNAhgsxvv",
+      "id" : "VcRx8Pw3r29bNfeEGy"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "sEpA85Vk6i"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "J0BfRjbKyqJbnF"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,25 +125,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eaqueea" ],
+  "subjects" : [ "https://www.example.org/quiet" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "myPAkZc9SlXvknZvrL8",
-    "mimeType" : "HtjwpcFERps1",
-    "size" : 1127001020,
+    "name" : "00PFmviem7",
+    "mimeType" : "Ibrm0GjnwFly7pU148c",
+    "size" : 1554882918,
     "license" : {
       "type" : "License",
-      "identifier" : "Hwe2Wjl8U8SbU",
+      "identifier" : "qhpYxtr9KBfB",
       "labels" : {
-        "40nSHGPGdun" : "tX3jzT2pDUhUYhXpe1"
+        "BdkQsoUWev" : "G3QX0ghGk19gO7Ls"
       },
-      "link" : "https://www.example.com/bvyustce8ip2Opnvx"
+      "link" : "https://www.example.com/84WRVuu3mI5B0LnA9"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "iepWRy8o4H"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "00PFmviem7",
+      "mimeType" : "Ibrm0GjnwFly7pU148c",
+      "size" : 1554882918,
+      "license" : {
+        "type" : "License",
+        "identifier" : "qhpYxtr9KBfB",
+        "labels" : {
+          "BdkQsoUWev" : "G3QX0ghGk19gO7Ls"
+        },
+        "link" : "https://www.example.com/84WRVuu3mI5B0LnA9"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "iVFh0CVhJaoGA",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "je7ZfFQz6f",
-    "ownerAffiliation" : "https://www.example.org/recusandaenumquam"
+    "owner" : "FHj7w3SShtC",
+    "ownerAffiliation" : "https://www.example.org/eosest"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sitlaudantium",
+    "id" : "https://www.example.org/voluptatibuscupiditate",
     "labels" : {
-      "LDrHr98dl57uqi" : "bDF63m4DugcRRB7Xiil"
+      "nboywXMifrICJkbv" : "LMXvInE1d1"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolorumet",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/temporibusdolorum",
+  "handle" : "https://www.example.org/liberorerum",
+  "doi" : "https://doi.org/10.1234/vero",
+  "link" : "https://www.example.org/estullam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lHVMzMZaRA24yVm",
+    "mainTitle" : "3KsFmMcL3czE",
     "alternativeTitles" : {
-      "el" : "U6GFkSOtGq"
+      "se" : "WywWiz7XWwObodNSH"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "zo1q5ixfo81qYOB6dS9",
-      "month" : "OnjMKBsIjAk2Ih",
-      "day" : "gTlFzoEtrn"
+      "year" : "jCXGnkQv6OzIQ",
+      "month" : "IOGH7OUk212ifmmP",
+      "day" : "DgYwlSiskDV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/7poyi0xbQo",
-        "name" : "5nlSy6KQ2b0nxLh4m",
+        "id" : "https://www.example.com/h2gd9544FkyTD",
+        "name" : "bI5qRpOI3Z",
         "nameType" : "Personal",
-        "orcId" : "uBww44s2ocBVLdlDJ"
+        "orcId" : "CCMuSk0aMYVC0D75M6S"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Qy8IQgEXdyhxF",
+        "id" : "https://www.example.com/eOKW2EKf3HCn5",
         "labels" : {
-          "U0Wd3EWCX9vDg9Rg" : "wYbSyhVqa03"
+          "i2xWpI4KW5kZtVD5EA" : "vzUHBjBVSqmmcGSDnlQ"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 2,
+      "role" : "Musician",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cRhK9gPT2bU2Rom",
-        "name" : "dJp4RAuMiU5fgo0V",
-        "nameType" : "Organizational",
-        "orcId" : "rnjuXpLfUmny2rea"
+        "id" : "https://www.example.com/v0dwTOODYw",
+        "name" : "KBQOUXNuT14",
+        "nameType" : "Personal",
+        "orcId" : "EeZtk2KVBvatcJw"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LfBww0vZ4i",
+        "id" : "https://www.example.com/WMwwPncfP6at9",
         "labels" : {
-          "xuvgurzHvF4Nw5H" : "hQGgjqo9phsOt"
+          "jVTDnL7GkKjw71XUy" : "0g1lFYtmp5AohGw"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 1,
+      "role" : "Librettist",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "YM7o4bK670ySK",
-    "tags" : [ "8vgOAyB7asBULfy" ],
-    "description" : "uUxMCpZ5WHVJssx",
+    "npiSubjectHeading" : "hmpKkbwoDt",
+    "tags" : [ "lvjFRdrL4GxFkH" ],
+    "description" : "Bcijt8BDc7yUwk4yew",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Radio"
         },
-        "format" : "Text",
-        "disseminationChannel" : "EfpwBIXbvGOCicjP2K",
+        "format" : "Sound",
+        "disseminationChannel" : "JiqQ7WGuNO9z42IR",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "g3RnImjoLCi9",
-          "seriesPart" : "H0zTpWjfDdYSrY"
+          "series" : "YiVpblOocn3nYx6H",
+          "seriesPart" : "3yY3xoPuv8tK4F8hUC1"
         }
       },
-      "doi" : "https://www.example.com/7kRb0jB8q6K",
+      "doi" : "https://www.example.com/ZCVCTEz3lC",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/myMX1lU5pXVAiu76",
-    "abstract" : "jzCMWwKp7pT1"
+    "metadataSource" : "https://www.example.com/VRxz0G7zKZDsUAUD2",
+    "abstract" : "TRRZqoGYUUESlibIE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/abinventore",
-    "name" : "21SvuJFn67hxMjTDOd",
+    "id" : "https://www.example.org/autemmodi",
+    "name" : "2DLDzyCP7Rr53",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "nQd00CWvWtOJVrs",
-      "id" : "iNriafGBCkI3NwT"
+      "source" : "PICg0ZnmHMt0J",
+      "id" : "WPNz2awMrhtHSQQEGS"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "yRixvmrQT7Ww84A"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "PCoAJtURDN"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/undeet" ],
+  "subjects" : [ "https://www.example.org/quibusdamaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "C7eHqVaBPbqvKiyu1h",
-      "mimeType" : "a7CUESXeNncHGfnu",
-      "size" : 669381261,
+      "name" : "0XWGHeMS7Bj",
+      "mimeType" : "p2tPDC1XoX84x",
+      "size" : 1495521331,
       "license" : {
         "type" : "License",
-        "identifier" : "Hsa8Akx8ajvnT",
+        "identifier" : "YZGwtdXzc4sUQxZ8uAD",
         "labels" : {
-          "ERxaQyxzmfy" : "vlLe1iAGcb"
+          "eyOqAm524J7xx1DhD" : "Vd61mhNijgAZ3TCbWa8"
         },
-        "link" : "https://www.example.com/mgMAQoW6t1ZbZ2L"
+        "link" : "https://www.example.com/HYX3EKyBQcB"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "C7eHqVaBPbqvKiyu1h",
-    "mimeType" : "a7CUESXeNncHGfnu",
-    "size" : 669381261,
+    "name" : "0XWGHeMS7Bj",
+    "mimeType" : "p2tPDC1XoX84x",
+    "size" : 1495521331,
     "license" : {
       "type" : "License",
-      "identifier" : "Hsa8Akx8ajvnT",
+      "identifier" : "YZGwtdXzc4sUQxZ8uAD",
       "labels" : {
-        "ERxaQyxzmfy" : "vlLe1iAGcb"
+        "eyOqAm524J7xx1DhD" : "Vd61mhNijgAZ3TCbWa8"
       },
-      "link" : "https://www.example.com/mgMAQoW6t1ZbZ2L"
+      "link" : "https://www.example.com/HYX3EKyBQcB"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "je7ZfFQz6f",
+  "owner" : "FHj7w3SShtC",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -3,95 +3,94 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "iVFh0CVhJaoGA",
-    "ownerAffiliation" : "https://www.example.org/rerumperferendis"
+    "owner" : "A2yPmmvMjgpvjgF",
+    "ownerAffiliation" : "https://www.example.org/ullamullam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autut",
+    "id" : "https://www.example.org/consequaturdolor",
     "labels" : {
-      "oP8VeKcxPtTrG20GNlF" : "Z95CVonlBF"
+      "HTJ4fJNBFzGR232ba" : "PAJvgpz57oZ"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/delenitiiusto",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/nondeserunt",
+  "handle" : "https://www.example.org/itaquequi",
+  "doi" : "https://doi.org/10.1234/provident",
+  "link" : "https://www.example.org/possimusat",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "V7mpuFyWDoNCNzLevt",
+    "mainTitle" : "bVMRXfQfuNVZG0VJ",
     "alternativeTitles" : {
-      "bg" : "7F2dK0pvEndZ"
+      "hu" : "Jg0mzb0elDzCn3MQ9"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "HMTiWjKsfgZgvfM",
-      "month" : "ZWWCudsSSyo5f",
-      "day" : "G9HAhmJLFMPZrFm2"
+      "year" : "XUjklG04HrjDxuwh5b",
+      "month" : "L0QtJlJbOXv",
+      "day" : "y9JUDC3XgggMYb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ynjLSTmrzcW",
-        "name" : "ULo2oi9lZasN3AjNiS",
+        "id" : "https://www.example.com/FLJqiiujYkGH",
+        "name" : "MbOCje6eCZqQIEQhrdz",
         "nameType" : "Personal",
-        "orcId" : "LHzee7j9I21Ztw"
+        "orcId" : "sKxHRq1y80h"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/BAErmNXwYLi79",
+        "id" : "https://www.example.com/ju4nmw1b9K3JCtMlMvy",
         "labels" : {
-          "TE2Gkxh37M4mJ" : "CrO7jn7JY8mN4"
+          "HvnDqhm4eJuwVFJfKv7" : "VaaYEV4vklb"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 1,
+      "role" : "RightsHolder",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dK0Cs1IfcK7HKt1hzrD",
-        "name" : "aRf5p6FdO6gxIgOZwa",
-        "nameType" : "Personal",
-        "orcId" : "qryAdvBQZVhdKelY4"
+        "id" : "https://www.example.com/hpu4tB1WHte4",
+        "name" : "kt7WG4ct3JUkl73S5V",
+        "nameType" : "Organizational",
+        "orcId" : "n0dobGXuPNzjBa9"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5wXV7DqIOe5",
+        "id" : "https://www.example.com/gUAl9f0IsPeqBN",
         "labels" : {
-          "lkCiYGzm4tDuX" : "Q2hSPTMiDsOrw"
+          "0Kurh4RTMQZScylwZ" : "MrJI4HoFk4n"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 7,
+      "role" : "EditorialBoardMember",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "WMd9EB9VpX",
-    "tags" : [ "3K8cH4BPbfXJc" ],
-    "description" : "zCfgFesociaE",
+    "npiSubjectHeading" : "zO1u4P8YeMo",
+    "tags" : [ "ATC5itE4Zjw" ],
+    "description" : "JC6Rjs380nUET1nnO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Other",
-          "description" : "8Vb10rTB0dkrL2ukO"
+          "type" : "Radio"
         },
         "format" : "Text",
-        "disseminationChannel" : "MHfFC5cbtXp",
+        "disseminationChannel" : "AU1Zp8frDFdsLZE5J",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "2NlRttUfy1ZdQdRfr7G",
-          "seriesPart" : "0ft7qOGZEluXQvJfq"
+          "series" : "Kan9aCxGB3rMxBmP",
+          "seriesPart" : "qTTNdXSctk0tIAO"
         }
       },
-      "doi" : "https://www.example.com/udsn0hwRuYMgsMlb8",
+      "doi" : "https://www.example.com/IOPTniqIZFE0r",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "peerReviewed" : false,
@@ -100,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/IepEAqxJOuRZwywxP",
-    "abstract" : "xr9YIzgiRP"
+    "metadataSource" : "https://www.example.com/Gd3VahRrmynv4AXSQKp",
+    "abstract" : "tWNhKcJAbFGMBhu4512"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloremqueplaceat",
-    "name" : "7CRfrkQFOxOo",
+    "id" : "https://www.example.org/estvoluptas",
+    "name" : "HttfkaV5s2",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "1678tNAhgsxvv",
-      "id" : "VcRx8Pw3r29bNfeEGy"
+      "source" : "YtM80St4QMPDsRa",
+      "id" : "h6Ez9aZJh16X"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "J0BfRjbKyqJbnF"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "htaflKosTsFoU"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -125,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quiet" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "00PFmviem7",
-    "mimeType" : "Ibrm0GjnwFly7pU148c",
-    "size" : 1554882918,
-    "license" : {
-      "type" : "License",
-      "identifier" : "qhpYxtr9KBfB",
-      "labels" : {
-        "BdkQsoUWev" : "G3QX0ghGk19gO7Ls"
-      },
-      "link" : "https://www.example.com/84WRVuu3mI5B0LnA9"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/quosest" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "00PFmviem7",
-      "mimeType" : "Ibrm0GjnwFly7pU148c",
-      "size" : 1554882918,
+      "name" : "BwG9cOxLwb5lg",
+      "mimeType" : "2i5sjLsuHAtF",
+      "size" : 955844979,
       "license" : {
         "type" : "License",
-        "identifier" : "qhpYxtr9KBfB",
+        "identifier" : "083pryi7Q7e",
         "labels" : {
-          "BdkQsoUWev" : "G3QX0ghGk19gO7Ls"
+          "gBWMpiVLAB" : "KY4qkvjh84z"
         },
-        "link" : "https://www.example.com/84WRVuu3mI5B0LnA9"
+        "link" : "https://www.example.com/Py7j6TGxZBg9s"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "iVFh0CVhJaoGA",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "BwG9cOxLwb5lg",
+    "mimeType" : "2i5sjLsuHAtF",
+    "size" : 955844979,
+    "license" : {
+      "type" : "License",
+      "identifier" : "083pryi7Q7e",
+      "labels" : {
+        "gBWMpiVLAB" : "KY4qkvjh84z"
+      },
+      "link" : "https://www.example.com/Py7j6TGxZBg9s"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "A2yPmmvMjgpvjgF",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,96 +1,97 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "6XxuknZ7TWz",
-    "ownerAffiliation" : "https://www.example.org/inomnis"
+    "owner" : "YAHB5rILpva1hyqWxE",
+    "ownerAffiliation" : "https://www.example.org/perspiciatisbeatae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/autdebitis",
+    "id" : "https://www.example.org/aperiamqui",
     "labels" : {
-      "lj73ODpowIutFbaC" : "cGqswJuWu7"
+      "Ow3cN2KDx5ubdfY" : "pZOFVSSQ8A7AUF1"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quidemaccusantium",
-  "doi" : "https://doi.org/10.1234/laudantium",
-  "link" : "https://www.example.org/quisminima",
+  "handle" : "https://www.example.org/quoeum",
+  "doi" : "https://doi.org/10.1234/totam",
+  "link" : "https://www.example.org/officiaprovident",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "x6j1r82f37QdTpAVrj",
+    "mainTitle" : "26FLGcGYRCp",
     "alternativeTitles" : {
-      "da" : "00DWSPzg3CD"
+      "es" : "FgaQWYjcftkNWP"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "c4a5lTCVyO9z",
-      "month" : "1J37lIxIMPIBO",
-      "day" : "ChPYjlh5bpGkbYG09"
+      "year" : "EURQkLpDAfqG7FIUe",
+      "month" : "jJHkZTvO1M8yih",
+      "day" : "50hYZeddNEmtCMniQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/U7DYQq9Uz051J0a9",
-        "name" : "xxVVoQLlKjK3lre",
-        "nameType" : "Personal",
-        "orcId" : "HhutvYWZ8bHflIwm"
+        "id" : "https://www.example.com/dimxfPi44NL1V",
+        "name" : "cxmuCHTWjAjye18E8",
+        "nameType" : "Organizational",
+        "orcId" : "iaxGXUWgKolzjK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tclLvQhKtSzT",
+        "id" : "https://www.example.com/haHYav57riWR",
         "labels" : {
-          "o1v1tBnMcXyb14PO" : "OCpd5zz7Lq"
+          "9aPOJgyNdgDNaB5V" : "CoZmp2L9mIDHaYJhf9"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 1,
+      "role" : "RegistrationAgency",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rOVsyAbrzcdVL3yv",
-        "name" : "SIFZbTFL4LP",
+        "id" : "https://www.example.com/DIdcRi1HFRxulI",
+        "name" : "bQddvH00NJiZZToA6t",
         "nameType" : "Personal",
-        "orcId" : "DWHsOnZgo4ES"
+        "orcId" : "4KoSI2xTYreU1i"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VfRlFN3McT6ucJdQnm",
+        "id" : "https://www.example.com/FAYMnXFo3ufFX",
         "labels" : {
-          "vfBaL757vJ5Tu" : "t310DpXoDdIzoFJM"
+          "a7KubKN9KTsP6XmVgt" : "RZSeytSJ7XTpfJR4pJj"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 4,
+      "role" : "Designer",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1OxCNNBVQXSNMNe",
-    "tags" : [ "Ok9rChQjTlfRvD4Z" ],
-    "description" : "tDv7fX0PXfGaC7nJcJ",
+    "npiSubjectHeading" : "abzdCZcLq4sCCXx",
+    "tags" : [ "k8LkpkTqWRiSQ" ],
+    "description" : "SCX3b6sMgXf9zpK7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Other",
+          "description" : "V6fOzG8HuD"
         },
-        "format" : "Video",
-        "disseminationChannel" : "FPsX9owjiSNsse1U",
+        "format" : "Text",
+        "disseminationChannel" : "4gUQsZZ3vWmAAsDvjvD",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "Byn72qscFqb",
-          "seriesPart" : "MUfmmRloh4wjp4b3Elg"
+          "series" : "c4aOvVDz6Jx3ht",
+          "seriesPart" : "DAiElsB29uy9OITh9Be"
         }
       },
-      "doi" : "https://www.example.com/5Z2mXOsyM8L5",
+      "doi" : "https://www.example.com/TQzK4R5yfSpYEz1P2",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
         "peerReviewed" : false,
@@ -99,45 +100,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/J7L3MmomjD",
-    "abstract" : "MchhzqqXFClXGMkHb"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "L2x4jpbohhCdcH",
-      "mimeType" : "8wXEkcLdyMaBp",
-      "size" : 1799699941,
-      "license" : {
-        "type" : "License",
-        "identifier" : "0NNVyc4oACZy",
-        "labels" : {
-          "eNHNGBjqSMM" : "U2NNtuQijtLReyFUfD"
-        },
-        "link" : "https://www.example.com/MRtb3mpNViJIzZ"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/JO3bCgPQWS1nxQCM",
+    "abstract" : "JJKiw4XdJmldHvMG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/commoditenetur",
-    "name" : "htBnMqAPNoPppKLM36",
+    "id" : "https://www.example.org/eligendidignissimos",
+    "name" : "QehUw3SUXbdU",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "MjGFlYCXX50Y4",
-      "id" : "0BwJ46DX3nMvjn2te2K"
+      "source" : "K2p1RHu3uXo9vRi",
+      "id" : "qLvGlLvr232re"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "LLn6tM0gmOyuj0xzoPa"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "svrTkLC6Vmsh2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,25 +125,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ipsamsunt" ],
+  "subjects" : [ "https://www.example.org/sedfacere" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "L2x4jpbohhCdcH",
-    "mimeType" : "8wXEkcLdyMaBp",
-    "size" : 1799699941,
+    "name" : "BX9LQR1MBh",
+    "mimeType" : "eNRueykfnr71z0dcZ",
+    "size" : 1194829136,
     "license" : {
       "type" : "License",
-      "identifier" : "0NNVyc4oACZy",
+      "identifier" : "JvfY3qSvT7OID6T31J",
       "labels" : {
-        "eNHNGBjqSMM" : "U2NNtuQijtLReyFUfD"
+        "LWyb0ChcgMDE4IKD0SR" : "SCCVOpUAAuy"
       },
-      "link" : "https://www.example.com/MRtb3mpNViJIzZ"
+      "link" : "https://www.example.com/TqftqsOYbC0E6wRo6"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "6XxuknZ7TWz"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "BX9LQR1MBh",
+      "mimeType" : "eNRueykfnr71z0dcZ",
+      "size" : 1194829136,
+      "license" : {
+        "type" : "License",
+        "identifier" : "JvfY3qSvT7OID6T31J",
+        "labels" : {
+          "LWyb0ChcgMDE4IKD0SR" : "SCCVOpUAAuy"
+        },
+        "link" : "https://www.example.com/TqftqsOYbC0E6wRo6"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "YAHB5rILpva1hyqWxE",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,97 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "YAHB5rILpva1hyqWxE",
-    "ownerAffiliation" : "https://www.example.org/perspiciatisbeatae"
+    "owner" : "CSgWxj1sncmjU29TF",
+    "ownerAffiliation" : "https://www.example.org/etnam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aperiamqui",
+    "id" : "https://www.example.org/etvel",
     "labels" : {
-      "Ow3cN2KDx5ubdfY" : "pZOFVSSQ8A7AUF1"
+      "YW8oMzqjkoIqYqqtzG" : "QSSmPUXBFwq2e"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quoeum",
-  "doi" : "https://doi.org/10.1234/totam",
-  "link" : "https://www.example.org/officiaprovident",
+  "handle" : "https://www.example.org/maioresdolorum",
+  "doi" : "https://doi.org/10.1234/necessitatibus",
+  "link" : "https://www.example.org/voluptasblanditiis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "26FLGcGYRCp",
+    "mainTitle" : "eA8clfLUyh",
     "alternativeTitles" : {
-      "es" : "FgaQWYjcftkNWP"
+      "sv" : "oSRetQUbte"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/eng",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "EURQkLpDAfqG7FIUe",
-      "month" : "jJHkZTvO1M8yih",
-      "day" : "50hYZeddNEmtCMniQ"
+      "year" : "NlHwziwJq7rRpnjXR",
+      "month" : "3dOXmxY3k7frx",
+      "day" : "hnpLNYwFNHOvj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dimxfPi44NL1V",
-        "name" : "cxmuCHTWjAjye18E8",
-        "nameType" : "Organizational",
-        "orcId" : "iaxGXUWgKolzjK"
+        "id" : "https://www.example.com/P3Hiz7eIfGpJh7u",
+        "name" : "ltYzb9LhoALt",
+        "nameType" : "Personal",
+        "orcId" : "qS108jusvhCiRZp"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/haHYav57riWR",
+        "id" : "https://www.example.com/5YT7P7YiSHCNJlSyZl",
         "labels" : {
-          "9aPOJgyNdgDNaB5V" : "CoZmp2L9mIDHaYJhf9"
+          "obUlfbqfkI4t2kt0Vla" : "mxpZvpD3Q5m"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 8,
+      "role" : "Architect",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DIdcRi1HFRxulI",
-        "name" : "bQddvH00NJiZZToA6t",
+        "id" : "https://www.example.com/fLO9KtObI768gUeu9m",
+        "name" : "uGOL4TuSvJrt5Uj",
         "nameType" : "Personal",
-        "orcId" : "4KoSI2xTYreU1i"
+        "orcId" : "nRJPkQKggBKhwC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FAYMnXFo3ufFX",
+        "id" : "https://www.example.com/6qDb1ftZvr066THLvP7",
         "labels" : {
-          "a7KubKN9KTsP6XmVgt" : "RZSeytSJ7XTpfJR4pJj"
+          "BwmZes8yr8LGWO5GvN6" : "OJEbqGuKMTN"
         }
       } ],
-      "role" : "Designer",
-      "sequence" : 7,
+      "role" : "RegistrationAuthority",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "abzdCZcLq4sCCXx",
-    "tags" : [ "k8LkpkTqWRiSQ" ],
-    "description" : "SCX3b6sMgXf9zpK7",
+    "npiSubjectHeading" : "i2VMF7qzguF",
+    "tags" : [ "1ARcJZ0B45qn" ],
+    "description" : "ZPlCEEzIaXj5CTZ52a",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Other",
-          "description" : "V6fOzG8HuD"
+          "type" : "Journal"
         },
-        "format" : "Text",
-        "disseminationChannel" : "4gUQsZZ3vWmAAsDvjvD",
+        "format" : "Sound",
+        "disseminationChannel" : "uTRtBgYtId9nRbjQaJ",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "c4aOvVDz6Jx3ht",
-          "seriesPart" : "DAiElsB29uy9OITh9Be"
+          "series" : "dbW9yAWMMsItf9",
+          "seriesPart" : "FNi0iRYqNzVl9ZVBJFf"
         }
       },
-      "doi" : "https://www.example.com/TQzK4R5yfSpYEz1P2",
+      "doi" : "https://www.example.com/YUf8WwY9TH4sA7q9o",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
         "peerReviewed" : false,
@@ -100,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/JO3bCgPQWS1nxQCM",
-    "abstract" : "JJKiw4XdJmldHvMG"
+    "metadataSource" : "https://www.example.com/FsFAWU8jSt",
+    "abstract" : "3CVBmhlbiSopd6AKDsM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eligendidignissimos",
-    "name" : "QehUw3SUXbdU",
+    "id" : "https://www.example.org/temporetempore",
+    "name" : "9Ggi3PNZJ0nk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "K2p1RHu3uXo9vRi",
-      "id" : "qLvGlLvr232re"
+      "source" : "FpgFxQJKMxpBQfMUD",
+      "id" : "tawMxpgDe96md"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "svrTkLC6Vmsh2"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "8rLcgiM6jdgr"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -125,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sedfacere" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "BX9LQR1MBh",
-    "mimeType" : "eNRueykfnr71z0dcZ",
-    "size" : 1194829136,
-    "license" : {
-      "type" : "License",
-      "identifier" : "JvfY3qSvT7OID6T31J",
-      "labels" : {
-        "LWyb0ChcgMDE4IKD0SR" : "SCCVOpUAAuy"
-      },
-      "link" : "https://www.example.com/TqftqsOYbC0E6wRo6"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/nihilaperiam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "BX9LQR1MBh",
-      "mimeType" : "eNRueykfnr71z0dcZ",
-      "size" : 1194829136,
+      "name" : "qBNybdrZUFPfCsRnT",
+      "mimeType" : "6C7ybZyFhhFUvfG5",
+      "size" : 123856917,
       "license" : {
         "type" : "License",
-        "identifier" : "JvfY3qSvT7OID6T31J",
+        "identifier" : "GDyLm11tNHW6nG8J0",
         "labels" : {
-          "LWyb0ChcgMDE4IKD0SR" : "SCCVOpUAAuy"
+          "Qkyti2kmF6jPg" : "zz2GhVw4i1XsrMttQa"
         },
-        "link" : "https://www.example.com/TqftqsOYbC0E6wRo6"
+        "link" : "https://www.example.com/OtJw2gytojlHcsXg"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "YAHB5rILpva1hyqWxE",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "qBNybdrZUFPfCsRnT",
+    "mimeType" : "6C7ybZyFhhFUvfG5",
+    "size" : 123856917,
+    "license" : {
+      "type" : "License",
+      "identifier" : "GDyLm11tNHW6nG8J0",
+      "labels" : {
+        "Qkyti2kmF6jPg" : "zz2GhVw4i1XsrMttQa"
+      },
+      "link" : "https://www.example.com/OtJw2gytojlHcsXg"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "CSgWxj1sncmjU29TF",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -3,78 +3,78 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "CSgWxj1sncmjU29TF",
-    "ownerAffiliation" : "https://www.example.org/etnam"
+    "owner" : "h2Uf4CZdVX",
+    "ownerAffiliation" : "https://www.example.org/numquamaliquid"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etvel",
+    "id" : "https://www.example.org/nisinihil",
     "labels" : {
-      "YW8oMzqjkoIqYqqtzG" : "QSSmPUXBFwq2e"
+      "0K9TWUCoe808A4" : "Rt2c7Dx8C4o"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/maioresdolorum",
-  "doi" : "https://doi.org/10.1234/necessitatibus",
-  "link" : "https://www.example.org/voluptasblanditiis",
+  "handle" : "https://www.example.org/minusperferendis",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/fugitrepudiandae",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eA8clfLUyh",
+    "mainTitle" : "7hYbnBmOVPTFhYEK7Dg",
     "alternativeTitles" : {
-      "sv" : "oSRetQUbte"
+      "it" : "1Muo7aeSVVVGu4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/eng",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "NlHwziwJq7rRpnjXR",
-      "month" : "3dOXmxY3k7frx",
-      "day" : "hnpLNYwFNHOvj"
+      "year" : "HlqjddlSFbu",
+      "month" : "v9DvDJfjdkaGO5YNoZs",
+      "day" : "tzZv48cg6miu5wNr5MI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/P3Hiz7eIfGpJh7u",
-        "name" : "ltYzb9LhoALt",
+        "id" : "https://www.example.com/oQwvYwvqHD5A0",
+        "name" : "OCAvguhGNN",
         "nameType" : "Personal",
-        "orcId" : "qS108jusvhCiRZp"
+        "orcId" : "eceMc41M4BVdGgowt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5YT7P7YiSHCNJlSyZl",
+        "id" : "https://www.example.com/qTYa5jafb7HHY",
         "labels" : {
-          "obUlfbqfkI4t2kt0Vla" : "mxpZvpD3Q5m"
+          "tKjP9YdHX8CPIiQ" : "KrBP0cuE8SA7XimIk1z"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 9,
+      "role" : "ArchitecturalPlanner",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fLO9KtObI768gUeu9m",
-        "name" : "uGOL4TuSvJrt5Uj",
-        "nameType" : "Personal",
-        "orcId" : "nRJPkQKggBKhwC"
+        "id" : "https://www.example.com/eZ2MPphqUoMitj",
+        "name" : "DOGmKtavOngAJ2kiR",
+        "nameType" : "Organizational",
+        "orcId" : "IQG96Ei4kieIee87"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/6qDb1ftZvr066THLvP7",
+        "id" : "https://www.example.com/0JebAb3oYzWiPP",
         "labels" : {
-          "BwmZes8yr8LGWO5GvN6" : "OJEbqGuKMTN"
+          "OOIQ9NLAmgZhgFuWy" : "DW9lpW7bmfVOtcVad"
         }
       } ],
-      "role" : "RegistrationAuthority",
-      "sequence" : 5,
+      "role" : "DataCurator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "i2VMF7qzguF",
-    "tags" : [ "1ARcJZ0B45qn" ],
-    "description" : "ZPlCEEzIaXj5CTZ52a",
+    "npiSubjectHeading" : "5Qt563HuXyh9",
+    "tags" : [ "3rTVXcbQIbv" ],
+    "description" : "TpxoQI5WTIbAqI0e",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -83,14 +83,14 @@
           "type" : "Journal"
         },
         "format" : "Sound",
-        "disseminationChannel" : "uTRtBgYtId9nRbjQaJ",
+        "disseminationChannel" : "lEgL7mlnOyQVm",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "dbW9yAWMMsItf9",
-          "seriesPart" : "FNi0iRYqNzVl9ZVBJFf"
+          "series" : "EcwoKtQmTDPQjF",
+          "seriesPart" : "Q0H925aD5VzV"
         }
       },
-      "doi" : "https://www.example.com/YUf8WwY9TH4sA7q9o",
+      "doi" : "https://www.example.com/JYdmDUG9PQyP",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/FsFAWU8jSt",
-    "abstract" : "3CVBmhlbiSopd6AKDsM"
+    "metadataSource" : "https://www.example.com/4WuXn6FWDXfBir0",
+    "abstract" : "2kUSzmvF3xr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/temporetempore",
-    "name" : "9Ggi3PNZJ0nk",
+    "id" : "https://www.example.org/etvitae",
+    "name" : "m88EmaQM8fk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FpgFxQJKMxpBQfMUD",
-      "id" : "tawMxpgDe96md"
+      "source" : "AGVs3Y84JR0UxL35Mg",
+      "id" : "YJanFpjagy"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "8rLcgiM6jdgr"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "RNBXnkAHbzwo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nihilaperiam" ],
+  "subjects" : [ "https://www.example.org/sedhic" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "qBNybdrZUFPfCsRnT",
-      "mimeType" : "6C7ybZyFhhFUvfG5",
-      "size" : 123856917,
+      "name" : "lcZuiwrjQJXQ",
+      "mimeType" : "UBStIcOxyBML8HYbpF",
+      "size" : 929290023,
       "license" : {
         "type" : "License",
-        "identifier" : "GDyLm11tNHW6nG8J0",
+        "identifier" : "hd6dbEOprG",
         "labels" : {
-          "Qkyti2kmF6jPg" : "zz2GhVw4i1XsrMttQa"
+          "moYaIhGaH8Wvs" : "xSSJ2loQPw43n"
         },
-        "link" : "https://www.example.com/OtJw2gytojlHcsXg"
+        "link" : "https://www.example.com/9B5xmUGaYUl0"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "qBNybdrZUFPfCsRnT",
-    "mimeType" : "6C7ybZyFhhFUvfG5",
-    "size" : 123856917,
+    "name" : "lcZuiwrjQJXQ",
+    "mimeType" : "UBStIcOxyBML8HYbpF",
+    "size" : 929290023,
     "license" : {
       "type" : "License",
-      "identifier" : "GDyLm11tNHW6nG8J0",
+      "identifier" : "hd6dbEOprG",
       "labels" : {
-        "Qkyti2kmF6jPg" : "zz2GhVw4i1XsrMttQa"
+        "moYaIhGaH8Wvs" : "xSSJ2loQPw43n"
       },
-      "link" : "https://www.example.com/OtJw2gytojlHcsXg"
+      "link" : "https://www.example.com/9B5xmUGaYUl0"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "CSgWxj1sncmjU29TF",
+  "owner" : "h2Uf4CZdVX",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "h2Uf4CZdVX",
-    "ownerAffiliation" : "https://www.example.org/numquamaliquid"
+    "owner" : "3NSLIPL8YbmqI",
+    "ownerAffiliation" : "https://www.example.org/quiaea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nisinihil",
+    "id" : "https://www.example.org/doloretempore",
     "labels" : {
-      "0K9TWUCoe808A4" : "Rt2c7Dx8C4o"
+      "yq6hONWJLb8xRRLYG" : "bmaX7DeULIPMrHV950"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/minusperferendis",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/fugitrepudiandae",
+  "handle" : "https://www.example.org/similiqueharum",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/odiocupiditate",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7hYbnBmOVPTFhYEK7Dg",
+    "mainTitle" : "vdBzv4AfTvXCvj0y",
     "alternativeTitles" : {
-      "it" : "1Muo7aeSVVVGu4"
+      "se" : "09TCNTzlObby"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "HlqjddlSFbu",
-      "month" : "v9DvDJfjdkaGO5YNoZs",
-      "day" : "tzZv48cg6miu5wNr5MI"
+      "year" : "n7H8rd2jOtML4Nd3Fx",
+      "month" : "Tf3g7jGpMOg9",
+      "day" : "kKb7PPJ8JjRo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/oQwvYwvqHD5A0",
-        "name" : "OCAvguhGNN",
+        "id" : "https://www.example.com/In5AtlvH149J4yqhxRd",
+        "name" : "nryOexHBgq90CN",
         "nameType" : "Personal",
-        "orcId" : "eceMc41M4BVdGgowt"
+        "orcId" : "9Tbh9Sa6sc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qTYa5jafb7HHY",
+        "id" : "https://www.example.com/0tugkQpkOZ3el6jSF1",
         "labels" : {
-          "tKjP9YdHX8CPIiQ" : "KrBP0cuE8SA7XimIk1z"
+          "LkZpUtnwGE6iRNsGK" : "EBYGWlrqHNSfBZ9"
         }
       } ],
-      "role" : "ArchitecturalPlanner",
-      "sequence" : 6,
+      "role" : "Distributor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/eZ2MPphqUoMitj",
-        "name" : "DOGmKtavOngAJ2kiR",
+        "id" : "https://www.example.com/xlZ8JGUn11F",
+        "name" : "KSPHjkn1i7Igk7fT",
         "nameType" : "Organizational",
-        "orcId" : "IQG96Ei4kieIee87"
+        "orcId" : "vDIlAFxPCP7b5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0JebAb3oYzWiPP",
+        "id" : "https://www.example.com/XE5QVrLCaL7eM",
         "labels" : {
-          "OOIQ9NLAmgZhgFuWy" : "DW9lpW7bmfVOtcVad"
+          "PKo1PDQTSzW7TAmMtH" : "b31EaC4l9yYIXnnJ8W"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 3,
+      "role" : "ProgrammeParticipant",
+      "sequence" : 5,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5Qt563HuXyh9",
-    "tags" : [ "3rTVXcbQIbv" ],
-    "description" : "TpxoQI5WTIbAqI0e",
+    "npiSubjectHeading" : "NRlTWBI360IYizPB9d",
+    "tags" : [ "d9Ew5llHBkSgE9" ],
+    "description" : "OXVFfJIzVvB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "lEgL7mlnOyQVm",
+        "format" : "Text",
+        "disseminationChannel" : "YAZpOPOT77jQiqHGiBR",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "EcwoKtQmTDPQjF",
-          "seriesPart" : "Q0H925aD5VzV"
+          "series" : "4v1S6D9Xd3vVR",
+          "seriesPart" : "Hq77FmDXZKSjh2G7"
         }
       },
-      "doi" : "https://www.example.com/JYdmDUG9PQyP",
+      "doi" : "https://www.example.com/0zK5L3UizL9",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/4WuXn6FWDXfBir0",
-    "abstract" : "2kUSzmvF3xr"
+    "metadataSource" : "https://www.example.com/m2YARJR5sUPIip",
+    "abstract" : "841SleIog61K8ruhl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etvitae",
-    "name" : "m88EmaQM8fk",
+    "id" : "https://www.example.org/repellendusdebitis",
+    "name" : "z4i7DCn6u7o",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "AGVs3Y84JR0UxL35Mg",
-      "id" : "YJanFpjagy"
+      "source" : "SICCK7WsvyEmhwV",
+      "id" : "ivLRyepZ3vi"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "RNBXnkAHbzwo"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Uqp9Qf7rozWnu2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sedhic" ],
+  "subjects" : [ "https://www.example.org/quosquaerat" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lcZuiwrjQJXQ",
-      "mimeType" : "UBStIcOxyBML8HYbpF",
-      "size" : 929290023,
+      "name" : "ACD83XApTqYxAuXh",
+      "mimeType" : "Nez0GpmUCtjagQj",
+      "size" : 1571721911,
       "license" : {
         "type" : "License",
-        "identifier" : "hd6dbEOprG",
+        "identifier" : "T7z8JD2iTPOBUsyl",
         "labels" : {
-          "moYaIhGaH8Wvs" : "xSSJ2loQPw43n"
+          "WjpYUG1vJn7ZOwV" : "INyIzcmldwtjX"
         },
-        "link" : "https://www.example.com/9B5xmUGaYUl0"
+        "link" : "https://www.example.com/wYIcKg0dlGwf"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lcZuiwrjQJXQ",
-    "mimeType" : "UBStIcOxyBML8HYbpF",
-    "size" : 929290023,
+    "name" : "ACD83XApTqYxAuXh",
+    "mimeType" : "Nez0GpmUCtjagQj",
+    "size" : 1571721911,
     "license" : {
       "type" : "License",
-      "identifier" : "hd6dbEOprG",
+      "identifier" : "T7z8JD2iTPOBUsyl",
       "labels" : {
-        "moYaIhGaH8Wvs" : "xSSJ2loQPw43n"
+        "WjpYUG1vJn7ZOwV" : "INyIzcmldwtjX"
       },
-      "link" : "https://www.example.com/9B5xmUGaYUl0"
+      "link" : "https://www.example.com/wYIcKg0dlGwf"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "h2Uf4CZdVX",
+  "owner" : "3NSLIPL8YbmqI",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "PqMr9WmqFCYQf",
-    "ownerAffiliation" : "https://www.example.org/oditnihil"
+    "owner" : "6YgupcYVThf",
+    "ownerAffiliation" : "https://www.example.org/voluptateiure"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/inventoremollitia",
+    "id" : "https://www.example.org/accusamusnesciunt",
     "labels" : {
-      "4y6MsEHponFbMTkObwG" : "fK3KFcQnf8"
+      "2yZzeTob4rvipyO" : "i5P0h4rfWYTzsZPez"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/autnostrum",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/architectosint",
+  "handle" : "https://www.example.org/estcum",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/consequunturdicta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ITaySv0jgclqyenswSr",
+    "mainTitle" : "1lFWuwry2DWMZR97N1K",
     "alternativeTitles" : {
-      "en" : "Emn6Sp8mfJ0yDyh"
+      "es" : "MeuJP6hwLkw3zB"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "QOdB3pIQQWoT",
-      "month" : "7FyleKNvSw7Wk",
-      "day" : "iUGrBAnLlEG"
+      "year" : "SZkDJD0YjUkXcxnYMhV",
+      "month" : "VNTg21ho020R",
+      "day" : "M77dvAH5BTgSn8GSK8"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VRtSB2PQ75J",
-        "name" : "GHUoRapKphZ",
+        "id" : "https://www.example.com/KxOSePFSyElyUCU",
+        "name" : "VbXg8jAzKgXlMquyHk",
         "nameType" : "Personal",
-        "orcId" : "tZuA5uuzbRQBZ"
+        "orcId" : "r6uc2TUhMwK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/WTuLY4ymv5yqVbnyQQn",
+        "id" : "https://www.example.com/RlYxgIQDweGemE",
         "labels" : {
-          "XF7JUmHAyg9w0" : "uvwYuHc3AbB9Vb"
+          "RrK5GSBlsM2zB" : "CkGtmBgXjj1Jr"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 3,
+      "role" : "AcademicCoordinator",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VCy000lutT",
-        "name" : "LwNuJNpWPx",
+        "id" : "https://www.example.com/auVsCza4fcVBz0NJn7w",
+        "name" : "mDOvcVzEm7Zh8Mlc4",
         "nameType" : "Personal",
-        "orcId" : "2jc4bqBt0gT1Ds"
+        "orcId" : "zyTsWA3rZgjUlJ1"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LjfiEVYP6A",
+        "id" : "https://www.example.com/tlPjDehwrZt1nD3DfMK",
         "labels" : {
-          "fRbPyfJOZrJI6o" : "XXBIm3uL4eCCkotkM"
+          "vUuEDs92ykU" : "6NFShHcrfWRTkBdGQ"
         }
       } ],
-      "role" : "Producer",
-      "sequence" : 4,
+      "role" : "LandscapeArchitect",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "m3sHCbde3mc8YJnY",
-    "tags" : [ "bAxwHIrxMbcaZOg0bEn" ],
-    "description" : "nU2ITdFK4Njg0ZMWOhO",
+    "npiSubjectHeading" : "xREaFmpmuc8qRWRLZkW",
+    "tags" : [ "bcxOm5wuBIQNEOqN" ],
+    "description" : "FiB2B4KyUCMZXXslRKf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Radio"
         },
         "format" : "Text",
-        "disseminationChannel" : "SOtZPXczJKSA",
+        "disseminationChannel" : "lBc5CriUSIc",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "P3W4WHLVZyqkOD1",
-          "seriesPart" : "nuinQgHiif9SAcM"
+          "series" : "XyXLHpNLnr55u",
+          "seriesPart" : "23jwB2cj7N6HTY"
         }
       },
-      "doi" : "https://www.example.com/CN7J2yQCx3xUbXG2k",
+      "doi" : "https://www.example.com/QqzneEytiaNjLwI",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "peerReviewed" : false,
@@ -99,45 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/EAJVGmQdV5tG",
-    "abstract" : "fn46TOwAFF1"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "0t1tEYyAPq1o2m",
-      "mimeType" : "IkKLkk53JFFB2",
-      "size" : 1450245008,
-      "license" : {
-        "type" : "License",
-        "identifier" : "KYxfYC68g56",
-        "labels" : {
-          "GHQsfjv8W1Vnm" : "t0W61iUTpKa"
-        },
-        "link" : "https://www.example.com/mtJWqTRV430tgDH"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/VSSdwYFVEuXbEGy",
+    "abstract" : "p78r1T6MKfuf394Qr6L"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/impeditarchitecto",
-    "name" : "7UDgQ1V8Zh",
+    "id" : "https://www.example.org/quiincidunt",
+    "name" : "80yoZ5Eg3pEJgCmHrL",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "GhV4j9Qz2Y",
-      "id" : "OOe4QWWb6VPk9ye"
+      "source" : "gh3Ve41mM1UPQ",
+      "id" : "rE5s3sxztN3f"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "GAcGARpTK1XQ8SCRQv"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "DU9HTFGpGOUnX7Js6XG"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,25 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nobisut" ],
+  "subjects" : [ "https://www.example.org/rerumquas" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "0t1tEYyAPq1o2m",
-    "mimeType" : "IkKLkk53JFFB2",
-    "size" : 1450245008,
+    "name" : "OVJdlgp8JqUeG",
+    "mimeType" : "iHj0tSW1IuEAxEWnO",
+    "size" : 896864245,
     "license" : {
       "type" : "License",
-      "identifier" : "KYxfYC68g56",
+      "identifier" : "ZeprQDmDI3PZl1R5X",
       "labels" : {
-        "GHQsfjv8W1Vnm" : "t0W61iUTpKa"
+        "2V8Bb8OAiBrSu" : "YRulO916s81TCPqH"
       },
-      "link" : "https://www.example.com/mtJWqTRV430tgDH"
+      "link" : "https://www.example.com/bLaOodU5o1pH"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "PqMr9WmqFCYQf"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "OVJdlgp8JqUeG",
+      "mimeType" : "iHj0tSW1IuEAxEWnO",
+      "size" : 896864245,
+      "license" : {
+        "type" : "License",
+        "identifier" : "ZeprQDmDI3PZl1R5X",
+        "labels" : {
+          "2V8Bb8OAiBrSu" : "YRulO916s81TCPqH"
+        },
+        "link" : "https://www.example.com/bLaOodU5o1pH"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "6YgupcYVThf",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -3,94 +3,95 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "6YgupcYVThf",
-    "ownerAffiliation" : "https://www.example.org/voluptateiure"
+    "owner" : "clOpYEcDDgum9Iwq",
+    "ownerAffiliation" : "https://www.example.org/velducimus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/accusamusnesciunt",
+    "id" : "https://www.example.org/distinctiovoluptatum",
     "labels" : {
-      "2yZzeTob4rvipyO" : "i5P0h4rfWYTzsZPez"
+      "9nzKeJeoK7qD" : "k6WPjAlkm9LLa"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/estcum",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/consequunturdicta",
+  "handle" : "https://www.example.org/commodioccaecati",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/veritatisdolores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1lFWuwry2DWMZR97N1K",
+    "mainTitle" : "oyYO2HMwQjmdniw",
     "alternativeTitles" : {
-      "es" : "MeuJP6hwLkw3zB"
+      "no" : "zKMktfuQR7wa6gTvP5"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "SZkDJD0YjUkXcxnYMhV",
-      "month" : "VNTg21ho020R",
-      "day" : "M77dvAH5BTgSn8GSK8"
+      "year" : "8wSDtC5gBd8vbiztJJ",
+      "month" : "3Xs1No0GXk5",
+      "day" : "0NGbxGdlsA1j8"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KxOSePFSyElyUCU",
-        "name" : "VbXg8jAzKgXlMquyHk",
-        "nameType" : "Personal",
-        "orcId" : "r6uc2TUhMwK"
+        "id" : "https://www.example.com/rmJt7MvA4xZK",
+        "name" : "pMUjbnEwLsTwfo",
+        "nameType" : "Organizational",
+        "orcId" : "cdtYXWJPkx9Gz8nuiyO"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RlYxgIQDweGemE",
+        "id" : "https://www.example.com/LiAlqvTpwJJDE",
         "labels" : {
-          "RrK5GSBlsM2zB" : "CkGtmBgXjj1Jr"
+          "0mEn81T03jy" : "EU6Vd98ZqDgYjwqfVCn"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 5,
+      "role" : "ArchitecturalPlanner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/auVsCza4fcVBz0NJn7w",
-        "name" : "mDOvcVzEm7Zh8Mlc4",
-        "nameType" : "Personal",
-        "orcId" : "zyTsWA3rZgjUlJ1"
+        "id" : "https://www.example.com/f9bprUhac4cVgFGgbf",
+        "name" : "V4GuDbM8VjtqCYAV",
+        "nameType" : "Organizational",
+        "orcId" : "jIoaXq1CB27hwEEX9b"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tlPjDehwrZt1nD3DfMK",
+        "id" : "https://www.example.com/KyKZ4Si3YzKG",
         "labels" : {
-          "vUuEDs92ykU" : "6NFShHcrfWRTkBdGQ"
+          "vslYk1suEfa7oA" : "eYiU7q6JKQ"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 7,
+      "role" : "ProjectMember",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "xREaFmpmuc8qRWRLZkW",
-    "tags" : [ "bcxOm5wuBIQNEOqN" ],
-    "description" : "FiB2B4KyUCMZXXslRKf",
+    "npiSubjectHeading" : "H3fvTeAkOO0XzxHN18j",
+    "tags" : [ "z7a4oYF8rnT3mkoBG" ],
+    "description" : "4nIVZLoFsiM",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Other",
+          "description" : "3aSNRvi29eOgkzEx"
         },
-        "format" : "Text",
-        "disseminationChannel" : "lBc5CriUSIc",
+        "format" : "Sound",
+        "disseminationChannel" : "M7GYFK3Hg3HI5E",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "XyXLHpNLnr55u",
-          "seriesPart" : "23jwB2cj7N6HTY"
+          "series" : "MGRzVWUaIuS",
+          "seriesPart" : "lbQ69N2ZlsbxtT0j"
         }
       },
-      "doi" : "https://www.example.com/QqzneEytiaNjLwI",
+      "doi" : "https://www.example.com/NeQrnjz3gClIQYZE7jm",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "peerReviewed" : false,
@@ -99,24 +100,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/VSSdwYFVEuXbEGy",
-    "abstract" : "p78r1T6MKfuf394Qr6L"
+    "metadataSource" : "https://www.example.com/xUL81Qjq0YD",
+    "abstract" : "VpDQ0vfGB8TtDgSq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiincidunt",
-    "name" : "80yoZ5Eg3pEJgCmHrL",
+    "id" : "https://www.example.org/expeditavoluptatibus",
+    "name" : "QfkiSrxT0lmSV0M8dk",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "gh3Ve41mM1UPQ",
-      "id" : "rE5s3sxztN3f"
+      "source" : "ktO7fWNuMiAWRHRtcbO",
+      "id" : "BaZZYhWLNEf8ZmJpK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "DU9HTFGpGOUnX7Js6XG"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "AOfYHnwuCF7"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +125,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/rerumquas" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "OVJdlgp8JqUeG",
-    "mimeType" : "iHj0tSW1IuEAxEWnO",
-    "size" : 896864245,
-    "license" : {
-      "type" : "License",
-      "identifier" : "ZeprQDmDI3PZl1R5X",
-      "labels" : {
-        "2V8Bb8OAiBrSu" : "YRulO916s81TCPqH"
-      },
-      "link" : "https://www.example.com/bLaOodU5o1pH"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/dolorespossimus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "OVJdlgp8JqUeG",
-      "mimeType" : "iHj0tSW1IuEAxEWnO",
-      "size" : 896864245,
+      "name" : "ZzhAxfXZlqlAJlM0x",
+      "mimeType" : "paHycBX0aHoXlO1XbBx",
+      "size" : 1582245962,
       "license" : {
         "type" : "License",
-        "identifier" : "ZeprQDmDI3PZl1R5X",
+        "identifier" : "MP335lELJ3iNQ2I7Ht",
         "labels" : {
-          "2V8Bb8OAiBrSu" : "YRulO916s81TCPqH"
+          "88mcBPB44ZtxMEPl" : "FOVbNP7o34KD6Azm"
         },
-        "link" : "https://www.example.com/bLaOodU5o1pH"
+        "link" : "https://www.example.com/Uvofu16QGQALV9D"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "6YgupcYVThf",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "ZzhAxfXZlqlAJlM0x",
+    "mimeType" : "paHycBX0aHoXlO1XbBx",
+    "size" : 1582245962,
+    "license" : {
+      "type" : "License",
+      "identifier" : "MP335lELJ3iNQ2I7Ht",
+      "labels" : {
+        "88mcBPB44ZtxMEPl" : "FOVbNP7o34KD6Azm"
+      },
+      "link" : "https://www.example.com/Uvofu16QGQALV9D"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "clOpYEcDDgum9Iwq",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,97 +1,97 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "clOpYEcDDgum9Iwq",
-    "ownerAffiliation" : "https://www.example.org/velducimus"
+    "owner" : "NpDKEGGHoxBtU0wfo",
+    "ownerAffiliation" : "https://www.example.org/velitdolore"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/distinctiovoluptatum",
+    "id" : "https://www.example.org/dictaqui",
     "labels" : {
-      "9nzKeJeoK7qD" : "k6WPjAlkm9LLa"
+      "K7ThvAxbOrWjHk1p0L" : "AneefN2JnXEuc"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/commodioccaecati",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/veritatisdolores",
+  "handle" : "https://www.example.org/optioamet",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/autaccusamus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oyYO2HMwQjmdniw",
+    "mainTitle" : "QyEHTxjVI5c07RHSAUd",
     "alternativeTitles" : {
-      "no" : "zKMktfuQR7wa6gTvP5"
+      "sv" : "y6twGIYb9nzGtlPl1"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "8wSDtC5gBd8vbiztJJ",
-      "month" : "3Xs1No0GXk5",
-      "day" : "0NGbxGdlsA1j8"
+      "year" : "cNO39Wr7Qm",
+      "month" : "UBMBlwEBLxS7G0",
+      "day" : "c2P9uSpeas1C"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rmJt7MvA4xZK",
-        "name" : "pMUjbnEwLsTwfo",
+        "id" : "https://www.example.com/D4KuetYeinl",
+        "name" : "rLGVCUOILAdyfZi6vL",
         "nameType" : "Organizational",
-        "orcId" : "cdtYXWJPkx9Gz8nuiyO"
+        "orcId" : "EcWIdclcNbNzEha"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/LiAlqvTpwJJDE",
+        "id" : "https://www.example.com/OCbB8sqrGX",
         "labels" : {
-          "0mEn81T03jy" : "EU6Vd98ZqDgYjwqfVCn"
+          "FFTSX1PhVPgxo8" : "rpVGRNTxjK1DVyjmTK"
         }
       } ],
-      "role" : "ArchitecturalPlanner",
-      "sequence" : 9,
+      "role" : "LightDesigner",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/f9bprUhac4cVgFGgbf",
-        "name" : "V4GuDbM8VjtqCYAV",
-        "nameType" : "Organizational",
-        "orcId" : "jIoaXq1CB27hwEEX9b"
+        "id" : "https://www.example.com/Gn5iEbwDjrVqKI",
+        "name" : "MODahi3AR9",
+        "nameType" : "Personal",
+        "orcId" : "DjyFjOe8BFlYfwGo7v"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/KyKZ4Si3YzKG",
+        "id" : "https://www.example.com/ZSC6BidosZLpd7Hn",
         "labels" : {
-          "vslYk1suEfa7oA" : "eYiU7q6JKQ"
+          "QNtDRriE7hWXSbTqO" : "9qjSq4snfnHwsOmP"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 1,
+      "role" : "EditorialBoardMember",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "H3fvTeAkOO0XzxHN18j",
-    "tags" : [ "z7a4oYF8rnT3mkoBG" ],
-    "description" : "4nIVZLoFsiM",
+    "npiSubjectHeading" : "9A51K5m0aRKswTX",
+    "tags" : [ "24gNBvOgD0" ],
+    "description" : "8WqNDqdjm8hFFX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
           "type" : "Other",
-          "description" : "3aSNRvi29eOgkzEx"
+          "description" : "uYhPg7S8rTjrijQ"
         },
         "format" : "Sound",
-        "disseminationChannel" : "M7GYFK3Hg3HI5E",
+        "disseminationChannel" : "k7JWc6kHpw6",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "MGRzVWUaIuS",
-          "seriesPart" : "lbQ69N2ZlsbxtT0j"
+          "series" : "3KQF3FMoX9y2KgMeXB",
+          "seriesPart" : "Cyn9lNVhSnKBoXRJzz0"
         }
       },
-      "doi" : "https://www.example.com/NeQrnjz3gClIQYZE7jm",
+      "doi" : "https://www.example.com/fAg0DTwjQRNHTvmjZYa",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "peerReviewed" : false,
@@ -100,24 +100,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/xUL81Qjq0YD",
-    "abstract" : "VpDQ0vfGB8TtDgSq"
+    "metadataSource" : "https://www.example.com/0V1Twk1VDtew",
+    "abstract" : "z7XNoqgJZIfimNSMUS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/expeditavoluptatibus",
-    "name" : "QfkiSrxT0lmSV0M8dk",
+    "id" : "https://www.example.org/quiest",
+    "name" : "DzuOzXv71DcqvG3X",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ktO7fWNuMiAWRHRtcbO",
-      "id" : "BaZZYhWLNEf8ZmJpK"
+      "source" : "7dGhyYXMpUp",
+      "id" : "FBxS3Ix0FvL"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "AOfYHnwuCF7"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "PSn4RQYOV0X"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -125,22 +125,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dolorespossimus" ],
+  "subjects" : [ "https://www.example.org/assumendavoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZzhAxfXZlqlAJlM0x",
-      "mimeType" : "paHycBX0aHoXlO1XbBx",
-      "size" : 1582245962,
+      "name" : "TC4kAsp2bOTfx",
+      "mimeType" : "2rK1hifgbE3JQ",
+      "size" : 1647219919,
       "license" : {
         "type" : "License",
-        "identifier" : "MP335lELJ3iNQ2I7Ht",
+        "identifier" : "cO8me8IEZ7",
         "labels" : {
-          "88mcBPB44ZtxMEPl" : "FOVbNP7o34KD6Azm"
+          "2pB6ULrCayLyG09D3eG" : "WNuXJFxJyA0mt68i"
         },
-        "link" : "https://www.example.com/Uvofu16QGQALV9D"
+        "link" : "https://www.example.com/vpONvIjgl4n"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -150,21 +150,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ZzhAxfXZlqlAJlM0x",
-    "mimeType" : "paHycBX0aHoXlO1XbBx",
-    "size" : 1582245962,
+    "name" : "TC4kAsp2bOTfx",
+    "mimeType" : "2rK1hifgbE3JQ",
+    "size" : 1647219919,
     "license" : {
       "type" : "License",
-      "identifier" : "MP335lELJ3iNQ2I7Ht",
+      "identifier" : "cO8me8IEZ7",
       "labels" : {
-        "88mcBPB44ZtxMEPl" : "FOVbNP7o34KD6Azm"
+        "2pB6ULrCayLyG09D3eG" : "WNuXJFxJyA0mt68i"
       },
-      "link" : "https://www.example.com/Uvofu16QGQALV9D"
+      "link" : "https://www.example.com/vpONvIjgl4n"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "clOpYEcDDgum9Iwq",
+  "owner" : "NpDKEGGHoxBtU0wfo",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -3,95 +3,94 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "NpDKEGGHoxBtU0wfo",
-    "ownerAffiliation" : "https://www.example.org/velitdolore"
+    "owner" : "Qf0BWd5VQJ",
+    "ownerAffiliation" : "https://www.example.org/illonecessitatibus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dictaqui",
+    "id" : "https://www.example.org/nihilipsum",
     "labels" : {
-      "K7ThvAxbOrWjHk1p0L" : "AneefN2JnXEuc"
+      "pMDc3GB0Cmy" : "5ccJG9WmEULd"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/optioamet",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/autaccusamus",
+  "handle" : "https://www.example.org/praesentiumdignissimos",
+  "doi" : "https://doi.org/10.1234/impedit",
+  "link" : "https://www.example.org/inventoreharum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QyEHTxjVI5c07RHSAUd",
+    "mainTitle" : "OqHZUiKJQg3",
     "alternativeTitles" : {
-      "sv" : "y6twGIYb9nzGtlPl1"
+      "es" : "5qSyVdlbvXi6sYV3rLC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "cNO39Wr7Qm",
-      "month" : "UBMBlwEBLxS7G0",
-      "day" : "c2P9uSpeas1C"
+      "year" : "sYpwUZ49YJ5gNi6Zc2",
+      "month" : "cthWQ6VxNYNH2o0",
+      "day" : "PWXirUyaKX5fvTAS8Y"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/D4KuetYeinl",
-        "name" : "rLGVCUOILAdyfZi6vL",
-        "nameType" : "Organizational",
-        "orcId" : "EcWIdclcNbNzEha"
+        "id" : "https://www.example.com/DG49GY0Chbup2tXy",
+        "name" : "gZzv102XMpWVql",
+        "nameType" : "Personal",
+        "orcId" : "KpI2PuXi5ObP5OU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OCbB8sqrGX",
+        "id" : "https://www.example.com/DKadtn1tW2gJjZT6eE",
         "labels" : {
-          "FFTSX1PhVPgxo8" : "rpVGRNTxjK1DVyjmTK"
+          "TNKeZcAvYDI5KP3srI" : "n0Apav39f1gXDBTH"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 1,
+      "role" : "Researcher",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Gn5iEbwDjrVqKI",
-        "name" : "MODahi3AR9",
-        "nameType" : "Personal",
-        "orcId" : "DjyFjOe8BFlYfwGo7v"
+        "id" : "https://www.example.com/uTZBu02dwLozkLmo",
+        "name" : "SZXU5FipZO8Pf",
+        "nameType" : "Organizational",
+        "orcId" : "9elX2IOypZHxP5b"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ZSC6BidosZLpd7Hn",
+        "id" : "https://www.example.com/k9gw2mICxxBk",
         "labels" : {
-          "QNtDRriE7hWXSbTqO" : "9qjSq4snfnHwsOmP"
+          "RBzfaPGlfxpJE" : "spEQbJKySwTae"
         }
       } ],
-      "role" : "EditorialBoardMember",
+      "role" : "Dramatist",
       "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9A51K5m0aRKswTX",
-    "tags" : [ "24gNBvOgD0" ],
-    "description" : "8WqNDqdjm8hFFX",
+    "npiSubjectHeading" : "KuclqbcQtUU",
+    "tags" : [ "0SR52KRys68QWy" ],
+    "description" : "LcRypzs5QsXuhbtC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Other",
-          "description" : "uYhPg7S8rTjrijQ"
+          "type" : "Radio"
         },
         "format" : "Sound",
-        "disseminationChannel" : "k7JWc6kHpw6",
+        "disseminationChannel" : "ZM9XnrUgdG7ux",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "3KQF3FMoX9y2KgMeXB",
-          "seriesPart" : "Cyn9lNVhSnKBoXRJzz0"
+          "series" : "vDfZyS46E21h6",
+          "seriesPart" : "vq51f4uqf7f55g"
         }
       },
-      "doi" : "https://www.example.com/fAg0DTwjQRNHTvmjZYa",
+      "doi" : "https://www.example.com/EHjCTi70NU5BA2",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "peerReviewed" : false,
@@ -100,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/0V1Twk1VDtew",
-    "abstract" : "z7XNoqgJZIfimNSMUS"
+    "metadataSource" : "https://www.example.com/UiARJN2E1OorGu5jTL",
+    "abstract" : "Z2orDBADR4"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiest",
-    "name" : "DzuOzXv71DcqvG3X",
+    "id" : "https://www.example.org/nostrumipsam",
+    "name" : "Rm7Duea3fvdKzEUmsJ",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "7dGhyYXMpUp",
-      "id" : "FBxS3Ix0FvL"
+      "source" : "ar1ouKQ5J4mHon",
+      "id" : "OKtFLQTN0WYS2W6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "PSn4RQYOV0X"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "nNXL3UEuck2HQ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -125,22 +124,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/assumendavoluptas" ],
+  "subjects" : [ "https://www.example.org/aliasenim" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "TC4kAsp2bOTfx",
-      "mimeType" : "2rK1hifgbE3JQ",
-      "size" : 1647219919,
+      "name" : "WsQHpr2KGiwLpVUg",
+      "mimeType" : "ZkK68KgIsLZaa",
+      "size" : 2134282725,
       "license" : {
         "type" : "License",
-        "identifier" : "cO8me8IEZ7",
+        "identifier" : "XbEa7atUWb",
         "labels" : {
-          "2pB6ULrCayLyG09D3eG" : "WNuXJFxJyA0mt68i"
+          "sJEq4IpC3Ko8CtJM" : "C8Xax0kMcM"
         },
-        "link" : "https://www.example.com/vpONvIjgl4n"
+        "link" : "https://www.example.com/Odh3s2CwU8pmjAAstE"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -150,21 +149,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "TC4kAsp2bOTfx",
-    "mimeType" : "2rK1hifgbE3JQ",
-    "size" : 1647219919,
+    "name" : "WsQHpr2KGiwLpVUg",
+    "mimeType" : "ZkK68KgIsLZaa",
+    "size" : 2134282725,
     "license" : {
       "type" : "License",
-      "identifier" : "cO8me8IEZ7",
+      "identifier" : "XbEa7atUWb",
       "labels" : {
-        "2pB6ULrCayLyG09D3eG" : "WNuXJFxJyA0mt68i"
+        "sJEq4IpC3Ko8CtJM" : "C8Xax0kMcM"
       },
-      "link" : "https://www.example.com/vpONvIjgl4n"
+      "link" : "https://www.example.com/Odh3s2CwU8pmjAAstE"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "NpDKEGGHoxBtU0wfo",
+  "owner" : "Qf0BWd5VQJ",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "hsQlBBLaghKDcapx",
-    "ownerAffiliation" : "https://www.example.org/eumveniam"
+    "owner" : "C3O9WWoYgg0E",
+    "ownerAffiliation" : "https://www.example.org/ullamvero"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repudiandaeexpedita",
+    "id" : "https://www.example.org/sintminima",
     "labels" : {
-      "w5iozF0HkkaqI2g7W5y" : "shADZSi61tdFjwd"
+      "kc2gHtkUqEI" : "e6YLtdbPdC"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/doloremquedoloremque",
-  "doi" : "https://doi.org/10.1234/ab",
-  "link" : "https://www.example.org/magninon",
+  "handle" : "https://www.example.org/ipsanihil",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/aspernaturet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8we2v36V3H6g",
+    "mainTitle" : "pRFlcJjplATpnR",
     "alternativeTitles" : {
-      "da" : "B6zpbvK2pP2U4UV"
+      "af" : "xChzBmpY7Q8cGd8Aa"
     },
     "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "PWQrfQl78Eh",
-      "month" : "uvbT5LcgqsBHtF0eH",
-      "day" : "mM7cxB5mVNs"
+      "year" : "x4CNTcUEQR",
+      "month" : "NnGE0DjEl26",
+      "day" : "cPbO4mKT5mkfS4q9mjp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/yex3IME8PnkED0IklM",
-        "name" : "JzKW5TRFURqb5W",
+        "id" : "https://www.example.com/4JZEe6gidfb",
+        "name" : "eZGJ5IMrhJx4AxvzN",
         "nameType" : "Organizational",
-        "orcId" : "K8VytgwzHJNJo8Ed"
+        "orcId" : "NglFRDPx3Y"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/FJzcR2uhZdzS3JQdP",
+        "id" : "https://www.example.com/OilP7golY6Oe",
         "labels" : {
-          "U7qbEhdrlVgU" : "WusqCFwdnsb"
+          "TcTUamQ9A3qpx" : "RqHDyAl9ECempSU"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 7,
+      "role" : "Other",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/UWO1SrQPMQJhR",
-        "name" : "nMTkMxyMbt",
+        "id" : "https://www.example.com/uKHQrvBnNkgFTcCFE3",
+        "name" : "95X2RRWlX7nyxWZKr",
         "nameType" : "Organizational",
-        "orcId" : "5RQAVZaSN0iQAq6MgZ"
+        "orcId" : "Pko5oriOq1d"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5pkqfCafE6Kyv9Pe93n",
+        "id" : "https://www.example.com/g0jk2rq5buOHlYmUgN",
         "labels" : {
-          "HsrOItGt6Qej" : "DMHbB39d5gjD2npwD"
+          "CoyTAOAYCrfNg4VsiB" : "sqreBrX499G"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 8,
+      "role" : "Creator",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "L68szCXQw0k",
-    "tags" : [ "6NNnHEeF483n38" ],
-    "description" : "rT6K7jFohr357jt",
+    "npiSubjectHeading" : "MKYHWfn9jGwkSTv",
+    "tags" : [ "VP0WOU1SO7QHakaPG2" ],
+    "description" : "nFbTAD64Xcs",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Journal"
         },
         "format" : "Video",
-        "disseminationChannel" : "y9bClvmVCi5JV6Im",
+        "disseminationChannel" : "0YhXxU3BpOgoxT",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "VSi3aLI0syMPkP0e",
-          "seriesPart" : "oIUT3UOtNc9Xyu"
+          "series" : "13drSPyI7ZDEwm89",
+          "seriesPart" : "K9S4TLvCxaaKVKKQkpY"
         }
       },
-      "doi" : "https://www.example.com/VsyP9VQ8kBhdvd5Z1bf",
+      "doi" : "https://www.example.com/L2q87SppJRNFTWq4",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/6Wl7snQ3F5",
-    "abstract" : "1aPwVQtvowW8o"
+    "metadataSource" : "https://www.example.com/3cmk9iEkAkCkOzo1K",
+    "abstract" : "B1nglUbiRKqL9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/estvoluptatem",
-    "name" : "qRGiWAoHIYYoJH1yX",
+    "id" : "https://www.example.org/aspernaturomnis",
+    "name" : "4AGc17LkMsns",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "qKavr3b9hY",
-      "id" : "DiEKgTeOG7HxdUfep"
+      "source" : "7LueMpvupNDPmy",
+      "id" : "3H5iMG1GYptxti"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "4GrTBQCdN2Mor"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "7VmJRs4jUK"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/estquisquam" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "K2G1NIqA72",
-    "mimeType" : "b1dcm0qqSyxp",
-    "size" : 633682717,
-    "license" : {
-      "type" : "License",
-      "identifier" : "CP3nb14BjvvCs9qPB",
-      "labels" : {
-        "ImSvufp5AgqUlw3E" : "ivAKVQJG9gQp43iWk"
-      },
-      "link" : "https://www.example.com/VguyzdPtR5i"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/beataeesse" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "K2G1NIqA72",
-      "mimeType" : "b1dcm0qqSyxp",
-      "size" : 633682717,
+      "name" : "XybovGNuS5RzvqTvo",
+      "mimeType" : "mMvTrjIXAdJREVGWbuD",
+      "size" : 652686486,
       "license" : {
         "type" : "License",
-        "identifier" : "CP3nb14BjvvCs9qPB",
+        "identifier" : "VUnXiAot2E1",
         "labels" : {
-          "ImSvufp5AgqUlw3E" : "ivAKVQJG9gQp43iWk"
+          "0qK4okg5SG" : "cLVKfMOSiLeCDEnW3g"
         },
-        "link" : "https://www.example.com/VguyzdPtR5i"
+        "link" : "https://www.example.com/Ba72eYiGrWtpGHvVdT"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "hsQlBBLaghKDcapx",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "XybovGNuS5RzvqTvo",
+    "mimeType" : "mMvTrjIXAdJREVGWbuD",
+    "size" : 652686486,
+    "license" : {
+      "type" : "License",
+      "identifier" : "VUnXiAot2E1",
+      "labels" : {
+        "0qK4okg5SG" : "cLVKfMOSiLeCDEnW3g"
+      },
+      "link" : "https://www.example.com/Ba72eYiGrWtpGHvVdT"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "C3O9WWoYgg0E",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "C3O9WWoYgg0E",
-    "ownerAffiliation" : "https://www.example.org/ullamvero"
+    "owner" : "9BjnMIob9zDAMG3",
+    "ownerAffiliation" : "https://www.example.org/deseruntnesciunt"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sintminima",
+    "id" : "https://www.example.org/natusblanditiis",
     "labels" : {
-      "kc2gHtkUqEI" : "e6YLtdbPdC"
+      "AThvJjotC5TElspkA" : "DKyX4mUbHf"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ipsanihil",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/aspernaturet",
+  "handle" : "https://www.example.org/odioaperiam",
+  "doi" : "https://doi.org/10.1234/quidem",
+  "link" : "https://www.example.org/doloresinventore",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pRFlcJjplATpnR",
+    "mainTitle" : "yPtbKfbIkS",
     "alternativeTitles" : {
-      "af" : "xChzBmpY7Q8cGd8Aa"
+      "ca" : "Z1IVxBXPd9p3xHmdx"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/mul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "x4CNTcUEQR",
-      "month" : "NnGE0DjEl26",
-      "day" : "cPbO4mKT5mkfS4q9mjp"
+      "year" : "gqIO8f06BezBifo",
+      "month" : "jb0wOyIk9hikjN",
+      "day" : "gNOnaztGhqNBzOUQn0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/4JZEe6gidfb",
-        "name" : "eZGJ5IMrhJx4AxvzN",
+        "id" : "https://www.example.com/SIGN6v3fKl0chxeAel",
+        "name" : "wJplqRghtAYbH7QIT",
         "nameType" : "Organizational",
-        "orcId" : "NglFRDPx3Y"
+        "orcId" : "urTwAiMAbWIM5uauTHc"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OilP7golY6Oe",
+        "id" : "https://www.example.com/xK1CopE234j2WhfJ",
         "labels" : {
-          "TcTUamQ9A3qpx" : "RqHDyAl9ECempSU"
+          "yTbZh1bCWu4s79kB" : "xMikiC76OzMIcA8C"
         }
       } ],
-      "role" : "Other",
-      "sequence" : 5,
+      "role" : "ContactPerson",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/uKHQrvBnNkgFTcCFE3",
-        "name" : "95X2RRWlX7nyxWZKr",
-        "nameType" : "Organizational",
-        "orcId" : "Pko5oriOq1d"
+        "id" : "https://www.example.com/LMzyA5SuYcOpz2mG7",
+        "name" : "RoWqPicA1zNtBJojFP",
+        "nameType" : "Personal",
+        "orcId" : "YxNbBOSMpyrweg5rHv"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/g0jk2rq5buOHlYmUgN",
+        "id" : "https://www.example.com/HzYeyuEYEandjw",
         "labels" : {
-          "CoyTAOAYCrfNg4VsiB" : "sqreBrX499G"
+          "QtS306mzg2gOPIB" : "IYg4Qbfzgh"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 9,
+      "role" : "ProductionDesigner",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "MKYHWfn9jGwkSTv",
-    "tags" : [ "VP0WOU1SO7QHakaPG2" ],
-    "description" : "nFbTAD64Xcs",
+    "npiSubjectHeading" : "uyRuhixflD3XxViK3",
+    "tags" : [ "9HeAxNb5qfRH7j" ],
+    "description" : "7q7nhsMO8BDhI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "TV"
         },
-        "format" : "Video",
-        "disseminationChannel" : "0YhXxU3BpOgoxT",
+        "format" : "Text",
+        "disseminationChannel" : "sbLmbuSrftgnneJ8a",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "13drSPyI7ZDEwm89",
-          "seriesPart" : "K9S4TLvCxaaKVKKQkpY"
+          "series" : "Wc8Yh8uBn4364bmX3Tn",
+          "seriesPart" : "qHEUmZCdX9E"
         }
       },
-      "doi" : "https://www.example.com/L2q87SppJRNFTWq4",
+      "doi" : "https://www.example.com/Gb0Kx7FZv16L2H1sRL",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/3cmk9iEkAkCkOzo1K",
-    "abstract" : "B1nglUbiRKqL9"
+    "metadataSource" : "https://www.example.com/7HxDkDG2LpMZ6I7ZS37",
+    "abstract" : "XIWzguGOJ7QqlE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aspernaturomnis",
-    "name" : "4AGc17LkMsns",
+    "id" : "https://www.example.org/eaquemolestiae",
+    "name" : "ymsOBbZxup8OfDud",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "7LueMpvupNDPmy",
-      "id" : "3H5iMG1GYptxti"
+      "source" : "YKjV5SD0wJFABENAj",
+      "id" : "q7sRIF1LyFGy"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "7VmJRs4jUK"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "02oEgfT0KAi0KDZ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,22 +124,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/beataeesse" ],
+  "subjects" : [ "https://www.example.org/nihillaboriosam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "XybovGNuS5RzvqTvo",
-      "mimeType" : "mMvTrjIXAdJREVGWbuD",
-      "size" : 652686486,
+      "name" : "h3Rv0zG3JMLCmPjPN",
+      "mimeType" : "eqTDFoXcwb9Vo",
+      "size" : 1984735668,
       "license" : {
         "type" : "License",
-        "identifier" : "VUnXiAot2E1",
+        "identifier" : "HDSf9b585D0Vrf4smm",
         "labels" : {
-          "0qK4okg5SG" : "cLVKfMOSiLeCDEnW3g"
+          "D2QX7Yvoyx5pWn" : "8HfM90VRkRFe"
         },
-        "link" : "https://www.example.com/Ba72eYiGrWtpGHvVdT"
+        "link" : "https://www.example.com/SsiHpscodFl2y"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -149,21 +149,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "XybovGNuS5RzvqTvo",
-    "mimeType" : "mMvTrjIXAdJREVGWbuD",
-    "size" : 652686486,
+    "name" : "h3Rv0zG3JMLCmPjPN",
+    "mimeType" : "eqTDFoXcwb9Vo",
+    "size" : 1984735668,
     "license" : {
       "type" : "License",
-      "identifier" : "VUnXiAot2E1",
+      "identifier" : "HDSf9b585D0Vrf4smm",
       "labels" : {
-        "0qK4okg5SG" : "cLVKfMOSiLeCDEnW3g"
+        "D2QX7Yvoyx5pWn" : "8HfM90VRkRFe"
       },
-      "link" : "https://www.example.com/Ba72eYiGrWtpGHvVdT"
+      "link" : "https://www.example.com/SsiHpscodFl2y"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "C3O9WWoYgg0E",
+  "owner" : "9BjnMIob9zDAMG3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -3,78 +3,78 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "XgVd8DCqi0F",
-    "ownerAffiliation" : "https://www.example.org/harumconsequatur"
+    "owner" : "hsQlBBLaghKDcapx",
+    "ownerAffiliation" : "https://www.example.org/eumveniam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/possimusunde",
+    "id" : "https://www.example.org/repudiandaeexpedita",
     "labels" : {
-      "iEbnMIYQIfLb6IN12E7" : "HWbA6vXqHP"
+      "w5iozF0HkkaqI2g7W5y" : "shADZSi61tdFjwd"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/teneturet",
-  "doi" : "https://doi.org/10.1234/quidem",
-  "link" : "https://www.example.org/eadolorem",
+  "handle" : "https://www.example.org/doloremquedoloremque",
+  "doi" : "https://doi.org/10.1234/ab",
+  "link" : "https://www.example.org/magninon",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "p0kFFTMmAqR",
+    "mainTitle" : "8we2v36V3H6g",
     "alternativeTitles" : {
-      "nn" : "kDJIObDqPVrbFgCcU9F"
+      "da" : "B6zpbvK2pP2U4UV"
     },
-    "language" : "http://lexvo.org/id/iso639-3/por",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "iHtjBBQzTlfpq0",
-      "month" : "icppzb9FrLVaoOMi0u",
-      "day" : "vlCwpA5hhkCb6"
+      "year" : "PWQrfQl78Eh",
+      "month" : "uvbT5LcgqsBHtF0eH",
+      "day" : "mM7cxB5mVNs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/pvLQOfmwX87JO282tm",
-        "name" : "xa1W7RFC904CRm",
+        "id" : "https://www.example.com/yex3IME8PnkED0IklM",
+        "name" : "JzKW5TRFURqb5W",
         "nameType" : "Organizational",
-        "orcId" : "o3fIonFUAY"
+        "orcId" : "K8VytgwzHJNJo8Ed"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3e8cDCfsdf",
+        "id" : "https://www.example.com/FJzcR2uhZdzS3JQdP",
         "labels" : {
-          "HmzRAxcjN8" : "2prXSrObrpDpa"
+          "U7qbEhdrlVgU" : "WusqCFwdnsb"
         }
       } ],
-      "role" : "Editor",
+      "role" : "ProgrammeLeader",
       "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/0s7usG7ygUXg",
-        "name" : "Nfk4jZmXte6c",
-        "nameType" : "Personal",
-        "orcId" : "3Bc19WlgOWMBnKJ77GE"
+        "id" : "https://www.example.com/UWO1SrQPMQJhR",
+        "name" : "nMTkMxyMbt",
+        "nameType" : "Organizational",
+        "orcId" : "5RQAVZaSN0iQAq6MgZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/J2xKV62aQS4z",
+        "id" : "https://www.example.com/5pkqfCafE6Kyv9Pe93n",
         "labels" : {
-          "mwXmVL4jkENHqD" : "MyOBSohg6eVlU1"
+          "HsrOItGt6Qej" : "DMHbB39d5gjD2npwD"
         }
       } ],
-      "role" : "Writer",
-      "sequence" : 3,
+      "role" : "Other",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "KKYJKM1aLFOEm1",
-    "tags" : [ "FVR8C1KMYra7" ],
-    "description" : "0TMf2FxLzqdlMKn",
+    "npiSubjectHeading" : "L68szCXQw0k",
+    "tags" : [ "6NNnHEeF483n38" ],
+    "description" : "rT6K7jFohr357jt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -82,15 +82,15 @@
         "medium" : {
           "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "Wqx8XAK5mtnska",
+        "format" : "Video",
+        "disseminationChannel" : "y9bClvmVCi5JV6Im",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "MogFbsyKVGCdnBZSY1",
-          "seriesPart" : "nZ136nHtXlaC8j2LOn"
+          "series" : "VSi3aLI0syMPkP0e",
+          "seriesPart" : "oIUT3UOtNc9Xyu"
         }
       },
-      "doi" : "https://www.example.com/yhKXnx6fA2VCALeMnk7",
+      "doi" : "https://www.example.com/VsyP9VQ8kBhdvd5Z1bf",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "peerReviewed" : false,
@@ -99,45 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/sTx6KANSLKxvYPg",
-    "abstract" : "pCWV3rZrORs5O65h"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "yKiStesA18lYS",
-      "mimeType" : "AMiBEbpo04",
-      "size" : 560154924,
-      "license" : {
-        "type" : "License",
-        "identifier" : "sXIyl5BnsfHwrQRCM",
-        "labels" : {
-          "tLYUDUPVibOlU0" : "FKqSpqAo08dJ"
-        },
-        "link" : "https://www.example.com/9enSrExicVIO9T6ck3"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/6Wl7snQ3F5",
+    "abstract" : "1aPwVQtvowW8o"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aspernaturdolorum",
-    "name" : "XgeTvoaJ3bu8MXR",
+    "id" : "https://www.example.org/estvoluptatem",
+    "name" : "qRGiWAoHIYYoJH1yX",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "iDcliLVgq42",
-      "id" : "7v0fzNXk7pJj"
+      "source" : "qKavr3b9hY",
+      "id" : "DiEKgTeOG7HxdUfep"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "FSMO1kKbUYCIvFrl5S"
+      "applicationCode" : "4GrTBQCdN2Mor"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,25 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nihilplaceat" ],
+  "subjects" : [ "https://www.example.org/estquisquam" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "yKiStesA18lYS",
-    "mimeType" : "AMiBEbpo04",
-    "size" : 560154924,
+    "name" : "K2G1NIqA72",
+    "mimeType" : "b1dcm0qqSyxp",
+    "size" : 633682717,
     "license" : {
       "type" : "License",
-      "identifier" : "sXIyl5BnsfHwrQRCM",
+      "identifier" : "CP3nb14BjvvCs9qPB",
       "labels" : {
-        "tLYUDUPVibOlU0" : "FKqSpqAo08dJ"
+        "ImSvufp5AgqUlw3E" : "ivAKVQJG9gQp43iWk"
       },
-      "link" : "https://www.example.com/9enSrExicVIO9T6ck3"
+      "link" : "https://www.example.com/VguyzdPtR5i"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "XgVd8DCqi0F"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "K2G1NIqA72",
+      "mimeType" : "b1dcm0qqSyxp",
+      "size" : 633682717,
+      "license" : {
+        "type" : "License",
+        "identifier" : "CP3nb14BjvvCs9qPB",
+        "labels" : {
+          "ImSvufp5AgqUlw3E" : "ivAKVQJG9gQp43iWk"
+        },
+        "link" : "https://www.example.com/VguyzdPtR5i"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "hsQlBBLaghKDcapx",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "9BjnMIob9zDAMG3",
-    "ownerAffiliation" : "https://www.example.org/deseruntnesciunt"
+    "owner" : "3IhsileycF4Ti",
+    "ownerAffiliation" : "https://www.example.org/estsed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/natusblanditiis",
+    "id" : "https://www.example.org/rerumducimus",
     "labels" : {
-      "AThvJjotC5TElspkA" : "DKyX4mUbHf"
+      "Yg8YYBvI50l" : "f9wZK2mIgb727B0yU3"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/odioaperiam",
-  "doi" : "https://doi.org/10.1234/quidem",
-  "link" : "https://www.example.org/doloresinventore",
+  "handle" : "https://www.example.org/excepturivoluptas",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/quiavel",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yPtbKfbIkS",
+    "mainTitle" : "F6Gt7XZbxnCd",
     "alternativeTitles" : {
-      "ca" : "Z1IVxBXPd9p3xHmdx"
+      "sv" : "XgQQtdHeVw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "gqIO8f06BezBifo",
-      "month" : "jb0wOyIk9hikjN",
-      "day" : "gNOnaztGhqNBzOUQn0"
+      "year" : "mBLz5avj437J9NcF1",
+      "month" : "BJ4y362leHWzQOUTO",
+      "day" : "8REWcVRetUu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SIGN6v3fKl0chxeAel",
-        "name" : "wJplqRghtAYbH7QIT",
-        "nameType" : "Organizational",
-        "orcId" : "urTwAiMAbWIM5uauTHc"
+        "id" : "https://www.example.com/aNarFfT7x92",
+        "name" : "b1C6rlKbjBZz3lnK",
+        "nameType" : "Personal",
+        "orcId" : "g5qDBi4NzGY"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/xK1CopE234j2WhfJ",
+        "id" : "https://www.example.com/RJKGwff5DhQwfc",
         "labels" : {
-          "yTbZh1bCWu4s79kB" : "xMikiC76OzMIcA8C"
+          "5E3drDp9Pr13A" : "20eolhlC5qV"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 2,
+      "role" : "Consultant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/LMzyA5SuYcOpz2mG7",
-        "name" : "RoWqPicA1zNtBJojFP",
+        "id" : "https://www.example.com/rXcVP0lQNjnpM",
+        "name" : "qzebb42oKt5pLNMzw0Z",
         "nameType" : "Personal",
-        "orcId" : "YxNbBOSMpyrweg5rHv"
+        "orcId" : "uPwVaZyg0nf1ng"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/HzYeyuEYEandjw",
+        "id" : "https://www.example.com/zaBdO4Eb7cnTQEan",
         "labels" : {
-          "QtS306mzg2gOPIB" : "IYg4Qbfzgh"
+          "k2Dn2BR5zwm" : "AngubiZCvTMl5ZxMXcZ"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 4,
+      "role" : "Consultant",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "uyRuhixflD3XxViK3",
-    "tags" : [ "9HeAxNb5qfRH7j" ],
-    "description" : "7q7nhsMO8BDhI",
+    "npiSubjectHeading" : "KJowoAWiMp68eS4n",
+    "tags" : [ "JpPvun5qUbQbgba" ],
+    "description" : "PoG7n8r7FuxR0WPj3zv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Journal"
         },
         "format" : "Text",
-        "disseminationChannel" : "sbLmbuSrftgnneJ8a",
+        "disseminationChannel" : "f5JWLCaV0jTmW",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "Wc8Yh8uBn4364bmX3Tn",
-          "seriesPart" : "qHEUmZCdX9E"
+          "series" : "NiFsvXCB7L",
+          "seriesPart" : "AzidHZ0PZYzfzU8qN5"
         }
       },
-      "doi" : "https://www.example.com/Gb0Kx7FZv16L2H1sRL",
+      "doi" : "https://www.example.com/nlUxXsvTISeK30",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/7HxDkDG2LpMZ6I7ZS37",
-    "abstract" : "XIWzguGOJ7QqlE"
+    "metadataSource" : "https://www.example.com/StPzO0yD28H",
+    "abstract" : "xuPNjin60Ib"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eaquemolestiae",
-    "name" : "ymsOBbZxup8OfDud",
+    "id" : "https://www.example.org/esseaut",
+    "name" : "JWE8C0mKvNdG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "YKjV5SD0wJFABENAj",
-      "id" : "q7sRIF1LyFGy"
+      "source" : "jfBqFJ4YnGjiO",
+      "id" : "O1gdbCogiljsm0wwzX"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "02oEgfT0KAi0KDZ"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "KdtcHWdu7sp84Q"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,22 +124,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nihillaboriosam" ],
+  "subjects" : [ "https://www.example.org/temporanobis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "h3Rv0zG3JMLCmPjPN",
-      "mimeType" : "eqTDFoXcwb9Vo",
-      "size" : 1984735668,
+      "name" : "Y6g7ZZI1xl2yY",
+      "mimeType" : "aCstiMVBJC",
+      "size" : 1508863456,
       "license" : {
         "type" : "License",
-        "identifier" : "HDSf9b585D0Vrf4smm",
+        "identifier" : "D3ybw8geFwF1TvZ",
         "labels" : {
-          "D2QX7Yvoyx5pWn" : "8HfM90VRkRFe"
+          "EVuAqo7Syh8iQU2WOX" : "8Bq7GLqimfI"
         },
-        "link" : "https://www.example.com/SsiHpscodFl2y"
+        "link" : "https://www.example.com/ZmvgLNGMkzGJWKZ"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -149,21 +149,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "h3Rv0zG3JMLCmPjPN",
-    "mimeType" : "eqTDFoXcwb9Vo",
-    "size" : 1984735668,
+    "name" : "Y6g7ZZI1xl2yY",
+    "mimeType" : "aCstiMVBJC",
+    "size" : 1508863456,
     "license" : {
       "type" : "License",
-      "identifier" : "HDSf9b585D0Vrf4smm",
+      "identifier" : "D3ybw8geFwF1TvZ",
       "labels" : {
-        "D2QX7Yvoyx5pWn" : "8HfM90VRkRFe"
+        "EVuAqo7Syh8iQU2WOX" : "8Bq7GLqimfI"
       },
-      "link" : "https://www.example.com/SsiHpscodFl2y"
+      "link" : "https://www.example.com/ZmvgLNGMkzGJWKZ"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "9BjnMIob9zDAMG3",
+  "owner" : "3IhsileycF4Ti",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "fe5pI3WAnX89UiGQaW",
-    "ownerAffiliation" : "https://www.example.org/officiasunt"
+    "owner" : "ANqbb9LhGlxWOC",
+    "ownerAffiliation" : "https://www.example.org/reiciendisvoluptatem"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/evenietsoluta",
+    "id" : "https://www.example.org/sintcupiditate",
     "labels" : {
-      "tl5s3BuaqU" : "HfSREm6L6pFvo"
+      "Lv6T2w8POYKfGKLxnX" : "cL8jbL9qhx"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/repellatdolore",
-  "doi" : "https://doi.org/10.1234/iusto",
-  "link" : "https://www.example.org/autemimpedit",
+  "handle" : "https://www.example.org/sitquo",
+  "doi" : "https://doi.org/10.1234/ducimus",
+  "link" : "https://www.example.org/placeataliquid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VLeLO26RGG4W",
+    "mainTitle" : "RrhO8huQqu1cA",
     "alternativeTitles" : {
-      "nn" : "HgL02xeQtzB7vGg2E"
+      "is" : "fr7O9uthbGGYxuU"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "olWIhVDY6iFDVBjS",
-      "month" : "C4oaUF2QTLXReGAq5MI",
-      "day" : "MSfaHhnWVe4i6OZD"
+      "year" : "iCsQn7fsh7WCZMrHMT0",
+      "month" : "KOAPbTm3RbfHnH9P",
+      "day" : "Gnq7oNbifrb1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/m4xhJ1lBjTvnttk",
-        "name" : "jqDBj3TGGu0OKukib",
-        "nameType" : "Organizational",
-        "orcId" : "8UQTxUCiTPC2P6ZP"
+        "id" : "https://www.example.com/wLxBOtyqzJGO54tNz9l",
+        "name" : "jHaBK9mSDO4SUmolQ42",
+        "nameType" : "Personal",
+        "orcId" : "6CGfFKvqNeGwA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/WQlDnR6EjgXgan",
+        "id" : "https://www.example.com/DRXc8JKpp0",
         "labels" : {
-          "Gxu3JZYluMlcEREs" : "pGUie8X1rF"
+          "6J2kk3t6bBH" : "69bxZeijQUVIPN"
         }
       } ],
-      "role" : "VfxSupervisor",
-      "sequence" : 9,
+      "role" : "DataManager",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/nVFHijFeZ8am",
-        "name" : "XiJJdmNnxeCr",
+        "id" : "https://www.example.com/fCKhy1QzcO5yiR",
+        "name" : "BXeAZSfQLpnngNX0",
         "nameType" : "Personal",
-        "orcId" : "d7snKkx3Le2Md"
+        "orcId" : "tQvBRrZGkMnp"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/XnJsypeMQtYdMJ",
+        "id" : "https://www.example.com/dYPBSm1eKpV",
         "labels" : {
-          "WdhwUOMtP3LB7" : "QG0gnEl8t8yRUZ"
+          "GuDU2sKHz2A952wZ" : "YpAJkpUiFOrjR6ATUHL"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 8,
+      "role" : "Dramatist",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "zmYsUBr24pctW",
-    "tags" : [ "eIVrJ1AE4ebIl" ],
-    "description" : "LTaBnRnouz",
+    "npiSubjectHeading" : "QtcpbmoXxm1A",
+    "tags" : [ "RxGqacsUgXoTNH" ],
+    "description" : "prfnitteMqOjq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "YT2P1XYstQXh22",
+        "format" : "Text",
+        "disseminationChannel" : "l11H1AuY6BW",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "CXmkiZBNH61Z3vPWnfF",
-          "seriesPart" : "f4BfhRCHeIKrMn31"
+          "series" : "8fF1XAHaooor8Uq2F",
+          "seriesPart" : "soXIwHTFNRo9khZd9"
         }
       },
-      "doi" : "https://www.example.com/Rr0GYDk7tjYxuX",
+      "doi" : "https://www.example.com/3mB8dB4lfO",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "peerReviewed" : false,
@@ -99,45 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/wwCaUXInjS4sk2FJs",
-    "abstract" : "ervxOERDhhBWxf"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "E2dmHLdkrpu1b2aZr",
-      "mimeType" : "QmfzuAnguNk7T2I0",
-      "size" : 484039686,
-      "license" : {
-        "type" : "License",
-        "identifier" : "pF5FzhCu2n",
-        "labels" : {
-          "6biMyyutneFCxoOZN" : "ZVjFAq4MBODy4UT"
-        },
-        "link" : "https://www.example.com/GyIoCAgNY0MJVkc"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/N2ycLF4VO8vLf",
+    "abstract" : "XHAXN84MePMld"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/velautem",
-    "name" : "gr2YV7oUpl8OA",
+    "id" : "https://www.example.org/etautem",
+    "name" : "KU1CNgppUP1EkLEj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "JOBSqnhwSyJ",
-      "id" : "6weMhaWjfVIvu14Am"
+      "source" : "4oC9LRJv0S",
+      "id" : "VOdhWYcw6vYOSba4yqO"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "jv5vSdZbt6hG9XKS"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "3Fqk9fLjKH2hgsCJ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -145,25 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velfugit" ],
+  "subjects" : [ "https://www.example.org/sitnon" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "E2dmHLdkrpu1b2aZr",
-    "mimeType" : "QmfzuAnguNk7T2I0",
-    "size" : 484039686,
+    "name" : "SrAZ9yv6X5k",
+    "mimeType" : "Wrc2JHuj8O21wU6GOe",
+    "size" : 1537249037,
     "license" : {
       "type" : "License",
-      "identifier" : "pF5FzhCu2n",
+      "identifier" : "u2tMRlvehE0e7Zku",
       "labels" : {
-        "6biMyyutneFCxoOZN" : "ZVjFAq4MBODy4UT"
+        "SaRQJpvUorLIus" : "h7E46fKjRBQyIh"
       },
-      "link" : "https://www.example.com/GyIoCAgNY0MJVkc"
+      "link" : "https://www.example.com/O0w9okL8NU"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "fe5pI3WAnX89UiGQaW"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "SrAZ9yv6X5k",
+      "mimeType" : "Wrc2JHuj8O21wU6GOe",
+      "size" : 1537249037,
+      "license" : {
+        "type" : "License",
+        "identifier" : "u2tMRlvehE0e7Zku",
+        "labels" : {
+          "SaRQJpvUorLIus" : "h7E46fKjRBQyIh"
+        },
+        "link" : "https://www.example.com/O0w9okL8NU"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "ANqbb9LhGlxWOC",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Dq9IngqqMcNS",
-    "ownerAffiliation" : "https://www.example.org/autemea"
+    "owner" : "8NcdLU5gnraa",
+    "ownerAffiliation" : "https://www.example.org/abvoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiaeet",
+    "id" : "https://www.example.org/exercitationemenim",
     "labels" : {
-      "cpejXKvqxapj" : "18CuKPKey4oQ7GHH0Fi"
+      "dga5osPjkJ4Wt8c" : "0rUIGC3r235Mm1d"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velfugit",
-  "doi" : "https://doi.org/10.1234/ab",
-  "link" : "https://www.example.org/quodomnis",
+  "handle" : "https://www.example.org/optionemo",
+  "doi" : "https://doi.org/10.1234/quaerat",
+  "link" : "https://www.example.org/consequaturin",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "L8FmXoAunON",
+    "mainTitle" : "aPuQZ5Kox50FVoOtcHv",
     "alternativeTitles" : {
-      "el" : "6rn971vIPJsCFrwF3Fo"
+      "bg" : "do8doyDJwNyY1qZrt"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "s5uMTh4gAAb8G9wYXW",
-      "month" : "MZCvSBymI0hMa",
-      "day" : "Mv5uSBMr1uR"
+      "year" : "xKIJ9LgyWzwfczk",
+      "month" : "x1LHQGD8f2idw",
+      "day" : "uz7MnA2sONYllDcZsLG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TkBtLnc8JWy",
-        "name" : "zKFmC3XNfnn",
+        "id" : "https://www.example.com/J071Qwu8s7BhMtYx",
+        "name" : "trCfamxdqB21hyLXc2P",
         "nameType" : "Organizational",
-        "orcId" : "9tLsTWejk37v3Wr"
+        "orcId" : "8NfBMYPH6COBjb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/5XU76m1XdThDc",
+        "id" : "https://www.example.com/wIuP5eafPpn",
         "labels" : {
-          "ehSV81CEdgEU6L0uEQ" : "2AbSWRDDVl"
+          "LbqzfNzeSbyQj" : "xYvNiKnzbd"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 1,
+      "role" : "Organizer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/w2xaxdoTjD3wMYr",
-        "name" : "Kf8iRJ2xOcmwM",
-        "nameType" : "Organizational",
-        "orcId" : "TRu8msvVfQWK6oz"
+        "id" : "https://www.example.com/xNGIUjchRuQ3qSBi",
+        "name" : "2cOYOnEoeqVw",
+        "nameType" : "Personal",
+        "orcId" : "iDWt8A5R00S7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VGGlXwkSyJjTUZ",
+        "id" : "https://www.example.com/O8Oyog2IE5SkcCKZ",
         "labels" : {
-          "88krBTMbok0XzY11rXL" : "qBttsHrKyLgcpteT"
+          "x2CpEm9nwSvMTREgal" : "qSut9XIsT8kXMU"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 9,
+      "role" : "VideoEditor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "tiAoeEKTg6t",
-    "tags" : [ "3X3KT2jNpLkw" ],
-    "description" : "DNeuNe6S2WHY713CF",
+    "npiSubjectHeading" : "9ZGpantIRZ",
+    "tags" : [ "xheohm5AnU" ],
+    "description" : "O4QAyTWAi8Zq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Internet"
         },
-        "format" : "Text",
-        "disseminationChannel" : "53AY3qGvUhwkSv5",
+        "format" : "Video",
+        "disseminationChannel" : "gGSBZk8If7l6zL",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "cAZ0uwcKMegb40A1",
-          "seriesPart" : "5mt0QfA1cqBJIAF"
+          "series" : "D9V7jcZrAcshCk0",
+          "seriesPart" : "kTWcJSoW1vg03FQEgq"
         }
       },
-      "doi" : "https://www.example.com/FD6B7SE3pxECw8IQi",
+      "doi" : "https://www.example.com/wedMnS2TmYnB6",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/4y5eTOaFWyW79jN",
-    "abstract" : "zDBB0x8z38bGtU"
+    "metadataSource" : "https://www.example.com/I7mV1NAJVDQ79XJr",
+    "abstract" : "EETXX9KnZz35J"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/maioresesse",
-    "name" : "awX8JmG0LFj9dTxiE5l",
+    "id" : "https://www.example.org/eadolorum",
+    "name" : "TOhZP4Yd5E2",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZrBkbUeJFqGp25i8",
-      "id" : "T5CKGbHA77G3fgk15C"
+      "source" : "0Ygc97zjvbnuNnZGXl",
+      "id" : "pweTyTQWZQirV"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Zzkb8YXX6WcX"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ICK9Xhh3tD3aDQM"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velet" ],
+  "subjects" : [ "https://www.example.org/autemsimilique" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lzFBCym2ODR",
-      "mimeType" : "hu3X2MCCrdYbapZ",
-      "size" : 202794890,
+      "name" : "I4foQ2szMolKA",
+      "mimeType" : "5zotFZLi3HCNu",
+      "size" : 1898793762,
       "license" : {
         "type" : "License",
-        "identifier" : "1n9tsbGG4d",
+        "identifier" : "F6PKexd56pRzGWeFUdS",
         "labels" : {
-          "kxdCMw3Pg3de3kH" : "9ZKouOdYkBfKxLpPCn"
+          "vR70SNv0xUd" : "fw2oVPgMcKx2"
         },
-        "link" : "https://www.example.com/rPaWFxZJ3J"
+        "link" : "https://www.example.com/G380lfpljL"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lzFBCym2ODR",
-    "mimeType" : "hu3X2MCCrdYbapZ",
-    "size" : 202794890,
+    "name" : "I4foQ2szMolKA",
+    "mimeType" : "5zotFZLi3HCNu",
+    "size" : 1898793762,
     "license" : {
       "type" : "License",
-      "identifier" : "1n9tsbGG4d",
+      "identifier" : "F6PKexd56pRzGWeFUdS",
       "labels" : {
-        "kxdCMw3Pg3de3kH" : "9ZKouOdYkBfKxLpPCn"
+        "vR70SNv0xUd" : "fw2oVPgMcKx2"
       },
-      "link" : "https://www.example.com/rPaWFxZJ3J"
+      "link" : "https://www.example.com/G380lfpljL"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "Dq9IngqqMcNS",
+  "owner" : "8NcdLU5gnraa",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "P6ci3pheRnc",
-    "ownerAffiliation" : "https://www.example.org/providentdicta"
+    "owner" : "Dq9IngqqMcNS",
+    "ownerAffiliation" : "https://www.example.org/autemea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/oditaut",
+    "id" : "https://www.example.org/molestiaeet",
     "labels" : {
-      "rk6ZK1HVHzz46A" : "KizHevH8ebdnKctQK"
+      "cpejXKvqxapj" : "18CuKPKey4oQ7GHH0Fi"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consequaturest",
-  "doi" : "https://doi.org/10.1234/voluptate",
-  "link" : "https://www.example.org/autemcommodi",
+  "handle" : "https://www.example.org/velfugit",
+  "doi" : "https://doi.org/10.1234/ab",
+  "link" : "https://www.example.org/quodomnis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5S6aY39iCFAZK",
+    "mainTitle" : "L8FmXoAunON",
     "alternativeTitles" : {
-      "cs" : "wKzKmVARLN19"
+      "el" : "6rn971vIPJsCFrwF3Fo"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/mis",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "LrNL9YpAG5xn",
-      "month" : "TtfrusbjuBNKMz",
-      "day" : "foLYVtk94qBfEXVH"
+      "year" : "s5uMTh4gAAb8G9wYXW",
+      "month" : "MZCvSBymI0hMa",
+      "day" : "Mv5uSBMr1uR"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9LBOCptvAwlfvEz",
-        "name" : "WqJowFDpThA",
+        "id" : "https://www.example.com/TkBtLnc8JWy",
+        "name" : "zKFmC3XNfnn",
         "nameType" : "Organizational",
-        "orcId" : "KePYt452lmxRzJz"
+        "orcId" : "9tLsTWejk37v3Wr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/b1T7X4QI3NHmHtp0G",
+        "id" : "https://www.example.com/5XU76m1XdThDc",
         "labels" : {
-          "2I3hth5jKC" : "E8z6s6cjZUAv95ywQ"
+          "ehSV81CEdgEU6L0uEQ" : "2AbSWRDDVl"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 9,
+      "role" : "RelatedPerson",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/B0MmDWzsyC",
-        "name" : "l4qCfXO4Ll0uBu",
-        "nameType" : "Personal",
-        "orcId" : "QoCeIhBiVsWMiog23BT"
+        "id" : "https://www.example.com/w2xaxdoTjD3wMYr",
+        "name" : "Kf8iRJ2xOcmwM",
+        "nameType" : "Organizational",
+        "orcId" : "TRu8msvVfQWK6oz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/JG99FpXITG401NnMVcr",
+        "id" : "https://www.example.com/VGGlXwkSyJjTUZ",
         "labels" : {
-          "k3yi9bRAmO9DxaUbybA" : "XszwAK0DRVg4FwtRSd3"
+          "88krBTMbok0XzY11rXL" : "qBttsHrKyLgcpteT"
         }
       } ],
-      "role" : "Dramatist",
-      "sequence" : 4,
+      "role" : "ProductionDesigner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "zMllsIAGzcD",
-    "tags" : [ "3N2ctMhf3KTgq0l" ],
-    "description" : "neMcx4GR2c",
+    "npiSubjectHeading" : "tiAoeEKTg6t",
+    "tags" : [ "3X3KT2jNpLkw" ],
+    "description" : "DNeuNe6S2WHY713CF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "HLTqpM6JC9z56rz",
+        "format" : "Text",
+        "disseminationChannel" : "53AY3qGvUhwkSv5",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "ZpscaQcgV2Rb3oba",
-          "seriesPart" : "HxOQxkKWLhsIKIK2WEn"
+          "series" : "cAZ0uwcKMegb40A1",
+          "seriesPart" : "5mt0QfA1cqBJIAF"
         }
       },
-      "doi" : "https://www.example.com/EIWZtf44fqgIGQ",
+      "doi" : "https://www.example.com/FD6B7SE3pxECw8IQi",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/HNY8ooAJsH1",
-    "abstract" : "VpKncHfEe4V"
+    "metadataSource" : "https://www.example.com/4y5eTOaFWyW79jN",
+    "abstract" : "zDBB0x8z38bGtU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/delectuseaque",
-    "name" : "nu5D5cAJxiInVaKg",
+    "id" : "https://www.example.org/maioresesse",
+    "name" : "awX8JmG0LFj9dTxiE5l",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "4HW3BL5LJi",
-      "id" : "Un3maVLnzBgkJBM7"
+      "source" : "ZrBkbUeJFqGp25i8",
+      "id" : "T5CKGbHA77G3fgk15C"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "1gKObqSIbM7vLyV"
+      "applicationCode" : "Zzkb8YXX6WcX"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,22 +124,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/evenietquo" ],
+  "subjects" : [ "https://www.example.org/velet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "kxonPd1tJyp",
-      "mimeType" : "5mMYoMYUsJbxB",
-      "size" : 350058200,
+      "name" : "lzFBCym2ODR",
+      "mimeType" : "hu3X2MCCrdYbapZ",
+      "size" : 202794890,
       "license" : {
         "type" : "License",
-        "identifier" : "IUBdCUeDRNj7urUGsuv",
+        "identifier" : "1n9tsbGG4d",
         "labels" : {
-          "9JFBkdgOaViSJRphGqH" : "vvAWNDmsNA"
+          "kxdCMw3Pg3de3kH" : "9ZKouOdYkBfKxLpPCn"
         },
-        "link" : "https://www.example.com/TxWIbT7vCoDC75FX"
+        "link" : "https://www.example.com/rPaWFxZJ3J"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -149,21 +149,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "kxonPd1tJyp",
-    "mimeType" : "5mMYoMYUsJbxB",
-    "size" : 350058200,
+    "name" : "lzFBCym2ODR",
+    "mimeType" : "hu3X2MCCrdYbapZ",
+    "size" : 202794890,
     "license" : {
       "type" : "License",
-      "identifier" : "IUBdCUeDRNj7urUGsuv",
+      "identifier" : "1n9tsbGG4d",
       "labels" : {
-        "9JFBkdgOaViSJRphGqH" : "vvAWNDmsNA"
+        "kxdCMw3Pg3de3kH" : "9ZKouOdYkBfKxLpPCn"
       },
-      "link" : "https://www.example.com/TxWIbT7vCoDC75FX"
+      "link" : "https://www.example.com/rPaWFxZJ3J"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "P6ci3pheRnc",
+  "owner" : "Dq9IngqqMcNS",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "ANqbb9LhGlxWOC",
-    "ownerAffiliation" : "https://www.example.org/reiciendisvoluptatem"
+    "owner" : "P6ci3pheRnc",
+    "ownerAffiliation" : "https://www.example.org/providentdicta"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/sintcupiditate",
+    "id" : "https://www.example.org/oditaut",
     "labels" : {
-      "Lv6T2w8POYKfGKLxnX" : "cL8jbL9qhx"
+      "rk6ZK1HVHzz46A" : "KizHevH8ebdnKctQK"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/sitquo",
-  "doi" : "https://doi.org/10.1234/ducimus",
-  "link" : "https://www.example.org/placeataliquid",
+  "handle" : "https://www.example.org/consequaturest",
+  "doi" : "https://doi.org/10.1234/voluptate",
+  "link" : "https://www.example.org/autemcommodi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RrhO8huQqu1cA",
+    "mainTitle" : "5S6aY39iCFAZK",
     "alternativeTitles" : {
-      "is" : "fr7O9uthbGGYxuU"
+      "cs" : "wKzKmVARLN19"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "iCsQn7fsh7WCZMrHMT0",
-      "month" : "KOAPbTm3RbfHnH9P",
-      "day" : "Gnq7oNbifrb1"
+      "year" : "LrNL9YpAG5xn",
+      "month" : "TtfrusbjuBNKMz",
+      "day" : "foLYVtk94qBfEXVH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wLxBOtyqzJGO54tNz9l",
-        "name" : "jHaBK9mSDO4SUmolQ42",
-        "nameType" : "Personal",
-        "orcId" : "6CGfFKvqNeGwA"
+        "id" : "https://www.example.com/9LBOCptvAwlfvEz",
+        "name" : "WqJowFDpThA",
+        "nameType" : "Organizational",
+        "orcId" : "KePYt452lmxRzJz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DRXc8JKpp0",
+        "id" : "https://www.example.com/b1T7X4QI3NHmHtp0G",
         "labels" : {
-          "6J2kk3t6bBH" : "69bxZeijQUVIPN"
+          "2I3hth5jKC" : "E8z6s6cjZUAv95ywQ"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 1,
+      "role" : "Sponsor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fCKhy1QzcO5yiR",
-        "name" : "BXeAZSfQLpnngNX0",
+        "id" : "https://www.example.com/B0MmDWzsyC",
+        "name" : "l4qCfXO4Ll0uBu",
         "nameType" : "Personal",
-        "orcId" : "tQvBRrZGkMnp"
+        "orcId" : "QoCeIhBiVsWMiog23BT"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/dYPBSm1eKpV",
+        "id" : "https://www.example.com/JG99FpXITG401NnMVcr",
         "labels" : {
-          "GuDU2sKHz2A952wZ" : "YpAJkpUiFOrjR6ATUHL"
+          "k3yi9bRAmO9DxaUbybA" : "XszwAK0DRVg4FwtRSd3"
         }
       } ],
       "role" : "Dramatist",
-      "sequence" : 1,
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "QtcpbmoXxm1A",
-    "tags" : [ "RxGqacsUgXoTNH" ],
-    "description" : "prfnitteMqOjq",
+    "npiSubjectHeading" : "zMllsIAGzcD",
+    "tags" : [ "3N2ctMhf3KTgq0l" ],
+    "description" : "neMcx4GR2c",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Journal"
         },
-        "format" : "Text",
-        "disseminationChannel" : "l11H1AuY6BW",
+        "format" : "Sound",
+        "disseminationChannel" : "HLTqpM6JC9z56rz",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "8fF1XAHaooor8Uq2F",
-          "seriesPart" : "soXIwHTFNRo9khZd9"
+          "series" : "ZpscaQcgV2Rb3oba",
+          "seriesPart" : "HxOQxkKWLhsIKIK2WEn"
         }
       },
-      "doi" : "https://www.example.com/3mB8dB4lfO",
+      "doi" : "https://www.example.com/EIWZtf44fqgIGQ",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/N2ycLF4VO8vLf",
-    "abstract" : "XHAXN84MePMld"
+    "metadataSource" : "https://www.example.com/HNY8ooAJsH1",
+    "abstract" : "VpKncHfEe4V"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etautem",
-    "name" : "KU1CNgppUP1EkLEj",
+    "id" : "https://www.example.org/delectuseaque",
+    "name" : "nu5D5cAJxiInVaKg",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "4oC9LRJv0S",
-      "id" : "VOdhWYcw6vYOSba4yqO"
+      "source" : "4HW3BL5LJi",
+      "id" : "Un3maVLnzBgkJBM7"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "3Fqk9fLjKH2hgsCJ"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "1gKObqSIbM7vLyV"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sitnon" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "SrAZ9yv6X5k",
-    "mimeType" : "Wrc2JHuj8O21wU6GOe",
-    "size" : 1537249037,
-    "license" : {
-      "type" : "License",
-      "identifier" : "u2tMRlvehE0e7Zku",
-      "labels" : {
-        "SaRQJpvUorLIus" : "h7E46fKjRBQyIh"
-      },
-      "link" : "https://www.example.com/O0w9okL8NU"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/evenietquo" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "SrAZ9yv6X5k",
-      "mimeType" : "Wrc2JHuj8O21wU6GOe",
-      "size" : 1537249037,
+      "name" : "kxonPd1tJyp",
+      "mimeType" : "5mMYoMYUsJbxB",
+      "size" : 350058200,
       "license" : {
         "type" : "License",
-        "identifier" : "u2tMRlvehE0e7Zku",
+        "identifier" : "IUBdCUeDRNj7urUGsuv",
         "labels" : {
-          "SaRQJpvUorLIus" : "h7E46fKjRBQyIh"
+          "9JFBkdgOaViSJRphGqH" : "vvAWNDmsNA"
         },
-        "link" : "https://www.example.com/O0w9okL8NU"
+        "link" : "https://www.example.com/TxWIbT7vCoDC75FX"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "ANqbb9LhGlxWOC",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "kxonPd1tJyp",
+    "mimeType" : "5mMYoMYUsJbxB",
+    "size" : 350058200,
+    "license" : {
+      "type" : "License",
+      "identifier" : "IUBdCUeDRNj7urUGsuv",
+      "labels" : {
+        "9JFBkdgOaViSJRphGqH" : "vvAWNDmsNA"
+      },
+      "link" : "https://www.example.com/TxWIbT7vCoDC75FX"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "P6ci3pheRnc",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,97 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "C6Q29mzZUZC",
-    "ownerAffiliation" : "https://www.example.org/etfacere"
+    "owner" : "giJH8bqIwtWl0PCiV",
+    "ownerAffiliation" : "https://www.example.org/undeeaque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/rerumdolor",
+    "id" : "https://www.example.org/inincidunt",
     "labels" : {
-      "JDlHw2bYx7" : "bn37f7xwaPK31JdXx"
+      "FOx75JxijT" : "ARqZBwxOzvaK6qp8B56"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/perferendisatque",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/velitomnis",
+  "handle" : "https://www.example.org/adipiscilaborum",
+  "doi" : "https://doi.org/10.1234/velit",
+  "link" : "https://www.example.org/inciduntsint",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZjavnOPS5kN8229Gp",
+    "mainTitle" : "Q8Mlc2gqv7XmH",
     "alternativeTitles" : {
-      "pt" : "CUqo6Yh6gb"
+      "pt" : "n6r3f6UhaoA9x"
     },
-    "language" : "http://lexvo.org/id/iso639-3/und",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "MtRmzhJHSN0A8Vf4sC",
-      "month" : "RNfTPORdBhC",
-      "day" : "Eir8OVMy56n1SVsNQ"
+      "year" : "YzOMGhpQNhfQCcytU",
+      "month" : "Z8eZN8E3Y1W6eABAuV",
+      "day" : "3yDhgYQ3BLggGy0QMM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iyQYZ04oMTW9azPDQd",
-        "name" : "28RYWFRw7KQYFrD4bmB",
-        "nameType" : "Personal",
-        "orcId" : "lIUiEBQPF7EkaBs6G"
+        "id" : "https://www.example.com/n2mfQdO2lsEwdPUyf",
+        "name" : "5O6MDPHrJ8N",
+        "nameType" : "Organizational",
+        "orcId" : "hCJ3C97rOTSMNhv"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/z7WGvN84YZHF",
+        "id" : "https://www.example.com/iBDKJsVhqriWREGuyU",
         "labels" : {
-          "IZWmoFLb5pnN83" : "bjGMnQpWD6gIF5mrYn"
+          "WAne62wmMuFJ71" : "Qn7aS8y6wB7cI7rmtY"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 7,
+      "role" : "ProgrammeLeader",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Fm1EHuNZaRnskYnA4",
-        "name" : "PFPhUbUybcXlxy",
-        "nameType" : "Personal",
-        "orcId" : "UwFNDbum6Uk5NqaW0b"
+        "id" : "https://www.example.com/Yl3FSFKmWtCvXt9A0",
+        "name" : "Q3ItZl2Wsub",
+        "nameType" : "Organizational",
+        "orcId" : "ee95oimb8CQ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/je8pSZgyMRXKH",
+        "id" : "https://www.example.com/ATCsuCm7i3YCB",
         "labels" : {
-          "AHxErMGYG3J24v" : "DTsv0M2OOHzkhtz"
+          "FWG8CqBmxmIyn" : "yYRaSiDbX22bq56"
         }
       } ],
-      "role" : "Librettist",
-      "sequence" : 4,
+      "role" : "Sponsor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "FgZDJ89RszXCMB4vh",
-    "tags" : [ "dZTMtSkGhL8L5j0eft" ],
-    "description" : "hzQQkzFs9x5mGC",
+    "npiSubjectHeading" : "1vZzN8rAVnTSZm",
+    "tags" : [ "OpAF2YdOS965z" ],
+    "description" : "XFCMOtItz8LRGd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Other",
-          "description" : "RDRLLpbEraDKtv"
+          "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "NUJuMyvYTOpSF",
+        "format" : "Text",
+        "disseminationChannel" : "gnXh5VBSG2",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "ZMOTrCVMrgfz",
-          "seriesPart" : "1bt6kTquxSz5E"
+          "series" : "VJJ4oydFt3Pgb",
+          "seriesPart" : "Yov7IjTCTx5lRcLTjT"
         }
       },
-      "doi" : "https://www.example.com/FNbWARvoLvQTnKtjFK",
+      "doi" : "https://www.example.com/zGL4GStTGJ",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
         "peerReviewed" : false,
@@ -100,45 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/pgasEcwxdrhE0ZiSO",
-    "abstract" : "Sm59SXC0aVH7QJ4M6"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "y0eJYzualW5DfUtZEMb",
-      "mimeType" : "AprpfoBCyHz",
-      "size" : 981752025,
-      "license" : {
-        "type" : "License",
-        "identifier" : "xcVkK1LVuOSHD",
-        "labels" : {
-          "4aCZn4XiiRNIl" : "tk6gx6XtqNZ22nx4ipb"
-        },
-        "link" : "https://www.example.com/8ZaTQHEJNHrTefqtCqp"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/gkSsZA2q9j1jAM",
+    "abstract" : "ltkW7el2qrgl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aspernaturquia",
-    "name" : "rXos8j48RKYNEUA6",
+    "id" : "https://www.example.org/nullaaut",
+    "name" : "kTQwl2ZuraZqf",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ja2bFSAxLNW",
-      "id" : "K5QCaLWdaicJ0f5B"
+      "source" : "ZM8nFP6eyhDAI2F2kO2",
+      "id" : "VtWuOzl9whcmhJD"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "LznGHXrriTSIOuWeUF"
+      "applicationCode" : "vTnEZ3JJUK1qOubbZs4"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -146,25 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/rerumid" ],
+  "subjects" : [ "https://www.example.org/velvel" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "y0eJYzualW5DfUtZEMb",
-    "mimeType" : "AprpfoBCyHz",
-    "size" : 981752025,
+    "name" : "8gRwgUO68BF7",
+    "mimeType" : "jd96wX5aJaO",
+    "size" : 259280725,
     "license" : {
       "type" : "License",
-      "identifier" : "xcVkK1LVuOSHD",
+      "identifier" : "5e0hb494TANOExppal",
       "labels" : {
-        "4aCZn4XiiRNIl" : "tk6gx6XtqNZ22nx4ipb"
+        "MN0h7UbCSo0iLoOGdf" : "vddrTvrDx2U"
       },
-      "link" : "https://www.example.com/8ZaTQHEJNHrTefqtCqp"
+      "link" : "https://www.example.com/WVxDurtRQ3hLYGNYv"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "C6Q29mzZUZC"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "8gRwgUO68BF7",
+      "mimeType" : "jd96wX5aJaO",
+      "size" : 259280725,
+      "license" : {
+        "type" : "License",
+        "identifier" : "5e0hb494TANOExppal",
+        "labels" : {
+          "MN0h7UbCSo0iLoOGdf" : "vddrTvrDx2U"
+        },
+        "link" : "https://www.example.com/WVxDurtRQ3hLYGNYv"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "giJH8bqIwtWl0PCiV",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "hY4A2dinCkT",
-    "ownerAffiliation" : "https://www.example.org/eanostrum"
+    "owner" : "WFqo5awDtN0QPu5sHi9",
+    "ownerAffiliation" : "https://www.example.org/repellatsed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/optioquo",
+    "id" : "https://www.example.org/liberosuscipit",
     "labels" : {
-      "TY2GldsOE6W" : "TbYJ8z7nUtDQV56sh5i"
+      "Bynjg8TcCqPoyqb" : "oX60HJesir1qNXf1iH"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/eteveniet",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/illoreiciendis",
+  "handle" : "https://www.example.org/eosperferendis",
+  "doi" : "https://doi.org/10.1234/fuga",
+  "link" : "https://www.example.org/beataeeligendi",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cydlC82RhkCG",
+    "mainTitle" : "lrM8HmCKJO762Tsj",
     "alternativeTitles" : {
-      "el" : "vigYnFS8S8Z"
+      "pt" : "ePul9ZsX28BuyXLJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/pol",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "SDHxpaAdFscW7EcqUYD",
-      "month" : "knUJAY3MKesDfc",
-      "day" : "KdUuvalMkulNjuW8QD"
+      "year" : "v0fvh5huorCyMZKzSvL",
+      "month" : "xx77aBRCMefEhNS",
+      "day" : "l3VbFTZah8aZh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/MBp3JCZuaXAK",
-        "name" : "RjcjmUs0d4fo6Hn",
+        "id" : "https://www.example.com/mEzkkOwhXK",
+        "name" : "7kerV8TVaLGuNQbgE",
         "nameType" : "Organizational",
-        "orcId" : "dZA4LD7xwv"
+        "orcId" : "3S75KIJIL4XtbQ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CK6PvpHHS5gdWSWlAU",
+        "id" : "https://www.example.com/HIC3VKpasx7",
         "labels" : {
-          "GjJGeU25AdxgJMOfMg" : "ll4VY7jgotQiY6Uz"
+          "XZYsb8omiYJ66DsM" : "5UVdxPBM0R8qjyWFQ"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 6,
+      "role" : "DataManager",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ISeKUDyFcJ",
-        "name" : "H9slKZvd60IhI6JCqF4",
+        "id" : "https://www.example.com/u9ca2JIGPh",
+        "name" : "dIEZBvIO9hog4",
         "nameType" : "Organizational",
-        "orcId" : "vK8Ub6lCLCPuN"
+        "orcId" : "fKS5zR28YcL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9ZOx9fYhfw",
+        "id" : "https://www.example.com/ScZtYa8RDpFKa",
         "labels" : {
-          "xG6GWJystK" : "XkLea3iPqx2yh"
+          "DTJgHpxsHam" : "usRTCZtMuy"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 2,
+      "role" : "Photographer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "cvrdDGa9I2wAbCd",
-    "tags" : [ "tU41agcYs5" ],
-    "description" : "jSdsFyZ5lTkLO7",
+    "npiSubjectHeading" : "5oLJtfqjGUUIX",
+    "tags" : [ "rOzMbEtIDMwDedDvNp7" ],
+    "description" : "EHndISJS0t",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Radio"
         },
-        "format" : "Video",
-        "disseminationChannel" : "XOgumwZZ2jdCHcj",
+        "format" : "Sound",
+        "disseminationChannel" : "5Ky7KtB42IDxmgvn",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "1Zd52H9hpnC0y",
-          "seriesPart" : "CpeCqnj0by44"
+          "series" : "WVUHIefczA7",
+          "seriesPart" : "0bwKXwcyDolvkE"
         }
       },
-      "doi" : "https://www.example.com/QYAchktN1q3Gre",
+      "doi" : "https://www.example.com/c2Dx4Jomp1Fz",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/HYBA9wIER45tygWc",
-    "abstract" : "8PeEFgoOUZQjTc"
+    "metadataSource" : "https://www.example.com/c5R8xNLDLH",
+    "abstract" : "n19lfeuzuFo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quidemiure",
-    "name" : "QwPwM5x4zMcN",
+    "id" : "https://www.example.org/assumendacumque",
+    "name" : "DimpZXNItGYmvocF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6iiFgPOlPzdElGUj7l",
-      "id" : "Z76I9ApZtLoXiLSeFCq"
+      "source" : "YGuJ8pN7LdVU",
+      "id" : "GT0nHTFSjZhnY6VSN"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "NMxke2MXKRRwzcVo"
+      "applicationCode" : "M5xeFM4ThJ5ss"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/utquis" ],
+  "subjects" : [ "https://www.example.org/saepeminus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "5yVlADIXKRUfxd6CaG",
-      "mimeType" : "TMeVqSxZwA2hkFs1M",
-      "size" : 1979271879,
+      "name" : "Wq230LXx9cNEZ",
+      "mimeType" : "QexyivpuE4",
+      "size" : 1492553663,
       "license" : {
         "type" : "License",
-        "identifier" : "GIqHIn8x0V5I",
+        "identifier" : "Xyi2RJBVGCUJz7NF",
         "labels" : {
-          "Hz5XE7u1lUMNyDkvxiO" : "qK3cA5DX45w5ApTJGj"
+          "Cp5EHBF9xVvPsVs" : "Zpq58izeh9DurGuLA"
         },
-        "link" : "https://www.example.com/qSHSTKnaqx"
+        "link" : "https://www.example.com/QPS4lJlnf1oNVFb6PQk"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "5yVlADIXKRUfxd6CaG",
-    "mimeType" : "TMeVqSxZwA2hkFs1M",
-    "size" : 1979271879,
+    "name" : "Wq230LXx9cNEZ",
+    "mimeType" : "QexyivpuE4",
+    "size" : 1492553663,
     "license" : {
       "type" : "License",
-      "identifier" : "GIqHIn8x0V5I",
+      "identifier" : "Xyi2RJBVGCUJz7NF",
       "labels" : {
-        "Hz5XE7u1lUMNyDkvxiO" : "qK3cA5DX45w5ApTJGj"
+        "Cp5EHBF9xVvPsVs" : "Zpq58izeh9DurGuLA"
       },
-      "link" : "https://www.example.com/qSHSTKnaqx"
+      "link" : "https://www.example.com/QPS4lJlnf1oNVFb6PQk"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "hY4A2dinCkT",
+  "owner" : "WFqo5awDtN0QPu5sHi9",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,80 +1,80 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "emkVcvt6sB41m",
-    "ownerAffiliation" : "https://www.example.org/nisicorrupti"
+    "owner" : "hY4A2dinCkT",
+    "ownerAffiliation" : "https://www.example.org/eanostrum"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eaharum",
+    "id" : "https://www.example.org/optioquo",
     "labels" : {
-      "eCG240W5rt9MeAE4" : "1aj5YaWRUr"
+      "TY2GldsOE6W" : "TbYJ8z7nUtDQV56sh5i"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quisimilique",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/rationesunt",
+  "handle" : "https://www.example.org/eteveniet",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/illoreiciendis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HYZIYI6HiK",
+    "mainTitle" : "cydlC82RhkCG",
     "alternativeTitles" : {
-      "af" : "ahUuKCamiib"
+      "el" : "vigYnFS8S8Z"
     },
     "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "1AxcEffoLaxLodOl7",
-      "month" : "WpAKDMQ0C9NMWOZ",
-      "day" : "N1Ak84bd8QTrK9M"
+      "year" : "SDHxpaAdFscW7EcqUYD",
+      "month" : "knUJAY3MKesDfc",
+      "day" : "KdUuvalMkulNjuW8QD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dC23I91ql3XKl",
-        "name" : "MzZ2NbhFOTc",
+        "id" : "https://www.example.com/MBp3JCZuaXAK",
+        "name" : "RjcjmUs0d4fo6Hn",
         "nameType" : "Organizational",
-        "orcId" : "LjlhrwThnWvKP"
+        "orcId" : "dZA4LD7xwv"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/MAuY5ebudO5w72sj",
+        "id" : "https://www.example.com/CK6PvpHHS5gdWSWlAU",
         "labels" : {
-          "Hlxeu489f4bGvIQQJ" : "aLf10D2f5qZVMxNkja"
+          "GjJGeU25AdxgJMOfMg" : "ll4VY7jgotQiY6Uz"
         }
       } ],
-      "role" : "Choreographer",
-      "sequence" : 9,
+      "role" : "Supervisor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/9kwfwQSjFYytW",
-        "name" : "9NnWAAWnb5ExW",
+        "id" : "https://www.example.com/ISeKUDyFcJ",
+        "name" : "H9slKZvd60IhI6JCqF4",
         "nameType" : "Organizational",
-        "orcId" : "0C1gMwlIIIJhsNdON4"
+        "orcId" : "vK8Ub6lCLCPuN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/uZm2deTSfLv",
+        "id" : "https://www.example.com/9ZOx9fYhfw",
         "labels" : {
-          "0O5BhcabjmM" : "gLbMQ4RAfvXXWC5dlEu"
+          "xG6GWJystK" : "XkLea3iPqx2yh"
         }
       } ],
-      "role" : "CuratorOrganizer",
-      "sequence" : 6,
+      "role" : "SoundDesigner",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "0nJchtRZgW5",
-    "tags" : [ "W2BffXH07gULNsW2FK" ],
-    "description" : "8l04jVXO5JH6",
+    "npiSubjectHeading" : "cvrdDGa9I2wAbCd",
+    "tags" : [ "tU41agcYs5" ],
+    "description" : "jSdsFyZ5lTkLO7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -82,15 +82,15 @@
         "medium" : {
           "type" : "Journal"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "8bdXZsrsoDLV4675kK",
+        "format" : "Video",
+        "disseminationChannel" : "XOgumwZZ2jdCHcj",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "Yq2cRyX6D3e5B",
-          "seriesPart" : "hr7GYb8i2aaJpJXhGw"
+          "series" : "1Zd52H9hpnC0y",
+          "seriesPart" : "CpeCqnj0by44"
         }
       },
-      "doi" : "https://www.example.com/Da9u4vrk0i3UvQw18n",
+      "doi" : "https://www.example.com/QYAchktN1q3Gre",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/pbSks4MmfIKWhCyo",
-    "abstract" : "j3q15rcTEzYzhoxt"
+    "metadataSource" : "https://www.example.com/HYBA9wIER45tygWc",
+    "abstract" : "8PeEFgoOUZQjTc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatumnumquam",
-    "name" : "5aVtUhBmkc5f2b",
+    "id" : "https://www.example.org/quidemiure",
+    "name" : "QwPwM5x4zMcN",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ChWT4I2Pf8E9CzeUhW",
-      "id" : "wGXxTouHIb0K9pf7aK"
+      "source" : "6iiFgPOlPzdElGUj7l",
+      "id" : "Z76I9ApZtLoXiLSeFCq"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "JB1vv5bRMHBFI5ibAD"
+      "applicationCode" : "NMxke2MXKRRwzcVo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/abcupiditate" ],
+  "subjects" : [ "https://www.example.org/utquis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "t8IHoOwqmrRnFsI00Lx",
-      "mimeType" : "liWneXEbBM",
-      "size" : 1905715953,
+      "name" : "5yVlADIXKRUfxd6CaG",
+      "mimeType" : "TMeVqSxZwA2hkFs1M",
+      "size" : 1979271879,
       "license" : {
         "type" : "License",
-        "identifier" : "x3ShmMyI5v",
+        "identifier" : "GIqHIn8x0V5I",
         "labels" : {
-          "rzCFbYhO1r" : "zogI7bg6U6v"
+          "Hz5XE7u1lUMNyDkvxiO" : "qK3cA5DX45w5ApTJGj"
         },
-        "link" : "https://www.example.com/X3flJqVLGq"
+        "link" : "https://www.example.com/qSHSTKnaqx"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "t8IHoOwqmrRnFsI00Lx",
-    "mimeType" : "liWneXEbBM",
-    "size" : 1905715953,
+    "name" : "5yVlADIXKRUfxd6CaG",
+    "mimeType" : "TMeVqSxZwA2hkFs1M",
+    "size" : 1979271879,
     "license" : {
       "type" : "License",
-      "identifier" : "x3ShmMyI5v",
+      "identifier" : "GIqHIn8x0V5I",
       "labels" : {
-        "rzCFbYhO1r" : "zogI7bg6U6v"
+        "Hz5XE7u1lUMNyDkvxiO" : "qK3cA5DX45w5ApTJGj"
       },
-      "link" : "https://www.example.com/X3flJqVLGq"
+      "link" : "https://www.example.com/qSHSTKnaqx"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "emkVcvt6sB41m",
+  "owner" : "hY4A2dinCkT",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "giJH8bqIwtWl0PCiV",
-    "ownerAffiliation" : "https://www.example.org/undeeaque"
+    "owner" : "emkVcvt6sB41m",
+    "ownerAffiliation" : "https://www.example.org/nisicorrupti"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/inincidunt",
+    "id" : "https://www.example.org/eaharum",
     "labels" : {
-      "FOx75JxijT" : "ARqZBwxOzvaK6qp8B56"
+      "eCG240W5rt9MeAE4" : "1aj5YaWRUr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/adipiscilaborum",
-  "doi" : "https://doi.org/10.1234/velit",
-  "link" : "https://www.example.org/inciduntsint",
+  "handle" : "https://www.example.org/quisimilique",
+  "doi" : "https://doi.org/10.1234/minus",
+  "link" : "https://www.example.org/rationesunt",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Q8Mlc2gqv7XmH",
+    "mainTitle" : "HYZIYI6HiK",
     "alternativeTitles" : {
-      "pt" : "n6r3f6UhaoA9x"
+      "af" : "ahUuKCamiib"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/pol",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "YzOMGhpQNhfQCcytU",
-      "month" : "Z8eZN8E3Y1W6eABAuV",
-      "day" : "3yDhgYQ3BLggGy0QMM"
+      "year" : "1AxcEffoLaxLodOl7",
+      "month" : "WpAKDMQ0C9NMWOZ",
+      "day" : "N1Ak84bd8QTrK9M"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/n2mfQdO2lsEwdPUyf",
-        "name" : "5O6MDPHrJ8N",
+        "id" : "https://www.example.com/dC23I91ql3XKl",
+        "name" : "MzZ2NbhFOTc",
         "nameType" : "Organizational",
-        "orcId" : "hCJ3C97rOTSMNhv"
+        "orcId" : "LjlhrwThnWvKP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iBDKJsVhqriWREGuyU",
+        "id" : "https://www.example.com/MAuY5ebudO5w72sj",
         "labels" : {
-          "WAne62wmMuFJ71" : "Qn7aS8y6wB7cI7rmtY"
+          "Hlxeu489f4bGvIQQJ" : "aLf10D2f5qZVMxNkja"
         }
       } ],
-      "role" : "ProgrammeLeader",
-      "sequence" : 8,
+      "role" : "Choreographer",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Yl3FSFKmWtCvXt9A0",
-        "name" : "Q3ItZl2Wsub",
+        "id" : "https://www.example.com/9kwfwQSjFYytW",
+        "name" : "9NnWAAWnb5ExW",
         "nameType" : "Organizational",
-        "orcId" : "ee95oimb8CQ"
+        "orcId" : "0C1gMwlIIIJhsNdON4"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/ATCsuCm7i3YCB",
+        "id" : "https://www.example.com/uZm2deTSfLv",
         "labels" : {
-          "FWG8CqBmxmIyn" : "yYRaSiDbX22bq56"
+          "0O5BhcabjmM" : "gLbMQ4RAfvXXWC5dlEu"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 7,
+      "role" : "CuratorOrganizer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1vZzN8rAVnTSZm",
-    "tags" : [ "OpAF2YdOS965z" ],
-    "description" : "XFCMOtItz8LRGd",
+    "npiSubjectHeading" : "0nJchtRZgW5",
+    "tags" : [ "W2BffXH07gULNsW2FK" ],
+    "description" : "8l04jVXO5JH6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Radio"
+          "type" : "Journal"
         },
-        "format" : "Text",
-        "disseminationChannel" : "gnXh5VBSG2",
+        "format" : "Sound",
+        "disseminationChannel" : "8bdXZsrsoDLV4675kK",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "series" : "VJJ4oydFt3Pgb",
-          "seriesPart" : "Yov7IjTCTx5lRcLTjT"
+          "series" : "Yq2cRyX6D3e5B",
+          "seriesPart" : "hr7GYb8i2aaJpJXhGw"
         }
       },
-      "doi" : "https://www.example.com/zGL4GStTGJ",
+      "doi" : "https://www.example.com/Da9u4vrk0i3UvQw18n",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
         "peerReviewed" : false,
@@ -99,24 +99,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/gkSsZA2q9j1jAM",
-    "abstract" : "ltkW7el2qrgl"
+    "metadataSource" : "https://www.example.com/pbSks4MmfIKWhCyo",
+    "abstract" : "j3q15rcTEzYzhoxt"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nullaaut",
-    "name" : "kTQwl2ZuraZqf",
+    "id" : "https://www.example.org/voluptatumnumquam",
+    "name" : "5aVtUhBmkc5f2b",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ZM8nFP6eyhDAI2F2kO2",
-      "id" : "VtWuOzl9whcmhJD"
+      "source" : "ChWT4I2Pf8E9CzeUhW",
+      "id" : "wGXxTouHIb0K9pf7aK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "vTnEZ3JJUK1qOubbZs4"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "JB1vv5bRMHBFI5ibAD"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -124,46 +124,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velvel" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "8gRwgUO68BF7",
-    "mimeType" : "jd96wX5aJaO",
-    "size" : 259280725,
-    "license" : {
-      "type" : "License",
-      "identifier" : "5e0hb494TANOExppal",
-      "labels" : {
-        "MN0h7UbCSo0iLoOGdf" : "vddrTvrDx2U"
-      },
-      "link" : "https://www.example.com/WVxDurtRQ3hLYGNYv"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/abcupiditate" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "8gRwgUO68BF7",
-      "mimeType" : "jd96wX5aJaO",
-      "size" : 259280725,
+      "name" : "t8IHoOwqmrRnFsI00Lx",
+      "mimeType" : "liWneXEbBM",
+      "size" : 1905715953,
       "license" : {
         "type" : "License",
-        "identifier" : "5e0hb494TANOExppal",
+        "identifier" : "x3ShmMyI5v",
         "labels" : {
-          "MN0h7UbCSo0iLoOGdf" : "vddrTvrDx2U"
+          "rzCFbYhO1r" : "zogI7bg6U6v"
         },
-        "link" : "https://www.example.com/WVxDurtRQ3hLYGNYv"
+        "link" : "https://www.example.com/X3flJqVLGq"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "giJH8bqIwtWl0PCiV",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "t8IHoOwqmrRnFsI00Lx",
+    "mimeType" : "liWneXEbBM",
+    "size" : 1905715953,
+    "license" : {
+      "type" : "License",
+      "identifier" : "x3ShmMyI5v",
+      "labels" : {
+        "rzCFbYhO1r" : "zogI7bg6U6v"
+      },
+      "link" : "https://www.example.com/X3flJqVLGq"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "emkVcvt6sB41m",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,132 +1,133 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "tGhoTJdS7bY8tOmF",
-    "ownerAffiliation" : "https://www.example.org/autnon"
+    "owner" : "FegF4WEoi3YRbf9IZ",
+    "ownerAffiliation" : "https://www.example.org/velimpedit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/animilabore",
+    "id" : "https://www.example.org/ducimuset",
     "labels" : {
-      "nPJOfACN4zgLYexJ" : "TyHjP9TQwe7IYlKy8"
+      "NriAPZmAby" : "szb9Wah1zKeIBO"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/fugitperferendis",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/laboreaccusantium",
+  "handle" : "https://www.example.org/officiaqui",
+  "doi" : "https://doi.org/10.1234/quasi",
+  "link" : "https://www.example.org/doloremeos",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "qvH8myCSFzfjLHIKfS",
+    "mainTitle" : "ElKLUByBa6ybA",
     "alternativeTitles" : {
-      "no" : "ks9vVVHpPH"
+      "pt" : "3BOmKGVPorlObEGv"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "hwulu0ZBBA0",
-      "month" : "LOMeRnRusaagxs",
-      "day" : "g8LIN9dNhnPbd"
+      "year" : "pfqdGbVRtn9XjiwsP",
+      "month" : "0u5j1P8hEdb7kV6AWe",
+      "day" : "5E05uQX08u7ypK08u"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/syqC658IT0",
-        "name" : "YMZry4ONpEky7utr",
+        "id" : "https://www.example.com/BBpmqXymM6wUDlo",
+        "name" : "io3ONfPVl2qhTqpi",
         "nameType" : "Organizational",
-        "orcId" : "KqAjG9XQGj8"
+        "orcId" : "J04EgP5WpmEg8"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7yNV774QFK8XXM4",
+        "id" : "https://www.example.com/Zfol0QcF2GG1VPgB0",
         "labels" : {
-          "OopZCZzJpLp5w8H" : "SHQq47ENKY1"
+          "Hnq78vnEbW99PldEu0A" : "l1w43YZWYdfDMPhsv"
         }
       } ],
-      "role" : "VfxSupervisor",
-      "sequence" : 2,
+      "role" : "VideoEditor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SZmF6m8K4CVaKuU2z8d",
-        "name" : "puQPUxNohxiLc",
-        "nameType" : "Organizational",
-        "orcId" : "2qeuyEgAqhl"
+        "id" : "https://www.example.com/TL1aQLch6TQ8loeeXeg",
+        "name" : "BifPOboHscQEDxqOyp",
+        "nameType" : "Personal",
+        "orcId" : "b6n3sXK3AxvmhS"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/EHJswmcn7mAa",
+        "id" : "https://www.example.com/qoRXeb4nuiBk",
         "labels" : {
-          "Vi2tK4B9h7Ae" : "jUUdv8UOFJuqE"
+          "qmVDhihYH6zKBSQxDm" : "QJ5vTttvVJeJ"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 2,
+      "role" : "Supervisor",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "3UFNFu3jLnvoii",
-    "tags" : [ "fczWPp0BwNxZ2oZ" ],
-    "description" : "A8Gf9ukb48Pmy",
+    "npiSubjectHeading" : "C816RCgfd6",
+    "tags" : [ "xGKaIfGdDwA" ],
+    "description" : "ercjWbRR3mqHtwZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/dF7GVJllUyece",
+      "doi" : "https://www.example.com/jtmJhNia8esCXhZpJ",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Film"
+          "type" : "Other",
+          "description" : "C3c6d8zNDO3atVuZ5g"
         },
-        "description" : "hL6rPsxMKOen99WCKrp",
+        "description" : "UdgtGLX29K5Qt",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "qDUsXPlquTrgx5"
+            "name" : "NdiikXeaaXBm"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 911112327
+          "sequence" : 1571368078
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "yxLFwKkaOtnA",
-            "country" : "A8qmLPNbIn415"
+            "label" : "HAZyOtg8agG8lRWTQWT",
+            "country" : "b3aPFY5tK0XhKhwbUaA"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 394427467
+          "sequence" : 1224149818
         }, {
           "type" : "OtherRelease",
-          "description" : "hjzlSGwSJJ",
+          "description" : "0brsVDCvuTVUcF753",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XrTixnKUTxzE4s4oGpl",
-            "country" : "on6cC11lT9jEem4bAM0"
+            "label" : "Yn5SBKgtb5Iwer0Y4",
+            "country" : "gLspK0s6vPypvwYKU1"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "eV94D8m1YIi9zOayf1"
+            "name" : "UNVOXgg9p5AjVGuTw"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 439070524
+          "sequence" : 924767789
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -134,24 +135,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/owkqYZ6snIb6cRkoawV",
-    "abstract" : "Hwdhg1So51"
+    "metadataSource" : "https://www.example.com/aNymrGGS13wk",
+    "abstract" : "Kf0tPEw2N7Z"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloremrem",
-    "name" : "ePGUwOlNcMzDx",
+    "id" : "https://www.example.org/doloremquenon",
+    "name" : "2vzZoLnfxm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "KoMkTukCaYc3w5",
-      "id" : "BN4AGgeVhYO6"
+      "source" : "ALrUT4gtEzzg9joH",
+      "id" : "WVE1XOt0yMVrli72"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "bephLFOXovuhBy"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "xcDN57wu7m"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -159,46 +160,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/itaqueillum" ],
+  "subjects" : [ "https://www.example.org/sedtempore" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "LJvRQCFgXH2t6ug",
-      "mimeType" : "7vRf1VeotcvbekCaVA",
-      "size" : 446668675,
+      "name" : "CN4yIq8kTUUadB1JAHX",
+      "mimeType" : "L7aM8z2s5jUNcoXW",
+      "size" : 1398473863,
       "license" : {
         "type" : "License",
-        "identifier" : "6oWZ1kmfLL",
+        "identifier" : "r6xxa65blO",
         "labels" : {
-          "8tDIaKlhVglkwpPM9s" : "tS5DXVR5Ga1zg3Ips"
+          "mWQzyKyjqwNj" : "PH9ZIqcbapD3eKQ"
         },
-        "link" : "https://www.example.com/MafSggABiIZOMO"
+        "link" : "https://www.example.com/kVp1FWP3ipG6o6iMTX"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "LJvRQCFgXH2t6ug",
-    "mimeType" : "7vRf1VeotcvbekCaVA",
-    "size" : 446668675,
+    "name" : "CN4yIq8kTUUadB1JAHX",
+    "mimeType" : "L7aM8z2s5jUNcoXW",
+    "size" : 1398473863,
     "license" : {
       "type" : "License",
-      "identifier" : "6oWZ1kmfLL",
+      "identifier" : "r6xxa65blO",
       "labels" : {
-        "8tDIaKlhVglkwpPM9s" : "tS5DXVR5Ga1zg3Ips"
+        "mWQzyKyjqwNj" : "PH9ZIqcbapD3eKQ"
       },
-      "link" : "https://www.example.com/MafSggABiIZOMO"
+      "link" : "https://www.example.com/kVp1FWP3ipG6o6iMTX"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "tGhoTJdS7bY8tOmF",
+  "owner" : "FegF4WEoi3YRbf9IZ",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,133 +1,132 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "Z60mjq6hf5DMXs",
-    "ownerAffiliation" : "https://www.example.org/repellendusquas"
+    "owner" : "EjSFNNpEknrVJ",
+    "ownerAffiliation" : "https://www.example.org/laborumnon"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eoscupiditate",
+    "id" : "https://www.example.org/etet",
     "labels" : {
-      "dGrSD9nKLru" : "9ZOdc7DpWDya"
+      "sEssKF0ULDq" : "u4oi1b8wRUXH"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etratione",
-  "doi" : "https://doi.org/10.1234/nobis",
-  "link" : "https://www.example.org/sitvoluptatum",
+  "handle" : "https://www.example.org/molestiaequi",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/ipsameius",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NBNkwraYoYE0G",
+    "mainTitle" : "7coKZIqWFc2",
     "alternativeTitles" : {
-      "se" : "C4KQRIJghn23"
+      "ru" : "3obuhdSriquHDDGaq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "Gu3TdaxWSwJhWz",
-      "month" : "73Fw8qvvQNzt0nwae",
-      "day" : "pQRjOTK58DivjnYnOwW"
+      "year" : "qcmG5jCYlaM",
+      "month" : "DeTIPCSsNhMmOO4YtQo",
+      "day" : "4Hh9kf3fAEREGHzD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/I8Rv7tdsq0wUdVk",
-        "name" : "3JniXEtUMUI6ijMkno",
-        "nameType" : "Personal",
-        "orcId" : "9kvUWRkTKuW"
+        "id" : "https://www.example.com/833DQZYuSHHvoOqxfWM",
+        "name" : "j8h2CMhqlTWBv2j4eZw",
+        "nameType" : "Organizational",
+        "orcId" : "2HsW6cy9cWNpLtfZrB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VPBpUD5UZFKb",
+        "id" : "https://www.example.com/21gehSR29M",
         "labels" : {
-          "Fqdf71nBN56hJbJ" : "prMme5MIrVrsKj9o"
+          "qbzRNnhVTNxprxRk" : "tElIbGQYoWl6s"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 6,
+      "role" : "ArtisticDirector",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/bGdgFLpOSco",
-        "name" : "AHOUPkBkGap486z",
+        "id" : "https://www.example.com/LETMLYrKN6gv0",
+        "name" : "N0Zao10llV3TkURRTm",
         "nameType" : "Organizational",
-        "orcId" : "GEQ3GvrXjyBCLYuD"
+        "orcId" : "9JBFenCLCP6f"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/i6wklMIBrSakm",
+        "id" : "https://www.example.com/iywt60aNEty4",
         "labels" : {
-          "LdZKZkTgaDv32HZYb" : "Hetwfb3xq0oIkLwhU"
+          "OBIwvNnEZm" : "1JBBkcqFfE08vsnN4KE"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 6,
+      "role" : "InterviewSubject",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "d2cJmPcT9jWhCKMR4",
-    "tags" : [ "gbINLevxbtJ9x3EVjjj" ],
-    "description" : "JnLJxf9J6KnG6mxQ",
+    "npiSubjectHeading" : "F2qOWTxaDR5Ie5I",
+    "tags" : [ "wpIh8y1cwUqU5yAUEm" ],
+    "description" : "awnCaKYCyIYgDXo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/1oLgRlc1jTO",
+      "doi" : "https://www.example.com/7oRb8iKoW44YaVdtI6y",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Other",
-          "description" : "oVyz3VQj4r"
+          "type" : "InteractiveFilm"
         },
-        "description" : "ye2L2quMPJhr",
+        "description" : "2acUDZ8Yrb8DXyL",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "zRWKfyPMkeH"
+            "name" : "6M1GlSIREaBWd"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 895930392
+          "sequence" : 1427633530
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "nMAsak1Huz1kLs",
-            "country" : "b2ZNg9riPWh"
+            "label" : "2CilEfVGGxFOprpAu",
+            "country" : "qDBsLeCbjzjsoITAaO"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 880393150
+          "sequence" : 1186441505
         }, {
           "type" : "OtherRelease",
-          "description" : "aNNK9gcoy55of",
+          "description" : "g6jNhATpOPOnbECGhJ",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XyRY8xzWhLWzi",
-            "country" : "V8Nc8tizHA"
+            "label" : "dh5a9266nLcMH",
+            "country" : "UYPADhyiZI0LI527"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "9Wob7GMP9T"
+            "name" : "C6u3e0Thq1FE2"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 372909740
+          "sequence" : 918501807
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -135,45 +134,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/S8yGMtie2mSl",
-    "abstract" : "rFXtSu7wGKstfjivS"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "fisA2EyxI0M",
-      "mimeType" : "U5jMhCkAnzgUto2B",
-      "size" : 779189972,
-      "license" : {
-        "type" : "License",
-        "identifier" : "TteLFQ66LF7C",
-        "labels" : {
-          "i7S574y6kTt" : "VpuVo6En3td0ZVddx28"
-        },
-        "link" : "https://www.example.com/EbL4pJSVEtPM4x1"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/GTT9OXeGuVb7JeKkwmK",
+    "abstract" : "YSXjoEq2lZN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/rationeexpedita",
-    "name" : "Hrb3IiUTL8LrcXTXe",
+    "id" : "https://www.example.org/sitvoluptas",
+    "name" : "1kz3dDCvgi5W",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "TFBgz4WkPSH3SqX",
-      "id" : "2KaJr3iEwYYCGFtKz"
+      "source" : "DIyAfQ71hYK3tJYDHYL",
+      "id" : "HJ96TSK83io5yj"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Yyz4J27DK0No"
+      "applicationCode" : "NfQy8TtSX8onZ7nxQQK"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -181,25 +159,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/molestiaepariatur" ],
+  "subjects" : [ "https://www.example.org/temporibusid" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "fisA2EyxI0M",
-    "mimeType" : "U5jMhCkAnzgUto2B",
-    "size" : 779189972,
+    "name" : "zMnV5GlsGnU6Tf",
+    "mimeType" : "GD5nlVQVnT6VqJmR3dK",
+    "size" : 538438190,
     "license" : {
       "type" : "License",
-      "identifier" : "TteLFQ66LF7C",
+      "identifier" : "BLxu70ymSICuWeqdkB",
       "labels" : {
-        "i7S574y6kTt" : "VpuVo6En3td0ZVddx28"
+        "YsXisxhI4LQcV" : "wbVlA0Akzfsy9AjHnr7"
       },
-      "link" : "https://www.example.com/EbL4pJSVEtPM4x1"
+      "link" : "https://www.example.com/ojOL2JJuH0lw"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "Z60mjq6hf5DMXs"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "zMnV5GlsGnU6Tf",
+      "mimeType" : "GD5nlVQVnT6VqJmR3dK",
+      "size" : 538438190,
+      "license" : {
+        "type" : "License",
+        "identifier" : "BLxu70ymSICuWeqdkB",
+        "labels" : {
+          "YsXisxhI4LQcV" : "wbVlA0Akzfsy9AjHnr7"
+        },
+        "link" : "https://www.example.com/ojOL2JJuH0lw"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "EjSFNNpEknrVJ",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -3,130 +3,130 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "EjSFNNpEknrVJ",
-    "ownerAffiliation" : "https://www.example.org/laborumnon"
+    "owner" : "tGhoTJdS7bY8tOmF",
+    "ownerAffiliation" : "https://www.example.org/autnon"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etet",
+    "id" : "https://www.example.org/animilabore",
     "labels" : {
-      "sEssKF0ULDq" : "u4oi1b8wRUXH"
+      "nPJOfACN4zgLYexJ" : "TyHjP9TQwe7IYlKy8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/molestiaequi",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/ipsameius",
+  "handle" : "https://www.example.org/fugitperferendis",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/laboreaccusantium",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7coKZIqWFc2",
+    "mainTitle" : "qvH8myCSFzfjLHIKfS",
     "alternativeTitles" : {
-      "ru" : "3obuhdSriquHDDGaq"
+      "no" : "ks9vVVHpPH"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "qcmG5jCYlaM",
-      "month" : "DeTIPCSsNhMmOO4YtQo",
-      "day" : "4Hh9kf3fAEREGHzD"
+      "year" : "hwulu0ZBBA0",
+      "month" : "LOMeRnRusaagxs",
+      "day" : "g8LIN9dNhnPbd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/833DQZYuSHHvoOqxfWM",
-        "name" : "j8h2CMhqlTWBv2j4eZw",
+        "id" : "https://www.example.com/syqC658IT0",
+        "name" : "YMZry4ONpEky7utr",
         "nameType" : "Organizational",
-        "orcId" : "2HsW6cy9cWNpLtfZrB"
+        "orcId" : "KqAjG9XQGj8"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/21gehSR29M",
+        "id" : "https://www.example.com/7yNV774QFK8XXM4",
         "labels" : {
-          "qbzRNnhVTNxprxRk" : "tElIbGQYoWl6s"
+          "OopZCZzJpLp5w8H" : "SHQq47ENKY1"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 4,
+      "role" : "VfxSupervisor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/LETMLYrKN6gv0",
-        "name" : "N0Zao10llV3TkURRTm",
+        "id" : "https://www.example.com/SZmF6m8K4CVaKuU2z8d",
+        "name" : "puQPUxNohxiLc",
         "nameType" : "Organizational",
-        "orcId" : "9JBFenCLCP6f"
+        "orcId" : "2qeuyEgAqhl"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iywt60aNEty4",
+        "id" : "https://www.example.com/EHJswmcn7mAa",
         "labels" : {
-          "OBIwvNnEZm" : "1JBBkcqFfE08vsnN4KE"
+          "Vi2tK4B9h7Ae" : "jUUdv8UOFJuqE"
         }
       } ],
-      "role" : "InterviewSubject",
+      "role" : "ProjectLeader",
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "F2qOWTxaDR5Ie5I",
-    "tags" : [ "wpIh8y1cwUqU5yAUEm" ],
-    "description" : "awnCaKYCyIYgDXo",
+    "npiSubjectHeading" : "3UFNFu3jLnvoii",
+    "tags" : [ "fczWPp0BwNxZ2oZ" ],
+    "description" : "A8Gf9ukb48Pmy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/7oRb8iKoW44YaVdtI6y",
+      "doi" : "https://www.example.com/dF7GVJllUyece",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "InteractiveFilm"
+          "type" : "Film"
         },
-        "description" : "2acUDZ8Yrb8DXyL",
+        "description" : "hL6rPsxMKOen99WCKrp",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "6M1GlSIREaBWd"
+            "name" : "qDUsXPlquTrgx5"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1427633530
+          "sequence" : 911112327
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "2CilEfVGGxFOprpAu",
-            "country" : "qDBsLeCbjzjsoITAaO"
+            "label" : "yxLFwKkaOtnA",
+            "country" : "A8qmLPNbIn415"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1186441505
+          "sequence" : 394427467
         }, {
           "type" : "OtherRelease",
-          "description" : "g6jNhATpOPOnbECGhJ",
+          "description" : "hjzlSGwSJJ",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "dh5a9266nLcMH",
-            "country" : "UYPADhyiZI0LI527"
+            "label" : "XrTixnKUTxzE4s4oGpl",
+            "country" : "on6cC11lT9jEem4bAM0"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "C6u3e0Thq1FE2"
+            "name" : "eV94D8m1YIi9zOayf1"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 918501807
+          "sequence" : 439070524
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -134,24 +134,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/GTT9OXeGuVb7JeKkwmK",
-    "abstract" : "YSXjoEq2lZN"
+    "metadataSource" : "https://www.example.com/owkqYZ6snIb6cRkoawV",
+    "abstract" : "Hwdhg1So51"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sitvoluptas",
-    "name" : "1kz3dDCvgi5W",
+    "id" : "https://www.example.org/doloremrem",
+    "name" : "ePGUwOlNcMzDx",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "DIyAfQ71hYK3tJYDHYL",
-      "id" : "HJ96TSK83io5yj"
+      "source" : "KoMkTukCaYc3w5",
+      "id" : "BN4AGgeVhYO6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "NfQy8TtSX8onZ7nxQQK"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "bephLFOXovuhBy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -159,46 +159,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporibusid" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "zMnV5GlsGnU6Tf",
-    "mimeType" : "GD5nlVQVnT6VqJmR3dK",
-    "size" : 538438190,
-    "license" : {
-      "type" : "License",
-      "identifier" : "BLxu70ymSICuWeqdkB",
-      "labels" : {
-        "YsXisxhI4LQcV" : "wbVlA0Akzfsy9AjHnr7"
-      },
-      "link" : "https://www.example.com/ojOL2JJuH0lw"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/itaqueillum" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "zMnV5GlsGnU6Tf",
-      "mimeType" : "GD5nlVQVnT6VqJmR3dK",
-      "size" : 538438190,
+      "name" : "LJvRQCFgXH2t6ug",
+      "mimeType" : "7vRf1VeotcvbekCaVA",
+      "size" : 446668675,
       "license" : {
         "type" : "License",
-        "identifier" : "BLxu70ymSICuWeqdkB",
+        "identifier" : "6oWZ1kmfLL",
         "labels" : {
-          "YsXisxhI4LQcV" : "wbVlA0Akzfsy9AjHnr7"
+          "8tDIaKlhVglkwpPM9s" : "tS5DXVR5Ga1zg3Ips"
         },
-        "link" : "https://www.example.com/ojOL2JJuH0lw"
+        "link" : "https://www.example.com/MafSggABiIZOMO"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "EjSFNNpEknrVJ",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "LJvRQCFgXH2t6ug",
+    "mimeType" : "7vRf1VeotcvbekCaVA",
+    "size" : 446668675,
+    "license" : {
+      "type" : "License",
+      "identifier" : "6oWZ1kmfLL",
+      "labels" : {
+        "8tDIaKlhVglkwpPM9s" : "tS5DXVR5Ga1zg3Ips"
+      },
+      "link" : "https://www.example.com/MafSggABiIZOMO"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "tGhoTJdS7bY8tOmF",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,133 +1,132 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "FegF4WEoi3YRbf9IZ",
-    "ownerAffiliation" : "https://www.example.org/velimpedit"
+    "owner" : "gRpQYGOI2Q9TGcwM",
+    "ownerAffiliation" : "https://www.example.org/nesciunteos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ducimuset",
+    "id" : "https://www.example.org/accusantiumpariatur",
     "labels" : {
-      "NriAPZmAby" : "szb9Wah1zKeIBO"
+      "e7GSaaaKUGu1" : "gZVwraToSB"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/officiaqui",
-  "doi" : "https://doi.org/10.1234/quasi",
-  "link" : "https://www.example.org/doloremeos",
+  "handle" : "https://www.example.org/asperioreset",
+  "doi" : "https://doi.org/10.1234/perferendis",
+  "link" : "https://www.example.org/providentmaiores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ElKLUByBa6ybA",
+    "mainTitle" : "jUiWp4XxPpaYLU",
     "alternativeTitles" : {
-      "pt" : "3BOmKGVPorlObEGv"
+      "de" : "KpdBdlFSZaD"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "pfqdGbVRtn9XjiwsP",
-      "month" : "0u5j1P8hEdb7kV6AWe",
-      "day" : "5E05uQX08u7ypK08u"
+      "year" : "hSGUVJkwLWBPsA",
+      "month" : "iZ6DoC7nAOuYMNr",
+      "day" : "671kKCTZUhXhICzV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BBpmqXymM6wUDlo",
-        "name" : "io3ONfPVl2qhTqpi",
+        "id" : "https://www.example.com/EdopY3qM6CTw6hC",
+        "name" : "q34hLERqnwjG1",
         "nameType" : "Organizational",
-        "orcId" : "J04EgP5WpmEg8"
+        "orcId" : "O0tiMTy4RPvzg3iC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Zfol0QcF2GG1VPgB0",
+        "id" : "https://www.example.com/HC6uR2LWgW",
         "labels" : {
-          "Hnq78vnEbW99PldEu0A" : "l1w43YZWYdfDMPhsv"
+          "sZlPqNTyblZx6LF2SSW" : "5VVDbHf098M"
         }
       } ],
-      "role" : "VideoEditor",
-      "sequence" : 7,
+      "role" : "DataCurator",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TL1aQLch6TQ8loeeXeg",
-        "name" : "BifPOboHscQEDxqOyp",
+        "id" : "https://www.example.com/ltIgIrF678JeIe5",
+        "name" : "zPj1iLzqU55",
         "nameType" : "Personal",
-        "orcId" : "b6n3sXK3AxvmhS"
+        "orcId" : "eeXurOVOZWb4Mdf4T"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qoRXeb4nuiBk",
+        "id" : "https://www.example.com/piGOllQbBefG",
         "labels" : {
-          "qmVDhihYH6zKBSQxDm" : "QJ5vTttvVJeJ"
+          "ZPR4Szd0vdm" : "8inl2dxs2Yx"
         }
       } ],
-      "role" : "Supervisor",
-      "sequence" : 1,
+      "role" : "Distributor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "C816RCgfd6",
-    "tags" : [ "xGKaIfGdDwA" ],
-    "description" : "ercjWbRR3mqHtwZ",
+    "npiSubjectHeading" : "xnubgoqIVZaLFjy",
+    "tags" : [ "CjNNcPQAs9O3Wx" ],
+    "description" : "E1H19FNJ1hX9ia058L",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/jtmJhNia8esCXhZpJ",
+      "doi" : "https://www.example.com/mSfBQVBvMQT1OelIR6E",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Other",
-          "description" : "C3c6d8zNDO3atVuZ5g"
+          "type" : "SerialFilmProduction"
         },
-        "description" : "UdgtGLX29K5Qt",
+        "description" : "U9Oe6dPvnQ",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "NdiikXeaaXBm"
+            "name" : "cxautdyt7ID1FMURFjU"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1571368078
+          "sequence" : 1883911099
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "HAZyOtg8agG8lRWTQWT",
-            "country" : "b3aPFY5tK0XhKhwbUaA"
+            "label" : "fgEnGC8KcjY",
+            "country" : "IvOP76TibmQSMU"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1224149818
+          "sequence" : 1791359292
         }, {
           "type" : "OtherRelease",
-          "description" : "0brsVDCvuTVUcF753",
+          "description" : "rGg5kMv3e2wWAH",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Yn5SBKgtb5Iwer0Y4",
-            "country" : "gLspK0s6vPypvwYKU1"
+            "label" : "dN3avxr8dppre",
+            "country" : "A4eus2k0U02"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "UNVOXgg9p5AjVGuTw"
+            "name" : "1sROT8hu5t9IreisxhP"
           },
           "date" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 924767789
+          "sequence" : 1118332074
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -135,24 +134,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/aNymrGGS13wk",
-    "abstract" : "Kf0tPEw2N7Z"
+    "metadataSource" : "https://www.example.com/SLBUjQqNRG0mEM08wh",
+    "abstract" : "p7KIv3e1RxNZWVY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloremquenon",
-    "name" : "2vzZoLnfxm",
+    "id" : "https://www.example.org/excepturiqui",
+    "name" : "9RMfs3W54U",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ALrUT4gtEzzg9joH",
-      "id" : "WVE1XOt0yMVrli72"
+      "source" : "mMoakD3VtwuGTKWW",
+      "id" : "QZ4UwwBSLdukxU"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "xcDN57wu7m"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "zhXL2CP23M"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -160,46 +159,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/sedtempore" ],
+  "subjects" : [ "https://www.example.org/rerumaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "CN4yIq8kTUUadB1JAHX",
-      "mimeType" : "L7aM8z2s5jUNcoXW",
-      "size" : 1398473863,
+      "name" : "uH8LbfMjaI",
+      "mimeType" : "rK6OvxoNz2",
+      "size" : 1624812473,
       "license" : {
         "type" : "License",
-        "identifier" : "r6xxa65blO",
+        "identifier" : "yaRHymtIer",
         "labels" : {
-          "mWQzyKyjqwNj" : "PH9ZIqcbapD3eKQ"
+          "qPgqFyu9UqEsk8TDu" : "p0qvuokvD7Z"
         },
-        "link" : "https://www.example.com/kVp1FWP3ipG6o6iMTX"
+        "link" : "https://www.example.com/ytEktNBSvAYm"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "CN4yIq8kTUUadB1JAHX",
-    "mimeType" : "L7aM8z2s5jUNcoXW",
-    "size" : 1398473863,
+    "name" : "uH8LbfMjaI",
+    "mimeType" : "rK6OvxoNz2",
+    "size" : 1624812473,
     "license" : {
       "type" : "License",
-      "identifier" : "r6xxa65blO",
+      "identifier" : "yaRHymtIer",
       "labels" : {
-        "mWQzyKyjqwNj" : "PH9ZIqcbapD3eKQ"
+        "qPgqFyu9UqEsk8TDu" : "p0qvuokvD7Z"
       },
-      "link" : "https://www.example.com/kVp1FWP3ipG6o6iMTX"
+      "link" : "https://www.example.com/ytEktNBSvAYm"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "FegF4WEoi3YRbf9IZ",
+  "owner" : "gRpQYGOI2Q9TGcwM",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,127 +1,127 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "mvsD52mJukZ",
-    "ownerAffiliation" : "https://www.example.org/nihilexpedita"
+    "owner" : "kSIywsl1xccyI",
+    "ownerAffiliation" : "https://www.example.org/corporisquae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiasdolorum",
+    "id" : "https://www.example.org/architectotemporibus",
     "labels" : {
-      "GwXX8C831MEiA7c80" : "t9B9sxIZm4"
+      "k1gLWqeNcKYe3bFHh" : "lthlyL2BVkNNz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/magnidolor",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/sintid",
+  "handle" : "https://www.example.org/accusantiumnihil",
+  "doi" : "https://doi.org/10.1234/ipsa",
+  "link" : "https://www.example.org/quoddoloremque",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SmrE2GRcmyu6X4e",
+    "mainTitle" : "j0fcaWSHx2e9tYwoz5",
     "alternativeTitles" : {
-      "fr" : "yL0c26kuWJ6uy7HNXbJ"
+      "ca" : "LeJvb2Syot5TRK6hW1"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "LGIHcYsCR5q",
-      "month" : "sWH67ypQ9plE9hc",
-      "day" : "bFFoBO5S8xPmH"
+      "year" : "tkU4zF3alpKc6",
+      "month" : "U07OgBiYhsGRD",
+      "day" : "76ysJSHQv7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OKQckCYRUSmi00w",
-        "name" : "fGuop4vxoLFldeNUfmt",
+        "id" : "https://www.example.com/e1sx7voKmSPzlgCD",
+        "name" : "CKGFMPOBx7sXD1Q",
         "nameType" : "Personal",
-        "orcId" : "x2DGSg3S9B0u92oj"
+        "orcId" : "rNhhdZct1tI1nFC"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/aK2thmgGYy0tX1ihf",
+        "id" : "https://www.example.com/QbZvHIhSsGEHo",
         "labels" : {
-          "yxfSErCuzZBAhVrP" : "F4YIhDhnYt7i"
+          "FdLPeJ7CKNc" : "O1nApTdQieviUT"
         }
       } ],
-      "role" : "VideoEditor",
+      "role" : "ProjectManager",
       "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/hRlUS1j8bLTA",
-        "name" : "gHP23LxmSli96DNS",
+        "id" : "https://www.example.com/ERrTWH3ZdZI4DAD",
+        "name" : "Vge8ewn99kZOzrLf",
         "nameType" : "Personal",
-        "orcId" : "yUxqRkTP2adbWupUXX"
+        "orcId" : "bLCXkAkCH7eIYYfI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/eE9yBr9nVOhYHHq",
+        "id" : "https://www.example.com/CqgKPnE0bKoGJhdn7",
         "labels" : {
-          "Pmp6L31qGJv" : "RUJPBi2srLuph2BJt"
+          "YglCpO3U0H38FKu3" : "EohIA2Tr2fXiUgBFRp"
         }
       } ],
-      "role" : "LandscapeArchitect",
-      "sequence" : 3,
+      "role" : "Sponsor",
+      "sequence" : 9,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "MUO3GL5kGpGAqRp",
-    "tags" : [ "MYbMtbniDH1mMQkU8hr" ],
-    "description" : "ZdoM23QHTVXNvcE",
+    "npiSubjectHeading" : "MhW8HLpiyh",
+    "tags" : [ "TMWijfr7oani44Bo" ],
+    "description" : "sNR5wWc6nix",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/Pv4zYJ1MfR",
+      "doi" : "https://www.example.com/KcM59SVH5EqSQC",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : "Other",
-          "publisher" : "2m1FSsLw6lD3jpK",
-          "catalogueNumber" : "VvIydGB70o",
+          "publisher" : "9G4isGKZiuZ",
+          "catalogueNumber" : "dCp0xVFwOr",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "hOn7ct4zwWC8IdQuY",
-            "composer" : "OdOQ67HhmaFXqf",
-            "extent" : "2v2zhTUYc2J"
+            "title" : "WlXsss0try1IqT",
+            "composer" : "xmjFxGqwZ50",
+            "extent" : "A4xLdrbLwDr6"
           } ]
         }, {
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "MXq2lb5hgbrCJ",
-            "country" : "sIOBnU0VUszl"
+            "label" : "SzMDVIC9gyMoiVm",
+            "country" : "hygKXO7DfsN"
           },
           "time" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "extent" : "YewuTry3WL1Ci",
-          "description" : "AYJefE9JQlKKLUXL02",
+          "extent" : "nURet6KtpWu5",
+          "description" : "RTqU0SYLMLuzqJU",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "YdlVvapm7YVFvtPRXO",
-            "composer" : "UEEnGPQ4UCPni9zpjc",
-            "premiere" : true
+            "title" : "upU9IMYpBtoCU6HspP",
+            "composer" : "gXWwMlP5xRYfcQCj",
+            "premiere" : false
           } ],
-          "partOfSeries" : true
+          "partOfSeries" : false
         }, {
           "type" : "MusicScore",
-          "ensemble" : "mkjrgohIwfzanj",
-          "movements" : "0c2cmJbZWRak55",
-          "extent" : "NIMpGlaEwM",
+          "ensemble" : "tljX56q619",
+          "movements" : "HFFR2gR8mi7",
+          "extent" : "9cDdxISOrLXdgAFe",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "fvbtRCVrR0ucAp3AgAy"
+            "name" : "Hg6QrekSRz"
           },
           "ismn" : {
             "type" : "Ismn",
@@ -134,17 +134,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "nyYAXCaMFC",
+          "performanceType" : "VraD990Rx0uF",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "AwYVf4FXFq9S",
-            "country" : "Ef1FNp8d6UqiyRSetf"
+            "label" : "3KvJ23fXFURD9Rdzuj",
+            "country" : "jAmMhyhZfONddM8W7j"
           },
-          "extent" : "MiVZZYVBByPijH",
+          "extent" : "6Vq0aWWV8W6Ivtzr",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "fiovdUh4oyckxwma0S",
-            "composer" : "TOFnHepy0bT0dUEB10"
+            "title" : "8e6Bhjexju",
+            "composer" : "U0TVjsB8xXAXhp"
           } ]
         } ],
         "peerReviewed" : false,
@@ -153,24 +153,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/fGeUdHvweB",
-    "abstract" : "yboT8qhgwzIXhzy"
+    "metadataSource" : "https://www.example.com/M07nvCgBKGS2ik9Kgp",
+    "abstract" : "sOatNCcaPcJB0ZrDVPP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/rationeexpedita",
-    "name" : "8K8GyZNmyYKZlX",
+    "id" : "https://www.example.org/sequiipsa",
+    "name" : "q2XkYgW7txM",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "8SgmVwYHbS7XuaFl",
-      "id" : "wNA1qVdAM5wo2jWRa5b"
+      "source" : "UX7dOK427vn",
+      "id" : "7wCf2EJIDV"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "EUeBK4dvnVp4bWZ8"
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "0yfRFQukjwOI"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -178,22 +178,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eligendivitae" ],
+  "subjects" : [ "https://www.example.org/eanon" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "na7iRBTvehZT4M",
-      "mimeType" : "QZVed1I0qMi1J48zfP",
-      "size" : 1236898017,
+      "name" : "7k8CJSutDo",
+      "mimeType" : "MqYcI67g56ZM",
+      "size" : 2101271768,
       "license" : {
         "type" : "License",
-        "identifier" : "mDSc0k63BBDCekO",
+        "identifier" : "rcYzhPA4jDJ0R",
         "labels" : {
-          "B1vCg0nCZrH" : "iVAv4URbEUfMAqB"
+          "ZH5IeI7gcRcPf65V" : "FNcQBDQcESZAk6sbezg"
         },
-        "link" : "https://www.example.com/B5WhM5ufK7GnkMQ"
+        "link" : "https://www.example.com/8xGHAhrQHQcpU"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -203,21 +203,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "na7iRBTvehZT4M",
-    "mimeType" : "QZVed1I0qMi1J48zfP",
-    "size" : 1236898017,
+    "name" : "7k8CJSutDo",
+    "mimeType" : "MqYcI67g56ZM",
+    "size" : 2101271768,
     "license" : {
       "type" : "License",
-      "identifier" : "mDSc0k63BBDCekO",
+      "identifier" : "rcYzhPA4jDJ0R",
       "labels" : {
-        "B1vCg0nCZrH" : "iVAv4URbEUfMAqB"
+        "ZH5IeI7gcRcPf65V" : "FNcQBDQcESZAk6sbezg"
       },
-      "link" : "https://www.example.com/B5WhM5ufK7GnkMQ"
+      "link" : "https://www.example.com/8xGHAhrQHQcpU"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "mvsD52mJukZ",
+  "owner" : "kSIywsl1xccyI",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,128 +1,127 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "BYJuhBnB0Ij",
-    "ownerAffiliation" : "https://www.example.org/doloreplaceat"
+    "owner" : "TRVXDL3FGr",
+    "ownerAffiliation" : "https://www.example.org/etlibero"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/officiaet",
+    "id" : "https://www.example.org/estad",
     "labels" : {
-      "rL1dZ390S1y" : "XeqF3E9enhXhQJdvrJz"
+      "othLRaouB0jlX3QXWZ" : "zU0Bfn9evUwSmK"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/providentdolor",
-  "doi" : "https://doi.org/10.1234/soluta",
-  "link" : "https://www.example.org/hicin",
+  "handle" : "https://www.example.org/magnamquia",
+  "doi" : "https://doi.org/10.1234/dolorem",
+  "link" : "https://www.example.org/aliasenim",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1FG27SnLI4LHTl",
+    "mainTitle" : "nemvhktO5fTD9mN",
     "alternativeTitles" : {
-      "cs" : "KA2JszRzmI"
+      "fr" : "g3tsV6MQml5i"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nor",
+    "language" : "http://lexvo.org/id/iso639-3/isl",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "yU9Ajq9o7UxJ",
-      "month" : "fQDmLyvJEztej2mTJ",
-      "day" : "m5bGIiixJDmfiFO"
+      "year" : "OQYXPXfxwA",
+      "month" : "R9zX5AyHuMJNp0O",
+      "day" : "n4Tcu6VP68Rt2NVXbr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/q8D5CtqUmihGGsp",
-        "name" : "CmkhPj8OgnXKy",
+        "id" : "https://www.example.com/WmlTJoYyWWrQD78Zl",
+        "name" : "HexV30zTGItYsrep",
         "nameType" : "Organizational",
-        "orcId" : "enrNQsAxbSRi"
+        "orcId" : "UtYwxP2tWZZp7RFv"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/RVQ5WSIcDuPiiQ",
+        "id" : "https://www.example.com/hul4rPaBwh5W1rlkn",
         "labels" : {
-          "4G6T1rUOYBWgT" : "RbQvGFlHAURCUKfqd"
+          "keOysl2g1m7YUsXmJAc" : "85kcY4SXgffNeYuoGcW"
         }
       } ],
-      "role" : "Organizer",
-      "sequence" : 5,
+      "role" : "ResearchGroup",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lw92q3yE0S1S",
-        "name" : "udYNXbiCgLfm",
-        "nameType" : "Personal",
-        "orcId" : "vOctaNm5XcMo"
+        "id" : "https://www.example.com/SsUNzn4vX4bFqV",
+        "name" : "l0udA3K5rjeGvOlF",
+        "nameType" : "Organizational",
+        "orcId" : "PDUtgVp7kI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/wUrFEviBGina8",
+        "id" : "https://www.example.com/hCD2oGG8fwwQIW6yN",
         "labels" : {
-          "Z8A9gJKblYXTVI" : "YqlcBpBedXJpUcvO"
+          "iBYnaamnDMBiyn" : "OSluUgXrdtgZMd"
         }
       } ],
-      "role" : "CostumeDesigner",
-      "sequence" : 8,
+      "role" : "Organizer",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "0WMuwaaO1CHUmkkhoxp",
-    "tags" : [ "nsST95Y67F" ],
-    "description" : "HyRlh9AfaE",
+    "npiSubjectHeading" : "IrVvWnUoYPUqgtV4",
+    "tags" : [ "rDbJoFnzSN6sFJzU" ],
+    "description" : "XVkHi3MdllCvpNbWkun",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/2tg3wy8ws9",
+      "doi" : "https://www.example.com/ItQ63oPj14Mymf",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
-          "mediaType" : "Vinyl",
-          "publisher" : "ZyhMqH6CeQ22yoUybm",
-          "catalogueNumber" : "gAZWW6yTm3aNiP",
+          "mediaType" : "CompactDisc",
+          "publisher" : "MBWPsu1P0Wfe5ZBA",
+          "catalogueNumber" : "OXJBuZL2zy",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "9sP2TLkspjWGdpKY",
-            "composer" : "fN4zA4QqEAzWnRZrEp",
-            "extent" : "Wv53f0rYpCznu"
+            "title" : "BIBT9hShe1Uuxa",
+            "composer" : "YoQQkpjvMDZN",
+            "extent" : "nc49BSBwFen"
           } ]
         }, {
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "cU97imXKJfi9oUR0d",
-            "country" : "xYfYX0GxyKgilw"
+            "label" : "i41DaKdtissqz",
+            "country" : "GTz2hQfXcSZspQTu"
           },
           "time" : {
-            "type" : "Period",
-            "from" : "2020-09-23T09:51:23.044996Z",
-            "to" : "2020-09-23T09:51:23.044996Z"
+            "type" : "Instant",
+            "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "extent" : "RpqJGo9I0V4",
-          "description" : "yrG7xfE0TMYGW6",
+          "extent" : "QaTtzH2mH2t2DSLDL",
+          "description" : "gDQuWlMm1YWONXtd",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "SsZWIQrtbhVkwb",
-            "composer" : "bLm1DlurfgsGVfYXf",
+            "title" : "n8j4qIhnQKWoC0R",
+            "composer" : "vz8LM17oGSW",
             "premiere" : true
           } ],
           "partOfSeries" : true
         }, {
           "type" : "MusicScore",
-          "ensemble" : "z6v4jWhsqKlNsR",
-          "movements" : "qvcXFxVCc2Fu",
-          "extent" : "ymxnPT0i2HlWA",
+          "ensemble" : "TVfI4U7aWf",
+          "movements" : "3exgwUEtBpJ12gmEO",
+          "extent" : "L3UFSJSswCTrBCZbV8Q",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "21OxC3v00t"
+            "name" : "Xx7tcYM7eBvK"
           },
           "ismn" : {
             "type" : "Ismn",
@@ -135,17 +134,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "NcVsiMPDf0my",
+          "performanceType" : "Ks8fgSikcXE6IUuc0rM",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "xp5HMezaJ9MWz",
-            "country" : "l4DScsPgtDu0"
+            "label" : "wRGAA7nDqoW8lo",
+            "country" : "IFLXJXbanr712"
           },
-          "extent" : "nM5JzXYSKvZE096dMjm",
+          "extent" : "trmGksVSaqHy8eE2YTS",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "RrrByypIb1",
-            "composer" : "6VFQKxlXRYBAA0uM"
+            "title" : "urv3KFAjJACU501yis",
+            "composer" : "KwOpSwa9BDtyCloQIbI"
           } ]
         } ],
         "peerReviewed" : false,
@@ -154,24 +153,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/KKE7YLJi1TnB0IY",
-    "abstract" : "JysnSlETHpdVptFoO"
+    "metadataSource" : "https://www.example.com/FIXVcmdh8SxMSA",
+    "abstract" : "r9jRHASFz1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/autdolorem",
-    "name" : "pB9YdyedJ2vNXhb",
+    "id" : "https://www.example.org/etomnis",
+    "name" : "QOh1eZObDqpmy",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Hw9b6dbjdJjoFFSi",
-      "id" : "te7x19ERVOGsPI6"
+      "source" : "nl2kCIi1qc",
+      "id" : "kyWK02kL0UIVrXKZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "xSO1Pq7yVT"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "IW6tWetoljo"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -179,46 +178,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/animisunt" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "WwrLGBxhcCUC6IFsr",
-    "mimeType" : "J5hGOEtgDrY7B",
-    "size" : 960842297,
-    "license" : {
-      "type" : "License",
-      "identifier" : "DkY5cd0d2k1iGLgff",
-      "labels" : {
-        "2nSOsQPmJDLc" : "SjDE9Reqaz"
-      },
-      "link" : "https://www.example.com/nhe26P1UECLCi7"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/aliashic" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "WwrLGBxhcCUC6IFsr",
-      "mimeType" : "J5hGOEtgDrY7B",
-      "size" : 960842297,
+      "name" : "EP5wNuqx33dewSPW6R",
+      "mimeType" : "rEwpM11k3ukDB",
+      "size" : 2029712660,
       "license" : {
         "type" : "License",
-        "identifier" : "DkY5cd0d2k1iGLgff",
+        "identifier" : "Ab0IqhrVWFPBz",
         "labels" : {
-          "2nSOsQPmJDLc" : "SjDE9Reqaz"
+          "j2kcH2bvVSRsXuucSEr" : "2qbGhH6BOyb"
         },
-        "link" : "https://www.example.com/nhe26P1UECLCi7"
+        "link" : "https://www.example.com/kdfZaXhhobiBs4sly"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "BYJuhBnB0Ij",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "EP5wNuqx33dewSPW6R",
+    "mimeType" : "rEwpM11k3ukDB",
+    "size" : 2029712660,
+    "license" : {
+      "type" : "License",
+      "identifier" : "Ab0IqhrVWFPBz",
+      "labels" : {
+        "j2kcH2bvVSRsXuucSEr" : "2qbGhH6BOyb"
+      },
+      "link" : "https://www.example.com/kdfZaXhhobiBs4sly"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "TRVXDL3FGr",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,127 +1,127 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "TRVXDL3FGr",
-    "ownerAffiliation" : "https://www.example.org/etlibero"
+    "owner" : "mvsD52mJukZ",
+    "ownerAffiliation" : "https://www.example.org/nihilexpedita"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/estad",
+    "id" : "https://www.example.org/molestiasdolorum",
     "labels" : {
-      "othLRaouB0jlX3QXWZ" : "zU0Bfn9evUwSmK"
+      "GwXX8C831MEiA7c80" : "t9B9sxIZm4"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/magnamquia",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/aliasenim",
+  "handle" : "https://www.example.org/magnidolor",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/sintid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nemvhktO5fTD9mN",
+    "mainTitle" : "SmrE2GRcmyu6X4e",
     "alternativeTitles" : {
-      "fr" : "g3tsV6MQml5i"
+      "fr" : "yL0c26kuWJ6uy7HNXbJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/isl",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "OQYXPXfxwA",
-      "month" : "R9zX5AyHuMJNp0O",
-      "day" : "n4Tcu6VP68Rt2NVXbr"
+      "year" : "LGIHcYsCR5q",
+      "month" : "sWH67ypQ9plE9hc",
+      "day" : "bFFoBO5S8xPmH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WmlTJoYyWWrQD78Zl",
-        "name" : "HexV30zTGItYsrep",
-        "nameType" : "Organizational",
-        "orcId" : "UtYwxP2tWZZp7RFv"
+        "id" : "https://www.example.com/OKQckCYRUSmi00w",
+        "name" : "fGuop4vxoLFldeNUfmt",
+        "nameType" : "Personal",
+        "orcId" : "x2DGSg3S9B0u92oj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hul4rPaBwh5W1rlkn",
+        "id" : "https://www.example.com/aK2thmgGYy0tX1ihf",
         "labels" : {
-          "keOysl2g1m7YUsXmJAc" : "85kcY4SXgffNeYuoGcW"
+          "yxfSErCuzZBAhVrP" : "F4YIhDhnYt7i"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 4,
+      "role" : "VideoEditor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/SsUNzn4vX4bFqV",
-        "name" : "l0udA3K5rjeGvOlF",
-        "nameType" : "Organizational",
-        "orcId" : "PDUtgVp7kI"
+        "id" : "https://www.example.com/hRlUS1j8bLTA",
+        "name" : "gHP23LxmSli96DNS",
+        "nameType" : "Personal",
+        "orcId" : "yUxqRkTP2adbWupUXX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/hCD2oGG8fwwQIW6yN",
+        "id" : "https://www.example.com/eE9yBr9nVOhYHHq",
         "labels" : {
-          "iBYnaamnDMBiyn" : "OSluUgXrdtgZMd"
+          "Pmp6L31qGJv" : "RUJPBi2srLuph2BJt"
         }
       } ],
-      "role" : "Organizer",
-      "sequence" : 0,
+      "role" : "LandscapeArchitect",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "IrVvWnUoYPUqgtV4",
-    "tags" : [ "rDbJoFnzSN6sFJzU" ],
-    "description" : "XVkHi3MdllCvpNbWkun",
+    "npiSubjectHeading" : "MUO3GL5kGpGAqRp",
+    "tags" : [ "MYbMtbniDH1mMQkU8hr" ],
+    "description" : "ZdoM23QHTVXNvcE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/ItQ63oPj14Mymf",
+      "doi" : "https://www.example.com/Pv4zYJ1MfR",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
-          "mediaType" : "CompactDisc",
-          "publisher" : "MBWPsu1P0Wfe5ZBA",
-          "catalogueNumber" : "OXJBuZL2zy",
+          "mediaType" : "Other",
+          "publisher" : "2m1FSsLw6lD3jpK",
+          "catalogueNumber" : "VvIydGB70o",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "BIBT9hShe1Uuxa",
-            "composer" : "YoQQkpjvMDZN",
-            "extent" : "nc49BSBwFen"
+            "title" : "hOn7ct4zwWC8IdQuY",
+            "composer" : "OdOQ67HhmaFXqf",
+            "extent" : "2v2zhTUYc2J"
           } ]
         }, {
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "i41DaKdtissqz",
-            "country" : "GTz2hQfXcSZspQTu"
+            "label" : "MXq2lb5hgbrCJ",
+            "country" : "sIOBnU0VUszl"
           },
           "time" : {
             "type" : "Instant",
             "value" : "2020-09-23T09:51:23.044996Z"
           },
-          "extent" : "QaTtzH2mH2t2DSLDL",
-          "description" : "gDQuWlMm1YWONXtd",
+          "extent" : "YewuTry3WL1Ci",
+          "description" : "AYJefE9JQlKKLUXL02",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "n8j4qIhnQKWoC0R",
-            "composer" : "vz8LM17oGSW",
+            "title" : "YdlVvapm7YVFvtPRXO",
+            "composer" : "UEEnGPQ4UCPni9zpjc",
             "premiere" : true
           } ],
           "partOfSeries" : true
         }, {
           "type" : "MusicScore",
-          "ensemble" : "TVfI4U7aWf",
-          "movements" : "3exgwUEtBpJ12gmEO",
-          "extent" : "L3UFSJSswCTrBCZbV8Q",
+          "ensemble" : "mkjrgohIwfzanj",
+          "movements" : "0c2cmJbZWRak55",
+          "extent" : "NIMpGlaEwM",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Xx7tcYM7eBvK"
+            "name" : "fvbtRCVrR0ucAp3AgAy"
           },
           "ismn" : {
             "type" : "Ismn",
@@ -134,17 +134,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "Ks8fgSikcXE6IUuc0rM",
+          "performanceType" : "nyYAXCaMFC",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "wRGAA7nDqoW8lo",
-            "country" : "IFLXJXbanr712"
+            "label" : "AwYVf4FXFq9S",
+            "country" : "Ef1FNp8d6UqiyRSetf"
           },
-          "extent" : "trmGksVSaqHy8eE2YTS",
+          "extent" : "MiVZZYVBByPijH",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "urv3KFAjJACU501yis",
-            "composer" : "KwOpSwa9BDtyCloQIbI"
+            "title" : "fiovdUh4oyckxwma0S",
+            "composer" : "TOFnHepy0bT0dUEB10"
           } ]
         } ],
         "peerReviewed" : false,
@@ -153,24 +153,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/FIXVcmdh8SxMSA",
-    "abstract" : "r9jRHASFz1"
+    "metadataSource" : "https://www.example.com/fGeUdHvweB",
+    "abstract" : "yboT8qhgwzIXhzy"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etomnis",
-    "name" : "QOh1eZObDqpmy",
+    "id" : "https://www.example.org/rationeexpedita",
+    "name" : "8K8GyZNmyYKZlX",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "nl2kCIi1qc",
-      "id" : "kyWK02kL0UIVrXKZ"
+      "source" : "8SgmVwYHbS7XuaFl",
+      "id" : "wNA1qVdAM5wo2jWRa5b"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "IW6tWetoljo"
+      "applicationCode" : "EUeBK4dvnVp4bWZ8"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -178,46 +178,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aliashic" ],
+  "subjects" : [ "https://www.example.org/eligendivitae" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "EP5wNuqx33dewSPW6R",
-      "mimeType" : "rEwpM11k3ukDB",
-      "size" : 2029712660,
+      "name" : "na7iRBTvehZT4M",
+      "mimeType" : "QZVed1I0qMi1J48zfP",
+      "size" : 1236898017,
       "license" : {
         "type" : "License",
-        "identifier" : "Ab0IqhrVWFPBz",
+        "identifier" : "mDSc0k63BBDCekO",
         "labels" : {
-          "j2kcH2bvVSRsXuucSEr" : "2qbGhH6BOyb"
+          "B1vCg0nCZrH" : "iVAv4URbEUfMAqB"
         },
-        "link" : "https://www.example.com/kdfZaXhhobiBs4sly"
+        "link" : "https://www.example.com/B5WhM5ufK7GnkMQ"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "EP5wNuqx33dewSPW6R",
-    "mimeType" : "rEwpM11k3ukDB",
-    "size" : 2029712660,
+    "name" : "na7iRBTvehZT4M",
+    "mimeType" : "QZVed1I0qMi1J48zfP",
+    "size" : 1236898017,
     "license" : {
       "type" : "License",
-      "identifier" : "Ab0IqhrVWFPBz",
+      "identifier" : "mDSc0k63BBDCekO",
       "labels" : {
-        "j2kcH2bvVSRsXuucSEr" : "2qbGhH6BOyb"
+        "B1vCg0nCZrH" : "iVAv4URbEUfMAqB"
       },
-      "link" : "https://www.example.com/kdfZaXhhobiBs4sly"
+      "link" : "https://www.example.com/B5WhM5ufK7GnkMQ"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "TRVXDL3FGr",
+  "owner" : "mvsD52mJukZ",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -3,126 +3,126 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "d2QO72Movp",
-    "ownerAffiliation" : "https://www.example.org/ducimusimpedit"
+    "owner" : "BYJuhBnB0Ij",
+    "ownerAffiliation" : "https://www.example.org/doloreplaceat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dictareiciendis",
+    "id" : "https://www.example.org/officiaet",
     "labels" : {
-      "ySrE6GkxuH70LGI" : "vv0dKJ0OeVMwTbm"
+      "rL1dZ390S1y" : "XeqF3E9enhXhQJdvrJz"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/excepturieum",
-  "doi" : "https://doi.org/10.1234/distinctio",
-  "link" : "https://www.example.org/aliquidcumque",
+  "handle" : "https://www.example.org/providentdolor",
+  "doi" : "https://doi.org/10.1234/soluta",
+  "link" : "https://www.example.org/hicin",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JNjEqtmW7v2jv",
+    "mainTitle" : "1FG27SnLI4LHTl",
     "alternativeTitles" : {
-      "zh" : "mtiTTPySPAxaFX"
+      "cs" : "KA2JszRzmI"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/nor",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "gVoyfKBDqEp4yL",
-      "month" : "ktMXiD4sN3T",
-      "day" : "FfnYEWqhp8GY"
+      "year" : "yU9Ajq9o7UxJ",
+      "month" : "fQDmLyvJEztej2mTJ",
+      "day" : "m5bGIiixJDmfiFO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/PMByA6dpPFE7dJRE",
-        "name" : "jjDyH1ldJIbzch3Ecf",
+        "id" : "https://www.example.com/q8D5CtqUmihGGsp",
+        "name" : "CmkhPj8OgnXKy",
         "nameType" : "Organizational",
-        "orcId" : "mFSpFm1H5sq"
+        "orcId" : "enrNQsAxbSRi"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/IaR4ZGA8XBzHLpiCE7",
+        "id" : "https://www.example.com/RVQ5WSIcDuPiiQ",
         "labels" : {
-          "myfxOOz70cXQV" : "hXMlAxGDQcLq"
+          "4G6T1rUOYBWgT" : "RbQvGFlHAURCUKfqd"
         }
       } ],
-      "role" : "Director",
-      "sequence" : 0,
+      "role" : "Organizer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8SG0Ng9pnMKX5",
-        "name" : "bV7QQzLFJ81p8M3I",
-        "nameType" : "Organizational",
-        "orcId" : "ujatnF0YkS"
+        "id" : "https://www.example.com/lw92q3yE0S1S",
+        "name" : "udYNXbiCgLfm",
+        "nameType" : "Personal",
+        "orcId" : "vOctaNm5XcMo"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qT2cy5Gi87nRt0P",
+        "id" : "https://www.example.com/wUrFEviBGina8",
         "labels" : {
-          "7FLCjzZaza" : "nI0kwmdULK9GfIAsXB"
+          "Z8A9gJKblYXTVI" : "YqlcBpBedXJpUcvO"
         }
       } ],
-      "role" : "ProjectManager",
-      "sequence" : 2,
+      "role" : "CostumeDesigner",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "VQu4lJQcHX",
-    "tags" : [ "ls2PZLA0gW" ],
-    "description" : "BuM0PCfOTvLvf5bopkR",
+    "npiSubjectHeading" : "0WMuwaaO1CHUmkkhoxp",
+    "tags" : [ "nsST95Y67F" ],
+    "description" : "HyRlh9AfaE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/THkEodU1NIDAu",
+      "doi" : "https://www.example.com/2tg3wy8ws9",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
-          "mediaType" : "Streaming",
-          "publisher" : "k4McXg0tom7aqZ",
-          "catalogueNumber" : "XKqlfZOkLA2nSA8mqQm",
+          "mediaType" : "Vinyl",
+          "publisher" : "ZyhMqH6CeQ22yoUybm",
+          "catalogueNumber" : "gAZWW6yTm3aNiP",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "y57Fa2XKyhK8bB",
-            "composer" : "2OE086G8m9KcdPjihA",
-            "extent" : "MGU2NAtZ2Pkw"
+            "title" : "9sP2TLkspjWGdpKY",
+            "composer" : "fN4zA4QqEAzWnRZrEp",
+            "extent" : "Wv53f0rYpCznu"
           } ]
         }, {
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "UXbGVa5bAR",
-            "country" : "rmKO7iybxVxsi8W"
+            "label" : "cU97imXKJfi9oUR0d",
+            "country" : "xYfYX0GxyKgilw"
           },
           "time" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "extent" : "GTCruMpx8UnI",
-          "description" : "EhqtFAKBOS",
+          "extent" : "RpqJGo9I0V4",
+          "description" : "yrG7xfE0TMYGW6",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "kKqlk8eN7h",
-            "composer" : "v3W7ZFmhEbdeT3CU",
-            "premiere" : false
+            "title" : "SsZWIQrtbhVkwb",
+            "composer" : "bLm1DlurfgsGVfYXf",
+            "premiere" : true
           } ],
           "partOfSeries" : true
         }, {
           "type" : "MusicScore",
-          "ensemble" : "HrDERSPe3nOq",
-          "movements" : "XVjpLdNBa1",
-          "extent" : "VCgfHTEAInakXDpM9L",
+          "ensemble" : "z6v4jWhsqKlNsR",
+          "movements" : "qvcXFxVCc2Fu",
+          "extent" : "ymxnPT0i2HlWA",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "P8FGWx61kyOvpqK"
+            "name" : "21OxC3v00t"
           },
           "ismn" : {
             "type" : "Ismn",
@@ -135,17 +135,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "pVAJsbhsMyoh",
+          "performanceType" : "NcVsiMPDf0my",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "CnCQwEX8UvU",
-            "country" : "91iYmsy3gBLQuK"
+            "label" : "xp5HMezaJ9MWz",
+            "country" : "l4DScsPgtDu0"
           },
-          "extent" : "FYCkiq3s5C3SAGg",
+          "extent" : "nM5JzXYSKvZE096dMjm",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "MKY1FVMLBONCsGczLB",
-            "composer" : "moRLAkL48w5YvlBeYzF"
+            "title" : "RrrByypIb1",
+            "composer" : "6VFQKxlXRYBAA0uM"
           } ]
         } ],
         "peerReviewed" : false,
@@ -154,45 +154,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Hu0fMTze5KIWhVwIJ",
-    "abstract" : "TnX8ozeh2THaHpRRiwW"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "EAcZ21r89yfm",
-      "mimeType" : "kr4PoP45VZk",
-      "size" : 1223929910,
-      "license" : {
-        "type" : "License",
-        "identifier" : "bDLwGT283RZcXo",
-        "labels" : {
-          "pA2k83TanbafgjX" : "bS3Pnhzvt8gHhC8mph5"
-        },
-        "link" : "https://www.example.com/DjKGLvk1oJuBrplJ"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/KKE7YLJi1TnB0IY",
+    "abstract" : "JysnSlETHpdVptFoO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/maioresaperiam",
-    "name" : "NJDJKvzWvBV1u0z7",
+    "id" : "https://www.example.org/autdolorem",
+    "name" : "pB9YdyedJ2vNXhb",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "QDmkIpl9jiCzW29u",
-      "id" : "jV4sOnFsFayj"
+      "source" : "Hw9b6dbjdJjoFFSi",
+      "id" : "te7x19ERVOGsPI6"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "5kmrPhg8TwR8Z"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "xSO1Pq7yVT"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -200,25 +179,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatesnatus" ],
+  "subjects" : [ "https://www.example.org/animisunt" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "EAcZ21r89yfm",
-    "mimeType" : "kr4PoP45VZk",
-    "size" : 1223929910,
+    "name" : "WwrLGBxhcCUC6IFsr",
+    "mimeType" : "J5hGOEtgDrY7B",
+    "size" : 960842297,
     "license" : {
       "type" : "License",
-      "identifier" : "bDLwGT283RZcXo",
+      "identifier" : "DkY5cd0d2k1iGLgff",
       "labels" : {
-        "pA2k83TanbafgjX" : "bS3Pnhzvt8gHhC8mph5"
+        "2nSOsQPmJDLc" : "SjDE9Reqaz"
       },
-      "link" : "https://www.example.com/DjKGLvk1oJuBrplJ"
+      "link" : "https://www.example.com/nhe26P1UECLCi7"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "d2QO72Movp"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "WwrLGBxhcCUC6IFsr",
+      "mimeType" : "J5hGOEtgDrY7B",
+      "size" : 960842297,
+      "license" : {
+        "type" : "License",
+        "identifier" : "DkY5cd0d2k1iGLgff",
+        "labels" : {
+          "2nSOsQPmJDLc" : "SjDE9Reqaz"
+        },
+        "link" : "https://www.example.com/nhe26P1UECLCi7"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "BYJuhBnB0Ij",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,89 +1,89 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "qSs6r9AcCGNxH",
-    "ownerAffiliation" : "https://www.example.org/suntpariatur"
+    "owner" : "Ez7PxUSYtMPaF0qGX4z",
+    "ownerAffiliation" : "https://www.example.org/corporisenim"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eligendidoloribus",
+    "id" : "https://www.example.org/voluptatemdeserunt",
     "labels" : {
-      "4X7LJFPDlvtuNFUNei" : "85TQpH7awliam5Xo5vL"
+      "8YyNAfOpivAN5OsQ" : "W1t88PTSDSf2ybhOdn"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/abconsectetur",
-  "doi" : "https://doi.org/10.1234/esse",
-  "link" : "https://www.example.org/atquevero",
+  "handle" : "https://www.example.org/laboriosamquisquam",
+  "doi" : "https://doi.org/10.1234/error",
+  "link" : "https://www.example.org/molestiaserror",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "gLnqar9CLfVwXA",
+    "mainTitle" : "LiaPJLKILq",
     "alternativeTitles" : {
-      "da" : "qpZBKwp2gWq"
+      "ru" : "nAdXQlSP62Qa"
     },
-    "language" : "http://lexvo.org/id/iso639-3/rus",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "MRfTGe8ZZ7i",
-      "month" : "NlWwMBRtLDP9OuM7n",
-      "day" : "OMYoto8EehQvR"
+      "year" : "H3FuKk4b2Rk",
+      "month" : "uN4vJSS3R057X6D30b",
+      "day" : "IencoG6hWaom"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZLYtqeQdIEBbo",
-        "name" : "wZApc8azuX4dn",
+        "id" : "https://www.example.com/aoUxnTvHllwRgs",
+        "name" : "kUifoL9M0nSaJTBgy",
         "nameType" : "Organizational",
-        "orcId" : "5mt95ntOYiGImaEA"
+        "orcId" : "w1wbYXGVWuxQPQst"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QU2P8SSQHVWJ0",
+        "id" : "https://www.example.com/L3PciLgHPjyVwikZ",
         "labels" : {
-          "RUAvXsO3d43ogI" : "MQO6TOonzZqa"
+          "CWQi13khJ84PUWf" : "eJFgeWHUUpAj7JKJp"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 8,
+      "role" : "WorkPackageLeader",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Y2XS65JrDc",
-        "name" : "8NyjVoz85BpqmhU",
-        "nameType" : "Personal",
-        "orcId" : "RERVA6aLARmq"
+        "id" : "https://www.example.com/JlNihnZzwY4QS5C5Ds",
+        "name" : "0Se8EzRNZar0ao",
+        "nameType" : "Organizational",
+        "orcId" : "Z1NRkfKhiin4eE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3eoapj6vBf0QHl5dsj",
+        "id" : "https://www.example.com/BkKrCs3hMX",
         "labels" : {
-          "6WwPFXKQfUhK" : "nwfBESprREcchp4QC"
+          "ygCXlPdT5a68dM1" : "EJf28al7LK"
         }
       } ],
-      "role" : "InterviewSubject",
+      "role" : "Scenographer",
       "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "gGQBk5R41LL4Vkgpa",
-    "tags" : [ "G7yFtgM4ViU3GfEpT" ],
-    "description" : "KuXd2knLvg",
+    "npiSubjectHeading" : "yaCu0Vd907m",
+    "tags" : [ "NCmE9oCwENB" ],
+    "description" : "Bzx5iRfpQ1l8xo5RHy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "RuMS1xJxmIrm",
+        "label" : "LdHl76G0bHR29",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "SF6KEZMtOW11mO",
-          "country" : "nHQCil0zCiJ"
+          "label" : "cMm0mtqAExNH6gC",
+          "country" : "GnMHx7Gl7Y4IPPcMe"
         },
         "time" : {
           "type" : "Period",
@@ -92,14 +92,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/OgtDA9K4e8Bi2e5q",
+          "id" : "https://www.example.com/tBjXolY3V6",
           "labels" : {
-            "wGksr7VeYH" : "OQ7o8TI7nYdX"
+            "v6YFm1xsip8SgbQdV" : "pJqTFZCAVVCObXLwuZ5"
           }
         },
-        "product" : "https://www.example.com/jx6eF7WKEjzViXhal1"
+        "product" : "https://www.example.com/RxliSOJja05Vht7qplb"
       },
-      "doi" : "https://www.example.com/qIYt3Fl1CipOz",
+      "doi" : "https://www.example.com/qGeaRsz3zJNAPfWagxn",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Op5tXaUdcNWDc",
-    "abstract" : "I1zxNXLT2657q"
+    "metadataSource" : "https://www.example.com/UT9sCTLhDQvPylS",
+    "abstract" : "7QTeEFeeeoFVF3L91rx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/remest",
-    "name" : "rD0a5q7P4s",
+    "id" : "https://www.example.org/eoseveniet",
+    "name" : "AvHOCx1SU5TfgHHMI0",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "e6k1ljEerq8TSb4ZPY",
-      "id" : "TJajv9xACb3QnPIeU1"
+      "source" : "rpHrksbSWqYTLEG9LI",
+      "id" : "XGKxbPLCZwu"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "zXhaEFvwHbzMM1H"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ypiIDwgHtB"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/velitsit" ],
+  "subjects" : [ "https://www.example.org/ametminima" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Yc2Kv6Q4I5",
-      "mimeType" : "15ptStbsO6d",
-      "size" : 724258917,
+      "name" : "m2eZ5vITBUyT",
+      "mimeType" : "r2LilQ21jM3b",
+      "size" : 1497651490,
       "license" : {
         "type" : "License",
-        "identifier" : "Qh528tdB5EM8",
+        "identifier" : "TrNHp5YtiY1ikXQ",
         "labels" : {
-          "gq1QRgv4JRFx6ByHv" : "wSR9dv46yOKSoSHBoq0"
+          "JNlncGN7PNn" : "lCUxpiYvZt"
         },
-        "link" : "https://www.example.com/Mkz0799PeYJ3iiItShL"
+        "link" : "https://www.example.com/yJMEfFqeImH9ntq"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "Yc2Kv6Q4I5",
-    "mimeType" : "15ptStbsO6d",
-    "size" : 724258917,
+    "name" : "m2eZ5vITBUyT",
+    "mimeType" : "r2LilQ21jM3b",
+    "size" : 1497651490,
     "license" : {
       "type" : "License",
-      "identifier" : "Qh528tdB5EM8",
+      "identifier" : "TrNHp5YtiY1ikXQ",
       "labels" : {
-        "gq1QRgv4JRFx6ByHv" : "wSR9dv46yOKSoSHBoq0"
+        "JNlncGN7PNn" : "lCUxpiYvZt"
       },
-      "link" : "https://www.example.com/Mkz0799PeYJ3iiItShL"
+      "link" : "https://www.example.com/yJMEfFqeImH9ntq"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "qSs6r9AcCGNxH",
+  "owner" : "Ez7PxUSYtMPaF0qGX4z",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,102 +3,103 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "4N5SxpALaJe7",
-    "ownerAffiliation" : "https://www.example.org/idofficia"
+    "owner" : "qSs6r9AcCGNxH",
+    "ownerAffiliation" : "https://www.example.org/suntpariatur"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/consequunturexpedita",
+    "id" : "https://www.example.org/eligendidoloribus",
     "labels" : {
-      "1b8iQIkt3i27J9" : "xWIkUXOpbvlPeAf50ci"
+      "4X7LJFPDlvtuNFUNei" : "85TQpH7awliam5Xo5vL"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quissoluta",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/etexplicabo",
+  "handle" : "https://www.example.org/abconsectetur",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/atquevero",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YViab2fjUjv3iLHRX",
+    "mainTitle" : "gLnqar9CLfVwXA",
     "alternativeTitles" : {
-      "da" : "KwyeVSIOCkT9QeM"
+      "da" : "qpZBKwp2gWq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/rus",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "R48jbXevaX",
-      "month" : "4cL48mJm3KS",
-      "day" : "T08tvlIO6SOJ"
+      "year" : "MRfTGe8ZZ7i",
+      "month" : "NlWwMBRtLDP9OuM7n",
+      "day" : "OMYoto8EehQvR"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/b7H00zfti1u4rm",
-        "name" : "ZJ8yuqT4HBxqJS",
+        "id" : "https://www.example.com/ZLYtqeQdIEBbo",
+        "name" : "wZApc8azuX4dn",
         "nameType" : "Organizational",
-        "orcId" : "2Z5aucfjYzvbGef"
+        "orcId" : "5mt95ntOYiGImaEA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Bf9LaXHU7lI",
+        "id" : "https://www.example.com/QU2P8SSQHVWJ0",
         "labels" : {
-          "m2rjUl5VcJwV" : "QI2hXRm01NZXzD"
+          "RUAvXsO3d43ogI" : "MQO6TOonzZqa"
         }
       } ],
-      "role" : "SoundDesigner",
+      "role" : "Editor",
       "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/DaRiwkkViyMXhGf",
-        "name" : "sYf152qpgMWfuiKXS",
-        "nameType" : "Organizational",
-        "orcId" : "hLCLO3LINbiUgZu6MG"
+        "id" : "https://www.example.com/Y2XS65JrDc",
+        "name" : "8NyjVoz85BpqmhU",
+        "nameType" : "Personal",
+        "orcId" : "RERVA6aLARmq"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bDrIpRyCGYmexIGPQ",
+        "id" : "https://www.example.com/3eoapj6vBf0QHl5dsj",
         "labels" : {
-          "E7MvJktnbz3Dfc0T" : "d3lITAy4f8ob1C5"
+          "6WwPFXKQfUhK" : "nwfBESprREcchp4QC"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 7,
+      "role" : "InterviewSubject",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "aXmshZrPab",
-    "tags" : [ "FzRAhOd3HzxtkOB" ],
-    "description" : "OAOtJEMIommb2t",
+    "npiSubjectHeading" : "gGQBk5R41LL4Vkgpa",
+    "tags" : [ "G7yFtgM4ViU3GfEpT" ],
+    "description" : "KuXd2knLvg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "RvJWKNvD0PrT0EBxNK",
+        "label" : "RuMS1xJxmIrm",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "MlkJrdnhrRyCQ5",
-          "country" : "vncAXtnhVakm"
+          "label" : "SF6KEZMtOW11mO",
+          "country" : "nHQCil0zCiJ"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Period",
+          "from" : "2020-09-23T09:51:23.044996Z",
+          "to" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/raXn1L8GuHqxQj7fI",
+          "id" : "https://www.example.com/OgtDA9K4e8Bi2e5q",
           "labels" : {
-            "Xt4uZe2N5Tz" : "vuOciJcLBtl3Z8w1"
+            "wGksr7VeYH" : "OQ7o8TI7nYdX"
           }
         },
-        "product" : "https://www.example.com/ySXCMU2EGJgxdqnIi"
+        "product" : "https://www.example.com/jx6eF7WKEjzViXhal1"
       },
-      "doi" : "https://www.example.com/iZwNm9meqHuGdohpiaB",
+      "doi" : "https://www.example.com/qIYt3Fl1CipOz",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -107,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/qzLOzI9d84sJBrR1o6l",
-    "abstract" : "fsaEMYsxuDhqasI"
+    "metadataSource" : "https://www.example.com/Op5tXaUdcNWDc",
+    "abstract" : "I1zxNXLT2657q"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/consequaturqui",
-    "name" : "8m8ljDpR4lsox",
+    "id" : "https://www.example.org/remest",
+    "name" : "rD0a5q7P4s",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2aVdkgMRNt",
-      "id" : "Jdwdeci1HJ"
+      "source" : "e6k1ljEerq8TSb4ZPY",
+      "id" : "TJajv9xACb3QnPIeU1"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "HTTalgBSxoZZXYQ"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "zXhaEFvwHbzMM1H"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloreest" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "zd1FOGTEKb",
-    "mimeType" : "Mn8evXrZ9dIsIkO",
-    "size" : 787563805,
-    "license" : {
-      "type" : "License",
-      "identifier" : "DfiKm9YA79I",
-      "labels" : {
-        "r1n0l8sXDBwLgQqtqJ1" : "vVTxG6YX1lp"
-      },
-      "link" : "https://www.example.com/WoShnTPXtRh"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/velitsit" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "zd1FOGTEKb",
-      "mimeType" : "Mn8evXrZ9dIsIkO",
-      "size" : 787563805,
+      "name" : "Yc2Kv6Q4I5",
+      "mimeType" : "15ptStbsO6d",
+      "size" : 724258917,
       "license" : {
         "type" : "License",
-        "identifier" : "DfiKm9YA79I",
+        "identifier" : "Qh528tdB5EM8",
         "labels" : {
-          "r1n0l8sXDBwLgQqtqJ1" : "vVTxG6YX1lp"
+          "gq1QRgv4JRFx6ByHv" : "wSR9dv46yOKSoSHBoq0"
         },
-        "link" : "https://www.example.com/WoShnTPXtRh"
+        "link" : "https://www.example.com/Mkz0799PeYJ3iiItShL"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "4N5SxpALaJe7",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "Yc2Kv6Q4I5",
+    "mimeType" : "15ptStbsO6d",
+    "size" : 724258917,
+    "license" : {
+      "type" : "License",
+      "identifier" : "Qh528tdB5EM8",
+      "labels" : {
+        "gq1QRgv4JRFx6ByHv" : "wSR9dv46yOKSoSHBoq0"
+      },
+      "link" : "https://www.example.com/Mkz0799PeYJ3iiItShL"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "qSs6r9AcCGNxH",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,87 +3,87 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "n7xn54BzwtF",
-    "ownerAffiliation" : "https://www.example.org/abfacilis"
+    "owner" : "4N5SxpALaJe7",
+    "ownerAffiliation" : "https://www.example.org/idofficia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/suntid",
+    "id" : "https://www.example.org/consequunturexpedita",
     "labels" : {
-      "AAS6y8S5cUOHrr" : "PJrdsOFAvc6uofy9SEg"
+      "1b8iQIkt3i27J9" : "xWIkUXOpbvlPeAf50ci"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/reprehenderitquo",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/sitlibero",
+  "handle" : "https://www.example.org/quissoluta",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/etexplicabo",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SCtuGtj42GQjNfhd",
+    "mainTitle" : "YViab2fjUjv3iLHRX",
     "alternativeTitles" : {
-      "pt" : "1iUyJIcV3nm"
+      "da" : "KwyeVSIOCkT9QeM"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "P6J5FajHhMIqQ34e",
-      "month" : "50BYYPnjxZW",
-      "day" : "YOTuRQoApwBky4YtvE"
+      "year" : "R48jbXevaX",
+      "month" : "4cL48mJm3KS",
+      "day" : "T08tvlIO6SOJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aFK6Y8xnCCzVL",
-        "name" : "xmraNByOrHyk0",
+        "id" : "https://www.example.com/b7H00zfti1u4rm",
+        "name" : "ZJ8yuqT4HBxqJS",
         "nameType" : "Organizational",
-        "orcId" : "xOWD8FJjzvm2QvvNDX"
+        "orcId" : "2Z5aucfjYzvbGef"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lUE8SrcQgqX3cTUA",
+        "id" : "https://www.example.com/Bf9LaXHU7lI",
         "labels" : {
-          "utagEntSJpNEAOerIG" : "RI9cKhinBDno"
+          "m2rjUl5VcJwV" : "QI2hXRm01NZXzD"
         }
       } ],
-      "role" : "Dramaturge",
-      "sequence" : 6,
+      "role" : "SoundDesigner",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/OiyGAv2tj2jIZXuSX88",
-        "name" : "yTkp6HMYAwastla",
+        "id" : "https://www.example.com/DaRiwkkViyMXhGf",
+        "name" : "sYf152qpgMWfuiKXS",
         "nameType" : "Organizational",
-        "orcId" : "nIpqwqrjY6FsIs39"
+        "orcId" : "hLCLO3LINbiUgZu6MG"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OdNpnijh6RpAI21",
+        "id" : "https://www.example.com/bDrIpRyCGYmexIGPQ",
         "labels" : {
-          "YBzkLXI0U7SV0mz" : "EiGbiRpKkP"
+          "E7MvJktnbz3Dfc0T" : "d3lITAy4f8ob1C5"
         }
       } ],
-      "role" : "Librettist",
-      "sequence" : 4,
+      "role" : "Advisor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "rbtW0Rj8Lt",
-    "tags" : [ "j23atWjNaJINpa5JJev" ],
-    "description" : "sUjvKaOKudnIK",
+    "npiSubjectHeading" : "aXmshZrPab",
+    "tags" : [ "FzRAhOd3HzxtkOB" ],
+    "description" : "OAOtJEMIommb2t",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "TA0FZA1lRAz8LwRF9m1",
+        "label" : "RvJWKNvD0PrT0EBxNK",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "ebyD3KHiVa88oPjuF",
-          "country" : "pIGmkhrPNkTHUV"
+          "label" : "MlkJrdnhrRyCQ5",
+          "country" : "vncAXtnhVakm"
         },
         "time" : {
           "type" : "Instant",
@@ -91,14 +91,14 @@
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/G3hIzd6Pvml0fbhorsD",
+          "id" : "https://www.example.com/raXn1L8GuHqxQj7fI",
           "labels" : {
-            "vi7l1uGELw9" : "prelnxbNG2It"
+            "Xt4uZe2N5Tz" : "vuOciJcLBtl3Z8w1"
           }
         },
-        "product" : "https://www.example.com/T61jxZIpQY"
+        "product" : "https://www.example.com/ySXCMU2EGJgxdqnIi"
       },
-      "doi" : "https://www.example.com/ZKYPYnq4EHUAmA",
+      "doi" : "https://www.example.com/iZwNm9meqHuGdohpiaB",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -107,45 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/7N9Tc7ABmkDPP6",
-    "abstract" : "ULZVC2jmK4V"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "RB6NNo2jTkM",
-      "mimeType" : "jsi3bKZ8bH83pCmCc",
-      "size" : 900502178,
-      "license" : {
-        "type" : "License",
-        "identifier" : "LDXPatZV74TMhEpz",
-        "labels" : {
-          "Ogk7btLkOpEK2nC" : "AHRDcaLkaUbTx"
-        },
-        "link" : "https://www.example.com/IYl3sDwzLPdUSWhlbfU"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/qzLOzI9d84sJBrR1o6l",
+    "abstract" : "fsaEMYsxuDhqasI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptateseveniet",
-    "name" : "ZOTvcCKLd3OJ",
+    "id" : "https://www.example.org/consequaturqui",
+    "name" : "8m8ljDpR4lsox",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "8rUcGOZ3BrOtS",
-      "id" : "VisCwZyfRV9g"
+      "source" : "2aVdkgMRNt",
+      "id" : "Jdwdeci1HJ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "J5H6KAdB8dcFx7cKCK"
+      "applicationCode" : "HTTalgBSxoZZXYQ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fugamaiores" ],
+  "subjects" : [ "https://www.example.org/doloreest" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "RB6NNo2jTkM",
-    "mimeType" : "jsi3bKZ8bH83pCmCc",
-    "size" : 900502178,
+    "name" : "zd1FOGTEKb",
+    "mimeType" : "Mn8evXrZ9dIsIkO",
+    "size" : 787563805,
     "license" : {
       "type" : "License",
-      "identifier" : "LDXPatZV74TMhEpz",
+      "identifier" : "DfiKm9YA79I",
       "labels" : {
-        "Ogk7btLkOpEK2nC" : "AHRDcaLkaUbTx"
+        "r1n0l8sXDBwLgQqtqJ1" : "vVTxG6YX1lp"
       },
-      "link" : "https://www.example.com/IYl3sDwzLPdUSWhlbfU"
+      "link" : "https://www.example.com/WoShnTPXtRh"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "n7xn54BzwtF"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "zd1FOGTEKb",
+      "mimeType" : "Mn8evXrZ9dIsIkO",
+      "size" : 787563805,
+      "license" : {
+        "type" : "License",
+        "identifier" : "DfiKm9YA79I",
+        "labels" : {
+          "r1n0l8sXDBwLgQqtqJ1" : "vVTxG6YX1lp"
+        },
+        "link" : "https://www.example.com/WoShnTPXtRh"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "4N5SxpALaJe7",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,103 +3,102 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Ez7PxUSYtMPaF0qGX4z",
-    "ownerAffiliation" : "https://www.example.org/corporisenim"
+    "owner" : "pC2aIhsyIE0JI72",
+    "ownerAffiliation" : "https://www.example.org/doloremvitae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatemdeserunt",
+    "id" : "https://www.example.org/doloredolor",
     "labels" : {
-      "8YyNAfOpivAN5OsQ" : "W1t88PTSDSf2ybhOdn"
+      "jxCaxRmo9GRlL3Ns5LQ" : "RRMpo6co1va6I5Q6Jx"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/laboriosamquisquam",
-  "doi" : "https://doi.org/10.1234/error",
-  "link" : "https://www.example.org/molestiaserror",
+  "handle" : "https://www.example.org/omnisaliquam",
+  "doi" : "https://doi.org/10.1234/blanditiis",
+  "link" : "https://www.example.org/voluptatemrecusandae",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LiaPJLKILq",
+    "mainTitle" : "ixbHDC8s6ei",
     "alternativeTitles" : {
-      "ru" : "nAdXQlSP62Qa"
+      "de" : "uX9UkBvoE2wzoOE"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "H3FuKk4b2Rk",
-      "month" : "uN4vJSS3R057X6D30b",
-      "day" : "IencoG6hWaom"
+      "year" : "SdHbjcTBad2lFtAxs5w",
+      "month" : "X0ZdR2z5Ke7H7zQs6",
+      "day" : "dX6BWepg8ZRno9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aoUxnTvHllwRgs",
-        "name" : "kUifoL9M0nSaJTBgy",
+        "id" : "https://www.example.com/fiG7NEUH4gQ",
+        "name" : "CWQAWg4HXq",
         "nameType" : "Organizational",
-        "orcId" : "w1wbYXGVWuxQPQst"
+        "orcId" : "kFu73TMJdCqz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/L3PciLgHPjyVwikZ",
+        "id" : "https://www.example.com/Nbhuyo9QUL2",
         "labels" : {
-          "CWQi13khJ84PUWf" : "eJFgeWHUUpAj7JKJp"
+          "dkIpkz8d88l" : "sdvIM8akH6xf101EW"
         }
       } ],
-      "role" : "WorkPackageLeader",
-      "sequence" : 5,
+      "role" : "InterviewSubject",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/JlNihnZzwY4QS5C5Ds",
-        "name" : "0Se8EzRNZar0ao",
+        "id" : "https://www.example.com/PCsSNajlhFZ4SY",
+        "name" : "qQwj3ycSu3CMb2aB1xW",
         "nameType" : "Organizational",
-        "orcId" : "Z1NRkfKhiin4eE"
+        "orcId" : "VagJ7lVGRh"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/BkKrCs3hMX",
+        "id" : "https://www.example.com/c3EbsRHrqn",
         "labels" : {
-          "ygCXlPdT5a68dM1" : "EJf28al7LK"
+          "zAjz8jXmkbNo9mN" : "jSAGJnDqa1gd1U9wY"
         }
       } ],
-      "role" : "Scenographer",
-      "sequence" : 0,
+      "role" : "InterviewSubject",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "yaCu0Vd907m",
-    "tags" : [ "NCmE9oCwENB" ],
-    "description" : "Bzx5iRfpQ1l8xo5RHy",
+    "npiSubjectHeading" : "P2sKqUOHmn",
+    "tags" : [ "kBPeAvBHoRwKfrhZr2" ],
+    "description" : "Le3mIKwMlWtK7P",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "LdHl76G0bHR29",
+        "label" : "FDnV14Spqu23H7dT",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "cMm0mtqAExNH6gC",
-          "country" : "GnMHx7Gl7Y4IPPcMe"
+          "label" : "ujp0faRe75ie",
+          "country" : "QufwFXoYFYOa2"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2020-09-23T09:51:23.044996Z",
-          "to" : "2020-09-23T09:51:23.044996Z"
+          "type" : "Instant",
+          "value" : "2020-09-23T09:51:23.044996Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/tBjXolY3V6",
+          "id" : "https://www.example.com/MGq5DI4t2Qa",
           "labels" : {
-            "v6YFm1xsip8SgbQdV" : "pJqTFZCAVVCObXLwuZ5"
+            "IVPAm37qQG7RDk" : "4jO7ZwQIfS"
           }
         },
-        "product" : "https://www.example.com/RxliSOJja05Vht7qplb"
+        "product" : "https://www.example.com/QQEaPgA3ssWkW"
       },
-      "doi" : "https://www.example.com/qGeaRsz3zJNAPfWagxn",
+      "doi" : "https://www.example.com/8HYJbLhWAwyY5CYcy",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "peerReviewed" : false,
@@ -108,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/UT9sCTLhDQvPylS",
-    "abstract" : "7QTeEFeeeoFVF3L91rx"
+    "metadataSource" : "https://www.example.com/3Jbgjh8st8BwuoE9",
+    "abstract" : "vkXxQSJz6HK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eoseveniet",
-    "name" : "AvHOCx1SU5TfgHHMI0",
+    "id" : "https://www.example.org/hicet",
+    "name" : "Jncx9zMDmMeTExJ0F",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "rpHrksbSWqYTLEG9LI",
-      "id" : "XGKxbPLCZwu"
+      "source" : "YIBuftXrKwLl",
+      "id" : "BoRTA8UXNUC"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ypiIDwgHtB"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "QA7MObGW4TGc"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,22 +132,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ametminima" ],
+  "subjects" : [ "https://www.example.org/doloremqueest" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "m2eZ5vITBUyT",
-      "mimeType" : "r2LilQ21jM3b",
-      "size" : 1497651490,
+      "name" : "4O23pV42II",
+      "mimeType" : "5j0HAFpqugdP",
+      "size" : 1122365748,
       "license" : {
         "type" : "License",
-        "identifier" : "TrNHp5YtiY1ikXQ",
+        "identifier" : "ISD9k1giDa",
         "labels" : {
-          "JNlncGN7PNn" : "lCUxpiYvZt"
+          "yR66cZ9XrcTBNsJfbp" : "seqURF8OTBXZ0"
         },
-        "link" : "https://www.example.com/yJMEfFqeImH9ntq"
+        "link" : "https://www.example.com/hSfkmvSnhfcu"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -158,21 +157,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "m2eZ5vITBUyT",
-    "mimeType" : "r2LilQ21jM3b",
-    "size" : 1497651490,
+    "name" : "4O23pV42II",
+    "mimeType" : "5j0HAFpqugdP",
+    "size" : 1122365748,
     "license" : {
       "type" : "License",
-      "identifier" : "TrNHp5YtiY1ikXQ",
+      "identifier" : "ISD9k1giDa",
       "labels" : {
-        "JNlncGN7PNn" : "lCUxpiYvZt"
+        "yR66cZ9XrcTBNsJfbp" : "seqURF8OTBXZ0"
       },
-      "link" : "https://www.example.com/yJMEfFqeImH9ntq"
+      "link" : "https://www.example.com/hSfkmvSnhfcu"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "Ez7PxUSYtMPaF0qGX4z",
+  "owner" : "pC2aIhsyIE0JI72",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,156 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "XveA4cUQ94i",
-    "ownerAffiliation" : "https://www.example.org/rerumaut"
+    "owner" : "5NbqIedFvr78DF0Q",
+    "ownerAffiliation" : "https://www.example.org/utsunt"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/hicvoluptatem",
+    "id" : "https://www.example.org/namvero",
     "labels" : {
-      "0fJqYRDqboRJY7" : "kiZ4R9d8EzGUSln4K"
+      "8lTwz5YTCoYxSSyPb" : "q3S3XLncLh"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/undeipsa",
-  "doi" : "https://doi.org/10.1234/nobis",
-  "link" : "https://www.example.org/inventoreest",
+  "handle" : "https://www.example.org/providentdeleniti",
+  "doi" : "https://doi.org/10.1234/molestiae",
+  "link" : "https://www.example.org/dolorumut",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FG3m3IRrtP",
+    "mainTitle" : "oAdXOWxpNBaGSodix",
     "alternativeTitles" : {
-      "nn" : "z1rZFeIy8i7uv"
+      "bg" : "wnxkYq5TI4EeV1b"
     },
     "language" : "http://lexvo.org/id/iso639-3/nob",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "N7XeIbsg389XCHQ6NmF",
-      "month" : "C69jSEmP04sxCo4",
-      "day" : "NwVlFTCddXoE"
+      "year" : "CLuim1TNCY",
+      "month" : "F4CGjiNdnxZOpp5uAW",
+      "day" : "UO2x4Xv0RqYRC99zB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/JE7SsodoCuN7CV",
-        "name" : "TUt5rOVHlwQ",
+        "id" : "https://www.example.com/IiX0aJbdae9A0S7",
+        "name" : "9NP0rOBaWOE1GkZ",
         "nameType" : "Personal",
-        "orcId" : "yIaUZjYnhBCuQOgB"
+        "orcId" : "bqvbfz7JkMq58uJVF"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/9bk1jsVHfO8",
+        "id" : "https://www.example.com/2JFYlUcWwnQG",
         "labels" : {
-          "2wlAKSLjUCuTkRz" : "DqfVbJ9h35rrkOt"
+          "jNEyJtLoKwcFwBEc7" : "NI7NxKIWhQU"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 7,
+      "role" : "DataManager",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/KmjYvgSZTU",
-        "name" : "iWP66A7869384",
-        "nameType" : "Personal",
-        "orcId" : "4kdroSj5mGNNT"
+        "id" : "https://www.example.com/Gsdi8l0NL2",
+        "name" : "3Q538NIfS75",
+        "nameType" : "Organizational",
+        "orcId" : "5y9Arfy3Bs"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yuc5UDTArZmU",
+        "id" : "https://www.example.com/MEFa3uP9TR",
         "labels" : {
-          "W8OH9f0e9QFWf8cA7" : "gj3joT5OLpAmUHdqwdW"
+          "KvUFIVq0PQz82G" : "U5mYPsAejrc8TeUo"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 9,
+      "role" : "ProductionDesigner",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "V75GuiEweMTk",
-    "tags" : [ "WdNipEo8bgmXsTxS" ],
-    "description" : "WlsVJSZ0f1XqtdkkUg",
+    "npiSubjectHeading" : "eo0KIVjUjfW7zqPm",
+    "tags" : [ "sYiTahy6Zhga" ],
+    "description" : "7W10fgbwzs6jdU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bxWp7b6BTRpkwSr0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/O0MxdGCBJHJE8qc"
         },
-        "seriesNumber" : "EyywLne6pvpVYtpcs",
+        "seriesNumber" : "ZyiLASwkO1xd8lOU7",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yL5DYsYYOCR9ETERwI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PHDkRKtC2F"
         },
-        "isbnList" : [ "9781052090324" ]
+        "isbnList" : [ "9780873681346" ]
       },
-      "doi" : "https://www.example.com/66AbBHSztFLqmC5",
+      "doi" : "https://www.example.com/Svyo8D4SFsRta",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "is6s7zUVMUp",
-          "month" : "3flk5lCmdU",
-          "day" : "E4XH4DRzi5Xu"
+          "year" : "VWrUJ3qUfl4L6jtzcw",
+          "month" : "J3NKVvDgwbq7Np15",
+          "day" : "M5rMUcKcM4EEZu0sHa4"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "atb8n5hMU7s",
-            "end" : "pN7jQ22ld7Ze2DcJM"
+            "begin" : "hPDL0HgVvD0DnF",
+            "end" : "PdYviXSTT1hOgLozEcA"
           },
-          "pages" : "kaCC7lqg1UlJ4wYPL",
-          "illustrated" : false
+          "pages" : "0I1yQ0I4b0j7q",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/uHtkupbeRuDd",
-    "abstract" : "DoLs24vbimdrF1ZL7DI"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "0fGUlPQWdaRgCao7",
-      "mimeType" : "s4zSFI8jdyqdq9K",
-      "size" : 22987523,
-      "license" : {
-        "type" : "License",
-        "identifier" : "Ry3khngVJiU",
-        "labels" : {
-          "SUDmuYOepfhO3BT" : "Q6WK4TECGR4ffTTJZQ"
-        },
-        "link" : "https://www.example.com/TSm96fUQTjZt57"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/F6wQfrjuLhfnM5x",
+    "abstract" : "mIuo2ICz2iJtUQHf"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/maximeincidunt",
-    "name" : "KUfJY2yilP3dh7sw",
+    "id" : "https://www.example.org/fugavelit",
+    "name" : "eFDY0RpxFuLG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "pRGZO9Dpcok7",
-      "id" : "cqpQmTj1uT3fDC"
+      "source" : "z0JtnpXpi0I9rfe6yHm",
+      "id" : "bSnTCt9qbB4HY81STM5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "llUEZmftXSbxEyz9k"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "m9bWrAS4tug6JONzSYT"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -158,25 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/enimsoluta" ],
+  "subjects" : [ "https://www.example.org/quasiaut" ],
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "0fGUlPQWdaRgCao7",
-    "mimeType" : "s4zSFI8jdyqdq9K",
-    "size" : 22987523,
+    "name" : "UhxKV0QcDo7M2",
+    "mimeType" : "lrP0Ejaa6G",
+    "size" : 1893763792,
     "license" : {
       "type" : "License",
-      "identifier" : "Ry3khngVJiU",
+      "identifier" : "so1nsMPZgq6BEp9Mh",
       "labels" : {
-        "SUDmuYOepfhO3BT" : "Q6WK4TECGR4ffTTJZQ"
+        "1XaVYwsWgUzfwMg3Hdr" : "c2Hg9YUK4qDyMaz"
       },
-      "link" : "https://www.example.com/TSm96fUQTjZt57"
+      "link" : "https://www.example.com/f5g1aKBxlZzHakKjap"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "XveA4cUQ94i"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "UhxKV0QcDo7M2",
+      "mimeType" : "lrP0Ejaa6G",
+      "size" : 1893763792,
+      "license" : {
+        "type" : "License",
+        "identifier" : "so1nsMPZgq6BEp9Mh",
+        "labels" : {
+          "1XaVYwsWgUzfwMg3Hdr" : "c2Hg9YUK4qDyMaz"
+        },
+        "link" : "https://www.example.com/f5g1aKBxlZzHakKjap"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "5NbqIedFvr78DF0Q",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "YhfnCQwCkqilLeKgE",
-    "ownerAffiliation" : "https://www.example.org/consequaturaperiam"
+    "owner" : "VGhndWEZGschnGc1gYi",
+    "ownerAffiliation" : "https://www.example.org/etodio"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etsed",
+    "id" : "https://www.example.org/explicaboeaque",
     "labels" : {
-      "IBeuqpy8uYb" : "0uzedCoxjER4qxdKt2"
+      "m1UqngLgVO6x7Zk0UW" : "LAewrvcKbhBADnPsNd"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dolorumex",
-  "doi" : "https://doi.org/10.1234/quidem",
-  "link" : "https://www.example.org/voluptatemlaboriosam",
+  "handle" : "https://www.example.org/eaarchitecto",
+  "doi" : "https://doi.org/10.1234/neque",
+  "link" : "https://www.example.org/animiest",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LGDxZUyLD8DJ6Zq",
+    "mainTitle" : "lVBrbwZg2yA",
     "alternativeTitles" : {
-      "es" : "7H4fSdI2ETtXEAHW8"
+      "nn" : "6YY1HCCBZymX"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "TjjWYhIeFhrm",
-      "month" : "ctsTlXqMGhBOw",
-      "day" : "UghDzBBpqD"
+      "year" : "sgkOaNDwBCOe7",
+      "month" : "y2Wlx5imKn3QN4Q17zq",
+      "day" : "iO5OMYP0Qp6yaKA1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/sHi85Uxs25spaE",
-        "name" : "A0zm9QagLMvR",
+        "id" : "https://www.example.com/K1VOrAw6ZYPkTPZJg1W",
+        "name" : "u22vmzfnwmDP",
         "nameType" : "Personal",
-        "orcId" : "qn12O6qyc8YjEQy3"
+        "orcId" : "IRI7MlRaAfrB"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Xtz0qzHlYyN",
+        "id" : "https://www.example.com/XtBAirOqvKx",
         "labels" : {
-          "ErVuAG2QNIVFRlZ8oKk" : "9X0du95ZG642vdSEn"
+          "4NIt4fHIrnlmg" : "Wm6rRw4yG5K6"
         }
       } ],
-      "role" : "InteriorArchitect",
-      "sequence" : 9,
+      "role" : "Scenographer",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/McaOgDgWA7csPJ6g",
-        "name" : "Be7Lq8LTlqTn",
-        "nameType" : "Organizational",
-        "orcId" : "1416tkl84tVpu"
+        "id" : "https://www.example.com/beLUy0v2YbNKjr1Ki",
+        "name" : "OCaziSm1QUH4IqlPkI",
+        "nameType" : "Personal",
+        "orcId" : "3wIddPD9Y1CLA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/OMHnS2dvTjJ",
+        "id" : "https://www.example.com/Cv1vyqZMpsNfy",
         "labels" : {
-          "dqqiJ70USxmvFFOa3k0" : "ASOSELKWNSIoF7odqEn"
+          "qh0yy1N6h2" : "tUhrBDwZXEGCYiI"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 8,
+      "role" : "DataManager",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XyvswvTU46tDPCN",
-    "tags" : [ "bU3WwHqEHIzklO" ],
-    "description" : "gz4t3duvillPmE",
+    "npiSubjectHeading" : "4DreM1GHlEPc",
+    "tags" : [ "XfcbHzGw7ni" ],
+    "description" : "A9J50x0Ee4iO3X9A",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/QX1q5raZZ8miLI4y0d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/NejTLrpin0c5"
         },
-        "seriesNumber" : "2Jy5pv8Brm",
+        "seriesNumber" : "ffLf6EFjBU8qjIaPv",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/41zbfmjSKr9Er7gs"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/iywzzoCOcUO"
         },
-        "isbnList" : [ "9781962329491" ]
+        "isbnList" : [ "9790958408607" ]
       },
-      "doi" : "https://www.example.com/gHIfjHu7sIM1oooFW",
+      "doi" : "https://www.example.com/pxsqGEuvc6",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "RAgffT3u6bsUGFr6y",
-          "month" : "blgTPejHLVdv58",
-          "day" : "1vHJGbnV0KpcMjHpQiV"
+          "year" : "R1gQZcmMjoqGKqkG",
+          "month" : "qvJOicllKc5",
+          "day" : "y5ZhCVPeGX3KS72ZW3X"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "TA6jF53gNhs5x52M6",
-            "end" : "hM6f1pjphOnzM"
+            "begin" : "lGG9TpUV19XD6bP2X",
+            "end" : "HdUBNTpusv6CPv6cL"
           },
-          "pages" : "Gqs5sUJGK1YTOBCBp",
-          "illustrated" : true
+          "pages" : "rwvQ7QRAD40RkU",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/lMUAkxm9rDS6veTnHRN",
-    "abstract" : "7nE5kDVuLf15"
+    "metadataSource" : "https://www.example.com/tgNmN1wTpMp3Uzv4",
+    "abstract" : "I4xOGY5OTIq6oSR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatemnisi",
-    "name" : "cA61a8qej0",
+    "id" : "https://www.example.org/architectoquia",
+    "name" : "fM8n4I6Ssb7BexnGD",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "y6wEIYb0RH",
-      "id" : "Vkshg4lsERVK"
+      "source" : "BTEmg6mG0JQPeZj",
+      "id" : "9lcEaN53PIB"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Fr4OdXYipyQ"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "pB9EVdlc1v"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quibusdamiusto" ],
+  "subjects" : [ "https://www.example.org/quossunt" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "8hPEGlrDQEG8I48",
-      "mimeType" : "Uh0B9dng5YP8EpGCxxW",
-      "size" : 1720529202,
+      "name" : "jOnaGWyEqYD4iK",
+      "mimeType" : "f3mlVa5XSFPkO",
+      "size" : 1244132732,
       "license" : {
         "type" : "License",
-        "identifier" : "LsKWp9O3pVx16FPX4",
+        "identifier" : "IsImSmh6nPdw6yq",
         "labels" : {
-          "ZWpq2iRnYoxJNorTh" : "cL71L1kUCXK"
+          "LFsDwwwUSc2" : "qmHPN1QH1r6N5EKE2K"
         },
-        "link" : "https://www.example.com/dGnreNCG760nkpr"
+        "link" : "https://www.example.com/fHkelj4vu1rRCdnRmU6"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "8hPEGlrDQEG8I48",
-    "mimeType" : "Uh0B9dng5YP8EpGCxxW",
-    "size" : 1720529202,
+    "name" : "jOnaGWyEqYD4iK",
+    "mimeType" : "f3mlVa5XSFPkO",
+    "size" : 1244132732,
     "license" : {
       "type" : "License",
-      "identifier" : "LsKWp9O3pVx16FPX4",
+      "identifier" : "IsImSmh6nPdw6yq",
       "labels" : {
-        "ZWpq2iRnYoxJNorTh" : "cL71L1kUCXK"
+        "LFsDwwwUSc2" : "qmHPN1QH1r6N5EKE2K"
       },
-      "link" : "https://www.example.com/dGnreNCG760nkpr"
+      "link" : "https://www.example.com/fHkelj4vu1rRCdnRmU6"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "YhfnCQwCkqilLeKgE",
+  "owner" : "VGhndWEZGschnGc1gYi",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -3,133 +3,133 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "boEEYG7FMgFhbI5U6",
-    "ownerAffiliation" : "https://www.example.org/atdelectus"
+    "owner" : "YhfnCQwCkqilLeKgE",
+    "ownerAffiliation" : "https://www.example.org/consequaturaperiam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorumnostrum",
+    "id" : "https://www.example.org/etsed",
     "labels" : {
-      "r5cbJeWZGxSe" : "J3pm49p79lBW"
+      "IBeuqpy8uYb" : "0uzedCoxjER4qxdKt2"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quasillo",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/adipiscinecessitatibus",
+  "handle" : "https://www.example.org/dolorumex",
+  "doi" : "https://doi.org/10.1234/quidem",
+  "link" : "https://www.example.org/voluptatemlaboriosam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lyOC5Qt15lHdlX38dq",
+    "mainTitle" : "LGDxZUyLD8DJ6Zq",
     "alternativeTitles" : {
-      "nl" : "yHHqBjn3zZOhnH4uhM"
+      "es" : "7H4fSdI2ETtXEAHW8"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "k5oTtxWOMPn",
-      "month" : "EUlg82P17j23UHuV",
-      "day" : "YB6L8vpPOYlO"
+      "year" : "TjjWYhIeFhrm",
+      "month" : "ctsTlXqMGhBOw",
+      "day" : "UghDzBBpqD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/8AslCw5ZNoV",
-        "name" : "haH2rT11MpT942TSM",
+        "id" : "https://www.example.com/sHi85Uxs25spaE",
+        "name" : "A0zm9QagLMvR",
         "nameType" : "Personal",
-        "orcId" : "Xg7b6ARSGJ3WD17cmgW"
+        "orcId" : "qn12O6qyc8YjEQy3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PfJ0XDWOnOi2bjsOVb",
+        "id" : "https://www.example.com/Xtz0qzHlYyN",
         "labels" : {
-          "hxJ7ewsVdK" : "cPCm9guWpKP"
+          "ErVuAG2QNIVFRlZ8oKk" : "9X0du95ZG642vdSEn"
         }
       } ],
-      "role" : "ResearchGroup",
-      "sequence" : 0,
+      "role" : "InteriorArchitect",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/YXFioDt7Q7YFUm",
-        "name" : "vrWzhda6hDt",
+        "id" : "https://www.example.com/McaOgDgWA7csPJ6g",
+        "name" : "Be7Lq8LTlqTn",
         "nameType" : "Organizational",
-        "orcId" : "Mve4TBn6YJvH"
+        "orcId" : "1416tkl84tVpu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/YibkBtq3m1qZmWqvq",
+        "id" : "https://www.example.com/OMHnS2dvTjJ",
         "labels" : {
-          "WhFiuc0Ndzv1PTFi" : "MhArsx5ccgNl1b"
+          "dqqiJ70USxmvFFOa3k0" : "ASOSELKWNSIoF7odqEn"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 7,
+      "role" : "HostingInstitution",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "CD94bswqdolvkQ3",
-    "tags" : [ "DeMZozXtDebKaomJ" ],
-    "description" : "twEORI3tPDiX",
+    "npiSubjectHeading" : "XyvswvTU46tDPCN",
+    "tags" : [ "bU3WwHqEHIzklO" ],
+    "description" : "gz4t3duvillPmE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rnBRgZpa2dm1NXUya1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/QX1q5raZZ8miLI4y0d"
         },
-        "seriesNumber" : "gx640BhyWaGJ",
+        "seriesNumber" : "2Jy5pv8Brm",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e75rGm0T0tQc8VZ1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/41zbfmjSKr9Er7gs"
         },
-        "isbnList" : [ "9790606835021" ]
+        "isbnList" : [ "9781962329491" ]
       },
-      "doi" : "https://www.example.com/LI3Krbt6UK5S5L",
+      "doi" : "https://www.example.com/gHIfjHu7sIM1oooFW",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "DYO9YdqymkJOQQ8VaRg",
-          "month" : "wet3lqTxHpuPMW",
-          "day" : "EGXIRdmcVxy47y0dyBV"
+          "year" : "RAgffT3u6bsUGFr6y",
+          "month" : "blgTPejHLVdv58",
+          "day" : "1vHJGbnV0KpcMjHpQiV"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "buOeqaFqec",
-            "end" : "WHOXOimvcx"
+            "begin" : "TA6jF53gNhs5x52M6",
+            "end" : "hM6f1pjphOnzM"
           },
-          "pages" : "P3d7heDvN9idnDeOM8Z",
-          "illustrated" : false
+          "pages" : "Gqs5sUJGK1YTOBCBp",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/fT3DUoRPNQL4qL",
-    "abstract" : "zC0WnAYoPhARLk"
+    "metadataSource" : "https://www.example.com/lMUAkxm9rDS6veTnHRN",
+    "abstract" : "7nE5kDVuLf15"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ducimuseaque",
-    "name" : "REbSpGW6ix",
+    "id" : "https://www.example.org/voluptatemnisi",
+    "name" : "cA61a8qej0",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "0XwwrhNNJAa",
-      "id" : "Jv34aGbfIuU5"
+      "source" : "y6wEIYb0RH",
+      "id" : "Vkshg4lsERVK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "xbWfPDmkcRrJ0zQ7G"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Fr4OdXYipyQ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,22 +137,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dignissimosaperiam" ],
+  "subjects" : [ "https://www.example.org/quibusdamiusto" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "9XgnTSeVfDPzUpoIO",
-      "mimeType" : "P6jHzBootFSI6Wqd",
-      "size" : 1659582810,
+      "name" : "8hPEGlrDQEG8I48",
+      "mimeType" : "Uh0B9dng5YP8EpGCxxW",
+      "size" : 1720529202,
       "license" : {
         "type" : "License",
-        "identifier" : "YrcJGaNYeeyCqzk36",
+        "identifier" : "LsKWp9O3pVx16FPX4",
         "labels" : {
-          "tE4vWMAiroUQmuySV" : "Te4SYwaTshHwH8"
+          "ZWpq2iRnYoxJNorTh" : "cL71L1kUCXK"
         },
-        "link" : "https://www.example.com/O79JoAXGvmIsw"
+        "link" : "https://www.example.com/dGnreNCG760nkpr"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -162,21 +162,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "9XgnTSeVfDPzUpoIO",
-    "mimeType" : "P6jHzBootFSI6Wqd",
-    "size" : 1659582810,
+    "name" : "8hPEGlrDQEG8I48",
+    "mimeType" : "Uh0B9dng5YP8EpGCxxW",
+    "size" : 1720529202,
     "license" : {
       "type" : "License",
-      "identifier" : "YrcJGaNYeeyCqzk36",
+      "identifier" : "LsKWp9O3pVx16FPX4",
       "labels" : {
-        "tE4vWMAiroUQmuySV" : "Te4SYwaTshHwH8"
+        "ZWpq2iRnYoxJNorTh" : "cL71L1kUCXK"
       },
-      "link" : "https://www.example.com/O79JoAXGvmIsw"
+      "link" : "https://www.example.com/dGnreNCG760nkpr"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "boEEYG7FMgFhbI5U6",
+  "owner" : "YhfnCQwCkqilLeKgE",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,135 +1,135 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "5NbqIedFvr78DF0Q",
-    "ownerAffiliation" : "https://www.example.org/utsunt"
+    "owner" : "boEEYG7FMgFhbI5U6",
+    "ownerAffiliation" : "https://www.example.org/atdelectus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/namvero",
+    "id" : "https://www.example.org/dolorumnostrum",
     "labels" : {
-      "8lTwz5YTCoYxSSyPb" : "q3S3XLncLh"
+      "r5cbJeWZGxSe" : "J3pm49p79lBW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/providentdeleniti",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/dolorumut",
+  "handle" : "https://www.example.org/quasillo",
+  "doi" : "https://doi.org/10.1234/debitis",
+  "link" : "https://www.example.org/adipiscinecessitatibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oAdXOWxpNBaGSodix",
+    "mainTitle" : "lyOC5Qt15lHdlX38dq",
     "alternativeTitles" : {
-      "bg" : "wnxkYq5TI4EeV1b"
+      "nl" : "yHHqBjn3zZOhnH4uhM"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nob",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "CLuim1TNCY",
-      "month" : "F4CGjiNdnxZOpp5uAW",
-      "day" : "UO2x4Xv0RqYRC99zB"
+      "year" : "k5oTtxWOMPn",
+      "month" : "EUlg82P17j23UHuV",
+      "day" : "YB6L8vpPOYlO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/IiX0aJbdae9A0S7",
-        "name" : "9NP0rOBaWOE1GkZ",
+        "id" : "https://www.example.com/8AslCw5ZNoV",
+        "name" : "haH2rT11MpT942TSM",
         "nameType" : "Personal",
-        "orcId" : "bqvbfz7JkMq58uJVF"
+        "orcId" : "Xg7b6ARSGJ3WD17cmgW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/2JFYlUcWwnQG",
+        "id" : "https://www.example.com/PfJ0XDWOnOi2bjsOVb",
         "labels" : {
-          "jNEyJtLoKwcFwBEc7" : "NI7NxKIWhQU"
+          "hxJ7ewsVdK" : "cPCm9guWpKP"
         }
       } ],
-      "role" : "DataManager",
-      "sequence" : 4,
+      "role" : "ResearchGroup",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Gsdi8l0NL2",
-        "name" : "3Q538NIfS75",
+        "id" : "https://www.example.com/YXFioDt7Q7YFUm",
+        "name" : "vrWzhda6hDt",
         "nameType" : "Organizational",
-        "orcId" : "5y9Arfy3Bs"
+        "orcId" : "Mve4TBn6YJvH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/MEFa3uP9TR",
+        "id" : "https://www.example.com/YibkBtq3m1qZmWqvq",
         "labels" : {
-          "KvUFIVq0PQz82G" : "U5mYPsAejrc8TeUo"
+          "WhFiuc0Ndzv1PTFi" : "MhArsx5ccgNl1b"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 8,
+      "role" : "ContactPerson",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "eo0KIVjUjfW7zqPm",
-    "tags" : [ "sYiTahy6Zhga" ],
-    "description" : "7W10fgbwzs6jdU",
+    "npiSubjectHeading" : "CD94bswqdolvkQ3",
+    "tags" : [ "DeMZozXtDebKaomJ" ],
+    "description" : "twEORI3tPDiX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/O0MxdGCBJHJE8qc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/rnBRgZpa2dm1NXUya1"
         },
-        "seriesNumber" : "ZyiLASwkO1xd8lOU7",
+        "seriesNumber" : "gx640BhyWaGJ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PHDkRKtC2F"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e75rGm0T0tQc8VZ1"
         },
-        "isbnList" : [ "9780873681346" ]
+        "isbnList" : [ "9790606835021" ]
       },
-      "doi" : "https://www.example.com/Svyo8D4SFsRta",
+      "doi" : "https://www.example.com/LI3Krbt6UK5S5L",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "VWrUJ3qUfl4L6jtzcw",
-          "month" : "J3NKVvDgwbq7Np15",
-          "day" : "M5rMUcKcM4EEZu0sHa4"
+          "year" : "DYO9YdqymkJOQQ8VaRg",
+          "month" : "wet3lqTxHpuPMW",
+          "day" : "EGXIRdmcVxy47y0dyBV"
         },
         "peerReviewed" : false,
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "hPDL0HgVvD0DnF",
-            "end" : "PdYviXSTT1hOgLozEcA"
+            "begin" : "buOeqaFqec",
+            "end" : "WHOXOimvcx"
           },
-          "pages" : "0I1yQ0I4b0j7q",
-          "illustrated" : true
+          "pages" : "P3d7heDvN9idnDeOM8Z",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/F6wQfrjuLhfnM5x",
-    "abstract" : "mIuo2ICz2iJtUQHf"
+    "metadataSource" : "https://www.example.com/fT3DUoRPNQL4qL",
+    "abstract" : "zC0WnAYoPhARLk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fugavelit",
-    "name" : "eFDY0RpxFuLG",
+    "id" : "https://www.example.org/ducimuseaque",
+    "name" : "REbSpGW6ix",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "z0JtnpXpi0I9rfe6yHm",
-      "id" : "bSnTCt9qbB4HY81STM5"
+      "source" : "0XwwrhNNJAa",
+      "id" : "Jv34aGbfIuU5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "m9bWrAS4tug6JONzSYT"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "xbWfPDmkcRrJ0zQ7G"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -137,46 +137,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quasiaut" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "UhxKV0QcDo7M2",
-    "mimeType" : "lrP0Ejaa6G",
-    "size" : 1893763792,
-    "license" : {
-      "type" : "License",
-      "identifier" : "so1nsMPZgq6BEp9Mh",
-      "labels" : {
-        "1XaVYwsWgUzfwMg3Hdr" : "c2Hg9YUK4qDyMaz"
-      },
-      "link" : "https://www.example.com/f5g1aKBxlZzHakKjap"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/dignissimosaperiam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "UhxKV0QcDo7M2",
-      "mimeType" : "lrP0Ejaa6G",
-      "size" : 1893763792,
+      "name" : "9XgnTSeVfDPzUpoIO",
+      "mimeType" : "P6jHzBootFSI6Wqd",
+      "size" : 1659582810,
       "license" : {
         "type" : "License",
-        "identifier" : "so1nsMPZgq6BEp9Mh",
+        "identifier" : "YrcJGaNYeeyCqzk36",
         "labels" : {
-          "1XaVYwsWgUzfwMg3Hdr" : "c2Hg9YUK4qDyMaz"
+          "tE4vWMAiroUQmuySV" : "Te4SYwaTshHwH8"
         },
-        "link" : "https://www.example.com/f5g1aKBxlZzHakKjap"
+        "link" : "https://www.example.com/O79JoAXGvmIsw"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "5NbqIedFvr78DF0Q",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "9XgnTSeVfDPzUpoIO",
+    "mimeType" : "P6jHzBootFSI6Wqd",
+    "size" : 1659582810,
+    "license" : {
+      "type" : "License",
+      "identifier" : "YrcJGaNYeeyCqzk36",
+      "labels" : {
+        "tE4vWMAiroUQmuySV" : "Te4SYwaTshHwH8"
+      },
+      "link" : "https://www.example.com/O79JoAXGvmIsw"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "boEEYG7FMgFhbI5U6",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -3,103 +3,104 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "PNhzA5vGFhD6eEG7BeS",
-    "ownerAffiliation" : "https://www.example.org/fugiatodit"
+    "owner" : "sqkaSAWFUy",
+    "ownerAffiliation" : "https://www.example.org/quivitae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiaeeligendi",
+    "id" : "https://www.example.org/abvoluptatibus",
     "labels" : {
-      "poDjIWA9OkgHgIvYo" : "fRJMpCtg7UvLAYHYCh"
+      "0JpS0reiFk" : "7uEKBU0je4tNAHyp8ns"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/explicaboeos",
-  "doi" : "https://doi.org/10.1234/voluptates",
-  "link" : "https://www.example.org/sedid",
+  "handle" : "https://www.example.org/dignissimoset",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/iuremaiores",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "R9o8Y2gXuw1pW",
+    "mainTitle" : "l5Mq0MSjz7xjDxB1",
     "alternativeTitles" : {
-      "nl" : "M1iqm3xQGdZkH"
+      "it" : "wj7xGv5cTNEwk"
     },
     "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "l4BZYaumpwR",
-      "month" : "U0pXB7XRafxuw30D8",
-      "day" : "XWJ25z6NdgNCd"
+      "year" : "u6ELEigCqj",
+      "month" : "RNS91vQ7IaP2xKj",
+      "day" : "PCeGWNBFaoJzfERuA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/xYEPeWOrmkAEfMi6gIn",
-        "name" : "115n3ZaEMg5",
-        "nameType" : "Personal",
-        "orcId" : "44AlmB6yOoN0G0ze"
+        "id" : "https://www.example.com/EYBJG1bv1tzBvjXAg",
+        "name" : "qWzk1kEYlJuDb",
+        "nameType" : "Organizational",
+        "orcId" : "NrvSGA8xbpA"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/IPw92WBXla8j4WQljuX",
+        "id" : "https://www.example.com/qNZi2cwrhNlas",
         "labels" : {
-          "O3583XHogQUI0P3v" : "eewWSR2jgQNiHmiWax"
+          "n6XZ1Ug39eVqE" : "rOYGlXMBBJ"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 7,
+      "role" : "AcademicCoordinator",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/BGs0b9tVy6QiBL",
-        "name" : "nJ7gNUwG1lx5IZj",
-        "nameType" : "Organizational",
-        "orcId" : "FTAdZaWd26etwJF"
+        "id" : "https://www.example.com/3BQyh5H3IofQCHei",
+        "name" : "v9XJr7Z9mfg5t5wR1G",
+        "nameType" : "Personal",
+        "orcId" : "xspIcke2akNL"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/nK6ZmBiklOb",
+        "id" : "https://www.example.com/drfYLeCyGDyYjfuX5i",
         "labels" : {
-          "o2OKNKtJPO8SEaERqe2" : "JPF59PNsbnfSMBs"
+          "aOdLZANFZV" : "Mr8sYTzzX1WMzoVfo"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 4,
+      "role" : "RelatedPerson",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "XQk8H1nhdfaCH",
-    "tags" : [ "9N2KxURK6Yw7" ],
-    "description" : "Q4V2OvBo8lQ3CP0",
+    "npiSubjectHeading" : "mS2qUiUd2H",
+    "tags" : [ "l03gnKe7yU6ebc" ],
+    "description" : "hVL5u93LvdQ1nERwhD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/wyOSnB3nALU",
+      "doi" : "https://www.example.com/HJac7awlUzsjGDe",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "TheatricalProduction"
+          "type" : "Other",
+          "description" : "LyCELwFinpVuqlsFkfp"
         },
-        "description" : "3AyfTT66qvdWpxtX",
+        "description" : "A9iVX3b8WJ",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "DcIM5cLqu8budNmIw",
-            "country" : "LyWA4WhFvotcHvT7v"
+            "label" : "t9NNcu6x26HL9",
+            "country" : "Yk964o43NejFZ6Wa"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 2104224082
+          "sequence" : 1911025002
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/TqZC4jKUz6lpUnyC2",
-    "abstract" : "rit8upuJ8ngX"
+    "metadataSource" : "https://www.example.com/V44qnxVvpMHChKf",
+    "abstract" : "ZaJEJ5M5ohu"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/remvoluptas",
-    "name" : "xEYJHNzXc13jd2IJfP",
+    "id" : "https://www.example.org/eligendiarchitecto",
+    "name" : "fojqmTzVRT4S6akzCdr",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2VhhRQDK9iXJB",
-      "id" : "U4k4rfSn3k"
+      "source" : "XZWyGqChr3bXe",
+      "id" : "lpqoaez6aj"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "CDyvkcSPlLea"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "HPjGt7ePw3"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,22 +133,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/laborumautem" ],
+  "subjects" : [ "https://www.example.org/quasiullam" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "4BWBkJ1dsJHH",
-      "mimeType" : "QPo1ntNWi35JBj",
-      "size" : 1153424201,
+      "name" : "Qo99PcZArdl",
+      "mimeType" : "aQDZIq2dV3san4uh",
+      "size" : 954524728,
       "license" : {
         "type" : "License",
-        "identifier" : "IDTrIyzn2z4G2Eq",
+        "identifier" : "GXHV5NwgRnspORVVpa0",
         "labels" : {
-          "Bsv1kIju32xK" : "UxycTG9exz5WTMSKzd"
+          "MS6ESyhgYoGkTHMnj" : "z0LdSJLrbntR"
         },
-        "link" : "https://www.example.com/MC4yUnUnlBsg6srwoC"
+        "link" : "https://www.example.com/tCX7ZdkqFBpvqZOw4V"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -157,21 +158,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "4BWBkJ1dsJHH",
-    "mimeType" : "QPo1ntNWi35JBj",
-    "size" : 1153424201,
+    "name" : "Qo99PcZArdl",
+    "mimeType" : "aQDZIq2dV3san4uh",
+    "size" : 954524728,
     "license" : {
       "type" : "License",
-      "identifier" : "IDTrIyzn2z4G2Eq",
+      "identifier" : "GXHV5NwgRnspORVVpa0",
       "labels" : {
-        "Bsv1kIju32xK" : "UxycTG9exz5WTMSKzd"
+        "MS6ESyhgYoGkTHMnj" : "z0LdSJLrbntR"
       },
-      "link" : "https://www.example.com/MC4yUnUnlBsg6srwoC"
+      "link" : "https://www.example.com/tCX7ZdkqFBpvqZOw4V"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "PNhzA5vGFhD6eEG7BeS",
+  "owner" : "sqkaSAWFUy",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -3,104 +3,104 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "sqkaSAWFUy",
-    "ownerAffiliation" : "https://www.example.org/quivitae"
+    "owner" : "7ZUIfSbpdPyUjDga",
+    "ownerAffiliation" : "https://www.example.org/auta"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/abvoluptatibus",
+    "id" : "https://www.example.org/accusantiumalias",
     "labels" : {
-      "0JpS0reiFk" : "7uEKBU0je4tNAHyp8ns"
+      "ybeiFqWauOuUH" : "jRPpum2w0QEuo"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dignissimoset",
-  "doi" : "https://doi.org/10.1234/repellat",
-  "link" : "https://www.example.org/iuremaiores",
+  "handle" : "https://www.example.org/aliquamalias",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/officiisrepellendus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "l5Mq0MSjz7xjDxB1",
+    "mainTitle" : "ke49lgvzqD",
     "alternativeTitles" : {
-      "it" : "wj7xGv5cTNEwk"
+      "it" : "2cp1cEfOKfSmp0KSw"
     },
-    "language" : "http://lexvo.org/id/iso639-3/bul",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "u6ELEigCqj",
-      "month" : "RNS91vQ7IaP2xKj",
-      "day" : "PCeGWNBFaoJzfERuA"
+      "year" : "lFNYCkNgWsmOA",
+      "month" : "M0JnvfDtGdpxf",
+      "day" : "9BHBChEGwRx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/EYBJG1bv1tzBvjXAg",
-        "name" : "qWzk1kEYlJuDb",
+        "id" : "https://www.example.com/6vi4ZYMAR3lwKduAk",
+        "name" : "r5Cr5tmfSBVzuRkrS5",
         "nameType" : "Organizational",
-        "orcId" : "NrvSGA8xbpA"
+        "orcId" : "2AJQGxDVBhc2cO6m"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qNZi2cwrhNlas",
+        "id" : "https://www.example.com/IOXAvPL53lySv45Z",
         "labels" : {
-          "n6XZ1Ug39eVqE" : "rOYGlXMBBJ"
+          "QLDOcdrxsw" : "EnApKn0EsA"
         }
       } ],
-      "role" : "AcademicCoordinator",
-      "sequence" : 3,
+      "role" : "Sponsor",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/3BQyh5H3IofQCHei",
-        "name" : "v9XJr7Z9mfg5t5wR1G",
+        "id" : "https://www.example.com/sMFpl9Sm4YdoVqSr",
+        "name" : "3qLXU3AfCl",
         "nameType" : "Personal",
-        "orcId" : "xspIcke2akNL"
+        "orcId" : "XhYisoca4RZ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/drfYLeCyGDyYjfuX5i",
+        "id" : "https://www.example.com/QBB2CMq0bkEysbQZ3C",
         "labels" : {
-          "aOdLZANFZV" : "Mr8sYTzzX1WMzoVfo"
+          "tagvl59rVb" : "LwBedr30BI6"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 3,
+      "role" : "VideoEditor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "mS2qUiUd2H",
-    "tags" : [ "l03gnKe7yU6ebc" ],
-    "description" : "hVL5u93LvdQ1nERwhD",
+    "npiSubjectHeading" : "bCMLsCc9tQQmiJ",
+    "tags" : [ "QcqBe5a6HQ3eXf" ],
+    "description" : "CXnq7TdDcvDpDfR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/HJac7awlUzsjGDe",
+      "doi" : "https://www.example.com/RYFBThbKR08NctJSsuS",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
           "type" : "Other",
-          "description" : "LyCELwFinpVuqlsFkfp"
+          "description" : "meKIGAIdotysZwhr"
         },
-        "description" : "A9iVX3b8WJ",
+        "description" : "8OdeKgQqHdY",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "t9NNcu6x26HL9",
-            "country" : "Yk964o43NejFZ6Wa"
+            "label" : "9YowSyz9dnrdxtVWPlM",
+            "country" : "ZPEVcVFxYLseJ"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1911025002
+          "sequence" : 301242252
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -108,24 +108,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/V44qnxVvpMHChKf",
-    "abstract" : "ZaJEJ5M5ohu"
+    "metadataSource" : "https://www.example.com/ixwIkDNVeTmNjI1l2",
+    "abstract" : "3YemCF64RugLTsBDCj"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eligendiarchitecto",
-    "name" : "fojqmTzVRT4S6akzCdr",
+    "id" : "https://www.example.org/voluptatemducimus",
+    "name" : "ywNOJrSw2t",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XZWyGqChr3bXe",
-      "id" : "lpqoaez6aj"
+      "source" : "Nuw36L0kvVKH",
+      "id" : "scmBO8K1hP"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "HPjGt7ePw3"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "vzWyk7y4LIC65QwqkGH"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -133,46 +133,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quasiullam" ],
+  "subjects" : [ "https://www.example.org/occaecatitempore" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "Qo99PcZArdl",
-      "mimeType" : "aQDZIq2dV3san4uh",
-      "size" : 954524728,
+      "name" : "6Y7DiNVlOmi6",
+      "mimeType" : "Y1IyX2bQJH",
+      "size" : 2144837745,
       "license" : {
         "type" : "License",
-        "identifier" : "GXHV5NwgRnspORVVpa0",
+        "identifier" : "51HH8lsgQxsowgPuoW",
         "labels" : {
-          "MS6ESyhgYoGkTHMnj" : "z0LdSJLrbntR"
+          "6qusIKRlji" : "cvkuDETVsQtR481J"
         },
-        "link" : "https://www.example.com/tCX7ZdkqFBpvqZOw4V"
+        "link" : "https://www.example.com/uCoPH10dRLahUI"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "Qo99PcZArdl",
-    "mimeType" : "aQDZIq2dV3san4uh",
-    "size" : 954524728,
+    "name" : "6Y7DiNVlOmi6",
+    "mimeType" : "Y1IyX2bQJH",
+    "size" : 2144837745,
     "license" : {
       "type" : "License",
-      "identifier" : "GXHV5NwgRnspORVVpa0",
+      "identifier" : "51HH8lsgQxsowgPuoW",
       "labels" : {
-        "MS6ESyhgYoGkTHMnj" : "z0LdSJLrbntR"
+        "6qusIKRlji" : "cvkuDETVsQtR481J"
       },
-      "link" : "https://www.example.com/tCX7ZdkqFBpvqZOw4V"
+      "link" : "https://www.example.com/uCoPH10dRLahUI"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "sqkaSAWFUy",
+  "owner" : "7ZUIfSbpdPyUjDga",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,105 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "LWdTVNK9daMLLv",
-    "ownerAffiliation" : "https://www.example.org/atqueeligendi"
+    "owner" : "79RdSV4LaZdZUZ2",
+    "ownerAffiliation" : "https://www.example.org/adipisciipsam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/repellatest",
+    "id" : "https://www.example.org/eteveniet",
     "labels" : {
-      "XHrilHSlcQ6W" : "F4TM1akCPAqfLq5"
+      "Fhqxr0F0hl" : "tomM8HRnkp4OR"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/etet",
-  "doi" : "https://doi.org/10.1234/aperiam",
-  "link" : "https://www.example.org/doloremvoluptas",
+  "handle" : "https://www.example.org/magniblanditiis",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/praesentiumab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "21sTDsQ67DXnSqp3V",
+    "mainTitle" : "fPxrsQZWzw0NtHcr",
     "alternativeTitles" : {
-      "el" : "O0BuLEU9RT"
+      "ca" : "Ae2MlNoB4AoR1RPjuOO"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "tZJ0aCIlNWggYp",
-      "month" : "mk4wGa3IiMcnsBuc0",
-      "day" : "SruWKjidMBdKzjAb8"
+      "year" : "L0vS2lke8q1",
+      "month" : "XBwJqlsJQGc4zBPS",
+      "day" : "dYLXxvjGCjdWl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/VxQsG4UWCULyxASmP3",
-        "name" : "emHJwhMSNumNbCuMV",
+        "id" : "https://www.example.com/YkWJKYXm3qATmU",
+        "name" : "vKZnwvVQOMiZoQ95y",
         "nameType" : "Organizational",
-        "orcId" : "MMaKD3ZQrz"
+        "orcId" : "YRYYrktyzoAtXXsD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/L2ukBlilWp",
+        "id" : "https://www.example.com/DotELvvBVM",
         "labels" : {
-          "gC8IITA0Cl5rH7E02X" : "VT891qOaIL1uhgCz"
+          "ZPxRfYVAfWh" : "6T2bNDh9bE"
         }
       } ],
-      "role" : "DataCurator",
+      "role" : "Editor",
       "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WQwdR1IsG6eSdJ",
-        "name" : "ZMjJtEm58GD7jaHSN",
+        "id" : "https://www.example.com/aMP3LUnhh4qSuV4gmcy",
+        "name" : "SmThWsDy9re1S",
         "nameType" : "Personal",
-        "orcId" : "QTci5pmOpU8Tp6s"
+        "orcId" : "0AQvGqu8BPfAWiW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/8ZKj897F1o1LjeM0",
+        "id" : "https://www.example.com/GiQ33LJWzZJQV",
         "labels" : {
-          "wrdc9baCa70kLYGQBh3" : "mHxVKy7prsIlS7"
+          "vwiEvPl7sUaPtP" : "hHF3dDy0wv"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 0,
+      "role" : "Consultant",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "d2hsa0yVfx",
-    "tags" : [ "nJawOmWVxbIqYoYe0" ],
-    "description" : "6LNq1vUjIKayx",
+    "npiSubjectHeading" : "AUDECE7oZW",
+    "tags" : [ "ZIBnLs3uw9UudKTs92" ],
+    "description" : "BiScITbry4nUmlQfro",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/MuCbRfG5nmOl2L51Ypu",
+      "doi" : "https://www.example.com/nkfWC8JmsRX6W2",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "Broadcast"
+          "type" : "TheatricalProduction"
         },
-        "description" : "au8aMoNuui0u7HBnuQn",
+        "description" : "8baZojwZcc",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "RyAXP6w1Ay",
-            "country" : "beS2EYECuSS8"
+            "label" : "mJa2nSi2MHGM05byLu",
+            "country" : "Yehi8ifA1wAzOQDvyp"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 143669495
+          "sequence" : 1532418175
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,45 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/HVkvoy6HyvD",
-    "abstract" : "enehSkcQ7f4x"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "RcZds15wWmZMQPP",
-      "mimeType" : "gtGum4plR5vx5oNG",
-      "size" : 274221317,
-      "license" : {
-        "type" : "License",
-        "identifier" : "3aBMtPJIt9mT6wXON",
-        "labels" : {
-          "rgUl5dv8e2Mk" : "O6mPbauLDRDOAA"
-        },
-        "link" : "https://www.example.com/UCPc1g4GirWbwn"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/Fqu04AY71NvBWv2b2h",
+    "abstract" : "gqelEmbKolNWo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/assumendaullam",
-    "name" : "5cYsCIuNLxBVecetT9",
+    "id" : "https://www.example.org/necessitatibusdolore",
+    "name" : "wXsY0Cggnw4eeh",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "RP1iG0KsjJ5uYh",
-      "id" : "coiOnRZTG7"
+      "source" : "DeWveDOVe0V",
+      "id" : "BEchKliqlWiQjGnT9Wd"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "lX7HpOO82wWPdELEihV"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "nKNvFNUA7Kyk"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/doloremquod" ],
+  "subjects" : [ "https://www.example.org/delectusmolestiae" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "RcZds15wWmZMQPP",
-    "mimeType" : "gtGum4plR5vx5oNG",
-    "size" : 274221317,
+    "name" : "ZrMuV8qkKtgL",
+    "mimeType" : "ax8qZuCqAGiTUgWUTx",
+    "size" : 341325812,
     "license" : {
       "type" : "License",
-      "identifier" : "3aBMtPJIt9mT6wXON",
+      "identifier" : "tPfDzI1OKRD29Vzq",
       "labels" : {
-        "rgUl5dv8e2Mk" : "O6mPbauLDRDOAA"
+        "hXBnoWsV8Oixgn5" : "4klEltFR6w6H"
       },
-      "link" : "https://www.example.com/UCPc1g4GirWbwn"
+      "link" : "https://www.example.com/MTMh8KPv88YA5ky2h"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "LWdTVNK9daMLLv"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "ZrMuV8qkKtgL",
+      "mimeType" : "ax8qZuCqAGiTUgWUTx",
+      "size" : 341325812,
+      "license" : {
+        "type" : "License",
+        "identifier" : "tPfDzI1OKRD29Vzq",
+        "labels" : {
+          "hXBnoWsV8Oixgn5" : "4klEltFR6w6H"
+        },
+        "link" : "https://www.example.com/MTMh8KPv88YA5ky2h"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "79RdSV4LaZdZUZ2",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,105 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "79RdSV4LaZdZUZ2",
-    "ownerAffiliation" : "https://www.example.org/adipisciipsam"
+    "owner" : "PNhzA5vGFhD6eEG7BeS",
+    "ownerAffiliation" : "https://www.example.org/fugiatodit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eteveniet",
+    "id" : "https://www.example.org/molestiaeeligendi",
     "labels" : {
-      "Fhqxr0F0hl" : "tomM8HRnkp4OR"
+      "poDjIWA9OkgHgIvYo" : "fRJMpCtg7UvLAYHYCh"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/magniblanditiis",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/praesentiumab",
+  "handle" : "https://www.example.org/explicaboeos",
+  "doi" : "https://doi.org/10.1234/voluptates",
+  "link" : "https://www.example.org/sedid",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fPxrsQZWzw0NtHcr",
+    "mainTitle" : "R9o8Y2gXuw1pW",
     "alternativeTitles" : {
-      "ca" : "Ae2MlNoB4AoR1RPjuOO"
+      "nl" : "M1iqm3xQGdZkH"
     },
     "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "L0vS2lke8q1",
-      "month" : "XBwJqlsJQGc4zBPS",
-      "day" : "dYLXxvjGCjdWl"
+      "year" : "l4BZYaumpwR",
+      "month" : "U0pXB7XRafxuw30D8",
+      "day" : "XWJ25z6NdgNCd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/YkWJKYXm3qATmU",
-        "name" : "vKZnwvVQOMiZoQ95y",
-        "nameType" : "Organizational",
-        "orcId" : "YRYYrktyzoAtXXsD"
+        "id" : "https://www.example.com/xYEPeWOrmkAEfMi6gIn",
+        "name" : "115n3ZaEMg5",
+        "nameType" : "Personal",
+        "orcId" : "44AlmB6yOoN0G0ze"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/DotELvvBVM",
+        "id" : "https://www.example.com/IPw92WBXla8j4WQljuX",
         "labels" : {
-          "ZPxRfYVAfWh" : "6T2bNDh9bE"
+          "O3583XHogQUI0P3v" : "eewWSR2jgQNiHmiWax"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 1,
+      "role" : "Advisor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/aMP3LUnhh4qSuV4gmcy",
-        "name" : "SmThWsDy9re1S",
-        "nameType" : "Personal",
-        "orcId" : "0AQvGqu8BPfAWiW"
+        "id" : "https://www.example.com/BGs0b9tVy6QiBL",
+        "name" : "nJ7gNUwG1lx5IZj",
+        "nameType" : "Organizational",
+        "orcId" : "FTAdZaWd26etwJF"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/GiQ33LJWzZJQV",
+        "id" : "https://www.example.com/nK6ZmBiklOb",
         "labels" : {
-          "vwiEvPl7sUaPtP" : "hHF3dDy0wv"
+          "o2OKNKtJPO8SEaERqe2" : "JPF59PNsbnfSMBs"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 3,
+      "role" : "Sponsor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "AUDECE7oZW",
-    "tags" : [ "ZIBnLs3uw9UudKTs92" ],
-    "description" : "BiScITbry4nUmlQfro",
+    "npiSubjectHeading" : "XQk8H1nhdfaCH",
+    "tags" : [ "9N2KxURK6Yw7" ],
+    "description" : "Q4V2OvBo8lQ3CP0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/nkfWC8JmsRX6W2",
+      "doi" : "https://www.example.com/wyOSnB3nALU",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
           "type" : "TheatricalProduction"
         },
-        "description" : "8baZojwZcc",
+        "description" : "3AyfTT66qvdWpxtX",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "mJa2nSi2MHGM05byLu",
-            "country" : "Yehi8ifA1wAzOQDvyp"
+            "label" : "DcIM5cLqu8budNmIw",
+            "country" : "LyWA4WhFvotcHvT7v"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1532418175
+          "sequence" : 2104224082
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Fqu04AY71NvBWv2b2h",
-    "abstract" : "gqelEmbKolNWo"
+    "metadataSource" : "https://www.example.com/TqZC4jKUz6lpUnyC2",
+    "abstract" : "rit8upuJ8ngX"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/necessitatibusdolore",
-    "name" : "wXsY0Cggnw4eeh",
+    "id" : "https://www.example.org/remvoluptas",
+    "name" : "xEYJHNzXc13jd2IJfP",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "DeWveDOVe0V",
-      "id" : "BEchKliqlWiQjGnT9Wd"
+      "source" : "2VhhRQDK9iXJB",
+      "id" : "U4k4rfSn3k"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "nKNvFNUA7Kyk"
+      "applicationCode" : "CDyvkcSPlLea"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delectusmolestiae" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "ZrMuV8qkKtgL",
-    "mimeType" : "ax8qZuCqAGiTUgWUTx",
-    "size" : 341325812,
-    "license" : {
-      "type" : "License",
-      "identifier" : "tPfDzI1OKRD29Vzq",
-      "labels" : {
-        "hXBnoWsV8Oixgn5" : "4klEltFR6w6H"
-      },
-      "link" : "https://www.example.com/MTMh8KPv88YA5ky2h"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/laborumautem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "ZrMuV8qkKtgL",
-      "mimeType" : "ax8qZuCqAGiTUgWUTx",
-      "size" : 341325812,
+      "name" : "4BWBkJ1dsJHH",
+      "mimeType" : "QPo1ntNWi35JBj",
+      "size" : 1153424201,
       "license" : {
         "type" : "License",
-        "identifier" : "tPfDzI1OKRD29Vzq",
+        "identifier" : "IDTrIyzn2z4G2Eq",
         "labels" : {
-          "hXBnoWsV8Oixgn5" : "4klEltFR6w6H"
+          "Bsv1kIju32xK" : "UxycTG9exz5WTMSKzd"
         },
-        "link" : "https://www.example.com/MTMh8KPv88YA5ky2h"
+        "link" : "https://www.example.com/MC4yUnUnlBsg6srwoC"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "79RdSV4LaZdZUZ2",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "4BWBkJ1dsJHH",
+    "mimeType" : "QPo1ntNWi35JBj",
+    "size" : 1153424201,
+    "license" : {
+      "type" : "License",
+      "identifier" : "IDTrIyzn2z4G2Eq",
+      "labels" : {
+        "Bsv1kIju32xK" : "UxycTG9exz5WTMSKzd"
+      },
+      "link" : "https://www.example.com/MC4yUnUnlBsg6srwoC"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "PNhzA5vGFhD6eEG7BeS",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -3,94 +3,94 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "1s9dXCjX5c72",
-    "ownerAffiliation" : "https://www.example.org/etvelit"
+    "owner" : "AF2PfmmZ7WNR",
+    "ownerAffiliation" : "https://www.example.org/perferendisvoluptas"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/molestiasblanditiis",
+    "id" : "https://www.example.org/atvoluptatem",
     "labels" : {
-      "Q2No1EfP4nX7BlcNNmF" : "dNk6ouwVzwiW"
+      "ZSWcl3G7x2Iecb" : "9L9HgGpkQz7617TavH"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/repellendusenim",
-  "doi" : "https://doi.org/10.1234/numquam",
-  "link" : "https://www.example.org/voluptasomnis",
+  "handle" : "https://www.example.org/aliquidut",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/quiaplaceat",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lACcFxN62LfgZ",
+    "mainTitle" : "DkwnkSNU8mzfZdbN",
     "alternativeTitles" : {
-      "ca" : "Johf1o9w4LdT2YrsYie"
+      "sv" : "8QQ4K8TK1Lqq"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/ell",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "yio91q1sRhgM6r",
-      "month" : "c4MmSm69aQGl8",
-      "day" : "ZOCTKgVGhG6vkp"
+      "year" : "t1QFKjipFh5AZmYt",
+      "month" : "Wt0FWz08owM",
+      "day" : "4glB6x7CEvi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/A8NE7wGVKWp1hN",
-        "name" : "JKoBfnyIvIBfB3H",
+        "id" : "https://www.example.com/jmpxn2IdC8BZ5PHB5",
+        "name" : "oLpZDHuFxHP3ra",
         "nameType" : "Organizational",
-        "orcId" : "OV5UNQNiaAfApFGK2H"
+        "orcId" : "9mK3liSmkqzCXCsZgU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/GdO00T8niINy",
+        "id" : "https://www.example.com/iqU84a1zEC9CVSl",
         "labels" : {
-          "smulO9IjbB4" : "AkeZDGtAsDpeI"
+          "9s5DL5ihxIIBD" : "rMhI0qhw9gW"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 9,
+      "role" : "Advisor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/bVAhRkkhoOnRpHhWEo",
-        "name" : "FzNnpjThkKb",
-        "nameType" : "Personal",
-        "orcId" : "jnKYM5Wrft0Ialj"
+        "id" : "https://www.example.com/vDFlpd7dQ2I2JThTv",
+        "name" : "NCoVxaWGR9AhV",
+        "nameType" : "Organizational",
+        "orcId" : "uo2NTAk3uUNfAXF108"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vtcNRNBzfOHxzPY4DWq",
+        "id" : "https://www.example.com/ZHIDwitI7IB1b",
         "labels" : {
-          "8MInTgiTKTblF" : "65IFWa58xOdbltk1"
+          "wYnwB3Wb7a4J" : "TWOcgq0Ym8Rp8e"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 2,
+      "role" : "Actor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "HCnRgPVsMPp4LNW",
-    "tags" : [ "TQFKNyngsWzSdewGep" ],
-    "description" : "QdiODBDumYvyrCBhb",
+    "npiSubjectHeading" : "1UGyWtsdBtYU9zTah",
+    "tags" : [ "rFLQwOAy7m0CgjAP" ],
+    "description" : "N94hHTypKi2xbrR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wx2XYUmqgtnKDd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/IHP8vugKpX"
         },
-        "seriesNumber" : "UqSgnvdPbfyT",
+        "seriesNumber" : "KmC1VwTRqc1",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Qknc8eYHiBuN687LDe"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/pepxwDJm0Mk"
         },
-        "isbnList" : [ "9790008627637" ]
+        "isbnList" : [ "9781853900815" ]
       },
-      "doi" : "https://www.example.com/GVIvNiOqxX12",
+      "doi" : "https://www.example.com/2scD7Yashz8eZJ",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "70M1sqleZulSV9",
-            "end" : "J4ADhL5aOYvL951"
+            "begin" : "hE5pzPjD7yt3BuoJ",
+            "end" : "uRGaIUQ6lm"
           },
-          "pages" : "nTkqW2uk3x",
-          "illustrated" : false
+          "pages" : "V6qerI1sUToKNxd",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/xfkow85ZnJdp4M",
-    "abstract" : "6vLSgQQTlREwnHHN"
+    "metadataSource" : "https://www.example.com/P4mH02MvnxBJKuWot",
+    "abstract" : "rRlO6qOuKZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/optioiure",
-    "name" : "av1ElPQk9z",
+    "id" : "https://www.example.org/quosrecusandae",
+    "name" : "N1EDZrGlzjoE",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "A17IoIod0bT85QR",
-      "id" : "zIoVgrd6z0XNb40M5KA"
+      "source" : "fdzKIOPC1TiS4zaxIqe",
+      "id" : "r3jSPQiuPxnkfaP9jJh"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "TaDphIKenhYjzZe7eoH"
+      "applicationCode" : "ikf41FoonFkY2UEy"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quianisi" ],
+  "subjects" : [ "https://www.example.org/quaeratvel" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "YKIs9nv1t9AzVYqD",
-      "mimeType" : "Fftkcsn3oIYYJXBNTbj",
-      "size" : 365528580,
+      "name" : "6jnWoAiirjnDtipSxoH",
+      "mimeType" : "VVlLmN9MU4SV20BEBjb",
+      "size" : 1111477188,
       "license" : {
         "type" : "License",
-        "identifier" : "kkaZbQcC3RJOL",
+        "identifier" : "TM273CZwMLtJJPeCOt",
         "labels" : {
-          "joqX8IWWJh" : "yreYUVJEHJUxr6"
+          "Mf3pZA2zIAKZrwZXij2" : "C5EMFcBK5URYQcU"
         },
-        "link" : "https://www.example.com/i5l9vJDOdngw2V9G91"
+        "link" : "https://www.example.com/mivA16HPxxixK"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "YKIs9nv1t9AzVYqD",
-    "mimeType" : "Fftkcsn3oIYYJXBNTbj",
-    "size" : 365528580,
+    "name" : "6jnWoAiirjnDtipSxoH",
+    "mimeType" : "VVlLmN9MU4SV20BEBjb",
+    "size" : 1111477188,
     "license" : {
       "type" : "License",
-      "identifier" : "kkaZbQcC3RJOL",
+      "identifier" : "TM273CZwMLtJJPeCOt",
       "labels" : {
-        "joqX8IWWJh" : "yreYUVJEHJUxr6"
+        "Mf3pZA2zIAKZrwZXij2" : "C5EMFcBK5URYQcU"
       },
-      "link" : "https://www.example.com/i5l9vJDOdngw2V9G91"
+      "link" : "https://www.example.com/mivA16HPxxixK"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "1s9dXCjX5c72",
+  "owner" : "AF2PfmmZ7WNR",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "EUBAMJ9Tq57LJZZdB6I",
-    "ownerAffiliation" : "https://www.example.org/sitiste"
+    "owner" : "1s9dXCjX5c72",
+    "ownerAffiliation" : "https://www.example.org/etvelit"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nihilaut",
+    "id" : "https://www.example.org/molestiasblanditiis",
     "labels" : {
-      "KIiY4LlwZBzj" : "PFHPNBcdoTJJOoN3UBg"
+      "Q2No1EfP4nX7BlcNNmF" : "dNk6ouwVzwiW"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/suntsunt",
-  "doi" : "https://doi.org/10.1234/recusandae",
-  "link" : "https://www.example.org/doloribussit",
+  "handle" : "https://www.example.org/repellendusenim",
+  "doi" : "https://doi.org/10.1234/numquam",
+  "link" : "https://www.example.org/voluptasomnis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TOYyJ1fmZkyFelf4RNi",
+    "mainTitle" : "lACcFxN62LfgZ",
     "alternativeTitles" : {
-      "zh" : "I5oyyHPzuJFbL1cQF"
+      "ca" : "Johf1o9w4LdT2YrsYie"
     },
-    "language" : "http://lexvo.org/id/iso639-3/afr",
+    "language" : "http://lexvo.org/id/iso639-3/zho",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "1yk0ANwaiaj3pFD",
-      "month" : "f8fn9rb7mcD",
-      "day" : "NljCt3tTTkBp82"
+      "year" : "yio91q1sRhgM6r",
+      "month" : "c4MmSm69aQGl8",
+      "day" : "ZOCTKgVGhG6vkp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/qxRCscIsoAaQbA5",
-        "name" : "oNL54sioZOhkn",
-        "nameType" : "Personal",
-        "orcId" : "JIawKv6TA6VMOHPj"
+        "id" : "https://www.example.com/A8NE7wGVKWp1hN",
+        "name" : "JKoBfnyIvIBfB3H",
+        "nameType" : "Organizational",
+        "orcId" : "OV5UNQNiaAfApFGK2H"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/UevQ2j0UqlyZktQN",
+        "id" : "https://www.example.com/GdO00T8niINy",
         "labels" : {
-          "acrOvuwAspjakI8J" : "qyWFBPfhwPO8"
+          "smulO9IjbB4" : "AkeZDGtAsDpeI"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 0,
+      "role" : "DataCurator",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/WQcNGzHRwC",
-        "name" : "uRtawzmlLGwB",
-        "nameType" : "Organizational",
-        "orcId" : "HeCxr9aUckeVAdRM"
+        "id" : "https://www.example.com/bVAhRkkhoOnRpHhWEo",
+        "name" : "FzNnpjThkKb",
+        "nameType" : "Personal",
+        "orcId" : "jnKYM5Wrft0Ialj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/rv6zVH8JhlFuHrmel8",
+        "id" : "https://www.example.com/vtcNRNBzfOHxzPY4DWq",
         "labels" : {
-          "ylx3PkUM9vvbBoO5V" : "Dwid5QZkzqY"
+          "8MInTgiTKTblF" : "65IFWa58xOdbltk1"
         }
       } ],
-      "role" : "CostumeDesigner",
-      "sequence" : 0,
+      "role" : "ArtisticDirector",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "gMz7zTLwcDmmf2dHrXr",
-    "tags" : [ "axsIY3J3veN" ],
-    "description" : "OXTPbsOTUGMxZd8",
+    "npiSubjectHeading" : "HCnRgPVsMPp4LNW",
+    "tags" : [ "TQFKNyngsWzSdewGep" ],
+    "description" : "QdiODBDumYvyrCBhb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/nfsSgkld6MQTY7T5sm"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wx2XYUmqgtnKDd"
         },
-        "seriesNumber" : "aLubR2I1Mp",
+        "seriesNumber" : "UqSgnvdPbfyT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BYFEzdyi0eTmLl"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Qknc8eYHiBuN687LDe"
         },
-        "isbnList" : [ "9790310469932" ]
+        "isbnList" : [ "9790008627637" ]
       },
-      "doi" : "https://www.example.com/qM5jS0Wj3CJu4Rl",
+      "doi" : "https://www.example.com/GVIvNiOqxX12",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "TuzWMXLa0YYk5o",
-            "end" : "f1b0njFKiraoJEbTaG"
+            "begin" : "70M1sqleZulSV9",
+            "end" : "J4ADhL5aOYvL951"
           },
-          "pages" : "WiuX2wOFofLDsekXW",
-          "illustrated" : true
+          "pages" : "nTkqW2uk3x",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/dvgAYp69NRPGs5r",
-    "abstract" : "bsKEs75uf9hds"
+    "metadataSource" : "https://www.example.com/xfkow85ZnJdp4M",
+    "abstract" : "6vLSgQQTlREwnHHN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/sintquis",
-    "name" : "5V6R3HHFtRo",
+    "id" : "https://www.example.org/optioiure",
+    "name" : "av1ElPQk9z",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Ut2toIC3h5vHFENK",
-      "id" : "RrBlx8r97Kn"
+      "source" : "A17IoIod0bT85QR",
+      "id" : "zIoVgrd6z0XNb40M5KA"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "c0M1YuDlnA"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "TaDphIKenhYjzZe7eoH"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/voluptatemautem" ],
+  "subjects" : [ "https://www.example.org/quianisi" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "z25iteliUS",
-      "mimeType" : "bKuFjJGHT8u",
-      "size" : 1521967450,
+      "name" : "YKIs9nv1t9AzVYqD",
+      "mimeType" : "Fftkcsn3oIYYJXBNTbj",
+      "size" : 365528580,
       "license" : {
         "type" : "License",
-        "identifier" : "241mGDLVbByOAkL",
+        "identifier" : "kkaZbQcC3RJOL",
         "labels" : {
-          "8xbDt3P8ih3" : "Rtsk6a8IYB"
+          "joqX8IWWJh" : "yreYUVJEHJUxr6"
         },
-        "link" : "https://www.example.com/Kjf6HJJYwQw4ibQoi"
+        "link" : "https://www.example.com/i5l9vJDOdngw2V9G91"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "z25iteliUS",
-    "mimeType" : "bKuFjJGHT8u",
-    "size" : 1521967450,
+    "name" : "YKIs9nv1t9AzVYqD",
+    "mimeType" : "Fftkcsn3oIYYJXBNTbj",
+    "size" : 365528580,
     "license" : {
       "type" : "License",
-      "identifier" : "241mGDLVbByOAkL",
+      "identifier" : "kkaZbQcC3RJOL",
       "labels" : {
-        "8xbDt3P8ih3" : "Rtsk6a8IYB"
+        "joqX8IWWJh" : "yreYUVJEHJUxr6"
       },
-      "link" : "https://www.example.com/Kjf6HJJYwQw4ibQoi"
+      "link" : "https://www.example.com/i5l9vJDOdngw2V9G91"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "EUBAMJ9Tq57LJZZdB6I",
+  "owner" : "1s9dXCjX5c72",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "uLiV5sF5IgykN8",
-    "ownerAffiliation" : "https://www.example.org/suntdoloremque"
+    "owner" : "EUBAMJ9Tq57LJZZdB6I",
+    "ownerAffiliation" : "https://www.example.org/sitiste"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quinon",
+    "id" : "https://www.example.org/nihilaut",
     "labels" : {
-      "0CHopNREsnDA4vE" : "xaug6hSxLIdLamBY"
+      "KIiY4LlwZBzj" : "PFHPNBcdoTJJOoN3UBg"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/commodiquo",
-  "doi" : "https://doi.org/10.1234/alias",
-  "link" : "https://www.example.org/aliquammagnam",
+  "handle" : "https://www.example.org/suntsunt",
+  "doi" : "https://doi.org/10.1234/recusandae",
+  "link" : "https://www.example.org/doloribussit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vUvsRxuDLwLw",
+    "mainTitle" : "TOYyJ1fmZkyFelf4RNi",
     "alternativeTitles" : {
-      "af" : "CbO8VH5xZ3X7"
+      "zh" : "I5oyyHPzuJFbL1cQF"
     },
-    "language" : "http://lexvo.org/id/iso639-3/hun",
+    "language" : "http://lexvo.org/id/iso639-3/afr",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "L7vidrJfHv55zQoqvU2",
-      "month" : "FwvnYy40Zjr",
-      "day" : "Pv7WotnY418gK"
+      "year" : "1yk0ANwaiaj3pFD",
+      "month" : "f8fn9rb7mcD",
+      "day" : "NljCt3tTTkBp82"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dumUA3dcqkk",
-        "name" : "y6k4erRMcFWsC1IGv98",
+        "id" : "https://www.example.com/qxRCscIsoAaQbA5",
+        "name" : "oNL54sioZOhkn",
         "nameType" : "Personal",
-        "orcId" : "EKy5FwecBwmt"
+        "orcId" : "JIawKv6TA6VMOHPj"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/TvxiHsEeUgf23UIxM9",
+        "id" : "https://www.example.com/UevQ2j0UqlyZktQN",
         "labels" : {
-          "HuF1NAe3WFLtk" : "QqiAUvuy1cjv4S"
+          "acrOvuwAspjakI8J" : "qyWFBPfhwPO8"
         }
       } ],
-      "role" : "Photographer",
-      "sequence" : 5,
+      "role" : "RelatedPerson",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/N3zJhEmyuO",
-        "name" : "UmeO64WGNqp",
-        "nameType" : "Personal",
-        "orcId" : "lhbJYOipXzM0KYQWmFy"
+        "id" : "https://www.example.com/WQcNGzHRwC",
+        "name" : "uRtawzmlLGwB",
+        "nameType" : "Organizational",
+        "orcId" : "HeCxr9aUckeVAdRM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/MTVpmJixuHuBwXuIC",
+        "id" : "https://www.example.com/rv6zVH8JhlFuHrmel8",
         "labels" : {
-          "P3XSgquBMXLu" : "lSLeLxKHYkBLCD"
+          "ylx3PkUM9vvbBoO5V" : "Dwid5QZkzqY"
         }
       } ],
-      "role" : "ContactPerson",
-      "sequence" : 3,
+      "role" : "CostumeDesigner",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "9UTVJfoqQL",
-    "tags" : [ "abf8Uwwbi5mLrQyR" ],
-    "description" : "ndd3uZlpZloReW8b",
+    "npiSubjectHeading" : "gMz7zTLwcDmmf2dHrXr",
+    "tags" : [ "axsIY3J3veN" ],
+    "description" : "OXTPbsOTUGMxZd8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jTRRMMYMisD"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/nfsSgkld6MQTY7T5sm"
         },
-        "seriesNumber" : "ujfFFiceT5JSFnhMct",
+        "seriesNumber" : "aLubR2I1Mp",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/APh8qn8Vj0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/BYFEzdyi0eTmLl"
         },
-        "isbnList" : [ "9781445728292" ]
+        "isbnList" : [ "9790310469932" ]
       },
-      "doi" : "https://www.example.com/9YpN7bOGScU",
+      "doi" : "https://www.example.com/qM5jS0Wj3CJu4Rl",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "3ki3UPQJm7ha2",
-            "end" : "jxgIx4Co4qr"
+            "begin" : "TuzWMXLa0YYk5o",
+            "end" : "f1b0njFKiraoJEbTaG"
           },
-          "pages" : "qe3k8sIXYSGvVsJ",
-          "illustrated" : false
+          "pages" : "WiuX2wOFofLDsekXW",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/EleZVxICk3f",
-    "abstract" : "CNYeAFhdZeh3wC"
+    "metadataSource" : "https://www.example.com/dvgAYp69NRPGs5r",
+    "abstract" : "bsKEs75uf9hds"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etmolestiae",
-    "name" : "OsTxEM7uoy72s8bL",
+    "id" : "https://www.example.org/sintquis",
+    "name" : "5V6R3HHFtRo",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "RqrAOmH7Zk",
-      "id" : "8t984JXreKr"
+      "source" : "Ut2toIC3h5vHFENK",
+      "id" : "RrBlx8r97Kn"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "IUE89ONyqZtVH"
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "c0M1YuDlnA"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/delectusrecusandae" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "uo8TTjuPOkx6lUaJg",
-    "mimeType" : "BJFqNvERYwHk1nQ",
-    "size" : 1468434687,
-    "license" : {
-      "type" : "License",
-      "identifier" : "YaBPBvbrlOZYQFno",
-      "labels" : {
-        "wKOLDPqwH8A" : "QXwxwvO9rN"
-      },
-      "link" : "https://www.example.com/x2GnD69NbTelo7ST8XW"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/voluptatemautem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "uo8TTjuPOkx6lUaJg",
-      "mimeType" : "BJFqNvERYwHk1nQ",
-      "size" : 1468434687,
+      "name" : "z25iteliUS",
+      "mimeType" : "bKuFjJGHT8u",
+      "size" : 1521967450,
       "license" : {
         "type" : "License",
-        "identifier" : "YaBPBvbrlOZYQFno",
+        "identifier" : "241mGDLVbByOAkL",
         "labels" : {
-          "wKOLDPqwH8A" : "QXwxwvO9rN"
+          "8xbDt3P8ih3" : "Rtsk6a8IYB"
         },
-        "link" : "https://www.example.com/x2GnD69NbTelo7ST8XW"
+        "link" : "https://www.example.com/Kjf6HJJYwQw4ibQoi"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "uLiV5sF5IgykN8",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "z25iteliUS",
+    "mimeType" : "bKuFjJGHT8u",
+    "size" : 1521967450,
+    "license" : {
+      "type" : "License",
+      "identifier" : "241mGDLVbByOAkL",
+      "labels" : {
+        "8xbDt3P8ih3" : "Rtsk6a8IYB"
+      },
+      "link" : "https://www.example.com/Kjf6HJJYwQw4ibQoi"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "EUBAMJ9Tq57LJZZdB6I",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "xJwZfpFL3k",
-    "ownerAffiliation" : "https://www.example.org/etratione"
+    "owner" : "uLiV5sF5IgykN8",
+    "ownerAffiliation" : "https://www.example.org/suntdoloremque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eatenetur",
+    "id" : "https://www.example.org/quinon",
     "labels" : {
-      "OZ4whkh2ey" : "httahFoSQ8hCQ7H"
+      "0CHopNREsnDA4vE" : "xaug6hSxLIdLamBY"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/omnismolestias",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/etfugiat",
+  "handle" : "https://www.example.org/commodiquo",
+  "doi" : "https://doi.org/10.1234/alias",
+  "link" : "https://www.example.org/aliquammagnam",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kiVzxyrMo8zTQU",
+    "mainTitle" : "vUvsRxuDLwLw",
     "alternativeTitles" : {
-      "bg" : "ljKfK7JzWK9v"
+      "af" : "CbO8VH5xZ3X7"
     },
-    "language" : "http://lexvo.org/id/iso639-3/zho",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "oFdV1qP1ET5Zyt",
-      "month" : "1JmVmE2je7BmPfNYobq",
-      "day" : "63CpQLTzlRFBwbrmcp"
+      "year" : "L7vidrJfHv55zQoqvU2",
+      "month" : "FwvnYy40Zjr",
+      "day" : "Pv7WotnY418gK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TUE0LczOeqDuYxv",
-        "name" : "pOfSfCuqXrwChQw",
+        "id" : "https://www.example.com/dumUA3dcqkk",
+        "name" : "y6k4erRMcFWsC1IGv98",
         "nameType" : "Personal",
-        "orcId" : "7ZCC96GTBpCQ"
+        "orcId" : "EKy5FwecBwmt"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/h8FJayF5fb",
+        "id" : "https://www.example.com/TvxiHsEeUgf23UIxM9",
         "labels" : {
-          "JxWdIwGJlMLiG" : "7yaWwOC2KjyNl"
+          "HuF1NAe3WFLtk" : "QqiAUvuy1cjv4S"
         }
       } ],
-      "role" : "RegistrationAgency",
-      "sequence" : 2,
+      "role" : "Photographer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ldImetvJBaIf0RVc1",
-        "name" : "aJePYqRZ1Lpp",
+        "id" : "https://www.example.com/N3zJhEmyuO",
+        "name" : "UmeO64WGNqp",
         "nameType" : "Personal",
-        "orcId" : "wlcPeFLyr5xiccC"
+        "orcId" : "lhbJYOipXzM0KYQWmFy"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cds5oCOSVYVDTe",
+        "id" : "https://www.example.com/MTVpmJixuHuBwXuIC",
         "labels" : {
-          "hkbAUXl9jOsQzg58m" : "cMwPDqS2iveVoYveA3"
+          "P3XSgquBMXLu" : "lSLeLxKHYkBLCD"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 2,
+      "role" : "ContactPerson",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "aDlhnMLZWDsvyUv",
-    "tags" : [ "E0GoeZXRBCo3aki4" ],
-    "description" : "JHwzv76gT7r3",
+    "npiSubjectHeading" : "9UTVJfoqQL",
+    "tags" : [ "abf8Uwwbi5mLrQyR" ],
+    "description" : "ndd3uZlpZloReW8b",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yynUuq1CFlbIUwkULwp"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jTRRMMYMisD"
         },
-        "seriesNumber" : "9ZRb0D1Qca8Piiwi1TZ",
+        "seriesNumber" : "ujfFFiceT5JSFnhMct",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Ynjcve4oGuHt"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/APh8qn8Vj0"
         },
-        "isbnList" : [ "9781543214659" ]
+        "isbnList" : [ "9781445728292" ]
       },
-      "doi" : "https://www.example.com/gaAz1uIx06Ze4",
+      "doi" : "https://www.example.com/9YpN7bOGScU",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "peerReviewed" : false,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "B2LINFay5N75V4ciJR",
-            "end" : "lO3BrlmEnx2"
+            "begin" : "3ki3UPQJm7ha2",
+            "end" : "jxgIx4Co4qr"
           },
-          "pages" : "3IkWUKWxn6WG0ny",
-          "illustrated" : true
+          "pages" : "qe3k8sIXYSGvVsJ",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/EDir1NNZgGnDYo",
-    "abstract" : "dKuf582Wr2lX"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "PFR14z9fqh3E",
-      "mimeType" : "haDuFV38nE5NtekGPG",
-      "size" : 758870197,
-      "license" : {
-        "type" : "License",
-        "identifier" : "fOjQevAKEc",
-        "labels" : {
-          "wAt8mnAZFsRE" : "xysg1qDUkk"
-        },
-        "link" : "https://www.example.com/ELSsHxHhwEhcEIxkS"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/EleZVxICk3f",
+    "abstract" : "CNYeAFhdZeh3wC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/mollitiased",
-    "name" : "AHmTULOKFDw0PrAXS",
+    "id" : "https://www.example.org/etmolestiae",
+    "name" : "OsTxEM7uoy72s8bL",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "1CvoyBasr6N7GhtbH",
-      "id" : "jw314a9an7W"
+      "source" : "RqrAOmH7Zk",
+      "id" : "8t984JXreKr"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "yyoE7rbCWL4a"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "IUE89ONyqZtVH"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/etanimi" ],
+  "subjects" : [ "https://www.example.org/delectusrecusandae" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "PFR14z9fqh3E",
-    "mimeType" : "haDuFV38nE5NtekGPG",
-    "size" : 758870197,
+    "name" : "uo8TTjuPOkx6lUaJg",
+    "mimeType" : "BJFqNvERYwHk1nQ",
+    "size" : 1468434687,
     "license" : {
       "type" : "License",
-      "identifier" : "fOjQevAKEc",
+      "identifier" : "YaBPBvbrlOZYQFno",
       "labels" : {
-        "wAt8mnAZFsRE" : "xysg1qDUkk"
+        "wKOLDPqwH8A" : "QXwxwvO9rN"
       },
-      "link" : "https://www.example.com/ELSsHxHhwEhcEIxkS"
+      "link" : "https://www.example.com/x2GnD69NbTelo7ST8XW"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "xJwZfpFL3k"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "uo8TTjuPOkx6lUaJg",
+      "mimeType" : "BJFqNvERYwHk1nQ",
+      "size" : 1468434687,
+      "license" : {
+        "type" : "License",
+        "identifier" : "YaBPBvbrlOZYQFno",
+        "labels" : {
+          "wKOLDPqwH8A" : "QXwxwvO9rN"
+        },
+        "link" : "https://www.example.com/x2GnD69NbTelo7ST8XW"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "uLiV5sF5IgykN8",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "D4kLkoL1PcaiGKzp",
-    "ownerAffiliation" : "https://www.example.org/doloradipisci"
+    "owner" : "CdjgWVC7WwDXGQKxsD",
+    "ownerAffiliation" : "https://www.example.org/culpaaliquam"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/odioquisquam",
+    "id" : "https://www.example.org/doloribuscorrupti",
     "labels" : {
-      "ApNUdP0pMqR" : "qPMqT1XuKjtJNBH0xx"
+      "hodreL1DuXdXoId" : "44vwGnYdg00m"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/harumcorporis",
-  "doi" : "https://doi.org/10.1234/dolores",
-  "link" : "https://www.example.org/voluptasaut",
+  "handle" : "https://www.example.org/consequaturculpa",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/voluptatemex",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Z8MM42rpsAU59n",
+    "mainTitle" : "ZHjdxkFc3y",
     "alternativeTitles" : {
-      "nl" : "86XjzLSG5FUTajKy5t5"
+      "it" : "YWkbCNYQvXY"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ell",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "rCI67CoLQEek85BGOO",
-      "month" : "Hfj2elYsZfDIraI1J",
-      "day" : "rUMEQi4V9jl"
+      "year" : "0pWdiSs9Q8k6TXpb",
+      "month" : "eSA3c40dKODtK2",
+      "day" : "6sEZnKbCMFmMPxjqTc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iHhVKGRVU6RmJg",
-        "name" : "dqn5RmRMX5AEMkVs0h",
+        "id" : "https://www.example.com/QNu6yrU4iujvifwQwMw",
+        "name" : "l8P1TPxVQC",
         "nameType" : "Personal",
-        "orcId" : "rY4UWILS8SLms98Q"
+        "orcId" : "i3cYj3ymeztR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/8wt4WrgYuDyl",
+        "id" : "https://www.example.com/i91zUjYsoJlCqKPuwTq",
         "labels" : {
-          "PsbTTB94omAfZap4" : "66rpAtUvKmgEJVyVtq"
+          "nJIONSIx68" : "AS4qRmgYbNn0Ba"
         }
       } ],
-      "role" : "Composer",
-      "sequence" : 7,
+      "role" : "SoundDesigner",
+      "sequence" : 9,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/D8wA3oV9O5Ys1i",
-        "name" : "Gxx3GZ87iL",
-        "nameType" : "Personal",
-        "orcId" : "2Buma50Alg"
+        "id" : "https://www.example.com/vsFE1AqSqBnFTgy",
+        "name" : "tL4uf2eB4dsSysKZ",
+        "nameType" : "Organizational",
+        "orcId" : "X6ORYPCDuLZicK"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Q3savqmBizf9v49",
+        "id" : "https://www.example.com/QDSJLNQNbnHN61NTPY",
         "labels" : {
-          "NXkCdWMrx9F" : "ldnGbmSJrrRbDXtWMr"
+          "tlecAONch1uBcltK" : "LtbZqFCITfv4dezXERZ"
         }
       } ],
-      "role" : "ResearchGroup",
+      "role" : "InterviewSubject",
       "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "RzoCsL1lZQCo",
-    "tags" : [ "CshyHi0UpjGX7YwOUf" ],
-    "description" : "dgaFc79OpJdpGW29a",
+    "npiSubjectHeading" : "w0JBpGtB65uBfAx",
+    "tags" : [ "4maULaZiJzWe" ],
+    "description" : "Lnmh1DDZAJd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xY2jCHu9Cxc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fffCikRJAZ"
         },
-        "seriesNumber" : "cRQiAOZFQddY",
+        "seriesNumber" : "e1JIkonJmnsik",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/B17mhIDiWFiSA3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yU162PwzMnF"
         },
-        "isbnList" : [ "9791907561459" ]
+        "isbnList" : [ "9790987465589" ]
       },
-      "doi" : "https://www.example.com/UXjDEz6u7Sw9R",
+      "doi" : "https://www.example.com/3YAc1KrmubP",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "peerReviewed" : false,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "JLdC0vZWOH12OhAmrwI",
-            "end" : "XteDhZfYlw6"
+            "begin" : "HEqLcr6RIm7R",
+            "end" : "JKQOqaeRFMy"
           },
-          "pages" : "vBPGglce1e2nAtv80v",
+          "pages" : "4PtcMYVvrBhkSHlJmV",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/XfoVJ7lO3F",
-    "abstract" : "eo9vfdbQGMSWb7IaHU"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "GVywGrATFy88Wjo",
-      "mimeType" : "66xjDIVoA8",
-      "size" : 1041286311,
-      "license" : {
-        "type" : "License",
-        "identifier" : "R2eiz7ts0ThGfB",
-        "labels" : {
-          "OjxHZFWeits" : "28Ea4n8OEkzBqx"
-        },
-        "link" : "https://www.example.com/eHtfSXkda2E"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/Egequ90QWu1U",
+    "abstract" : "RqBAmFdDaxR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/repellataccusantium",
-    "name" : "hI2FaYK8eMm",
+    "id" : "https://www.example.org/utconsequatur",
+    "name" : "ki50HQE5T3CiLBS9t",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "6iz9TjUJuGt0Sr7",
-      "id" : "DV1JYJ1vO4ETYGx"
+      "source" : "2EmKdBy5S9s",
+      "id" : "N130HOkZObMigtVM2P"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "HPfPwNFZm8xbmkCvC"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "5946aqnOBlauf3jbPL"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/temporequo" ],
+  "subjects" : [ "https://www.example.org/officiavoluptate" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "GVywGrATFy88Wjo",
-    "mimeType" : "66xjDIVoA8",
-    "size" : 1041286311,
+    "name" : "uTAETLF80WaiUF2gy",
+    "mimeType" : "qaT7C4V1wAiDgzQe",
+    "size" : 789422606,
     "license" : {
       "type" : "License",
-      "identifier" : "R2eiz7ts0ThGfB",
+      "identifier" : "VDRVBXdHB9KPudkm8",
       "labels" : {
-        "OjxHZFWeits" : "28Ea4n8OEkzBqx"
+        "kkoIz1RV1jt" : "GHc7ih9CinwOo1k"
       },
-      "link" : "https://www.example.com/eHtfSXkda2E"
+      "link" : "https://www.example.com/ui8s6WOLes"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "D4kLkoL1PcaiGKzp"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "uTAETLF80WaiUF2gy",
+      "mimeType" : "qaT7C4V1wAiDgzQe",
+      "size" : 789422606,
+      "license" : {
+        "type" : "License",
+        "identifier" : "VDRVBXdHB9KPudkm8",
+        "labels" : {
+          "kkoIz1RV1jt" : "GHc7ih9CinwOo1k"
+        },
+        "link" : "https://www.example.com/ui8s6WOLes"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "CdjgWVC7WwDXGQKxsD",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "NYnhR4AD4f6l1",
-    "ownerAffiliation" : "https://www.example.org/eosenim"
+    "owner" : "wEKoOs2kmrP136bTiN",
+    "ownerAffiliation" : "https://www.example.org/abex"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/etvoluptas",
+    "id" : "https://www.example.org/velitexercitationem",
     "labels" : {
-      "CLPtfXsIIUm" : "kyK5jBkRkhtZ2FilDyd"
+      "5ZGYaiMeizO" : "Dt55NU5Ze8"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/velitvoluptatem",
-  "doi" : "https://doi.org/10.1234/excepturi",
-  "link" : "https://www.example.org/nihilnihil",
+  "handle" : "https://www.example.org/quieos",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/magnamtemporibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "47GZGKqWphm94e",
+    "mainTitle" : "4vS6tCCWXU7ALe",
     "alternativeTitles" : {
-      "fi" : "r4wx3itJF77P3PTaVps"
+      "it" : "A9SwFqeWwebO8M4ieaS"
     },
-    "language" : "http://lexvo.org/id/iso639-3/hun",
+    "language" : "http://lexvo.org/id/iso639-3/nno",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "8FxUbyV59wroDv",
-      "month" : "5GsYFeISgwF8",
-      "day" : "DKZNeipnc5TKLL5YbM"
+      "year" : "zMmlHLXtB3iVQU",
+      "month" : "KqyQdJ1z6lkJMQmSG",
+      "day" : "0uSjRnK2DLjQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/iA62oZTVWpwc0",
-        "name" : "KOopbkyPBod8F0r3K0",
-        "nameType" : "Organizational",
-        "orcId" : "aawpENB2ipfmdxWRqb"
+        "id" : "https://www.example.com/twmgBUHbEY218Gh",
+        "name" : "rcwJMhgWCF",
+        "nameType" : "Personal",
+        "orcId" : "Ph3XGti25t8u12VZihM"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/VDzftStIAW9vO",
+        "id" : "https://www.example.com/lrWGMtqBrmMv93suw",
         "labels" : {
-          "JJJw9p53XVdbdo6z" : "rPtvXtwPNECyCoM85"
+          "fEWirEBYN3qIc8m" : "kg0YIDT4Jvpgh"
         }
       } ],
-      "role" : "Dramaturge",
-      "sequence" : 0,
+      "role" : "Consultant",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/taMsigtXrIZRG",
-        "name" : "UsQDCaGtESwI",
-        "nameType" : "Organizational",
-        "orcId" : "hLiJc09MFcn68Pm97P"
+        "id" : "https://www.example.com/u6kRNUIdiolpom",
+        "name" : "J10PDD3wjDe",
+        "nameType" : "Personal",
+        "orcId" : "PsTYJuq08R24"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QKKS9maiEMEY6b8I8",
+        "id" : "https://www.example.com/PCmVPAYc9EodnLSuuQ",
         "labels" : {
-          "bTYmnuCKH7" : "3CzLCvCPQ5E89"
+          "MMijcpjkBfepJkQ" : "WlOAJLQZ8Z"
         }
       } ],
-      "role" : "Sponsor",
-      "sequence" : 0,
+      "role" : "DataCurator",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "PVFCLba2F2S9Kve",
-    "tags" : [ "rHAdmQWTZO2t0" ],
-    "description" : "pqRVswXEuqKZeNkC8ei",
+    "npiSubjectHeading" : "TfT1yq2QKh",
+    "tags" : [ "B5WABcydynac" ],
+    "description" : "Ep6Wmx35XL9hngNVi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wOGVeNojnsSmDKc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bHgOUAb7KZW2zL"
         },
-        "seriesNumber" : "flR310JDQYzg",
+        "seriesNumber" : "0eCDCHxprGabgc4Yn",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/twX8jLfVBvPe"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZEYaHgPJDKdH"
         },
-        "isbnList" : [ "9790881959894" ]
+        "isbnList" : [ "9780896269934" ]
       },
-      "doi" : "https://www.example.com/LfFNavnEeP3NahO1wl",
+      "doi" : "https://www.example.com/BKlfDr9tgJpd",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "NEWBT1uM7K05JvR3X",
-            "end" : "kh6x5IVurpUsg"
+            "begin" : "FfUOwy267zDi",
+            "end" : "VGzs3zmiFi1A0va2Qhk"
           },
-          "pages" : "LpL1YUgZ0Yi5",
+          "pages" : "h6nTz50eWLWohb6QrF2",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/NuVNtNgZ4QChgaKM9WL",
-    "abstract" : "OouS94bDdEM8cxrKGBP"
+    "metadataSource" : "https://www.example.com/K35s1VZtEuqaAmZAV",
+    "abstract" : "LxdVmvnnWY7Ppjjz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/facilisvitae",
-    "name" : "JMC4jriCR0t82JyhF",
+    "id" : "https://www.example.org/quisint",
+    "name" : "qcAzwxQ6tPB0k5rtj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "fNFt6zIKYXMpQV",
-      "id" : "W9FRVhByzcPJc6z"
+      "source" : "ObbcPGcF7CRYvVy",
+      "id" : "7W2fQyi3DfJm"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "FnU0coFMwVmpch4UR2"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "37WiDSwx4ltG2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eiusdoloribus" ],
+  "subjects" : [ "https://www.example.org/autemfacilis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bixaIZaAcsgSj7",
-      "mimeType" : "R7QZIuBWBA",
-      "size" : 626357150,
+      "name" : "18XtppIyu9yCxKk",
+      "mimeType" : "qBL6oPy3u0f",
+      "size" : 1568296669,
       "license" : {
         "type" : "License",
-        "identifier" : "NhVvPVW6mOqFF",
+        "identifier" : "GduQzH5Vb9iLOq",
         "labels" : {
-          "xGBf5KHNolQ7JuR" : "bReyhMJgi9K"
+          "DvC3L3FeJi" : "4SvRgA0g18z"
         },
-        "link" : "https://www.example.com/ZTFZRiPnF4n"
+        "link" : "https://www.example.com/xpjfnXFwo4yEML"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bixaIZaAcsgSj7",
-    "mimeType" : "R7QZIuBWBA",
-    "size" : 626357150,
+    "name" : "18XtppIyu9yCxKk",
+    "mimeType" : "qBL6oPy3u0f",
+    "size" : 1568296669,
     "license" : {
       "type" : "License",
-      "identifier" : "NhVvPVW6mOqFF",
+      "identifier" : "GduQzH5Vb9iLOq",
       "labels" : {
-        "xGBf5KHNolQ7JuR" : "bReyhMJgi9K"
+        "DvC3L3FeJi" : "4SvRgA0g18z"
       },
-      "link" : "https://www.example.com/ZTFZRiPnF4n"
+      "link" : "https://www.example.com/xpjfnXFwo4yEML"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "NYnhR4AD4f6l1",
+  "owner" : "wEKoOs2kmrP136bTiN",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "CdjgWVC7WwDXGQKxsD",
-    "ownerAffiliation" : "https://www.example.org/culpaaliquam"
+    "owner" : "NYnhR4AD4f6l1",
+    "ownerAffiliation" : "https://www.example.org/eosenim"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/doloribuscorrupti",
+    "id" : "https://www.example.org/etvoluptas",
     "labels" : {
-      "hodreL1DuXdXoId" : "44vwGnYdg00m"
+      "CLPtfXsIIUm" : "kyK5jBkRkhtZ2FilDyd"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consequaturculpa",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/voluptatemex",
+  "handle" : "https://www.example.org/velitvoluptatem",
+  "doi" : "https://doi.org/10.1234/excepturi",
+  "link" : "https://www.example.org/nihilnihil",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZHjdxkFc3y",
+    "mainTitle" : "47GZGKqWphm94e",
     "alternativeTitles" : {
-      "it" : "YWkbCNYQvXY"
+      "fi" : "r4wx3itJF77P3PTaVps"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/hun",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "0pWdiSs9Q8k6TXpb",
-      "month" : "eSA3c40dKODtK2",
-      "day" : "6sEZnKbCMFmMPxjqTc"
+      "year" : "8FxUbyV59wroDv",
+      "month" : "5GsYFeISgwF8",
+      "day" : "DKZNeipnc5TKLL5YbM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/QNu6yrU4iujvifwQwMw",
-        "name" : "l8P1TPxVQC",
-        "nameType" : "Personal",
-        "orcId" : "i3cYj3ymeztR"
+        "id" : "https://www.example.com/iA62oZTVWpwc0",
+        "name" : "KOopbkyPBod8F0r3K0",
+        "nameType" : "Organizational",
+        "orcId" : "aawpENB2ipfmdxWRqb"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/i91zUjYsoJlCqKPuwTq",
+        "id" : "https://www.example.com/VDzftStIAW9vO",
         "labels" : {
-          "nJIONSIx68" : "AS4qRmgYbNn0Ba"
+          "JJJw9p53XVdbdo6z" : "rPtvXtwPNECyCoM85"
         }
       } ],
-      "role" : "SoundDesigner",
-      "sequence" : 9,
+      "role" : "Dramaturge",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/vsFE1AqSqBnFTgy",
-        "name" : "tL4uf2eB4dsSysKZ",
+        "id" : "https://www.example.com/taMsigtXrIZRG",
+        "name" : "UsQDCaGtESwI",
         "nameType" : "Organizational",
-        "orcId" : "X6ORYPCDuLZicK"
+        "orcId" : "hLiJc09MFcn68Pm97P"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/QDSJLNQNbnHN61NTPY",
+        "id" : "https://www.example.com/QKKS9maiEMEY6b8I8",
         "labels" : {
-          "tlecAONch1uBcltK" : "LtbZqFCITfv4dezXERZ"
+          "bTYmnuCKH7" : "3CzLCvCPQ5E89"
         }
       } ],
-      "role" : "InterviewSubject",
-      "sequence" : 8,
+      "role" : "Sponsor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "w0JBpGtB65uBfAx",
-    "tags" : [ "4maULaZiJzWe" ],
-    "description" : "Lnmh1DDZAJd",
+    "npiSubjectHeading" : "PVFCLba2F2S9Kve",
+    "tags" : [ "rHAdmQWTZO2t0" ],
+    "description" : "pqRVswXEuqKZeNkC8ei",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fffCikRJAZ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wOGVeNojnsSmDKc"
         },
-        "seriesNumber" : "e1JIkonJmnsik",
+        "seriesNumber" : "flR310JDQYzg",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/yU162PwzMnF"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/twX8jLfVBvPe"
         },
-        "isbnList" : [ "9790987465589" ]
+        "isbnList" : [ "9790881959894" ]
       },
-      "doi" : "https://www.example.com/3YAc1KrmubP",
+      "doi" : "https://www.example.com/LfFNavnEeP3NahO1wl",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "HEqLcr6RIm7R",
-            "end" : "JKQOqaeRFMy"
+            "begin" : "NEWBT1uM7K05JvR3X",
+            "end" : "kh6x5IVurpUsg"
           },
-          "pages" : "4PtcMYVvrBhkSHlJmV",
+          "pages" : "LpL1YUgZ0Yi5",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Egequ90QWu1U",
-    "abstract" : "RqBAmFdDaxR"
+    "metadataSource" : "https://www.example.com/NuVNtNgZ4QChgaKM9WL",
+    "abstract" : "OouS94bDdEM8cxrKGBP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utconsequatur",
-    "name" : "ki50HQE5T3CiLBS9t",
+    "id" : "https://www.example.org/facilisvitae",
+    "name" : "JMC4jriCR0t82JyhF",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "2EmKdBy5S9s",
-      "id" : "N130HOkZObMigtVM2P"
+      "source" : "fNFt6zIKYXMpQV",
+      "id" : "W9FRVhByzcPJc6z"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "5946aqnOBlauf3jbPL"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "FnU0coFMwVmpch4UR2"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/officiavoluptate" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "uTAETLF80WaiUF2gy",
-    "mimeType" : "qaT7C4V1wAiDgzQe",
-    "size" : 789422606,
-    "license" : {
-      "type" : "License",
-      "identifier" : "VDRVBXdHB9KPudkm8",
-      "labels" : {
-        "kkoIz1RV1jt" : "GHc7ih9CinwOo1k"
-      },
-      "link" : "https://www.example.com/ui8s6WOLes"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/eiusdoloribus" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "uTAETLF80WaiUF2gy",
-      "mimeType" : "qaT7C4V1wAiDgzQe",
-      "size" : 789422606,
+      "name" : "bixaIZaAcsgSj7",
+      "mimeType" : "R7QZIuBWBA",
+      "size" : 626357150,
       "license" : {
         "type" : "License",
-        "identifier" : "VDRVBXdHB9KPudkm8",
+        "identifier" : "NhVvPVW6mOqFF",
         "labels" : {
-          "kkoIz1RV1jt" : "GHc7ih9CinwOo1k"
+          "xGBf5KHNolQ7JuR" : "bReyhMJgi9K"
         },
-        "link" : "https://www.example.com/ui8s6WOLes"
+        "link" : "https://www.example.com/ZTFZRiPnF4n"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "CdjgWVC7WwDXGQKxsD",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "bixaIZaAcsgSj7",
+    "mimeType" : "R7QZIuBWBA",
+    "size" : 626357150,
+    "license" : {
+      "type" : "License",
+      "identifier" : "NhVvPVW6mOqFF",
+      "labels" : {
+        "xGBf5KHNolQ7JuR" : "bReyhMJgi9K"
+      },
+      "link" : "https://www.example.com/ZTFZRiPnF4n"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "NYnhR4AD4f6l1",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "wEKoOs2kmrP136bTiN",
-    "ownerAffiliation" : "https://www.example.org/abex"
+    "owner" : "gr7HbveND7MGfQjr",
+    "ownerAffiliation" : "https://www.example.org/explicaboesse"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/velitexercitationem",
+    "id" : "https://www.example.org/reprehenderitodio",
     "labels" : {
-      "5ZGYaiMeizO" : "Dt55NU5Ze8"
+      "6WN9BQCeA6Gb5" : "StFu3Xtn8IwK"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quieos",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/magnamtemporibus",
+  "handle" : "https://www.example.org/earumdolores",
+  "doi" : "https://doi.org/10.1234/reprehenderit",
+  "link" : "https://www.example.org/quidemquis",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4vS6tCCWXU7ALe",
+    "mainTitle" : "LZXu0JtzqsN",
     "alternativeTitles" : {
-      "it" : "A9SwFqeWwebO8M4ieaS"
+      "zh" : "ESsXaw5c5ugj"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nno",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "zMmlHLXtB3iVQU",
-      "month" : "KqyQdJ1z6lkJMQmSG",
-      "day" : "0uSjRnK2DLjQ"
+      "year" : "9BGxPfK9pXB",
+      "month" : "hgDNWJWMKZqguWfjoR",
+      "day" : "ymxAncwsoJbY"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/twmgBUHbEY218Gh",
-        "name" : "rcwJMhgWCF",
+        "id" : "https://www.example.com/IG21upFUW5wD0DgJUR",
+        "name" : "VgYbSEgeTusse",
         "nameType" : "Personal",
-        "orcId" : "Ph3XGti25t8u12VZihM"
+        "orcId" : "HydRzQHCXZ4DYg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lrWGMtqBrmMv93suw",
+        "id" : "https://www.example.com/gxgs1Wwlcz3dRmd2",
         "labels" : {
-          "fEWirEBYN3qIc8m" : "kg0YIDT4Jvpgh"
+          "DFkJkeRDWmDuXs" : "rhxD9SSluRD"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 3,
+      "role" : "Sponsor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/u6kRNUIdiolpom",
-        "name" : "J10PDD3wjDe",
+        "id" : "https://www.example.com/r8aq3pRmXeBd",
+        "name" : "kzzOBrKmjboWh3xw",
         "nameType" : "Personal",
-        "orcId" : "PsTYJuq08R24"
+        "orcId" : "JJ7pszMBVzh3tQLkxP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/PCmVPAYc9EodnLSuuQ",
+        "id" : "https://www.example.com/Swdya7tTeb4j",
         "labels" : {
-          "MMijcpjkBfepJkQ" : "WlOAJLQZ8Z"
+          "XAeZ7ktkkR" : "2hdJCer0eYdGKz"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 6,
+      "role" : "Editor",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "TfT1yq2QKh",
-    "tags" : [ "B5WABcydynac" ],
-    "description" : "Ep6Wmx35XL9hngNVi",
+    "npiSubjectHeading" : "JY2CmwlbvbEuPeymoB",
+    "tags" : [ "M91p3UdRDTuVP9" ],
+    "description" : "WcsWwNl6RjNHmPRz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bHgOUAb7KZW2zL"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dxnUrYoA4QBDab2K9"
         },
-        "seriesNumber" : "0eCDCHxprGabgc4Yn",
+        "seriesNumber" : "WD3YT8ebgIge",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZEYaHgPJDKdH"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/PZBMONctyjOUO"
         },
-        "isbnList" : [ "9780896269934" ]
+        "isbnList" : [ "9780861455317" ]
       },
-      "doi" : "https://www.example.com/BKlfDr9tgJpd",
+      "doi" : "https://www.example.com/XJTXHigowLkoHDOhwo",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "FfUOwy267zDi",
-            "end" : "VGzs3zmiFi1A0va2Qhk"
+            "begin" : "fG7iWtXixFtjkq3wHdI",
+            "end" : "7KboHcmRJKiM6H"
           },
-          "pages" : "h6nTz50eWLWohb6QrF2",
-          "illustrated" : false
+          "pages" : "KKAZp43wcP",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/K35s1VZtEuqaAmZAV",
-    "abstract" : "LxdVmvnnWY7Ppjjz"
+    "metadataSource" : "https://www.example.com/KFOhxTbb5E2GsufHoY",
+    "abstract" : "I23npvM4knR1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quisint",
-    "name" : "qcAzwxQ6tPB0k5rtj",
+    "id" : "https://www.example.org/maioresiusto",
+    "name" : "N7B5Z75YIdyz6l",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ObbcPGcF7CRYvVy",
-      "id" : "7W2fQyi3DfJm"
+      "source" : "QN85qR5OZdOx8ScY6",
+      "id" : "gD8I1yOdAras384xEK"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "37WiDSwx4ltG2"
+      "applicationCode" : "cNqB49wTbC2A2na7uUN"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/autemfacilis" ],
+  "subjects" : [ "https://www.example.org/quisint" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "18XtppIyu9yCxKk",
-      "mimeType" : "qBL6oPy3u0f",
-      "size" : 1568296669,
+      "name" : "zTOlHPUXYRq",
+      "mimeType" : "xhYO1TKN8c",
+      "size" : 22118937,
       "license" : {
         "type" : "License",
-        "identifier" : "GduQzH5Vb9iLOq",
+        "identifier" : "10k68dAkEFBatejt3",
         "labels" : {
-          "DvC3L3FeJi" : "4SvRgA0g18z"
+          "o3130tzEJLC2WNb5Wq" : "4LW7NvoLVd47V"
         },
-        "link" : "https://www.example.com/xpjfnXFwo4yEML"
+        "link" : "https://www.example.com/JevpFrhA0LW3"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "18XtppIyu9yCxKk",
-    "mimeType" : "qBL6oPy3u0f",
-    "size" : 1568296669,
+    "name" : "zTOlHPUXYRq",
+    "mimeType" : "xhYO1TKN8c",
+    "size" : 22118937,
     "license" : {
       "type" : "License",
-      "identifier" : "GduQzH5Vb9iLOq",
+      "identifier" : "10k68dAkEFBatejt3",
       "labels" : {
-        "DvC3L3FeJi" : "4SvRgA0g18z"
+        "o3130tzEJLC2WNb5Wq" : "4LW7NvoLVd47V"
       },
-      "link" : "https://www.example.com/xpjfnXFwo4yEML"
+      "link" : "https://www.example.com/JevpFrhA0LW3"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "wEKoOs2kmrP136bTiN",
+  "owner" : "gr7HbveND7MGfQjr",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "LGKtufJo58N21mXVx",
-    "ownerAffiliation" : "https://www.example.org/laboreat"
+    "owner" : "iqrubs6zQNkqte",
+    "ownerAffiliation" : "https://www.example.org/saepequi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/laudantiumsequi",
+    "id" : "https://www.example.org/adipiscinesciunt",
     "labels" : {
-      "SxoHRPkCkrkMvL" : "LVX6pFJSIjT5"
+      "3yxcd0VzAG25Qj" : "v1JaSNSjnI9qP3"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/dignissimosex",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/esttempore",
+  "handle" : "https://www.example.org/molestiasnon",
+  "doi" : "https://doi.org/10.1234/debitis",
+  "link" : "https://www.example.org/perferendisquod",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "X4OblGs3v76LoAUvCng",
+    "mainTitle" : "tqLCQtk6Olk35Czq",
     "alternativeTitles" : {
-      "it" : "dlmFXlaca1vk"
+      "zh" : "fTMAvEYgjjh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/fin",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "7omoF6A5CJ",
-      "month" : "BfuUqDMX745",
-      "day" : "42jctgnuqvdrgljBay"
+      "year" : "xEYbmne23jEef",
+      "month" : "OmXsvMU8U6AN",
+      "day" : "orGFH7s4cWBSOqfnJZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/a09DyZ77rSiLx0Z",
-        "name" : "Y8WE454RtjJkUU",
+        "id" : "https://www.example.com/cMI1sYLxyQO3X",
+        "name" : "co0W1LNySyb1YuMU",
         "nameType" : "Organizational",
-        "orcId" : "iyYoJZLc1Zh87o"
+        "orcId" : "pVAzPixXKzpgvhE"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Y4zCtIhd3nTDrfjk",
+        "id" : "https://www.example.com/qmhMrxBjwg7bKMoFM",
         "labels" : {
-          "KWSyDmqjOF8N8xT5" : "2B99Y0GboFXYUBvYF4"
+          "ZMFpCwwz1NMt" : "ThhMMFWzxENHhqEVwsv"
         }
       } ],
-      "role" : "LightDesigner",
-      "sequence" : 8,
+      "role" : "ProjectMember",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/txAS8KuNsrzKL5",
-        "name" : "jlEDi1LgpnTFfCwEB",
+        "id" : "https://www.example.com/rWqq2BqOyz",
+        "name" : "WAs5vTuDJqC",
         "nameType" : "Personal",
-        "orcId" : "jW59Kz2B9QpVqmnx"
+        "orcId" : "wIpcMw6kWr"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/zdiKgoYLo1Bx3Md",
+        "id" : "https://www.example.com/qx6M2hq3KdWie",
         "labels" : {
-          "cr2v4skdaT9r3Ozox3d" : "LurXPZ6LzRaU"
+          "Z4husImpAY" : "zxs2gvpzmUX5ia"
         }
       } ],
-      "role" : "Musician",
-      "sequence" : 1,
+      "role" : "Dancer",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "kz1b66vTyWi7yRmQ6W",
-    "tags" : [ "CQrL9R7l2FJ" ],
-    "description" : "X6cKHnteH8H0oA2",
+    "npiSubjectHeading" : "I5vP2YQXU15ndjv5",
+    "tags" : [ "ZBOflmkTn2CbpKMeKL" ],
+    "description" : "PXKKuQlTRNR46Cl",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Dnai9Axi9NFp"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/r3H4IPF6SihBSQy"
         },
-        "seriesNumber" : "44XMDFzieiD",
+        "seriesNumber" : "l2R2bZFFDA2F",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/HoavmDaggL"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jY7ZaCDkhcDb"
         },
-        "isbnList" : [ "9790258510543" ]
+        "isbnList" : [ "9781841405117" ]
       },
-      "doi" : "https://www.example.com/NCTDzcj6TrbdTt2L",
+      "doi" : "https://www.example.com/7I3scQCxaYbS",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rjobjAxiuiz7S",
-            "end" : "OnGB2e5fFOnj0o3"
+            "begin" : "bC8P7Z5qVmOyNmzfUn6",
+            "end" : "EoTNN9yAFfBuM4rf0vd"
           },
-          "pages" : "6Ph9YsEPvUDT65b",
+          "pages" : "OYHq8dv39fKy98",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/jL3ipZqVZ5u",
-    "abstract" : "wUPOn9pkY4x"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "F3WqmSRtynHrOlqeRWS",
-      "mimeType" : "woXvqABTj00t26Ye",
-      "size" : 1501613404,
-      "license" : {
-        "type" : "License",
-        "identifier" : "95lFGT5S6V5HS72fC",
-        "labels" : {
-          "x8WdNor1JlLOwVWQdOQ" : "Y5A6oJ883rSf3"
-        },
-        "link" : "https://www.example.com/KfZ25W2rLqQaShGzUXW"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/XGEJGF9Wz6IkzitJ9",
+    "abstract" : "H2ohJWzALXi9PSZ7w"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/molestiaenemo",
-    "name" : "GO11jKOdIJF1J",
+    "id" : "https://www.example.org/quiamolestiae",
+    "name" : "tIFBMrX5jeG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "xxsQFSeCZLlKL",
-      "id" : "q9NZ4LtUmYjGkGQoBgF"
+      "source" : "Uicop8B0LTS7j14",
+      "id" : "0eCpT1w50S1eenAy"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "sT6QiGFiEhcigb7N9"
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "cxYIXibLnmoWYy9"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/aspernatursint" ],
+  "subjects" : [ "https://www.example.org/odioab" ],
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "F3WqmSRtynHrOlqeRWS",
-    "mimeType" : "woXvqABTj00t26Ye",
-    "size" : 1501613404,
+    "name" : "n7fn1INdnGIMwuA7",
+    "mimeType" : "mPOn5fdtU6lnlQx9H",
+    "size" : 1738497204,
     "license" : {
       "type" : "License",
-      "identifier" : "95lFGT5S6V5HS72fC",
+      "identifier" : "oeL1yostYYO3dZP2D",
       "labels" : {
-        "x8WdNor1JlLOwVWQdOQ" : "Y5A6oJ883rSf3"
+        "YK3qSi9JfAd" : "KiBMgHIswAccN"
       },
-      "link" : "https://www.example.com/KfZ25W2rLqQaShGzUXW"
+      "link" : "https://www.example.com/2Uo3dc2hBJY5"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "LGKtufJo58N21mXVx"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "UnpublishableFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "n7fn1INdnGIMwuA7",
+      "mimeType" : "mPOn5fdtU6lnlQx9H",
+      "size" : 1738497204,
+      "license" : {
+        "type" : "License",
+        "identifier" : "oeL1yostYYO3dZP2D",
+        "labels" : {
+          "YK3qSi9JfAd" : "KiBMgHIswAccN"
+        },
+        "link" : "https://www.example.com/2Uo3dc2hBJY5"
+      },
+      "administrativeAgreement" : true,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "iqrubs6zQNkqte",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "iqrubs6zQNkqte",
-    "ownerAffiliation" : "https://www.example.org/saepequi"
+    "owner" : "UNUDEBUwBGn",
+    "ownerAffiliation" : "https://www.example.org/sedcumque"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/adipiscinesciunt",
+    "id" : "https://www.example.org/voluptatevoluptatem",
     "labels" : {
-      "3yxcd0VzAG25Qj" : "v1JaSNSjnI9qP3"
+      "hvb7jbiZTcB8sPsOK" : "ZgshhHmAW2HfMwAol"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/molestiasnon",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/perferendisquod",
+  "handle" : "https://www.example.org/utenim",
+  "doi" : "https://doi.org/10.1234/alias",
+  "link" : "https://www.example.org/aliasconsectetur",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tqLCQtk6Olk35Czq",
+    "mainTitle" : "ZTXaEFem1P",
     "alternativeTitles" : {
-      "zh" : "fTMAvEYgjjh"
+      "es" : "TbwSAcbTks"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fin",
+    "language" : "http://lexvo.org/id/iso639-3/spa",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "xEYbmne23jEef",
-      "month" : "OmXsvMU8U6AN",
-      "day" : "orGFH7s4cWBSOqfnJZ"
+      "year" : "SKZHLA0LA0mKO8P",
+      "month" : "GcinbURPggpVHBH6X3h",
+      "day" : "KKwsq3f3hEAGIY"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cMI1sYLxyQO3X",
-        "name" : "co0W1LNySyb1YuMU",
-        "nameType" : "Organizational",
-        "orcId" : "pVAzPixXKzpgvhE"
+        "id" : "https://www.example.com/bpu7y9cZohD95rRZeto",
+        "name" : "d9T09NYsI8yTrWbVrDg",
+        "nameType" : "Personal",
+        "orcId" : "MgebrNhzgskyhti"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qmhMrxBjwg7bKMoFM",
+        "id" : "https://www.example.com/rPbYepxp2i",
         "labels" : {
-          "ZMFpCwwz1NMt" : "ThhMMFWzxENHhqEVwsv"
+          "XzTuQcfZ2SC6" : "k5eBGHCO5cYDJ"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 6,
+      "role" : "Actor",
+      "sequence" : 0,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/rWqq2BqOyz",
-        "name" : "WAs5vTuDJqC",
-        "nameType" : "Personal",
-        "orcId" : "wIpcMw6kWr"
+        "id" : "https://www.example.com/flcdcdXxWKf",
+        "name" : "dR1CoebnSw8xVPvo",
+        "nameType" : "Organizational",
+        "orcId" : "Z6LG5m8wziIJxXSlcJk"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/qx6M2hq3KdWie",
+        "id" : "https://www.example.com/1GpOgP4Q0COdxrdq",
         "labels" : {
-          "Z4husImpAY" : "zxs2gvpzmUX5ia"
+          "xsRmu2MGNkQf" : "PpiZyquBWrr4tmLlgL"
         }
       } ],
-      "role" : "Dancer",
-      "sequence" : 2,
+      "role" : "ProjectLeader",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "I5vP2YQXU15ndjv5",
-    "tags" : [ "ZBOflmkTn2CbpKMeKL" ],
-    "description" : "PXKKuQlTRNR46Cl",
+    "npiSubjectHeading" : "5LTVzlYmjqpkW",
+    "tags" : [ "hCrZoMpRTh8bPO" ],
+    "description" : "imVcfe5DAvLBLsTv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/r3H4IPF6SihBSQy"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gNUbgbbWP0YlXuxW"
         },
-        "seriesNumber" : "l2R2bZFFDA2F",
+        "seriesNumber" : "QbPvJ2xlBEeEI",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/jY7ZaCDkhcDb"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Xb4cq7kHiQT8OBr01"
         },
-        "isbnList" : [ "9781841405117" ]
+        "isbnList" : [ "9780732226848" ]
       },
-      "doi" : "https://www.example.com/7I3scQCxaYbS",
+      "doi" : "https://www.example.com/8r5oE9TcLhf6SKUqASS",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "bC8P7Z5qVmOyNmzfUn6",
-            "end" : "EoTNN9yAFfBuM4rf0vd"
+            "begin" : "zanTriX1Nuxlw0Jup0P",
+            "end" : "K3cX6MiQ149QS"
           },
-          "pages" : "OYHq8dv39fKy98",
-          "illustrated" : false
+          "pages" : "VksTuY4n466h0NvEjx",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/XGEJGF9Wz6IkzitJ9",
-    "abstract" : "H2ohJWzALXi9PSZ7w"
+    "metadataSource" : "https://www.example.com/GBhQspijyK",
+    "abstract" : "nqsPyIGZMA4y6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quiamolestiae",
-    "name" : "tIFBMrX5jeG",
+    "id" : "https://www.example.org/quaereiciendis",
+    "name" : "AWnJj0EKS2BB98USbJN",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Uicop8B0LTS7j14",
-      "id" : "0eCpT1w50S1eenAy"
+      "source" : "AfsBwnpZ9Yz846YX",
+      "id" : "9LH8xgm2ob"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "cxYIXibLnmoWYy9"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "hv15yrve5Lf70N"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/odioab" ],
-  "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "n7fn1INdnGIMwuA7",
-    "mimeType" : "mPOn5fdtU6lnlQx9H",
-    "size" : 1738497204,
-    "license" : {
-      "type" : "License",
-      "identifier" : "oeL1yostYYO3dZP2D",
-      "labels" : {
-        "YK3qSi9JfAd" : "KiBMgHIswAccN"
-      },
-      "link" : "https://www.example.com/2Uo3dc2hBJY5"
-    },
-    "administrativeAgreement" : true,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/inciduntet" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "n7fn1INdnGIMwuA7",
-      "mimeType" : "mPOn5fdtU6lnlQx9H",
-      "size" : 1738497204,
+      "name" : "zBTMscOMpYHH0lP",
+      "mimeType" : "BqorNBsjwKe0Tq",
+      "size" : 1777280768,
       "license" : {
         "type" : "License",
-        "identifier" : "oeL1yostYYO3dZP2D",
+        "identifier" : "gVZ1PDTsBKRV",
         "labels" : {
-          "YK3qSi9JfAd" : "KiBMgHIswAccN"
+          "RaVQfcUO623nacTmD" : "tGpZJkSWmDzlY"
         },
-        "link" : "https://www.example.com/2Uo3dc2hBJY5"
+        "link" : "https://www.example.com/IZLOJzzlfGF"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "iqrubs6zQNkqte",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "zBTMscOMpYHH0lP",
+    "mimeType" : "BqorNBsjwKe0Tq",
+    "size" : 1777280768,
+    "license" : {
+      "type" : "License",
+      "identifier" : "gVZ1PDTsBKRV",
+      "labels" : {
+        "RaVQfcUO623nacTmD" : "tGpZJkSWmDzlY"
+      },
+      "link" : "https://www.example.com/IZLOJzzlfGF"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "UNUDEBUwBGn",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "UNUDEBUwBGn",
-    "ownerAffiliation" : "https://www.example.org/sedcumque"
+    "owner" : "SIMnk4xexHYK",
+    "ownerAffiliation" : "https://www.example.org/aliquamrepudiandae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/voluptatevoluptatem",
+    "id" : "https://www.example.org/fugain",
     "labels" : {
-      "hvb7jbiZTcB8sPsOK" : "ZgshhHmAW2HfMwAol"
+      "rXU9puSirN5HiQ15Eko" : "6xN28eaVe2UF4t"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utenim",
-  "doi" : "https://doi.org/10.1234/alias",
-  "link" : "https://www.example.org/aliasconsectetur",
+  "handle" : "https://www.example.org/perferendisaut",
+  "doi" : "https://doi.org/10.1234/magnam",
+  "link" : "https://www.example.org/beataedicta",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZTXaEFem1P",
+    "mainTitle" : "SuAvkB6k7M",
     "alternativeTitles" : {
-      "es" : "TbwSAcbTks"
+      "es" : "meqFQO4WgU58ZosyB"
     },
-    "language" : "http://lexvo.org/id/iso639-3/spa",
+    "language" : "http://lexvo.org/id/iso639-3/nld",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "SKZHLA0LA0mKO8P",
-      "month" : "GcinbURPggpVHBH6X3h",
-      "day" : "KKwsq3f3hEAGIY"
+      "year" : "PhCpGf5V0ndyk3z0YB",
+      "month" : "J9MTdbKTp0VN4noiJxD",
+      "day" : "rspYZKp6kfQcGEPV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/bpu7y9cZohD95rRZeto",
-        "name" : "d9T09NYsI8yTrWbVrDg",
+        "id" : "https://www.example.com/F2lOwcI5IGFzbc",
+        "name" : "voZUEYwv4va",
         "nameType" : "Personal",
-        "orcId" : "MgebrNhzgskyhti"
+        "orcId" : "DsReaXMxpWmb3"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/rPbYepxp2i",
+        "id" : "https://www.example.com/iL6uFMlzIS9NS2uU4",
         "labels" : {
-          "XzTuQcfZ2SC6" : "k5eBGHCO5cYDJ"
+          "20pKMWhpT17PflMgpbg" : "6Q5CQ3IeSpXy"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 0,
+      "role" : "EditorialBoardMember",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/flcdcdXxWKf",
-        "name" : "dR1CoebnSw8xVPvo",
-        "nameType" : "Organizational",
-        "orcId" : "Z6LG5m8wziIJxXSlcJk"
+        "id" : "https://www.example.com/w23tgv5KAz4oCa",
+        "name" : "sq4twtJQKT",
+        "nameType" : "Personal",
+        "orcId" : "UflkTlgPng9TQsN4j"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/1GpOgP4Q0COdxrdq",
+        "id" : "https://www.example.com/7Tx65lAPfJj",
         "labels" : {
-          "xsRmu2MGNkQf" : "PpiZyquBWrr4tmLlgL"
+          "wvBStNSEeq9wV" : "IeMzBoSzlSTKLd"
         }
       } ],
-      "role" : "ProjectLeader",
-      "sequence" : 0,
+      "role" : "AcademicCoordinator",
+      "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "5LTVzlYmjqpkW",
-    "tags" : [ "hCrZoMpRTh8bPO" ],
-    "description" : "imVcfe5DAvLBLsTv",
+    "npiSubjectHeading" : "iikzdC60XNDrBlG",
+    "tags" : [ "Qb6Gu7sEUP0bnY" ],
+    "description" : "fg1GBEC5saLrY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/gNUbgbbWP0YlXuxW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4IOmkm275eM6ViD2"
         },
-        "seriesNumber" : "QbPvJ2xlBEeEI",
+        "seriesNumber" : "qRFlR8er3jXpc6",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Xb4cq7kHiQT8OBr01"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Tlh77ZVow8y3fo6"
         },
-        "isbnList" : [ "9780732226848" ]
+        "isbnList" : [ "9781987391862" ]
       },
-      "doi" : "https://www.example.com/8r5oE9TcLhf6SKUqASS",
+      "doi" : "https://www.example.com/U61atLkrPJb",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zanTriX1Nuxlw0Jup0P",
-            "end" : "K3cX6MiQ149QS"
+            "begin" : "VX5EujWVyWYSN",
+            "end" : "WrtrKNGFEVsp"
           },
-          "pages" : "VksTuY4n466h0NvEjx",
-          "illustrated" : true
+          "pages" : "8VcJvWoJGwpK",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/GBhQspijyK",
-    "abstract" : "nqsPyIGZMA4y6"
+    "metadataSource" : "https://www.example.com/8iFQ06JTSBqDSLmP7",
+    "abstract" : "M5eMa1vj7Irxc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quaereiciendis",
-    "name" : "AWnJj0EKS2BB98USbJN",
+    "id" : "https://www.example.org/auttotam",
+    "name" : "GkeJizVpBDV6kvVUT",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "AfsBwnpZ9Yz846YX",
-      "id" : "9LH8xgm2ob"
+      "source" : "Iw6uz1gGHVtwZbdl",
+      "id" : "4l9VY4bM1ENu"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "hv15yrve5Lf70N"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "mNSAmDLON6"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inciduntet" ],
+  "subjects" : [ "https://www.example.org/eaqueut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "zBTMscOMpYHH0lP",
-      "mimeType" : "BqorNBsjwKe0Tq",
-      "size" : 1777280768,
+      "name" : "RPhoCuwoXBBB7FF5",
+      "mimeType" : "awCeIlnNJNQNN4Fu",
+      "size" : 673249973,
       "license" : {
         "type" : "License",
-        "identifier" : "gVZ1PDTsBKRV",
+        "identifier" : "AUsx5QVnjsD",
         "labels" : {
-          "RaVQfcUO623nacTmD" : "tGpZJkSWmDzlY"
+          "7P0Jf9DQPDxIB4NLQgE" : "fQ1mBczskmerATtJHi"
         },
-        "link" : "https://www.example.com/IZLOJzzlfGF"
+        "link" : "https://www.example.com/Z1zFl2SEsw8U2"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "zBTMscOMpYHH0lP",
-    "mimeType" : "BqorNBsjwKe0Tq",
-    "size" : 1777280768,
+    "name" : "RPhoCuwoXBBB7FF5",
+    "mimeType" : "awCeIlnNJNQNN4Fu",
+    "size" : 673249973,
     "license" : {
       "type" : "License",
-      "identifier" : "gVZ1PDTsBKRV",
+      "identifier" : "AUsx5QVnjsD",
       "labels" : {
-        "RaVQfcUO623nacTmD" : "tGpZJkSWmDzlY"
+        "7P0Jf9DQPDxIB4NLQgE" : "fQ1mBczskmerATtJHi"
       },
-      "link" : "https://www.example.com/IZLOJzzlfGF"
+      "link" : "https://www.example.com/Z1zFl2SEsw8U2"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "UNUDEBUwBGn",
+  "owner" : "SIMnk4xexHYK",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "SIMnk4xexHYK",
-    "ownerAffiliation" : "https://www.example.org/aliquamrepudiandae"
+    "owner" : "vpJ25YKl9LmMOw",
+    "ownerAffiliation" : "https://www.example.org/autemeius"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fugain",
+    "id" : "https://www.example.org/estquo",
     "labels" : {
-      "rXU9puSirN5HiQ15Eko" : "6xN28eaVe2UF4t"
+      "CXQ34H9s5g" : "9Jqxzj2IYTkZsO"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/perferendisaut",
-  "doi" : "https://doi.org/10.1234/magnam",
-  "link" : "https://www.example.org/beataedicta",
+  "handle" : "https://www.example.org/verocorporis",
+  "doi" : "https://doi.org/10.1234/in",
+  "link" : "https://www.example.org/utmaxime",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SuAvkB6k7M",
+    "mainTitle" : "Q9TJgrP8zeHZd1gPK",
     "alternativeTitles" : {
-      "es" : "meqFQO4WgU58ZosyB"
+      "it" : "tFQAPN0uqC"
     },
-    "language" : "http://lexvo.org/id/iso639-3/nld",
+    "language" : "http://lexvo.org/id/iso639-3/bul",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "PhCpGf5V0ndyk3z0YB",
-      "month" : "J9MTdbKTp0VN4noiJxD",
-      "day" : "rspYZKp6kfQcGEPV"
+      "year" : "3r4UTi9Tyo86",
+      "month" : "RQROIDCZoiWq4i6tqPo",
+      "day" : "HVRTd1kksk87a"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/F2lOwcI5IGFzbc",
-        "name" : "voZUEYwv4va",
+        "id" : "https://www.example.com/E9OITOFxPb5W",
+        "name" : "iO4J2lq3m2lVqu",
         "nameType" : "Personal",
-        "orcId" : "DsReaXMxpWmb3"
+        "orcId" : "eqEN2l8CKBeBLRQJtRi"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/iL6uFMlzIS9NS2uU4",
+        "id" : "https://www.example.com/Zub5jNZs8ggeyAMY",
         "labels" : {
-          "20pKMWhpT17PflMgpbg" : "6Q5CQ3IeSpXy"
+          "mALbzcz1MA9oC0z" : "B3lEFTfeo4QS2UlA"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 1,
+      "role" : "Producer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/w23tgv5KAz4oCa",
-        "name" : "sq4twtJQKT",
-        "nameType" : "Personal",
-        "orcId" : "UflkTlgPng9TQsN4j"
+        "id" : "https://www.example.com/aJKWkjafw4D1",
+        "name" : "ru69WLfKflb0TwJ",
+        "nameType" : "Organizational",
+        "orcId" : "tUefmM0XPbluj5"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/7Tx65lAPfJj",
+        "id" : "https://www.example.com/LK5VzzFGXT",
         "labels" : {
-          "wvBStNSEeq9wV" : "IeMzBoSzlSTKLd"
+          "g4Xeqi89UOZSOefCg6d" : "pVWjhOWNTHka4"
         }
       } ],
       "role" : "AcademicCoordinator",
       "sequence" : 1,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "iikzdC60XNDrBlG",
-    "tags" : [ "Qb6Gu7sEUP0bnY" ],
-    "description" : "fg1GBEC5saLrY",
+    "npiSubjectHeading" : "6VbSkkRU3U",
+    "tags" : [ "j1oYAI8WDslM26Lxb" ],
+    "description" : "SmcxNqC9PVTTxz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4IOmkm275eM6ViD2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/EP6wvuE1D7"
         },
-        "seriesNumber" : "qRFlR8er3jXpc6",
+        "seriesNumber" : "fpeAXkQlPdsUFHx2L",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Tlh77ZVow8y3fo6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/TsJiFFJyxVZ"
         },
-        "isbnList" : [ "9781987391862" ]
+        "isbnList" : [ "9781997038870" ]
       },
-      "doi" : "https://www.example.com/U61atLkrPJb",
+      "doi" : "https://www.example.com/Bf5xPKpWWz7JXWF",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "VX5EujWVyWYSN",
-            "end" : "WrtrKNGFEVsp"
+            "begin" : "nAyDKlpN3DWMkP",
+            "end" : "ewG1f64PzX8YF"
           },
-          "pages" : "8VcJvWoJGwpK",
+          "pages" : "6IjrhRBMNugbnBMJ",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/8iFQ06JTSBqDSLmP7",
-    "abstract" : "M5eMa1vj7Irxc"
+    "metadataSource" : "https://www.example.com/LPttnaQY17T",
+    "abstract" : "gZFqNbzEPaZK9nw5St"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/auttotam",
-    "name" : "GkeJizVpBDV6kvVUT",
+    "id" : "https://www.example.org/eiusest",
+    "name" : "LXW8CHCuN6ekEmp9s",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "Iw6uz1gGHVtwZbdl",
-      "id" : "4l9VY4bM1ENu"
+      "source" : "cmt7GHpBtXwMviq",
+      "id" : "BkWxVRbiQJcP"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "mNSAmDLON6"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "GIe3qvrI2RvrzLYY"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eaqueut" ],
+  "subjects" : [ "https://www.example.org/utvoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "RPhoCuwoXBBB7FF5",
-      "mimeType" : "awCeIlnNJNQNN4Fu",
-      "size" : 673249973,
+      "name" : "jh28rZ1w9w3cOHHE",
+      "mimeType" : "K7VDWN5p6vo8eM",
+      "size" : 2069041566,
       "license" : {
         "type" : "License",
-        "identifier" : "AUsx5QVnjsD",
+        "identifier" : "Dn0IfbRzyXyXr",
         "labels" : {
-          "7P0Jf9DQPDxIB4NLQgE" : "fQ1mBczskmerATtJHi"
+          "kHkdbcJqxE" : "rhBqi3D950aPfSC"
         },
-        "link" : "https://www.example.com/Z1zFl2SEsw8U2"
+        "link" : "https://www.example.com/7Iv3MJckO9POD5mhu"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "RPhoCuwoXBBB7FF5",
-    "mimeType" : "awCeIlnNJNQNN4Fu",
-    "size" : 673249973,
+    "name" : "jh28rZ1w9w3cOHHE",
+    "mimeType" : "K7VDWN5p6vo8eM",
+    "size" : 2069041566,
     "license" : {
       "type" : "License",
-      "identifier" : "AUsx5QVnjsD",
+      "identifier" : "Dn0IfbRzyXyXr",
       "labels" : {
-        "7P0Jf9DQPDxIB4NLQgE" : "fQ1mBczskmerATtJHi"
+        "kHkdbcJqxE" : "rhBqi3D950aPfSC"
       },
-      "link" : "https://www.example.com/Z1zFl2SEsw8U2"
+      "link" : "https://www.example.com/7Iv3MJckO9POD5mhu"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "SIMnk4xexHYK",
+  "owner" : "vpJ25YKl9LmMOw",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "RaX1YLk8RG02",
-    "ownerAffiliation" : "https://www.example.org/sunttempore"
+    "owner" : "AjmSkZf3yP8P",
+    "ownerAffiliation" : "https://www.example.org/itaquequia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/reiciendisveniam",
+    "id" : "https://www.example.org/ametenim",
     "labels" : {
-      "pQuwkBj9zETwpzt" : "DAvrj4YvOfPZKvFt"
+      "Fu54gFO0ndOeFUZy" : "WzsaMAaqUEGQiUNu"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/nobisducimus",
-  "doi" : "https://doi.org/10.1234/fugiat",
-  "link" : "https://www.example.org/ettemporibus",
+  "handle" : "https://www.example.org/harumdolor",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/suntea",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "50eyRPwmp2IUqPka",
+    "mainTitle" : "7OStK3Ua9sZjlPwHi",
     "alternativeTitles" : {
-      "bg" : "ft1yUUtLhD6de0xtTJf"
+      "ru" : "hPvoA7OkCuEh"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "MExjR0ieLeh",
-      "month" : "DwHLU0rINrglKWOtxk",
-      "day" : "CFuNeth2zxuRnw0"
+      "year" : "RvniQfV2l8OhzcFTyz",
+      "month" : "77IoGHFeaN2dnGmTF",
+      "day" : "zqlUuFT5Tot5MYUB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lXxWAsgdBWyLR",
-        "name" : "hpKkFh809a4WoBvSvXJ",
-        "nameType" : "Organizational",
-        "orcId" : "kkxFPlZNQ7"
+        "id" : "https://www.example.com/dQ39TYIQZrMHAopEdUq",
+        "name" : "RppUH7aTBHHQq",
+        "nameType" : "Personal",
+        "orcId" : "MCp74U0DYn4U73xKCN"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/0yoPpHQCUIwM",
+        "id" : "https://www.example.com/mGuImjekaJDlEZ",
         "labels" : {
-          "pINc5196uAi0e" : "kzaOjWUwbAwp"
+          "0HvLOeaGPNv" : "jTm7o3hQcP"
         }
       } ],
-      "role" : "ProductionDesigner",
-      "sequence" : 8,
+      "role" : "DataCurator",
+      "sequence" : 1,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/4jxIJfNJDhW2m",
-        "name" : "COUGTC3fdNI7UKVWy8",
-        "nameType" : "Personal",
-        "orcId" : "tgAHgJt0MixzLSKWVX"
+        "id" : "https://www.example.com/B79ANCHBNJ4XL5AXqFL",
+        "name" : "rdBaxlcMMJtYPdqqTTJ",
+        "nameType" : "Organizational",
+        "orcId" : "vShKOhe62HuD"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/AMTJ4CZ4MAZwzMHoI0N",
+        "id" : "https://www.example.com/eJeZj78lODl62eJRV3T",
         "labels" : {
-          "15tUR9sjWwDrT4rr1D" : "tYHKnBILANKW"
+          "259yH0pqhdiangV" : "ssxDvF5nKIjp5Gc4u"
         }
       } ],
-      "role" : "Funder",
-      "sequence" : 6,
+      "role" : "Editor",
+      "sequence" : 8,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "I2I39OurBDt8AQ",
-    "tags" : [ "6PTpc59Sq3Fq" ],
-    "description" : "oGXvcKgkrtDpMS",
+    "npiSubjectHeading" : "76JfCEYzOt5Vx",
+    "tags" : [ "N4fY3PbAPq7B" ],
+    "description" : "yYCDxyyREi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Yu0kcFxxKME"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/R8OKXxQnYyxue8hWGc"
         },
-        "seriesNumber" : "Vsz3Cm6dRbwLRCRmjTz",
+        "seriesNumber" : "kj6PIpTceKHp55S",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZYw5jagO8Cjma7T"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Msz2fPjPSvRYaCXq"
         },
-        "isbnList" : [ "9791887043525" ]
+        "isbnList" : [ "9791823399648" ]
       },
-      "doi" : "https://www.example.com/jfbu1IqoqB",
+      "doi" : "https://www.example.com/ajaK7tVzUarUZuhP",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "IfNRtO428K0cxmJ2",
-            "end" : "nlozEJXH87zki"
+            "begin" : "W3q57nFuz6sL3bg",
+            "end" : "B13ltbSsEBKK7"
           },
-          "pages" : "pkrThbkXH4lLBSBKjRd",
-          "illustrated" : false
+          "pages" : "KOqk3Z9A1az",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/RtBiovUaI9wGV",
-    "abstract" : "DNCTv4Px2auvgJcQz"
+    "metadataSource" : "https://www.example.com/k0dK19oRma2mNmZeOc",
+    "abstract" : "2BYmKu9s5uFLEI1oB"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/vitaevoluptatem",
-    "name" : "pKOMqV6NHCqTO",
+    "id" : "https://www.example.org/voluptatesid",
+    "name" : "ZKQ0aBeaWz",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "FK19r2KsgDOQ",
-      "id" : "WEuFoBFR4sINsO8E"
+      "source" : "lcS8phRr8DXF",
+      "id" : "hdCCyRQ4n7KG"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "agx3vXO9y6Qn"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "L27tbb9ivbxaNnmPd"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/inventoreconsequatur" ],
+  "subjects" : [ "https://www.example.org/excorporis" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "dg9rHBNk1MNpDtDl",
-      "mimeType" : "z01QJKeLb1E5zMlB",
-      "size" : 1740095539,
+      "name" : "HlLgpFDl3v3XjzyG",
+      "mimeType" : "oe1hjtuqkGTMp",
+      "size" : 2030903701,
       "license" : {
         "type" : "License",
-        "identifier" : "K2hleILTBCEs7tH",
+        "identifier" : "mLH1zsLtRf9",
         "labels" : {
-          "8N52BsPvGw" : "hxnw1bOD9hDVWBYfO"
+          "J3dmxQhAxHhqHFX" : "HqVPYMULl39U5k07"
         },
-        "link" : "https://www.example.com/1oRHXv5oksH0RDxr3"
+        "link" : "https://www.example.com/x1C2Mv4RIvZ1iT"
       },
       "administrativeAgreement" : true,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "dg9rHBNk1MNpDtDl",
-    "mimeType" : "z01QJKeLb1E5zMlB",
-    "size" : 1740095539,
+    "name" : "HlLgpFDl3v3XjzyG",
+    "mimeType" : "oe1hjtuqkGTMp",
+    "size" : 2030903701,
     "license" : {
       "type" : "License",
-      "identifier" : "K2hleILTBCEs7tH",
+      "identifier" : "mLH1zsLtRf9",
       "labels" : {
-        "8N52BsPvGw" : "hxnw1bOD9hDVWBYfO"
+        "J3dmxQhAxHhqHFX" : "HqVPYMULl39U5k07"
       },
-      "link" : "https://www.example.com/1oRHXv5oksH0RDxr3"
+      "link" : "https://www.example.com/x1C2Mv4RIvZ1iT"
     },
     "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "RaX1YLk8RG02",
+  "owner" : "AjmSkZf3yP8P",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "AjmSkZf3yP8P",
-    "ownerAffiliation" : "https://www.example.org/itaquequia"
+    "owner" : "s6ZvR7LWZGb2oyKvMYu",
+    "ownerAffiliation" : "https://www.example.org/inmollitia"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ametenim",
+    "id" : "https://www.example.org/omnistenetur",
     "labels" : {
-      "Fu54gFO0ndOeFUZy" : "WzsaMAaqUEGQiUNu"
+      "etXFBf0shzDt" : "MMFce7cJIF43vU"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/harumdolor",
-  "doi" : "https://doi.org/10.1234/dolor",
-  "link" : "https://www.example.org/suntea",
+  "handle" : "https://www.example.org/estsaepe",
+  "doi" : "https://doi.org/10.1234/dolores",
+  "link" : "https://www.example.org/fugaalias",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7OStK3Ua9sZjlPwHi",
+    "mainTitle" : "00ntNHCujDBnCKks",
     "alternativeTitles" : {
-      "ru" : "hPvoA7OkCuEh"
+      "pt" : "3MHvETw0uS"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "RvniQfV2l8OhzcFTyz",
-      "month" : "77IoGHFeaN2dnGmTF",
-      "day" : "zqlUuFT5Tot5MYUB"
+      "year" : "9L8CsOQdDob",
+      "month" : "id9pRL4IkxM2TaaJn",
+      "day" : "P7blzAXC0AeYFhScW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/dQ39TYIQZrMHAopEdUq",
-        "name" : "RppUH7aTBHHQq",
+        "id" : "https://www.example.com/C8asSDaT2OBFX",
+        "name" : "tblqP129E7C4",
         "nameType" : "Personal",
-        "orcId" : "MCp74U0DYn4U73xKCN"
+        "orcId" : "nez3OTRBGu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/mGuImjekaJDlEZ",
+        "id" : "https://www.example.com/Fadj66C9iHyE20Z",
         "labels" : {
-          "0HvLOeaGPNv" : "jTm7o3hQcP"
+          "FeLxPj1DllRggPC1fiX" : "3Tid4xABchqmWgr"
         }
       } ],
-      "role" : "DataCurator",
-      "sequence" : 1,
+      "role" : "DataCollector",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/B79ANCHBNJ4XL5AXqFL",
-        "name" : "rdBaxlcMMJtYPdqqTTJ",
+        "id" : "https://www.example.com/iFMx0awIipS",
+        "name" : "ITIP7eHRrU3ly8t",
         "nameType" : "Organizational",
-        "orcId" : "vShKOhe62HuD"
+        "orcId" : "eFR8H2FTPimYczg"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/eJeZj78lODl62eJRV3T",
+        "id" : "https://www.example.com/P72zG5viNvfc",
         "labels" : {
-          "259yH0pqhdiangV" : "ssxDvF5nKIjp5Gc4u"
+          "2wR4PKiauOYKtxB" : "eARH15NGAgW"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 8,
+      "role" : "Dancer",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "76JfCEYzOt5Vx",
-    "tags" : [ "N4fY3PbAPq7B" ],
-    "description" : "yYCDxyyREi",
+    "npiSubjectHeading" : "vBBcE8eHWbfTQeG",
+    "tags" : [ "X3ZmsfEdbdxZX3KUP" ],
+    "description" : "wjgpJFWIZ48x",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/R8OKXxQnYyxue8hWGc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aYahHo1EOE"
         },
-        "seriesNumber" : "kj6PIpTceKHp55S",
+        "seriesNumber" : "ephpZ4K7tj4Ig",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Msz2fPjPSvRYaCXq"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/wmW2JywAdwIrqV7isPP"
         },
-        "isbnList" : [ "9791823399648" ]
+        "isbnList" : [ "9780949187826" ]
       },
-      "doi" : "https://www.example.com/ajaK7tVzUarUZuhP",
+      "doi" : "https://www.example.com/QsBbv4nUnG9zEFxFq9h",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "W3q57nFuz6sL3bg",
-            "end" : "B13ltbSsEBKK7"
+            "begin" : "cP2R9AJyWfsCdijkSxB",
+            "end" : "d5O2EhQN2KOvPYG"
           },
-          "pages" : "KOqk3Z9A1az",
+          "pages" : "VzPcIWJ7xgCuel",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/k0dK19oRma2mNmZeOc",
-    "abstract" : "2BYmKu9s5uFLEI1oB"
+    "metadataSource" : "https://www.example.com/Jw58gJD3Us2Ee",
+    "abstract" : "3ZUI3I6X1FpV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatesid",
-    "name" : "ZKQ0aBeaWz",
+    "id" : "https://www.example.org/ullamad",
+    "name" : "fdnunQkKJHUGu4Rh",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "lcS8phRr8DXF",
-      "id" : "hdCCyRQ4n7KG"
+      "source" : "MbhySVAYbagsFJ",
+      "id" : "B6nG6R2BTpOgq"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "L27tbb9ivbxaNnmPd"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "dyRAQ58nU0VdxevEMs"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/excorporis" ],
+  "subjects" : [ "https://www.example.org/fugiatrem" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "HlLgpFDl3v3XjzyG",
-      "mimeType" : "oe1hjtuqkGTMp",
-      "size" : 2030903701,
+      "name" : "Vxv9sDl1L3OSVtsd",
+      "mimeType" : "LUHH5F6Oucea",
+      "size" : 502195468,
       "license" : {
         "type" : "License",
-        "identifier" : "mLH1zsLtRf9",
+        "identifier" : "SaGHNxKeiul90hsnRv",
         "labels" : {
-          "J3dmxQhAxHhqHFX" : "HqVPYMULl39U5k07"
+          "NyLFxdcIJny9g3Fw7" : "yuJObKqV4e"
         },
-        "link" : "https://www.example.com/x1C2Mv4RIvZ1iT"
+        "link" : "https://www.example.com/68B0pbmObF8"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "HlLgpFDl3v3XjzyG",
-    "mimeType" : "oe1hjtuqkGTMp",
-    "size" : 2030903701,
+    "name" : "Vxv9sDl1L3OSVtsd",
+    "mimeType" : "LUHH5F6Oucea",
+    "size" : 502195468,
     "license" : {
       "type" : "License",
-      "identifier" : "mLH1zsLtRf9",
+      "identifier" : "SaGHNxKeiul90hsnRv",
       "labels" : {
-        "J3dmxQhAxHhqHFX" : "HqVPYMULl39U5k07"
+        "NyLFxdcIJny9g3Fw7" : "yuJObKqV4e"
       },
-      "link" : "https://www.example.com/x1C2Mv4RIvZ1iT"
+      "link" : "https://www.example.com/68B0pbmObF8"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "AjmSkZf3yP8P",
+  "owner" : "s6ZvR7LWZGb2oyKvMYu",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "yAiOqswAQGWxzKTTd",
-    "ownerAffiliation" : "https://www.example.org/optiofugiat"
+    "owner" : "RaX1YLk8RG02",
+    "ownerAffiliation" : "https://www.example.org/sunttempore"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/reprehenderitsaepe",
+    "id" : "https://www.example.org/reiciendisveniam",
     "labels" : {
-      "QdEhGKSPDOcB" : "ysXnbA0Vb3wv"
+      "pQuwkBj9zETwpzt" : "DAvrj4YvOfPZKvFt"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quoblanditiis",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/quiipsa",
+  "handle" : "https://www.example.org/nobisducimus",
+  "doi" : "https://doi.org/10.1234/fugiat",
+  "link" : "https://www.example.org/ettemporibus",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "a2tj8hYwerlLckOz22W",
+    "mainTitle" : "50eyRPwmp2IUqPka",
     "alternativeTitles" : {
-      "nb" : "c1jCeb5bPjaUCJ4"
+      "bg" : "ft1yUUtLhD6de0xtTJf"
     },
-    "language" : "http://lexvo.org/id/iso639-3/deu",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "WfR5HXlqOV",
-      "month" : "evYtLYTJDuyQM",
-      "day" : "5h8c5nYrulUeU0l"
+      "year" : "MExjR0ieLeh",
+      "month" : "DwHLU0rINrglKWOtxk",
+      "day" : "CFuNeth2zxuRnw0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/HrKNqf2NkJ6V",
-        "name" : "3TohfcamYPDRJ7",
-        "nameType" : "Personal",
-        "orcId" : "9et2pWAk662"
+        "id" : "https://www.example.com/lXxWAsgdBWyLR",
+        "name" : "hpKkFh809a4WoBvSvXJ",
+        "nameType" : "Organizational",
+        "orcId" : "kkxFPlZNQ7"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/WU9UM8vyiGDxG9",
+        "id" : "https://www.example.com/0yoPpHQCUIwM",
         "labels" : {
-          "HlNiDhg9rIW" : "tSAV0WnnQ56R1WUnE"
+          "pINc5196uAi0e" : "kzaOjWUwbAwp"
         }
       } ],
-      "role" : "Illustrator",
-      "sequence" : 2,
+      "role" : "ProductionDesigner",
+      "sequence" : 8,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/g0We6f5UoaiQgT",
-        "name" : "StG0Ut0USIkJcjU",
+        "id" : "https://www.example.com/4jxIJfNJDhW2m",
+        "name" : "COUGTC3fdNI7UKVWy8",
         "nameType" : "Personal",
-        "orcId" : "nlxl0ffaNz"
+        "orcId" : "tgAHgJt0MixzLSKWVX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/af7IGrtVzbsSQevn",
+        "id" : "https://www.example.com/AMTJ4CZ4MAZwzMHoI0N",
         "labels" : {
-          "bHxg3iU6lNK" : "XQriw4UiXFt42l"
+          "15tUR9sjWwDrT4rr1D" : "tYHKnBILANKW"
         }
       } ],
-      "role" : "RelatedPerson",
-      "sequence" : 3,
+      "role" : "Funder",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "SQNJa2VJhf5g1GIV",
-    "tags" : [ "OXb5jg0E6gLqwgJuN" ],
-    "description" : "CsdGnIznPKEtuJdvAY",
+    "npiSubjectHeading" : "I2I39OurBDt8AQ",
+    "tags" : [ "6PTpc59Sq3Fq" ],
+    "description" : "oGXvcKgkrtDpMS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cV5KliIOv05epd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/Yu0kcFxxKME"
         },
-        "seriesNumber" : "Q0h7R2Nlsqz",
+        "seriesNumber" : "Vsz3Cm6dRbwLRCRmjTz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xclLZke5GHWu7OL"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ZYw5jagO8Cjma7T"
         },
-        "isbnList" : [ "9790704614429" ]
+        "isbnList" : [ "9791887043525" ]
       },
-      "doi" : "https://www.example.com/DZodlg8cSyAf4FrK",
+      "doi" : "https://www.example.com/jfbu1IqoqB",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "IDEMt0NwaLWiJ",
-            "end" : "WIwhbzlRAT066AO"
+            "begin" : "IfNRtO428K0cxmJ2",
+            "end" : "nlozEJXH87zki"
           },
-          "pages" : "YzLpZ0jt4Z8JJeaO",
-          "illustrated" : true
+          "pages" : "pkrThbkXH4lLBSBKjRd",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/13HXXLZTTTWIjIY",
-    "abstract" : "8bPk3GIlKdR1Yv"
+    "metadataSource" : "https://www.example.com/RtBiovUaI9wGV",
+    "abstract" : "DNCTv4Px2auvgJcQz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/nullaid",
-    "name" : "m7yxQu9Hd79",
+    "id" : "https://www.example.org/vitaevoluptatem",
+    "name" : "pKOMqV6NHCqTO",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XIWUGnAJulGwFOf",
-      "id" : "5M57kr6Jf5P3GqRC"
+      "source" : "FK19r2KsgDOQ",
+      "id" : "WEuFoBFR4sINsO8E"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "J2mRGLe8ggC"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "agx3vXO9y6Qn"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/enimsed" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "duJWoD27fy",
-    "mimeType" : "DhgxmG02N901BBq",
-    "size" : 970043354,
-    "license" : {
-      "type" : "License",
-      "identifier" : "wSCcSqDOlbzG0F8Rw",
-      "labels" : {
-        "TEOcne0sMU0QM4isJXj" : "c3607qN64nLmlZT"
-      },
-      "link" : "https://www.example.com/jBvvIq3YUb1ZhQqlm2a"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/inventoreconsequatur" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "duJWoD27fy",
-      "mimeType" : "DhgxmG02N901BBq",
-      "size" : 970043354,
+      "name" : "dg9rHBNk1MNpDtDl",
+      "mimeType" : "z01QJKeLb1E5zMlB",
+      "size" : 1740095539,
       "license" : {
         "type" : "License",
-        "identifier" : "wSCcSqDOlbzG0F8Rw",
+        "identifier" : "K2hleILTBCEs7tH",
         "labels" : {
-          "TEOcne0sMU0QM4isJXj" : "c3607qN64nLmlZT"
+          "8N52BsPvGw" : "hxnw1bOD9hDVWBYfO"
         },
-        "link" : "https://www.example.com/jBvvIq3YUb1ZhQqlm2a"
+        "link" : "https://www.example.com/1oRHXv5oksH0RDxr3"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "yAiOqswAQGWxzKTTd",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "dg9rHBNk1MNpDtDl",
+    "mimeType" : "z01QJKeLb1E5zMlB",
+    "size" : 1740095539,
+    "license" : {
+      "type" : "License",
+      "identifier" : "K2hleILTBCEs7tH",
+      "labels" : {
+        "8N52BsPvGw" : "hxnw1bOD9hDVWBYfO"
+      },
+      "link" : "https://www.example.com/1oRHXv5oksH0RDxr3"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "RaX1YLk8RG02",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "NPw7UVQtGKyaBfzpo",
-    "ownerAffiliation" : "https://www.example.org/dignissimoscorrupti"
+    "owner" : "yAiOqswAQGWxzKTTd",
+    "ownerAffiliation" : "https://www.example.org/optiofugiat"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nemodolor",
+    "id" : "https://www.example.org/reprehenderitsaepe",
     "labels" : {
-      "RLcoi5cZfLk6SFQCP" : "qHzUjW0dTlzR6DBu5A"
+      "QdEhGKSPDOcB" : "ysXnbA0Vb3wv"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/earumquia",
-  "doi" : "https://doi.org/10.1234/autem",
-  "link" : "https://www.example.org/minusnon",
+  "handle" : "https://www.example.org/quoblanditiis",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/quiipsa",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cVg5XZjt79npWT2",
+    "mainTitle" : "a2tj8hYwerlLckOz22W",
     "alternativeTitles" : {
-      "it" : "jsXhaY2yPRk"
+      "nb" : "c1jCeb5bPjaUCJ4"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mul",
+    "language" : "http://lexvo.org/id/iso639-3/deu",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "DHRAfUt1hNkFUSVnqEH",
-      "month" : "avssxTM015",
-      "day" : "4Cz4CwFihmy7"
+      "year" : "WfR5HXlqOV",
+      "month" : "evYtLYTJDuyQM",
+      "day" : "5h8c5nYrulUeU0l"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/W24LS6A2Wzs",
-        "name" : "p14GCtMtOiZC",
-        "nameType" : "Organizational",
-        "orcId" : "gbsfvBx7vCdX835"
+        "id" : "https://www.example.com/HrKNqf2NkJ6V",
+        "name" : "3TohfcamYPDRJ7",
+        "nameType" : "Personal",
+        "orcId" : "9et2pWAk662"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/yI88nzZpTlEH",
+        "id" : "https://www.example.com/WU9UM8vyiGDxG9",
         "labels" : {
-          "JxYJtW86rrm" : "Rbcx1X7oHbaG2RBf"
+          "HlNiDhg9rIW" : "tSAV0WnnQ56R1WUnE"
         }
       } ],
-      "role" : "ArtisticDirector",
-      "sequence" : 5,
+      "role" : "Illustrator",
+      "sequence" : 2,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/p1PUOzIgQLYs0",
-        "name" : "oaC2l3UzqS",
-        "nameType" : "Organizational",
-        "orcId" : "E6KOnacDwb4UvSF"
+        "id" : "https://www.example.com/g0We6f5UoaiQgT",
+        "name" : "StG0Ut0USIkJcjU",
+        "nameType" : "Personal",
+        "orcId" : "nlxl0ffaNz"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/oUMiAzlt18qs21ei91z",
+        "id" : "https://www.example.com/af7IGrtVzbsSQevn",
         "labels" : {
-          "L2hiffwgXINSjS9H6" : "fza9NZXSZLZ2pAP"
+          "bHxg3iU6lNK" : "XQriw4UiXFt42l"
         }
       } ],
-      "role" : "HostingInstitution",
-      "sequence" : 6,
+      "role" : "RelatedPerson",
+      "sequence" : 3,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "CGBt25ky4bS",
-    "tags" : [ "92yRrsr0AEPwx" ],
-    "description" : "jKk5FpiF9BYH1urs",
+    "npiSubjectHeading" : "SQNJa2VJhf5g1GIV",
+    "tags" : [ "OXb5jg0E6gLqwgJuN" ],
+    "description" : "CsdGnIznPKEtuJdvAY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/hmiIYgiCvOe1DI2FCd6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cV5KliIOv05epd"
         },
-        "seriesNumber" : "rH9rCzkIZkCIfI9HOPK",
+        "seriesNumber" : "Q0h7R2Nlsqz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/RHO9C0J3PmSKD3lLW"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xclLZke5GHWu7OL"
         },
-        "isbnList" : [ "9790747599127" ]
+        "isbnList" : [ "9790704614429" ]
       },
-      "doi" : "https://www.example.com/eiTHZmQg7n3",
+      "doi" : "https://www.example.com/DZodlg8cSyAf4FrK",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "peerReviewed" : false,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "NvxlsQOs6NLb",
-            "end" : "kKXUoixWt89u4ei"
+            "begin" : "IDEMt0NwaLWiJ",
+            "end" : "WIwhbzlRAT066AO"
           },
-          "pages" : "S2TvkcsuXkdVTU",
+          "pages" : "YzLpZ0jt4Z8JJeaO",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/sltP9LzURsHw4UYQD",
-    "abstract" : "MtBWywNcSX953"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "lGMP60uNcmdgn",
-      "mimeType" : "mjlTAD3qTMWarc",
-      "size" : 2095594362,
-      "license" : {
-        "type" : "License",
-        "identifier" : "uGJjloiYhvmX8",
-        "labels" : {
-          "KE9GkhYYla" : "QHRy1UbFm2E"
-        },
-        "link" : "https://www.example.com/88IGq01bgoUW"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/13HXXLZTTTWIjIY",
+    "abstract" : "8bPk3GIlKdR1Yv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/expeditased",
-    "name" : "0YuAReOX8pOWi89I",
+    "id" : "https://www.example.org/nullaid",
+    "name" : "m7yxQu9Hd79",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "oa5ICLBdNDPsATuV6",
-      "id" : "z9KH9KQbQ4b"
+      "source" : "XIWUGnAJulGwFOf",
+      "id" : "5M57kr6Jf5P3GqRC"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "zKc87FPQmCI"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "J2mRGLe8ggC"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/suntvero" ],
+  "subjects" : [ "https://www.example.org/enimsed" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "lGMP60uNcmdgn",
-    "mimeType" : "mjlTAD3qTMWarc",
-    "size" : 2095594362,
+    "name" : "duJWoD27fy",
+    "mimeType" : "DhgxmG02N901BBq",
+    "size" : 970043354,
     "license" : {
       "type" : "License",
-      "identifier" : "uGJjloiYhvmX8",
+      "identifier" : "wSCcSqDOlbzG0F8Rw",
       "labels" : {
-        "KE9GkhYYla" : "QHRy1UbFm2E"
+        "TEOcne0sMU0QM4isJXj" : "c3607qN64nLmlZT"
       },
-      "link" : "https://www.example.com/88IGq01bgoUW"
+      "link" : "https://www.example.com/jBvvIq3YUb1ZhQqlm2a"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "NPw7UVQtGKyaBfzpo"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "duJWoD27fy",
+      "mimeType" : "DhgxmG02N901BBq",
+      "size" : 970043354,
+      "license" : {
+        "type" : "License",
+        "identifier" : "wSCcSqDOlbzG0F8Rw",
+        "labels" : {
+          "TEOcne0sMU0QM4isJXj" : "c3607qN64nLmlZT"
+        },
+        "link" : "https://www.example.com/jBvvIq3YUb1ZhQqlm2a"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "yAiOqswAQGWxzKTTd",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "PxvugzTA0ygq",
-    "ownerAffiliation" : "https://www.example.org/quodomnis"
+    "owner" : "S85Xgcf2qj",
+    "ownerAffiliation" : "https://www.example.org/accusantiumporro"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cupiditateet",
+    "id" : "https://www.example.org/atquia",
     "labels" : {
-      "RQbROsmCNyMFxLgA6bA" : "AhJFzYnpJ7dc82"
+      "yLFN861OG7ePMjD9" : "bPP5QG9mqLi2GDR18wg"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quiid",
-  "doi" : "https://doi.org/10.1234/quas",
-  "link" : "https://www.example.org/ipsaanimi",
+  "handle" : "https://www.example.org/consecteturvoluptatibus",
+  "doi" : "https://doi.org/10.1234/numquam",
+  "link" : "https://www.example.org/reiciendissit",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yHOW88av4yER",
+    "mainTitle" : "X7TTOAJUNB2XjzRn8z",
     "alternativeTitles" : {
-      "pl" : "ImsHbdG0UB"
+      "zh" : "brxxflfwm9Imtru"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/car",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "hqftk4DygbNOF",
-      "month" : "Po4Kkn2UduE9CY",
-      "day" : "OhbomyXiflAT7"
+      "year" : "KRBMst9XK27",
+      "month" : "WV6ucgoWs0tuxZjJN",
+      "day" : "bimGhRpKb0I"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/945Oqji4GcDtLTS56kW",
-        "name" : "1txndWqtNcr",
+        "id" : "https://www.example.com/jfAxhHEUG6c",
+        "name" : "RbrrCUgnXEYAMqKMu",
         "nameType" : "Organizational",
-        "orcId" : "2KTyZpo4ZIlTfZ5qLuR"
+        "orcId" : "loq0o1k86PVes86r"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/tF1opVFZNeJvX",
+        "id" : "https://www.example.com/egoi2DXjczlX0kv",
         "labels" : {
-          "31AUs8R0yN" : "0fHx9GHzVXNxFQy8"
+          "YwhjRDuZTpqFN" : "OFqBSig8Eb8cbYfoKr"
         }
       } ],
-      "role" : "Editor",
-      "sequence" : 6,
+      "role" : "Advisor",
+      "sequence" : 3,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/vmf6bHeo7ZvsuQL",
-        "name" : "OLUFxUx4PRjHfM9Ycad",
+        "id" : "https://www.example.com/vEBHCRaBVJSAHe",
+        "name" : "iwYhu5mrm4",
         "nameType" : "Organizational",
-        "orcId" : "qU8dMinKtO"
+        "orcId" : "Wq43k6Lgbo78lETmlI"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/3Hr0QfcV8nnQ6mAxBx",
+        "id" : "https://www.example.com/KadVJ7Hro26XPmK3x",
         "labels" : {
-          "R8Vhogo30kDdwkY2Ri" : "dnmBsy7s593BJCjdJ"
+          "yYmmULT09zd" : "QYHCgWdRS3LN"
         }
       } ],
-      "role" : "ProjectMember",
-      "sequence" : 1,
+      "role" : "Dramatist",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "UPkMbsA0iQ",
-    "tags" : [ "N04zjKguBDBysXOJ" ],
-    "description" : "yWYO0ugtcary40EH",
+    "npiSubjectHeading" : "qTBJBDqtN2Dnv9PR",
+    "tags" : [ "LhirbEVhaSEkZ3l" ],
+    "description" : "JsoanU3DBWFB6vWhE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/qBL0azi5vMac4tvYpVI"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aonzRjJSyLXCw"
         },
-        "seriesNumber" : "3KmiVlMhCXw",
+        "seriesNumber" : "tmKujfClIyu2AJ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/xZbnczf4gE7r"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YAUwFJvXGTd6Oc7"
         },
-        "isbnList" : [ "9790853957248" ]
+        "isbnList" : [ "9791867422890" ]
       },
-      "doi" : "https://www.example.com/kEbHmBBUL6",
+      "doi" : "https://www.example.com/IPQNFn4bDDqQSY",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -98,53 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "LyfoWTXOw8YJVtpH",
-            "end" : "pX3GtCFKYM2"
+            "begin" : "zFXvOFIulZ4Srp",
+            "end" : "ftpteSOlQIRkZw"
           },
-          "pages" : "g9Xpv8WCkvJnGZhOR",
+          "pages" : "81XA0E6NFBnw",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/v64rIjRRgVqbW0k8LO0",
-    "abstract" : "SR1QnrnNldKws"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "PublishedFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "puiDCQuHLJgpNeFRL",
-      "mimeType" : "ungVGt20bR5e",
-      "size" : 1976140487,
-      "license" : {
-        "type" : "License",
-        "identifier" : "AgRTrere29",
-        "labels" : {
-          "iITbK447q8CBs" : "PJ79o1F5RPM"
-        },
-        "link" : "https://www.example.com/vzuYrrrstXUjQ4"
-      },
-      "administrativeAgreement" : false,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/xS0K1mbPgQNt",
+    "abstract" : "t9srWNHsfgnBOJJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etmolestiae",
-    "name" : "WX26UH2qoynO",
+    "id" : "https://www.example.org/hiccorrupti",
+    "name" : "bBgFOzVmNGqZbOmK",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "8DbI0MynFk",
-      "id" : "sSDSU7EVvjwXmrk"
+      "source" : "bwr8msuLlhmrwQl3n",
+      "id" : "bkoTI0KyyZ"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "cMW4JqM0vHwqwm5"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "28ixfxxQocOJEA0C"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -152,25 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/eosoptio" ],
+  "subjects" : [ "https://www.example.org/cupiditatequis" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "puiDCQuHLJgpNeFRL",
-    "mimeType" : "ungVGt20bR5e",
-    "size" : 1976140487,
+    "name" : "bRq21Ov4oPxk",
+    "mimeType" : "0lhyj0sxpN0",
+    "size" : 1706976602,
     "license" : {
       "type" : "License",
-      "identifier" : "AgRTrere29",
+      "identifier" : "XK0FqKvLHP",
       "labels" : {
-        "iITbK447q8CBs" : "PJ79o1F5RPM"
+        "AuallJItVc6m0" : "Y3mbZvYX6x3weqB"
       },
-      "link" : "https://www.example.com/vzuYrrrstXUjQ4"
+      "link" : "https://www.example.com/P4nqOL0nAI9yIMh0j"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "PxvugzTA0ygq"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "bRq21Ov4oPxk",
+      "mimeType" : "0lhyj0sxpN0",
+      "size" : 1706976602,
+      "license" : {
+        "type" : "License",
+        "identifier" : "XK0FqKvLHP",
+        "labels" : {
+          "AuallJItVc6m0" : "Y3mbZvYX6x3weqB"
+        },
+        "link" : "https://www.example.com/P4nqOL0nAI9yIMh0j"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "S85Xgcf2qj",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "sYtPPgQUmA36",
-    "ownerAffiliation" : "https://www.example.org/utvoluptatibus"
+    "owner" : "FW0DBulQ6y0ZRH69y",
+    "ownerAffiliation" : "https://www.example.org/cumodio"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/odiovel",
+    "id" : "https://www.example.org/quosvoluptas",
     "labels" : {
-      "DQ1yqe9mbSdU" : "VBh6TPHW1Xw63NRD"
+      "8FJ9t0QpXvs4lu4g5" : "9bnNtzkgRWCcifVx"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/delectusomnis",
-  "doi" : "https://doi.org/10.1234/dolor",
-  "link" : "https://www.example.org/quasivoluptate",
+  "handle" : "https://www.example.org/quibusdamodio",
+  "doi" : "https://doi.org/10.1234/dicta",
+  "link" : "https://www.example.org/dictaillum",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QPy9aqiVEl4",
+    "mainTitle" : "jrFB0EwihHfGxXo40vV",
     "alternativeTitles" : {
-      "se" : "YroIlv0dkoAnROkLM"
+      "it" : "etfOygp8xEi"
     },
-    "language" : "http://lexvo.org/id/iso639-3/dan",
+    "language" : "http://lexvo.org/id/iso639-3/fra",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "jy2Aqnc0iwDRgT",
-      "month" : "qkfVGq763Mg",
-      "day" : "sizHJZW4WzJiPYr"
+      "year" : "NHtyHnEjtLQSYR5N0Uq",
+      "month" : "ZNwf82tONUr",
+      "day" : "dIuC7QGKUFGU4WnW0B6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/Ld2bpWFYKj9e",
-        "name" : "XLV1SklE1oVqFV0r",
+        "id" : "https://www.example.com/B4tMKiB7hjaeCaVtO8",
+        "name" : "K1rOPfyna0xfc",
         "nameType" : "Organizational",
-        "orcId" : "Ccuhrsuqalu"
+        "orcId" : "NBybnzVFZi1kSvB2oW"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/cpDAGRDQgt1ez4mq",
+        "id" : "https://www.example.com/Utm9rR96Nw2edj",
         "labels" : {
-          "gWusrEI9HeFV" : "Wy2XUJW1PR"
+          "E2sbVHiEB8wAxJ" : "8MLYuwMw1GKBJMzLBtV"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 4,
+      "role" : "Journalist",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/wHIuACUeB6P8",
-        "name" : "0svl4Zs4EaBWelNMvp",
-        "nameType" : "Organizational",
-        "orcId" : "RfCJNbpkq491"
+        "id" : "https://www.example.com/lckXO2QNQHKVn1EUQ",
+        "name" : "3vUUSijjHBeWnFjTL",
+        "nameType" : "Personal",
+        "orcId" : "VSPh6qRgHZUVBJ"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/vm82lNVF5wSno8QFY",
+        "id" : "https://www.example.com/Qb28YzBhDE",
         "labels" : {
-          "hlCZ4DApArUBPFTc" : "LDBLFF6sp6SWDSPK0w"
+          "5GpbxCxgTtJNYxzGzjf" : "VHrOxOLYG91RZcS"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 7,
+      "role" : "Soloist",
+      "sequence" : 4,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "1wB2rXKoElU6",
-    "tags" : [ "6VPLoTLRTkxC" ],
-    "description" : "rxe4XuMlI3",
+    "npiSubjectHeading" : "ZRWFyL5FfU51sE48",
+    "tags" : [ "J9nV25ll7X7ccPhfwn" ],
+    "description" : "h7lCScaq0AljxWpC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9zkyOif3VOqCsRZ"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/pQTHC1lBjBL"
         },
-        "seriesNumber" : "tEUUJX56N0JGKJ",
+        "seriesNumber" : "5C5Xo571ytT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5sRiOGqUUYif"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MqlQbnNSJXkQ1"
         },
-        "isbnList" : [ "9781964256535" ]
+        "isbnList" : [ "9790916803871" ]
       },
-      "doi" : "https://www.example.com/CAKZiQzqa9sofRGuXin",
+      "doi" : "https://www.example.com/58z31yAKOwlnDHFGia",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "xDT5HHMQjoC6rJr",
-            "end" : "6zqhoLczHuwx"
+            "begin" : "cxpjDJ81yDIo",
+            "end" : "cKpAnE2CJpP"
           },
-          "pages" : "8LS8rDcMsbTwE",
-          "illustrated" : true
+          "pages" : "aNz5Q1oNn40Nhl188kq",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.com/B0ZywLSsJ3zg",
-    "abstract" : "hZDrpRW7Zj0GWsi"
+    "metadataSource" : "https://www.example.com/3X0uSHZAoP",
+    "abstract" : "63HAuRttEsXye9C51"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/quidemillum",
-    "name" : "w3wptxL7LJNPNl",
+    "id" : "https://www.example.org/utquasi",
+    "name" : "XFE0KugliafLG",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "srr91SLifpxB",
-      "id" : "xLvoh9XEIw7nbPP"
+      "source" : "XKQFsXtMlVe",
+      "id" : "zSxdBce5vnlZJd4Uuc7"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "8iWYhKsYJZF1Bb"
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "W3CzxGq69IMn3EGGx"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/quamvoluptas" ],
+  "subjects" : [ "https://www.example.org/nullaaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "UnpublishableFile",
+      "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "znqnJbyEEzoJMD1JB9",
-      "mimeType" : "Pfa2po4H914nIdNNJJd",
-      "size" : 897558693,
+      "name" : "kkfSGMongqkvYhoXsb",
+      "mimeType" : "oKJX4ksIiCQZ01qo59l",
+      "size" : 377849345,
       "license" : {
         "type" : "License",
-        "identifier" : "qUEokkGkki0ABFK4O",
+        "identifier" : "a4Qnd1hmixGkDtN",
         "labels" : {
-          "EAAcHSgqSYO" : "qnFF9vG8Dh"
+          "DiziTg46XouP1vUm" : "PQhUuMWUUzl"
         },
-        "link" : "https://www.example.com/06kh6LcXNEhivn4nXcz"
+        "link" : "https://www.example.com/OgzZg2Gahr"
       },
-      "administrativeAgreement" : true,
+      "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "znqnJbyEEzoJMD1JB9",
-    "mimeType" : "Pfa2po4H914nIdNNJJd",
-    "size" : 897558693,
+    "name" : "kkfSGMongqkvYhoXsb",
+    "mimeType" : "oKJX4ksIiCQZ01qo59l",
+    "size" : 377849345,
     "license" : {
       "type" : "License",
-      "identifier" : "qUEokkGkki0ABFK4O",
+      "identifier" : "a4Qnd1hmixGkDtN",
       "labels" : {
-        "EAAcHSgqSYO" : "qnFF9vG8Dh"
+        "DiziTg46XouP1vUm" : "PQhUuMWUUzl"
       },
-      "link" : "https://www.example.com/06kh6LcXNEhivn4nXcz"
+      "link" : "https://www.example.com/OgzZg2Gahr"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "sYtPPgQUmA36",
+  "owner" : "FW0DBulQ6y0ZRH69y",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "S85Xgcf2qj",
-    "ownerAffiliation" : "https://www.example.org/accusantiumporro"
+    "owner" : "sYtPPgQUmA36",
+    "ownerAffiliation" : "https://www.example.org/utvoluptatibus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/atquia",
+    "id" : "https://www.example.org/odiovel",
     "labels" : {
-      "yLFN861OG7ePMjD9" : "bPP5QG9mqLi2GDR18wg"
+      "DQ1yqe9mbSdU" : "VBh6TPHW1Xw63NRD"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/consecteturvoluptatibus",
-  "doi" : "https://doi.org/10.1234/numquam",
-  "link" : "https://www.example.org/reiciendissit",
+  "handle" : "https://www.example.org/delectusomnis",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/quasivoluptate",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "X7TTOAJUNB2XjzRn8z",
+    "mainTitle" : "QPy9aqiVEl4",
     "alternativeTitles" : {
-      "zh" : "brxxflfwm9Imtru"
+      "se" : "YroIlv0dkoAnROkLM"
     },
-    "language" : "http://lexvo.org/id/iso639-3/car",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "KRBMst9XK27",
-      "month" : "WV6ucgoWs0tuxZjJN",
-      "day" : "bimGhRpKb0I"
+      "year" : "jy2Aqnc0iwDRgT",
+      "month" : "qkfVGq763Mg",
+      "day" : "sizHJZW4WzJiPYr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/jfAxhHEUG6c",
-        "name" : "RbrrCUgnXEYAMqKMu",
+        "id" : "https://www.example.com/Ld2bpWFYKj9e",
+        "name" : "XLV1SklE1oVqFV0r",
         "nameType" : "Organizational",
-        "orcId" : "loq0o1k86PVes86r"
+        "orcId" : "Ccuhrsuqalu"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/egoi2DXjczlX0kv",
+        "id" : "https://www.example.com/cpDAGRDQgt1ez4mq",
         "labels" : {
-          "YwhjRDuZTpqFN" : "OFqBSig8Eb8cbYfoKr"
+          "gWusrEI9HeFV" : "Wy2XUJW1PR"
         }
       } ],
-      "role" : "Advisor",
-      "sequence" : 3,
+      "role" : "Actor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/vEBHCRaBVJSAHe",
-        "name" : "iwYhu5mrm4",
+        "id" : "https://www.example.com/wHIuACUeB6P8",
+        "name" : "0svl4Zs4EaBWelNMvp",
         "nameType" : "Organizational",
-        "orcId" : "Wq43k6Lgbo78lETmlI"
+        "orcId" : "RfCJNbpkq491"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/KadVJ7Hro26XPmK3x",
+        "id" : "https://www.example.com/vm82lNVF5wSno8QFY",
         "labels" : {
-          "yYmmULT09zd" : "QYHCgWdRS3LN"
+          "hlCZ4DApArUBPFTc" : "LDBLFF6sp6SWDSPK0w"
         }
       } ],
-      "role" : "Dramatist",
-      "sequence" : 0,
+      "role" : "Distributor",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "qTBJBDqtN2Dnv9PR",
-    "tags" : [ "LhirbEVhaSEkZ3l" ],
-    "description" : "JsoanU3DBWFB6vWhE",
+    "npiSubjectHeading" : "1wB2rXKoElU6",
+    "tags" : [ "6VPLoTLRTkxC" ],
+    "description" : "rxe4XuMlI3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aonzRjJSyLXCw"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9zkyOif3VOqCsRZ"
         },
-        "seriesNumber" : "tmKujfClIyu2AJ",
+        "seriesNumber" : "tEUUJX56N0JGKJ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/YAUwFJvXGTd6Oc7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5sRiOGqUUYif"
         },
-        "isbnList" : [ "9791867422890" ]
+        "isbnList" : [ "9781964256535" ]
       },
-      "doi" : "https://www.example.com/IPQNFn4bDDqQSY",
+      "doi" : "https://www.example.com/CAKZiQzqa9sofRGuXin",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zFXvOFIulZ4Srp",
-            "end" : "ftpteSOlQIRkZw"
+            "begin" : "xDT5HHMQjoC6rJr",
+            "end" : "6zqhoLczHuwx"
           },
-          "pages" : "81XA0E6NFBnw",
+          "pages" : "8LS8rDcMsbTwE",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/xS0K1mbPgQNt",
-    "abstract" : "t9srWNHsfgnBOJJ"
+    "metadataSource" : "https://www.example.com/B0ZywLSsJ3zg",
+    "abstract" : "hZDrpRW7Zj0GWsi"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/hiccorrupti",
-    "name" : "bBgFOzVmNGqZbOmK",
+    "id" : "https://www.example.org/quidemillum",
+    "name" : "w3wptxL7LJNPNl",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "bwr8msuLlhmrwQl3n",
-      "id" : "bkoTI0KyyZ"
+      "source" : "srr91SLifpxB",
+      "id" : "xLvoh9XEIw7nbPP"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "28ixfxxQocOJEA0C"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "8iWYhKsYJZF1Bb"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,46 +131,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cupiditatequis" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "bRq21Ov4oPxk",
-    "mimeType" : "0lhyj0sxpN0",
-    "size" : 1706976602,
-    "license" : {
-      "type" : "License",
-      "identifier" : "XK0FqKvLHP",
-      "labels" : {
-        "AuallJItVc6m0" : "Y3mbZvYX6x3weqB"
-      },
-      "link" : "https://www.example.com/P4nqOL0nAI9yIMh0j"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/quamvoluptas" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "bRq21Ov4oPxk",
-      "mimeType" : "0lhyj0sxpN0",
-      "size" : 1706976602,
+      "name" : "znqnJbyEEzoJMD1JB9",
+      "mimeType" : "Pfa2po4H914nIdNNJJd",
+      "size" : 897558693,
       "license" : {
         "type" : "License",
-        "identifier" : "XK0FqKvLHP",
+        "identifier" : "qUEokkGkki0ABFK4O",
         "labels" : {
-          "AuallJItVc6m0" : "Y3mbZvYX6x3weqB"
+          "EAAcHSgqSYO" : "qnFF9vG8Dh"
         },
-        "link" : "https://www.example.com/P4nqOL0nAI9yIMh0j"
+        "link" : "https://www.example.com/06kh6LcXNEhivn4nXcz"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "S85Xgcf2qj",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "UnpublishableFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "znqnJbyEEzoJMD1JB9",
+    "mimeType" : "Pfa2po4H914nIdNNJJd",
+    "size" : 897558693,
+    "license" : {
+      "type" : "License",
+      "identifier" : "qUEokkGkki0ABFK4O",
+      "labels" : {
+        "EAAcHSgqSYO" : "qnFF9vG8Dh"
+      },
+      "link" : "https://www.example.com/06kh6LcXNEhivn4nXcz"
+    },
+    "administrativeAgreement" : true,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "sYtPPgQUmA36",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,96 +1,96 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "FW0DBulQ6y0ZRH69y",
-    "ownerAffiliation" : "https://www.example.org/cumodio"
+    "owner" : "tjurJ9jei1",
+    "ownerAffiliation" : "https://www.example.org/accusantiumtempore"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/quosvoluptas",
+    "id" : "https://www.example.org/utat",
     "labels" : {
-      "8FJ9t0QpXvs4lu4g5" : "9bnNtzkgRWCcifVx"
+      "GuxvHFvXVWNG9jgaV" : "3Zucc5PJ2Ou2cxcpfsA"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/quibusdamodio",
-  "doi" : "https://doi.org/10.1234/dicta",
-  "link" : "https://www.example.org/dictaillum",
+  "handle" : "https://www.example.org/sitaut",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/exdolorem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jrFB0EwihHfGxXo40vV",
+    "mainTitle" : "3UEzoPXsjwspgTihogC",
     "alternativeTitles" : {
-      "it" : "etfOygp8xEi"
+      "en" : "tk7uk8ChySJGxnkBKYa"
     },
-    "language" : "http://lexvo.org/id/iso639-3/fra",
+    "language" : "http://lexvo.org/id/iso639-3/und",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "NHtyHnEjtLQSYR5N0Uq",
-      "month" : "ZNwf82tONUr",
-      "day" : "dIuC7QGKUFGU4WnW0B6"
+      "year" : "uC5Hr644ofC",
+      "month" : "HQp3j5MEaduLrDqg",
+      "day" : "4vsBxZOSyvObvmQxJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/B4tMKiB7hjaeCaVtO8",
-        "name" : "K1rOPfyna0xfc",
+        "id" : "https://www.example.com/NlKwKM0NkzzrmR",
+        "name" : "PI0Xn1IspffQBS9s",
         "nameType" : "Organizational",
-        "orcId" : "NBybnzVFZi1kSvB2oW"
+        "orcId" : "yydARi5wCHlRzjd"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Utm9rR96Nw2edj",
+        "id" : "https://www.example.com/n39V4ZRAdhFvQL",
         "labels" : {
-          "E2sbVHiEB8wAxJ" : "8MLYuwMw1GKBJMzLBtV"
+          "lsZFhAE5Z2ZT7XjL" : "sGiOvBSWCS8XXjR"
         }
       } ],
-      "role" : "Journalist",
-      "sequence" : 6,
+      "role" : "AcademicCoordinator",
+      "sequence" : 7,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/lckXO2QNQHKVn1EUQ",
-        "name" : "3vUUSijjHBeWnFjTL",
-        "nameType" : "Personal",
-        "orcId" : "VSPh6qRgHZUVBJ"
+        "id" : "https://www.example.com/UCUVpzP6pTgOaI",
+        "name" : "3upiOQrqGWxDn",
+        "nameType" : "Organizational",
+        "orcId" : "pWO55RqiZDUly"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/Qb28YzBhDE",
+        "id" : "https://www.example.com/hMD542YHGjX2eC0zFs2",
         "labels" : {
-          "5GpbxCxgTtJNYxzGzjf" : "VHrOxOLYG91RZcS"
+          "BV5CCNAnQ0" : "vFwy1BxVYk3HRDbyd"
         }
       } ],
-      "role" : "Soloist",
-      "sequence" : 4,
+      "role" : "Conductor",
+      "sequence" : 6,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "ZRWFyL5FfU51sE48",
-    "tags" : [ "J9nV25ll7X7ccPhfwn" ],
-    "description" : "h7lCScaq0AljxWpC",
+    "npiSubjectHeading" : "4X3KEQUJpUifnv",
+    "tags" : [ "X2O5F3wnvr0c" ],
+    "description" : "ZLWZ2BnJ7KL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/pQTHC1lBjBL"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/p9GsZGSx0xDNyRwkw"
         },
-        "seriesNumber" : "5C5Xo571ytT",
+        "seriesNumber" : "WO9m0HmeLyrqwIn",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/MqlQbnNSJXkQ1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ndA12miihq"
         },
-        "isbnList" : [ "9790916803871" ]
+        "isbnList" : [ "9781713210535" ]
       },
-      "doi" : "https://www.example.com/58z31yAKOwlnDHFGia",
+      "doi" : "https://www.example.com/yJ1xMilfMih00ix",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "peerReviewed" : false,
@@ -98,32 +98,32 @@
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "cxpjDJ81yDIo",
-            "end" : "cKpAnE2CJpP"
+            "begin" : "EXtXDHy822",
+            "end" : "Rx3q8aIOeSIQ6OzSB"
           },
-          "pages" : "aNz5Q1oNn40Nhl188kq",
-          "illustrated" : false
+          "pages" : "IFn4op8nwArNGdVGNa",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.com/3X0uSHZAoP",
-    "abstract" : "63HAuRttEsXye9C51"
+    "metadataSource" : "https://www.example.com/Gf5sqxk6jH82h",
+    "abstract" : "lmtLr6CfiqGsNk32d"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/utquasi",
-    "name" : "XFE0KugliafLG",
+    "id" : "https://www.example.org/quidemnihil",
+    "name" : "MMd5jhylfew8X",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "XKQFsXtMlVe",
-      "id" : "zSxdBce5vnlZJd4Uuc7"
+      "source" : "xPjJRGufrYl",
+      "id" : "wtwcgOEQQhi6e8NGSc5"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "W3CzxGq69IMn3EGGx"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "nFiWUmcljmdzFa"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -131,22 +131,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/nullaaut" ],
+  "subjects" : [ "https://www.example.org/liberodignissimos" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "kkfSGMongqkvYhoXsb",
-      "mimeType" : "oKJX4ksIiCQZ01qo59l",
-      "size" : 377849345,
+      "name" : "DUNeDSWO72C2Ew",
+      "mimeType" : "j9VWiY7DAYdW3",
+      "size" : 1085640089,
       "license" : {
         "type" : "License",
-        "identifier" : "a4Qnd1hmixGkDtN",
+        "identifier" : "rkjRgozqn1T",
         "labels" : {
-          "DiziTg46XouP1vUm" : "PQhUuMWUUzl"
+          "vYips3mJmVE" : "hE0UBFhktnSE2OdcS4"
         },
-        "link" : "https://www.example.com/OgzZg2Gahr"
+        "link" : "https://www.example.com/5SzhAVMlpSCMdu2tSm8"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -156,21 +156,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "kkfSGMongqkvYhoXsb",
-    "mimeType" : "oKJX4ksIiCQZ01qo59l",
-    "size" : 377849345,
+    "name" : "DUNeDSWO72C2Ew",
+    "mimeType" : "j9VWiY7DAYdW3",
+    "size" : 1085640089,
     "license" : {
       "type" : "License",
-      "identifier" : "a4Qnd1hmixGkDtN",
+      "identifier" : "rkjRgozqn1T",
       "labels" : {
-        "DiziTg46XouP1vUm" : "PQhUuMWUUzl"
+        "vYips3mJmVE" : "hE0UBFhktnSE2OdcS4"
       },
-      "link" : "https://www.example.com/OgzZg2Gahr"
+      "link" : "https://www.example.com/5SzhAVMlpSCMdu2tSm8"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "FW0DBulQ6y0ZRH69y",
+  "owner" : "tjurJ9jei1",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,105 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "wrcn4Z9HlFJCisBJE",
-    "ownerAffiliation" : "https://www.example.org/recusandaemodi"
+    "owner" : "BsJLKjWvDX3",
+    "ownerAffiliation" : "https://www.example.org/excepturiaccusamus"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dolorumfacere",
+    "id" : "https://www.example.org/reiciendisvel",
     "labels" : {
-      "2nIudklXxbFdoPp" : "de8UVMa6UOr"
+      "I04qr7QdVfHuy" : "jCNfjZ2jY72jH"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/utquo",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/faceredolorem",
+  "handle" : "https://www.example.org/autbeatae",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/consequaturet",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nY5u2sMNHfr4EJ",
+    "mainTitle" : "mKnyvGsAjFSM3d559GV",
     "alternativeTitles" : {
-      "hu" : "pyYU6efcEqJge"
+      "af" : "GEyyBkPZljkK"
     },
-    "language" : "http://lexvo.org/id/iso639-3/swe",
+    "language" : "http://lexvo.org/id/iso639-3/ces",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "oVukjn4ERnO",
-      "month" : "DnC50WSdZVd6GP3",
-      "day" : "sUWJjF0vtlBKJ"
+      "year" : "ngqcHkvQkir",
+      "month" : "GdIMnA4Cr0A1O",
+      "day" : "kYsA9NJriW2yaPhdw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/5MqTzInmD0LRj7kj",
-        "name" : "0yk7Y4VbTubqlKTK",
+        "id" : "https://www.example.com/cgc8M9GqvK",
+        "name" : "D3fwvijCjG5tgSstri",
         "nameType" : "Personal",
-        "orcId" : "x5khFpELOnWR"
+        "orcId" : "0ncAtqKt3J9A7Xp7wH"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/X8I5koMtzYIifU",
+        "id" : "https://www.example.com/CVdeP1Ui2v7Hk77M",
         "labels" : {
-          "IyxbVmUJF2OQ9VSb9FX" : "mVmFoUXesCy4"
+          "DCWcTMSFAJ4qxokavXs" : "UqmIQIadzU13wsjfZ"
         }
       } ],
-      "role" : "Consultant",
-      "sequence" : 6,
+      "role" : "Distributor",
+      "sequence" : 4,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/T9dfkSi9oha",
-        "name" : "WpDYyV5ynSVIMweQ5P",
+        "id" : "https://www.example.com/TipIq0SlE3jqHsoMLIF",
+        "name" : "LbrWZYCfcbn",
         "nameType" : "Personal",
-        "orcId" : "cAHmuOXzkIzmKU"
+        "orcId" : "2gNnM7JGXeBeViJke"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/L10aGCsCcpT",
+        "id" : "https://www.example.com/bYPv7TQ7F41V59hOU",
         "labels" : {
-          "5yYklS72fq22" : "ZkjRsiHNnR"
+          "lRISM6yhAF5e" : "D16SAF5hLUnE0k"
         }
       } ],
-      "role" : "Creator",
-      "sequence" : 7,
+      "role" : "InteriorArchitect",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "4kcsZLDELGi",
-    "tags" : [ "ECAZ0ltMsjHDbA9" ],
-    "description" : "ExqXMkCwlsbt",
+    "npiSubjectHeading" : "RBZsBbzfNlKUSvNplX",
+    "tags" : [ "pXxvS8TswgsWM" ],
+    "description" : "ldPgjpY03W",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/ELUpkNkYjPrRF",
+      "doi" : "https://www.example.com/XrsD9wpzJ6z",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "Performance"
+          "type" : "ArtistBook"
         },
-        "description" : "LUpwh1q4I9vDZrzas",
+        "description" : "aijW54awnE9f",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "t2ROcCn4lKCM05GH",
-            "country" : "VLkW7JfdGgiB"
+            "label" : "aODTtdL4W4yRrQhh9ay",
+            "country" : "DTFnErrwtHVfJg8"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1765704065
+          "sequence" : 32503439
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/ic3fgHPVY9qYeVyJsUj",
-    "abstract" : "CKO7GCtf38GAoapjd"
+    "metadataSource" : "https://www.example.com/THIFrtPk8WvQfIbtnM",
+    "abstract" : "bRO2CuqecjiLMfl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/etaut",
-    "name" : "gWvk9fKsB1ilR2xYdR",
+    "id" : "https://www.example.org/voluptatessuscipit",
+    "name" : "dbXDLwtQHKj",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "xHwKOd3GB4OwgX",
-      "id" : "12OBcXaWLJvy5dc"
+      "source" : "ikykAYLOv8toux",
+      "id" : "h4Pj4fl9CHic52jT"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "nlgHrc1kF1Yn"
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "DhP5DAihiITHHc8"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,22 +132,22 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/omnisaut" ],
+  "subjects" : [ "https://www.example.org/animiaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "jkZ0omvvBndXghbZ",
-      "mimeType" : "3sNR6zkkA1PS0",
-      "size" : 233543791,
+      "name" : "vtytUxHSiCxFFSb",
+      "mimeType" : "HJ1ivehQtY6wDRF",
+      "size" : 733675151,
       "license" : {
         "type" : "License",
-        "identifier" : "7OohjcOQ0Ud8Gae",
+        "identifier" : "bi6hX0kDaPnaHzsNfA",
         "labels" : {
-          "E4c6SE1Ole4OLDL" : "RnHWzbjDO2V"
+          "JVKw9Gi5fnp4H7" : "18SHEDIGqX"
         },
-        "link" : "https://www.example.com/o2PtUnVpBL2tuSy9"
+        "link" : "https://www.example.com/htjCneELYxd"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
@@ -157,21 +157,21 @@
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "jkZ0omvvBndXghbZ",
-    "mimeType" : "3sNR6zkkA1PS0",
-    "size" : 233543791,
+    "name" : "vtytUxHSiCxFFSb",
+    "mimeType" : "HJ1ivehQtY6wDRF",
+    "size" : 733675151,
     "license" : {
       "type" : "License",
-      "identifier" : "7OohjcOQ0Ud8Gae",
+      "identifier" : "bi6hX0kDaPnaHzsNfA",
       "labels" : {
-        "E4c6SE1Ole4OLDL" : "RnHWzbjDO2V"
+        "JVKw9Gi5fnp4H7" : "18SHEDIGqX"
       },
-      "link" : "https://www.example.com/o2PtUnVpBL2tuSy9"
+      "link" : "https://www.example.com/htjCneELYxd"
     },
     "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "wrcn4Z9HlFJCisBJE",
+  "owner" : "BsJLKjWvDX3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -3,103 +3,103 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "5L84CJ4T1dIm8SNMo8",
-    "ownerAffiliation" : "https://www.example.org/odioipsum"
+    "owner" : "pPKgWNjGoPd4kpBJgr",
+    "ownerAffiliation" : "https://www.example.org/exeos"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/providentomnis",
+    "id" : "https://www.example.org/nisieos",
     "labels" : {
-      "QU2gf1nhAuUj" : "8O9GmSeMRI"
+      "yA0Yhsv7um0JA08DfQ8" : "mMja4XLKj6srPab"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/ametodit",
-  "doi" : "https://doi.org/10.1234/ipsum",
-  "link" : "https://www.example.org/rerumqui",
+  "handle" : "https://www.example.org/illoprovident",
+  "doi" : "https://doi.org/10.1234/pariatur",
+  "link" : "https://www.example.org/aliquamvoluptas",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6sPF4RpzMb",
+    "mainTitle" : "AcXNpZbuCY9yYNn7Kv",
     "alternativeTitles" : {
-      "ru" : "k061A2zXn4"
+      "hu" : "mbx7e2yoM2GQUQt"
     },
-    "language" : "http://lexvo.org/id/iso639-3/mis",
+    "language" : "http://lexvo.org/id/iso639-3/sme",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "yyaUl6zahGs3rWaAVRe",
-      "month" : "M338b2Bb8D3i0",
-      "day" : "Q6AEq6nVXzOX"
+      "year" : "dwd9TQ9cvg",
+      "month" : "csCdAY5RweVSis",
+      "day" : "JUDZCzsVj2o0PoqbzK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/fJKJg8fcxuP",
-        "name" : "WkjPasNj4Y5hTNHh53",
+        "id" : "https://www.example.com/09cbYnIaQczrB",
+        "name" : "zaxBaE5GK5X",
         "nameType" : "Organizational",
-        "orcId" : "bJKmpNPbGY"
+        "orcId" : "WqxxsWg3WhytnRr4b3Z"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/2HJjQZwgBpSadqU",
+        "id" : "https://www.example.com/4EiYCf3jBVAV",
         "labels" : {
-          "8ufzPTZH8l" : "C6Ywzp7lntDqcEy5"
+          "vKADy2LpBaPTH" : "wq1W8yaZVG3nUM9W"
         }
       } ],
-      "role" : "Architect",
-      "sequence" : 1,
+      "role" : "Composer",
+      "sequence" : 5,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TAn585n3SEuFmsNaOFh",
-        "name" : "M4A9eEUNIX4yOVSOUhg",
-        "nameType" : "Personal",
-        "orcId" : "wc3nXJ7fsBR6b"
+        "id" : "https://www.example.com/ZsC5NMYFK9JqjlraM",
+        "name" : "MgVh01z0vW1NSUViJVy",
+        "nameType" : "Organizational",
+        "orcId" : "H2CFcUh5hxpISDTnYcX"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bz2QYQEBeebicPJaNE",
+        "id" : "https://www.example.com/lvYGoAtzexE",
         "labels" : {
-          "5Qou11bzMApPau" : "2ulxaPwG9ieN6ml"
+          "QZl06s0PwwQifeQ" : "akSn7Ji5LA"
         }
       } ],
-      "role" : "EditorialBoardMember",
-      "sequence" : 9,
+      "role" : "Actor",
+      "sequence" : 2,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "k0DgTUp3wbWn",
-    "tags" : [ "378yYGRdl7Bea5i" ],
-    "description" : "ewreISarfwla9Wfcy",
+    "npiSubjectHeading" : "iCJFSykhtllO",
+    "tags" : [ "zJSs0NXdIVKx" ],
+    "description" : "zZpbhsOQOj0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/BIeNvceHw1g5",
+      "doi" : "https://www.example.com/dCaiQEeG2UtV0JsrU8x",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "Installation"
+          "type" : "ArtistBook"
         },
-        "description" : "soORWPSBUrMGYzE",
+        "description" : "wMVxxYZqEB",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "V3tFi83vS8G7zGwb",
-            "country" : "Ih6OMIvtcJ"
+            "label" : "NFRtfnFGYRKl7",
+            "country" : "HfGxQxShqXcRYtKR"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 1064664888
+          "sequence" : 2143903559
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,45 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/Uw8aDCfYTtAVUZylNn",
-    "abstract" : "ko1M4pbZQYt6FKE"
-  },
-  "fileSet" : {
-    "type" : "FileSet",
-    "files" : [ {
-      "type" : "UnpublishableFile",
-      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "DJkz50EtPqjbncmv",
-      "mimeType" : "ASxI6IHfX0",
-      "size" : 2022060672,
-      "license" : {
-        "type" : "License",
-        "identifier" : "e9v4Ny1S3OZ",
-        "labels" : {
-          "CKN7RhcV7wTntTMI" : "jL9kc5CCFAMpE"
-        },
-        "link" : "https://www.example.com/OInKdiEAZGaXFZcwq9S"
-      },
-      "administrativeAgreement" : true,
-      "publisherAuthority" : false,
-      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-    } ]
+    "metadataSource" : "https://www.example.com/4FPPro3BvTfOdGbfRk",
+    "abstract" : "jO9mc0NYIqPef"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/doloreharum",
-    "name" : "RAbalXJAoxp9wbv",
+    "id" : "https://www.example.org/enimeligendi",
+    "name" : "ROcrNB9Jebm",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ddZBwuDz0wb",
-      "id" : "6VXGP1c1yMo7w"
+      "source" : "K4hMCDeXj5",
+      "id" : "ZJY9iYiqHaQNqaVfFnT"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "EAZQJkYhvexW2Oz"
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "pXXwPX8c5tp6slo7ism"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -153,25 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/expeditafuga" ],
+  "subjects" : [ "https://www.example.org/exeius" ],
   "associatedArtifacts" : [ {
-    "type" : "UnpublishableFile",
+    "type" : "PublishedFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "DJkz50EtPqjbncmv",
-    "mimeType" : "ASxI6IHfX0",
-    "size" : 2022060672,
+    "name" : "uzsk87rEUxAkZiZKIB8",
+    "mimeType" : "aA6gQjnOr190bBcnu",
+    "size" : 1325075967,
     "license" : {
       "type" : "License",
-      "identifier" : "e9v4Ny1S3OZ",
+      "identifier" : "kstIjSR3LCq",
       "labels" : {
-        "CKN7RhcV7wTntTMI" : "jL9kc5CCFAMpE"
+        "7fqjlBAtVmt9" : "oKcP70WBnyWK"
       },
-      "link" : "https://www.example.com/OInKdiEAZGaXFZcwq9S"
+      "link" : "https://www.example.com/YO039zvlRYrGcX"
     },
-    "administrativeAgreement" : true,
+    "administrativeAgreement" : false,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "modelVersion" : "0.18.6",
-  "owner" : "5L84CJ4T1dIm8SNMo8"
+  "fileSet" : {
+    "type" : "FileSet",
+    "files" : [ {
+      "type" : "PublishedFile",
+      "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+      "name" : "uzsk87rEUxAkZiZKIB8",
+      "mimeType" : "aA6gQjnOr190bBcnu",
+      "size" : 1325075967,
+      "license" : {
+        "type" : "License",
+        "identifier" : "kstIjSR3LCq",
+        "labels" : {
+          "7fqjlBAtVmt9" : "oKcP70WBnyWK"
+        },
+        "link" : "https://www.example.com/YO039zvlRYrGcX"
+      },
+      "administrativeAgreement" : false,
+      "publisherAuthority" : false,
+      "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+    } ]
+  },
+  "owner" : "pPKgWNjGoPd4kpBJgr",
+  "modelVersion" : "0.18.6"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,105 +1,105 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "BsJLKjWvDX3",
-    "ownerAffiliation" : "https://www.example.org/excepturiaccusamus"
+    "owner" : "t9q7VIfCiXd84NFQ3",
+    "ownerAffiliation" : "https://www.example.org/fugiatnisi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/reiciendisvel",
+    "id" : "https://www.example.org/voluptatibusearum",
     "labels" : {
-      "I04qr7QdVfHuy" : "jCNfjZ2jY72jH"
+      "ZjLlSknZqNp22Xwfohw" : "MWqcOUsjQpufSx9v7"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/autbeatae",
-  "doi" : "https://doi.org/10.1234/id",
-  "link" : "https://www.example.org/consequaturet",
+  "handle" : "https://www.example.org/maximeeligendi",
+  "doi" : "https://doi.org/10.1234/excepturi",
+  "link" : "https://www.example.org/harummaxime",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mKnyvGsAjFSM3d559GV",
+    "mainTitle" : "Q4CeEscF8JW",
     "alternativeTitles" : {
-      "af" : "GEyyBkPZljkK"
+      "nb" : "HPRXsyE328lJ"
     },
-    "language" : "http://lexvo.org/id/iso639-3/ces",
+    "language" : "http://lexvo.org/id/iso639-3/dan",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "ngqcHkvQkir",
-      "month" : "GdIMnA4Cr0A1O",
-      "day" : "kYsA9NJriW2yaPhdw"
+      "year" : "gGMkiXXmBBBsr",
+      "month" : "xXVqZUKN7phDk3",
+      "day" : "8GND9BrzR4M"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/cgc8M9GqvK",
-        "name" : "D3fwvijCjG5tgSstri",
+        "id" : "https://www.example.com/xYTOYXnGZoK5Tf6m",
+        "name" : "Uhoea0V6f8aqU",
         "nameType" : "Personal",
-        "orcId" : "0ncAtqKt3J9A7Xp7wH"
+        "orcId" : "iMZIfZaZC7BwwJNn5n"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/CVdeP1Ui2v7Hk77M",
+        "id" : "https://www.example.com/vqK20H1p0SBdUYX7S",
         "labels" : {
-          "DCWcTMSFAJ4qxokavXs" : "UqmIQIadzU13wsjfZ"
+          "DNtg2lDarrwcj" : "e21cjZqxD6cNx9ouL"
         }
       } ],
-      "role" : "Distributor",
-      "sequence" : 4,
+      "role" : "DataCollector",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/TipIq0SlE3jqHsoMLIF",
-        "name" : "LbrWZYCfcbn",
-        "nameType" : "Personal",
-        "orcId" : "2gNnM7JGXeBeViJke"
+        "id" : "https://www.example.com/x7EV6c9dRf",
+        "name" : "iE7BjjCim1a4",
+        "nameType" : "Organizational",
+        "orcId" : "RxOJAnyqPykfeeirZP"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/bYPv7TQ7F41V59hOU",
+        "id" : "https://www.example.com/bqoRpVIhZnhp",
         "labels" : {
-          "lRISM6yhAF5e" : "D16SAF5hLUnE0k"
+          "FBVnNIH2T8zT8yQvdsN" : "xA7t7XVUx0h"
         }
       } ],
-      "role" : "InteriorArchitect",
-      "sequence" : 2,
+      "role" : "Director",
+      "sequence" : 0,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "RBZsBbzfNlKUSvNplX",
-    "tags" : [ "pXxvS8TswgsWM" ],
-    "description" : "ldPgjpY03W",
+    "npiSubjectHeading" : "32gLMCMwWCsaaDIJTL2",
+    "tags" : [ "4V6aDmADWDMLEj" ],
+    "description" : "eh4g7g64ucpBRC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/XrsD9wpzJ6z",
+      "doi" : "https://www.example.com/CQB20cvx42zAXS",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "ArtistBook"
+          "type" : "VisualArts"
         },
-        "description" : "aijW54awnE9f",
+        "description" : "IWENOiwXLY",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "aODTtdL4W4yRrQhh9ay",
-            "country" : "DTFnErrwtHVfJg8"
+            "label" : "SO0wjtrtrTd",
+            "country" : "0rZ0zGslGiNG"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 32503439
+          "sequence" : 686886000
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/THIFrtPk8WvQfIbtnM",
-    "abstract" : "bRO2CuqecjiLMfl"
+    "metadataSource" : "https://www.example.com/qIA0tKm15J875xkQvB",
+    "abstract" : "sJTxL0TjZ1yKjyxD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/voluptatessuscipit",
-    "name" : "dbXDLwtQHKj",
+    "id" : "https://www.example.org/quaedignissimos",
+    "name" : "aNgMGSeCWLV5X",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "ikykAYLOv8toux",
-      "id" : "h4Pj4fl9CHic52jT"
+      "source" : "oxuJwy7W5WaY",
+      "id" : "WNuPKfItpYkDglQprYR"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "DhP5DAihiITHHc8"
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "1wIwziKYbygBYUY7eVZ"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/animiaut" ],
+  "subjects" : [ "https://www.example.org/quiased" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
-      "type" : "PublishedFile",
+      "type" : "UnpublishableFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "vtytUxHSiCxFFSb",
-      "mimeType" : "HJ1ivehQtY6wDRF",
-      "size" : 733675151,
+      "name" : "O78UT6FVRmyguKHW9",
+      "mimeType" : "d7mZ37zkXjph7f68",
+      "size" : 295215087,
       "license" : {
         "type" : "License",
-        "identifier" : "bi6hX0kDaPnaHzsNfA",
+        "identifier" : "D1L6ZV3BCWAg2fD3y",
         "labels" : {
-          "JVKw9Gi5fnp4H7" : "18SHEDIGqX"
+          "U0zxyi7xNc7CjDtGIb9" : "7Dn28itLJBmQwi5l"
         },
-        "link" : "https://www.example.com/htjCneELYxd"
+        "link" : "https://www.example.com/TgNLN2vIVs7336y8qrC"
       },
-      "administrativeAgreement" : false,
+      "administrativeAgreement" : true,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
   "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
+    "type" : "UnpublishableFile",
     "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "vtytUxHSiCxFFSb",
-    "mimeType" : "HJ1ivehQtY6wDRF",
-    "size" : 733675151,
+    "name" : "O78UT6FVRmyguKHW9",
+    "mimeType" : "d7mZ37zkXjph7f68",
+    "size" : 295215087,
     "license" : {
       "type" : "License",
-      "identifier" : "bi6hX0kDaPnaHzsNfA",
+      "identifier" : "D1L6ZV3BCWAg2fD3y",
       "labels" : {
-        "JVKw9Gi5fnp4H7" : "18SHEDIGqX"
+        "U0zxyi7xNc7CjDtGIb9" : "7Dn28itLJBmQwi5l"
       },
-      "link" : "https://www.example.com/htjCneELYxd"
+      "link" : "https://www.example.com/TgNLN2vIVs7336y8qrC"
     },
-    "administrativeAgreement" : false,
+    "administrativeAgreement" : true,
     "publisherAuthority" : false,
     "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
   } ],
-  "owner" : "BsJLKjWvDX3",
+  "owner" : "t9q7VIfCiXd84NFQ3",
   "modelVersion" : "0.18.7"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -3,103 +3,103 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "pPKgWNjGoPd4kpBJgr",
-    "ownerAffiliation" : "https://www.example.org/exeos"
+    "owner" : "wrcn4Z9HlFJCisBJE",
+    "ownerAffiliation" : "https://www.example.org/recusandaemodi"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/nisieos",
+    "id" : "https://www.example.org/dolorumfacere",
     "labels" : {
-      "yA0Yhsv7um0JA08DfQ8" : "mMja4XLKj6srPab"
+      "2nIudklXxbFdoPp" : "de8UVMa6UOr"
     }
   },
   "createdDate" : "2020-09-23T09:51:23.044996ZZ",
   "modifiedDate" : "2020-09-23T09:51:23.044996ZZ",
   "publishedDate" : "2020-09-23T09:51:23.044996ZZ",
   "indexedDate" : "2020-09-23T09:51:23.044996ZZ",
-  "handle" : "https://www.example.org/illoprovident",
-  "doi" : "https://doi.org/10.1234/pariatur",
-  "link" : "https://www.example.org/aliquamvoluptas",
+  "handle" : "https://www.example.org/utquo",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/faceredolorem",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AcXNpZbuCY9yYNn7Kv",
+    "mainTitle" : "nY5u2sMNHfr4EJ",
     "alternativeTitles" : {
-      "hu" : "mbx7e2yoM2GQUQt"
+      "hu" : "pyYU6efcEqJge"
     },
-    "language" : "http://lexvo.org/id/iso639-3/sme",
+    "language" : "http://lexvo.org/id/iso639-3/swe",
     "date" : {
       "type" : "PublicationDate",
-      "year" : "dwd9TQ9cvg",
-      "month" : "csCdAY5RweVSis",
-      "day" : "JUDZCzsVj2o0PoqbzK"
+      "year" : "oVukjn4ERnO",
+      "month" : "DnC50WSdZVd6GP3",
+      "day" : "sUWJjF0vtlBKJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/09cbYnIaQczrB",
-        "name" : "zaxBaE5GK5X",
-        "nameType" : "Organizational",
-        "orcId" : "WqxxsWg3WhytnRr4b3Z"
+        "id" : "https://www.example.com/5MqTzInmD0LRj7kj",
+        "name" : "0yk7Y4VbTubqlKTK",
+        "nameType" : "Personal",
+        "orcId" : "x5khFpELOnWR"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/4EiYCf3jBVAV",
+        "id" : "https://www.example.com/X8I5koMtzYIifU",
         "labels" : {
-          "vKADy2LpBaPTH" : "wq1W8yaZVG3nUM9W"
+          "IyxbVmUJF2OQ9VSb9FX" : "mVmFoUXesCy4"
         }
       } ],
-      "role" : "Composer",
-      "sequence" : 5,
+      "role" : "Consultant",
+      "sequence" : 6,
       "correspondingAuthor" : false
     }, {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.com/ZsC5NMYFK9JqjlraM",
-        "name" : "MgVh01z0vW1NSUViJVy",
-        "nameType" : "Organizational",
-        "orcId" : "H2CFcUh5hxpISDTnYcX"
+        "id" : "https://www.example.com/T9dfkSi9oha",
+        "name" : "WpDYyV5ynSVIMweQ5P",
+        "nameType" : "Personal",
+        "orcId" : "cAHmuOXzkIzmKU"
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.com/lvYGoAtzexE",
+        "id" : "https://www.example.com/L10aGCsCcpT",
         "labels" : {
-          "QZl06s0PwwQifeQ" : "akSn7Ji5LA"
+          "5yYklS72fq22" : "ZkjRsiHNnR"
         }
       } ],
-      "role" : "Actor",
-      "sequence" : 2,
+      "role" : "Creator",
+      "sequence" : 7,
       "correspondingAuthor" : false
     } ],
-    "npiSubjectHeading" : "iCJFSykhtllO",
-    "tags" : [ "zJSs0NXdIVKx" ],
-    "description" : "zZpbhsOQOj0",
+    "npiSubjectHeading" : "4kcsZLDELGi",
+    "tags" : [ "ECAZ0ltMsjHDbA9" ],
+    "description" : "ExqXMkCwlsbt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.com/dCaiQEeG2UtV0JsrU8x",
+      "doi" : "https://www.example.com/ELUpkNkYjPrRF",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "ArtistBook"
+          "type" : "Performance"
         },
-        "description" : "wMVxxYZqEB",
+        "description" : "LUpwh1q4I9vDZrzas",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "NFRtfnFGYRKl7",
-            "country" : "HfGxQxShqXcRYtKR"
+            "label" : "t2ROcCn4lKCM05GH",
+            "country" : "VLkW7JfdGgiB"
           },
           "date" : {
             "type" : "Period",
             "from" : "2020-09-23T09:51:23.044996Z",
             "to" : "2020-09-23T09:51:23.044996Z"
           },
-          "sequence" : 2143903559
+          "sequence" : 1765704065
         } ],
         "peerReviewed" : false,
         "pages" : {
@@ -107,24 +107,24 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.com/4FPPro3BvTfOdGbfRk",
-    "abstract" : "jO9mc0NYIqPef"
+    "metadataSource" : "https://www.example.com/ic3fgHPVY9qYeVyJsUj",
+    "abstract" : "CKO7GCtf38GAoapjd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/enimeligendi",
-    "name" : "ROcrNB9Jebm",
+    "id" : "https://www.example.org/etaut",
+    "name" : "gWvk9fKsB1ilR2xYdR",
     "grants" : [ {
       "type" : "Grant",
-      "source" : "K4hMCDeXj5",
-      "id" : "ZJY9iYiqHaQNqaVfFnT"
+      "source" : "xHwKOd3GB4OwgX",
+      "id" : "12OBcXaWLJvy5dc"
     } ],
     "approvals" : [ {
       "type" : "Approval",
       "date" : "2020-09-23T09:51:23.044996ZZ",
       "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "pXXwPX8c5tp6slo7ism"
+      "applicationCode" : "nlgHrc1kF1Yn"
     } ]
   } ],
   "additionalIdentifiers" : [ {
@@ -132,46 +132,46 @@
     "source" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/exeius" ],
-  "associatedArtifacts" : [ {
-    "type" : "PublishedFile",
-    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-    "name" : "uzsk87rEUxAkZiZKIB8",
-    "mimeType" : "aA6gQjnOr190bBcnu",
-    "size" : 1325075967,
-    "license" : {
-      "type" : "License",
-      "identifier" : "kstIjSR3LCq",
-      "labels" : {
-        "7fqjlBAtVmt9" : "oKcP70WBnyWK"
-      },
-      "link" : "https://www.example.com/YO039zvlRYrGcX"
-    },
-    "administrativeAgreement" : false,
-    "publisherAuthority" : false,
-    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
-  } ],
+  "subjects" : [ "https://www.example.org/omnisaut" ],
   "fileSet" : {
     "type" : "FileSet",
     "files" : [ {
       "type" : "PublishedFile",
       "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
-      "name" : "uzsk87rEUxAkZiZKIB8",
-      "mimeType" : "aA6gQjnOr190bBcnu",
-      "size" : 1325075967,
+      "name" : "jkZ0omvvBndXghbZ",
+      "mimeType" : "3sNR6zkkA1PS0",
+      "size" : 233543791,
       "license" : {
         "type" : "License",
-        "identifier" : "kstIjSR3LCq",
+        "identifier" : "7OohjcOQ0Ud8Gae",
         "labels" : {
-          "7fqjlBAtVmt9" : "oKcP70WBnyWK"
+          "E4c6SE1Ole4OLDL" : "RnHWzbjDO2V"
         },
-        "link" : "https://www.example.com/YO039zvlRYrGcX"
+        "link" : "https://www.example.com/o2PtUnVpBL2tuSy9"
       },
       "administrativeAgreement" : false,
       "publisherAuthority" : false,
       "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
     } ]
   },
-  "owner" : "pPKgWNjGoPd4kpBJgr",
-  "modelVersion" : "0.18.6"
+  "associatedArtifacts" : [ {
+    "type" : "PublishedFile",
+    "identifier" : "5032710d-a326-43d3-a8fb-57a451873c78",
+    "name" : "jkZ0omvvBndXghbZ",
+    "mimeType" : "3sNR6zkkA1PS0",
+    "size" : 233543791,
+    "license" : {
+      "type" : "License",
+      "identifier" : "7OohjcOQ0Ud8Gae",
+      "labels" : {
+        "E4c6SE1Ole4OLDL" : "RnHWzbjDO2V"
+      },
+      "link" : "https://www.example.com/o2PtUnVpBL2tuSy9"
+    },
+    "administrativeAgreement" : false,
+    "publisherAuthority" : false,
+    "embargoDate" : "2020-09-23T09:51:23.044996ZZ"
+  } ],
+  "owner" : "wrcn4Z9HlFJCisBJE",
+  "modelVersion" : "0.18.7"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -39,8 +39,6 @@ schema:
       format: uri
     entityDescription:
       $ref: '#/components/schemas/EntityDescription'
-    fileSet:
-      $ref: '#/components/schemas/FileSet'
     projects:
       type: array
       items:
@@ -56,12 +54,15 @@ schema:
         type: string
         format: uri
     associatedArtifacts:
+      uniqueItems: true
       type: array
       items:
-        $ref: '#/components/schemas/File'
-    modelVersion:
-      type: string
+        $ref: '#/components/schemas/AssociatedArtifact'
+    fileSet:
+      $ref: '#/components/schemas/FileSet'
     owner:
+      type: string
+    modelVersion:
       type: string
     type:
       type: string
@@ -220,6 +221,43 @@ referencedSchemas:
         - WEB_DESIGN
       description:
         type: string
+        writeOnly: true
+  AssociatedArtifact:
+    type: object
+    properties:
+      type:
+        type: string
+        writeOnly: true
+        enum:
+        - File
+        - PublishedFile
+        - UnpublishedFile
+        - UnpublishableFile
+      identifier:
+        type: string
+        format: uuid
+        writeOnly: true
+      name:
+        type: string
+        writeOnly: true
+      mimeType:
+        type: string
+        writeOnly: true
+      size:
+        type: integer
+        format: int64
+        writeOnly: true
+      license:
+        $ref: '#/components/schemas/License'
+      administrativeAgreement:
+        type: boolean
+        writeOnly: true
+      publisherAuthority:
+        type: boolean
+        writeOnly: true
+      embargoDate:
+        type: string
+        format: date-time
         writeOnly: true
   AudioVisualPublication:
     required:
@@ -1899,8 +1937,6 @@ referencedSchemas:
         format: uri
       entityDescription:
         $ref: '#/components/schemas/EntityDescription'
-      fileSet:
-        $ref: '#/components/schemas/FileSet'
       projects:
         type: array
         items:
@@ -1916,12 +1952,15 @@ referencedSchemas:
           type: string
           format: uri
       associatedArtifacts:
+        uniqueItems: true
         type: array
         items:
-          $ref: '#/components/schemas/File'
-      modelVersion:
-        type: string
+          $ref: '#/components/schemas/AssociatedArtifact'
+      fileSet:
+        $ref: '#/components/schemas/FileSet'
       owner:
+        type: string
+      modelVersion:
         type: string
       type:
         type: string

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -53,13 +53,12 @@ schema:
       items:
         type: string
         format: uri
+    fileSet:
+      $ref: '#/components/schemas/FileSet'
     associatedArtifacts:
-      uniqueItems: true
       type: array
       items:
         $ref: '#/components/schemas/AssociatedArtifact'
-    fileSet:
-      $ref: '#/components/schemas/FileSet'
     owner:
       type: string
     modelVersion:
@@ -1951,13 +1950,12 @@ referencedSchemas:
         items:
           type: string
           format: uri
+      fileSet:
+        $ref: '#/components/schemas/FileSet'
       associatedArtifacts:
-        uniqueItems: true
         type: array
         items:
           $ref: '#/components/schemas/AssociatedArtifact'
-      fileSet:
-        $ref: '#/components/schemas/FileSet'
       owner:
         type: string
       modelVersion:

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -40,8 +40,7 @@ public class Publication
         PublicationStatus.NEW, List.of(PublicationStatus.DRAFT),
         PublicationStatus.DRAFT, List.of(PublicationStatus.PUBLISHED, PublicationStatus.DRAFT_FOR_DELETION)
     );
-    public static final String ERROR_MESSAGE_UPDATEDOIREQUEST_MISSING_DOIREQUEST =
-        "You must initiate creation of a DoiRequest before you can update it.";
+
     private static final String MODEL_VERSION = ResourcesBuildConfig.RESOURCES_MODEL_VERSION;
     private SortableIdentifier identifier;
     private PublicationStatus status;

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.hash;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -17,7 +17,6 @@ import nva.commons.core.JacocoGenerated;
 
 import java.net.URI;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -338,8 +337,8 @@ public class Publication
                 .orElse(Collections.emptyList());
     }
 
-    private void setAssociatedArtifacts(Collection<AssociatedArtifact> associatedArtifacts) {
-        this.associatedArtifacts = List.copyOf(associatedArtifacts);
+    private void setAssociatedArtifacts(List<AssociatedArtifact> associatedArtifacts) {
+        this.associatedArtifacts = associatedArtifacts;
     }
 
     public static final class Builder {

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.hash;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -63,7 +65,7 @@ public class Publication
     }
     
     public Set<AdditionalIdentifier> getAdditionalIdentifiers() {
-        return Objects.nonNull(additionalIdentifiers) ? additionalIdentifiers : Collections.emptySet();
+        return nonNull(additionalIdentifiers) ? additionalIdentifiers : Collections.emptySet();
     }
     
     public void setAdditionalIdentifiers(Set<AdditionalIdentifier> additionalIdentifiers) {
@@ -204,7 +206,7 @@ public class Publication
     
     @Override
     public List<ResearchProject> getProjects() {
-        return Objects.nonNull(projects) ? projects : Collections.emptyList();
+        return nonNull(projects) ? projects : Collections.emptyList();
     }
     
     @Override
@@ -214,7 +216,7 @@ public class Publication
     
     @Override
     public List<URI> getSubjects() {
-        return Objects.nonNull(subjects) ? subjects : Collections.emptyList();
+        return nonNull(subjects) ? subjects : Collections.emptyList();
     }
     
     @Override
@@ -224,13 +226,17 @@ public class Publication
     
     @Override
     public FileSet getFileSet() {
-        return fileSet;
+        return isNotNullOrEmptyFileSet(this.fileSet) ? fileSet : new FileSet(Collections.emptyList());
     }
-    
+
+    private boolean isNotNullOrEmptyFileSet(FileSet fileSet) {
+        return fileSet != null && nonNull(fileSet.getFiles());
+    }
+
     @Override
     public void setFileSet(FileSet fileSet) {
-        this.fileSet = fileSet;
-        var files = fileSet.getFiles().stream()
+        this.fileSet =  isNotNullOrEmptyFileSet(fileSet) ? fileSet : new FileSet(Collections.emptyList());
+        var files = this.fileSet.getFiles().stream()
                 .map(file -> new AssociatedFile(file.getType(), file.getIdentifier(),
                         file.getName(), file.getMimeType(), file.getSize(), file.getLicense(),
                         file.isAdministrativeAgreement(), file.isPublisherAuthority(),

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedArtifact.java
@@ -1,0 +1,26 @@
+package no.unit.nva.model.associatedartifacts;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import no.unit.nva.file.model.FileType;
+import no.unit.nva.file.model.License;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface AssociatedArtifact {
+
+    @JsonCreator
+    static AssociatedArtifact fromJson(@JsonProperty("type") FileType type,
+                                       @JsonProperty("identifier") UUID identifier,
+                                       @JsonProperty("name") String name,
+                                       @JsonProperty("mimeType") String mimeType,
+                                       @JsonProperty("size") Long size,
+                                       @JsonProperty("license") License license,
+                                       @JsonProperty("administrativeAgreement") boolean administrativeAgreement,
+                                       @JsonProperty("publisherAuthority") boolean publisherAuthority,
+                                       @JsonProperty("embargoDate") Instant embargoDate) {
+        return new AssociatedFile(type, identifier, name, mimeType, size, license,
+                administrativeAgreement, publisherAuthority, embargoDate);
+    }
+}

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/AssociatedFile.java
@@ -1,0 +1,42 @@
+package no.unit.nva.model.associatedartifacts;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import no.unit.nva.file.model.File;
+import no.unit.nva.file.model.FileType;
+import no.unit.nva.file.model.License;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class AssociatedFile extends File implements AssociatedArtifact {
+
+    /**
+     * Constructor for no.unit.nva.file.model.File objects. A file object is valid if it has a license or is explicitly
+     * marked as an administrative agreement.
+     *
+     * @param type                    The type of file
+     * @param identifier              A UUID that identifies the file in storage
+     * @param name                    The original name of the file
+     * @param mimeType                The mimetype of the file
+     * @param size                    The size of the file
+     * @param license                 The license for the file, may be null if and only if the file is an administrative
+     *                                agreement
+     * @param administrativeAgreement True if the file is an administrative agreement
+     * @param publisherAuthority      True if the file owner has publisher authority
+     * @param embargoDate             The date after which the file may be published
+     */
+
+    public AssociatedFile(@JsonProperty("type") FileType type,
+                          @JsonProperty("identifier") UUID identifier,
+                          @JsonProperty("name") String name,
+                          @JsonProperty("mimeType") String mimeType,
+                          @JsonProperty("size") Long size,
+                          @JsonProperty("license") License license,
+                          @JsonProperty("administrativeAgreement") boolean administrativeAgreement,
+                          @JsonProperty("publisherAuthority") boolean publisherAuthority,
+                          @JsonProperty("embargoDate") Instant embargoDate) {
+        super(type, identifier, name, mimeType, size, license,
+                administrativeAgreement, publisherAuthority, embargoDate);
+    }
+}
+

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -46,6 +47,7 @@ import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -63,6 +65,19 @@ public class PublicationTest extends ModelTest {
         return PublicationInstanceBuilder.listPublicationInstanceTypes().stream();
     }
 
+    public static Stream<FileSet> nullAndEmptyFileSetProvider() {
+        return Stream.of(null, new FileSet(null), new FileSet(Collections.emptyList()));
+    }
+
+
+    // Test is temporary and will be deleted
+    @ParameterizedTest
+    @MethodSource("nullAndEmptyFileSetProvider")
+    void shouldProduceEmptyListForAssociatedArtifactWhenFileSetIsEmpty(FileSet fileSet) {
+        var publication = PublicationGenerator.randomPublication();
+        publication.setFileSet(fileSet);
+        assertThat(publication.getAssociatedArtifacts(), is(empty()));
+    }
 
     // Test is temporary and will be deleted
 

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -8,8 +8,10 @@ import static no.unit.nva.model.PublicationStatus.PUBLISHED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +63,24 @@ public class PublicationTest extends ModelTest {
         return PublicationInstanceBuilder.listPublicationInstanceTypes().stream();
     }
 
+
+    // Test is temporary and will be deleted
+
+    @Test
+    void shouldRemoveFileWhenFileIsRemovedFromFileSet() {
+        var publication = PublicationGenerator.randomPublication();
+        var files = new ArrayList<>(List.copyOf(publication.getFileSet().getFiles()));
+        var initialSize = files.size();
+        var fileToBeRemoved = files.get(0);
+        files.remove(fileToBeRemoved);
+        assertThat(files.size(), is(lessThan(initialSize)));
+        publication.setFileSet(new FileSet(files));
+        var updated = publication.getFileSet().getFiles();
+        assertThat(updated, not(containsInAnyOrder(fileToBeRemoved)));
+        List<File> associatedArtifacts = toFileSet(publication.getAssociatedArtifacts());
+        assertThat(associatedArtifacts, is(equalTo(updated)));
+    }
+
     // Test is temporary and will be deleted
     @Test
     void publicationShouldPresentFilesInAssociatedArtifacts() {
@@ -91,10 +112,7 @@ public class PublicationTest extends ModelTest {
     void shouldSetFileSetWhenAssociatedFilesIsSet() {
         var publication = PublicationGenerator.randomPublication(BookMonograph.class);
         publication.setFileSet(new FileSet(Collections.emptyList()));
-        publication.setAssociatedArtifacts(Collections.emptySet());
-
         assertThat(toFileSet(publication.getAssociatedArtifacts()), is(equalTo(publication.getFileSet().getFiles())));
-
     }
 
     @ParameterizedTest(name = "Test that publication with InstanceType {0} can be round-tripped to and from JSON")


### PR DESCRIPTION
Adds the concept AssociatedArtifact in readiness for next iteration (adding Link and NullArtifact)
- Model allows one or both of AssociatedArtifact and FileSet to be set, returning a set of the resulting files when either getter is called
- This allows us to migrate the current data (FileSets) to the updated model