### PR TITLE
Add status for published metadata

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 
 group 'com.github.bibsysdev'
 
-version '0.19.16'
+version '0.19.17'
 
 repositories {
     mavenCentral()

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/PublicationStatus.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/PublicationStatus.java
@@ -9,6 +9,7 @@ public enum PublicationStatus {
 
     NEW("NEW"),
     DRAFT("DRAFT"),
+    PUBLISHED_METADATA("PUBLISHED_METADATA"),
     PUBLISHED("PUBLISHED"),
     DRAFT_FOR_DELETION("DRAFT_FOR_DELETION");
 


### PR DESCRIPTION
- Adding, reluctantly, a status where only metadata is published
- This status is used as an interim status when a publishing process is only partially completed, and full PUBLISHED status is a logical transition from this status