### PR TITLE
Use UUID rather than random word in random URIs

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -11,7 +11,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.20.23'
+version '0.20.24'
 
 repositories {
     mavenCentral()

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -22,6 +22,8 @@ import nva.commons.core.JacocoGenerated;
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.model.testing.PublicationInstanceBuilder.randomPublicationInstanceType;
 import static no.unit.nva.model.testing.RandomCurrencyUtil.randomCurrency;
@@ -57,7 +59,7 @@ public final class PublicationGenerator {
     }
 
     public static URI randomUri() {
-        String uriString = "https://www.example.org/" + randomWord() + randomWord();
+        String uriString = "https://www.example.org/" + UUID.randomUUID();
         return URI.create(uriString);
     }
 


### PR DESCRIPTION
- This concerns scope TESTING, it is highly unlikely that we will experience the same in any normal deployed environment
- Random URIs are currently not very random and get repeated, sometimes leading to odd results when JSON-LD framing is applied (specifically, things that should be URIs (doi, subject, etc.) end up being objects that Jackson cannot deserialise)
- I tested the current set-up, it turns out that the chance of a clash is 1:4.71 * 10^2
- Using UUID::randomUuid, we get something approaching 1:2.71 * 10^18, which may suffice
- There is also a benefit of using the kinds of values we actually use, rather than values we don't use (short strings)