### PR TITLE
License model for rightsreserved should not format.

### DIFF
--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -235,7 +235,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
      * Validate license.
      */
     private URI validateUriLicense(URI license) {
-        if (nonNull(license) && isValidUriLicense(license)) {
+        if (nonNull(license) && isValidUriLicense(license) && !license.equals(LICENSE_MAP.get("RightsReserved"))) {
             return formatValidUriLicense(license);
         } else {
             logger.info("The specified license can not be converted into valid URI license: {}", license);


### PR DESCRIPTION
Remove formatting from rightsreserved license model. 

NB: https://rightsstatements.org/page/InC/1.0  funker ikke uten trailing slash og er case-sensitive.  