### PR TITLE
NP-46774-expand-publisher-version-to-support-more-types

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.20'
+version '0.22.01'
 
 repositories {
     mavenCentral()

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "ADRZhk4pzcv9aGqpFO8",
-    "ownerAffiliation" : "https://www.example.org/dcf42f4f-3d98-4af4-a838-c7250df2ace4"
+    "owner" : "LKvaqk1SnNnmLUkNe",
+    "ownerAffiliation" : "https://www.example.org/48a433eb-1b06-4bec-8757-755355025e5b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/da323617-8fdb-4d18-8099-54d40df0781a"
+    "id" : "https://www.example.org/b24919f7-4c58-4c79-8e88-a518edcfe38f"
   },
-  "createdDate" : "1986-07-18T03:18:45.444Z",
-  "modifiedDate" : "1974-01-22T07:11:28.242Z",
-  "publishedDate" : "2007-02-10T06:33:51.613Z",
-  "indexedDate" : "2006-01-06T07:31:55.719Z",
-  "handle" : "https://www.example.org/3f89c62e-16a5-4030-95fa-987fbca431ae",
-  "doi" : "https://doi.org/10.1234/asperiores",
-  "link" : "https://www.example.org/e400cde2-6c36-462b-8502-430e2696579b",
+  "createdDate" : "1980-05-11T11:31:20.280Z",
+  "modifiedDate" : "2016-01-19T16:46:52.564Z",
+  "publishedDate" : "2004-11-04T15:04:16.818Z",
+  "indexedDate" : "1993-11-02T12:57:49.992Z",
+  "handle" : "https://www.example.org/16c1aafc-5f8b-4341-a8ec-9e0e5fef2600",
+  "doi" : "https://doi.org/10.1234/error",
+  "link" : "https://www.example.org/04187fb5-01d8-4676-9215-beb78e22e481",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8jDiBjQqByg",
+    "mainTitle" : "coCAAKMbGkT4gYZ0",
     "alternativeTitles" : {
-      "it" : "mo2ZLNNT7oMcYnV"
+      "se" : "In81MkF8UN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zbpuC12IyKfMJ",
-      "month" : "Ge24QN8rMUuOj",
-      "day" : "2RQXmqV2qpPX"
+      "year" : "Y8ld3cARDyVbvwP",
+      "month" : "vrK4WqJwsArt3RR",
+      "day" : "xTXEDPZCZyRi6DH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/22a170ff-70bb-4ded-8ac1-e2b39dc369a7",
-        "name" : "iRsfC1jQiaD2rIziOyz",
+        "id" : "https://www.example.org/8765c11d-f558-48f0-8f8d-3e0921ad6c9f",
+        "name" : "bgGx9mDvF94AMS",
         "nameType" : "Organizational",
-        "orcId" : "dIl2dieDMmf8KPr0w",
+        "orcId" : "IAvKJyasfx",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sanOreCusLsndlQnlNt",
-          "value" : "D6mU4tLibSfwTs8"
+          "sourceName" : "c740hCVlMViMM3",
+          "value" : "1E3T7q7Pzn16L"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "785J5BpbiqOlR",
-          "value" : "PHKv64rR09Rx8"
+          "sourceName" : "sdC7TtDO2BkD5O",
+          "value" : "HLiB5OGpar"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/576d9a26-7509-4fd8-abb1-9f6da4dcf271"
+        "id" : "https://www.example.org/a7160c98-afa5-4436-83e6-09e84c746df6"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/938862c7-ba03-4e00-b853-6c58f28982da",
-        "name" : "jUftKWHs2urB6I",
-        "nameType" : "Organizational",
-        "orcId" : "VchaiUYqn2",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/94b6c968-2b8f-4d32-81e3-5ccde4abda79",
+        "name" : "NM65vhtBSf9i",
+        "nameType" : "Personal",
+        "orcId" : "yIBbvLody469CD",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3VHiAk3W2YQaMf",
-          "value" : "gGKY5DWEODY9UBUB"
+          "sourceName" : "ehg5GRrfNmYjutk12c",
+          "value" : "TupTPbDglMprfNt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Q25XuIT5yyZyd",
-          "value" : "syVZ3fvznZsh6"
+          "sourceName" : "ElHCsY2YLLR82fRev9",
+          "value" : "0UbDq3XCQ7DAU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/63b75930-d289-4911-8f07-c5e41e9b36a5"
+        "id" : "https://www.example.org/625f9b80-82ca-4df8-96bb-c389b1f1d084"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "yeKNEk8fYO9rIMQ"
+      "is" : "xveP0X9PRc"
     },
-    "npiSubjectHeading" : "Z1d4bgYhja4",
-    "tags" : [ "3mg0UgEOkQ" ],
-    "description" : "iUUDHglOSw",
+    "npiSubjectHeading" : "IDP1HQLP9nLjz",
+    "tags" : [ "hNB2j8bOMhBXVSLAT9" ],
+    "description" : "RRJZAdDVLXXN5d3J81K",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/334118e1-179a-436e-b3f1-6b796d48f451"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0eba3045-2578-4335-819b-489f4c25a590"
       },
-      "doi" : "https://www.example.org/0c4c814b-dec9-4004-b570-7d7045a0e182",
+      "doi" : "https://www.example.org/8ce0026d-6d4e-480b-a5b2-cec8d99824dc",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "tlhZm3NgfHV",
-          "end" : "7x09Ay5AmSuQoMSm"
+          "begin" : "lRW41F3B8q",
+          "end" : "SQDgMSaqu4fjZUO3el"
         },
-        "volume" : "7gGiLhhseJLVhURfZ2",
-        "issue" : "hej8CVp4qll",
-        "articleNumber" : "UGTGTdieeNY"
+        "volume" : "Lvwfg8NDnD",
+        "issue" : "AB8gVbKyxH",
+        "articleNumber" : "Ky9Ub8TuX8RDF"
       }
     },
-    "metadataSource" : "https://www.example.org/a943af45-3f0e-489a-9e0f-ed53ba6a6381",
-    "abstract" : "7NTClMV1LSiSeqq8i"
+    "metadataSource" : "https://www.example.org/1aee204a-e9fc-40d8-aeeb-5c93d7f1e152",
+    "abstract" : "HCjuG0r0E5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f438ab12-2dae-4ab1-b6cb-8dbf6f88b675",
-    "name" : "0ewBXUmkPTLAnDqMd",
+    "id" : "https://www.example.org/fc19b875-61a3-4ebb-83df-a88a564f0a45",
+    "name" : "cx6m6Qgx4tvf6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-09-13T15:35:16.364Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2017-03-04T20:45:19.170Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "FyMiQN5coQb"
+      "applicationCode" : "sfdHrcT4IpQeaZx7bpA"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/17f51ea7-1155-4d95-942b-c34e620e60e5",
-    "identifier" : "C4xFCT6yAi5RQUljCeF",
+    "source" : "https://www.example.org/d4ea7281-507a-4f89-98c2-765433015347",
+    "identifier" : "UtL0gsx0ojsUtb3e7L",
     "labels" : {
-      "bg" : "xubUkw3oCWFFQAZIY"
+      "da" : "kGJXl93rwvdt7"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1003338628
+      "currency" : "NOK",
+      "amount" : 2145096093
     },
-    "activeFrom" : "2009-06-28T15:19:17.205Z",
-    "activeTo" : "2011-03-14T18:09:57.198Z"
+    "activeFrom" : "2012-05-13T02:59:52.194Z",
+    "activeTo" : "2022-12-10T13:28:11.259Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/24b71442-b019-4664-bbc2-8c507dffd7f1",
-    "id" : "https://www.example.org/c1bb776a-6d26-4cad-8c77-f95b2ea4a4a5",
-    "identifier" : "XgPsF59js6dGfQfhB9e",
+    "source" : "https://www.example.org/74cf2907-8b72-4474-bbcc-a7b45090b5de",
+    "id" : "https://www.example.org/11795294-da5f-4b60-8b6f-a9170c284ce4",
+    "identifier" : "s5i6wHNDOM",
     "labels" : {
-      "cs" : "pcGBWfYRWfoFH0lsM"
+      "fr" : "LF25NoxbOf"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1536392874
+      "currency" : "EUR",
+      "amount" : 721092800
     },
-    "activeFrom" : "1976-01-15T20:11:26.621Z",
-    "activeTo" : "2008-09-14T20:21:26.039Z"
+    "activeFrom" : "2023-04-29T05:11:39.505Z",
+    "activeTo" : "2023-06-11T04:14:42.125Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/21ccb581-6315-488b-b177-eee67190ac6a" ],
+  "subjects" : [ "https://www.example.org/c7b14616-a40d-4608-8954-2ca465293149" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "87fa3b0d-1b47-4d3b-b306-cd5126803708",
-    "name" : "KEHTjEYQ8QiDpR6J",
-    "mimeType" : "416YUqqS8vkwM",
-    "size" : 1570787779,
-    "license" : "https://www.example.com/ahgpkkjztz",
+    "identifier" : "c008ab07-05b9-48bb-af24-33bc3f2e8fce",
+    "name" : "n3XFVoLgkqCta",
+    "mimeType" : "zgpngBfx3ZX6OV0i",
+    "size" : 1465330705,
+    "license" : "https://www.example.com/2nhiqke173o",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "UyU6c8hsadpgLNI"
+      "overriddenBy" : "hlnOokXLIlr5"
     },
-    "legalNote" : "XIijj7vLM15A",
-    "publishedDate" : "1996-05-09T13:01:31.344Z",
+    "legalNote" : "IAJ1QFw6W3mNqz",
+    "publishedDate" : "1976-06-18T12:12:06.283Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "G27MLl3i9N8",
-      "uploadedDate" : "1994-09-10T04:38:52.558Z"
+      "uploadedBy" : "x60MVSSmJa6",
+      "uploadedDate" : "2015-11-21T04:51:30.168Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/jZlgDn5O2juUV",
-    "name" : "HscdAapsLShiWCsnC",
-    "description" : "ndmyj3RxGPj"
+    "id" : "https://www.example.com/yzu67BW1NAaumHsvkAP",
+    "name" : "h312JhLvcCyAZCyGkxg",
+    "description" : "Z6OOHkO3T5bH"
   } ],
-  "rightsHolder" : "kOg1FedkmJ60wM",
-  "duplicateOf" : "https://www.example.org/d0f3609f-9ab6-43ff-8535-9c1333472613",
+  "rightsHolder" : "H6urxUZBr9GBzBseWdY",
+  "duplicateOf" : "https://www.example.org/26e1aa53-90c9-4be6-8200-2ddf36968278",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KpX6RE5iDxztN73"
+    "note" : "rXhkzpWvDsbvYlf7JRs"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GUzkgiur2SU",
-    "createdBy" : "suOrBMvN2BvgvUj",
-    "createdDate" : "2022-11-07T18:37:07.403Z"
+    "note" : "giRQLULcm1IkM",
+    "createdBy" : "XXy4YnwNWVh4l4oJe",
+    "createdDate" : "2005-10-28T11:16:27.809Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1b176e44-9b4b-43ad-b3dc-a9ce8a9cb2a7" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/2e617efd-6aa8-498c-9338-f5e429d43caf" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "LKvaqk1SnNnmLUkNe",
-    "ownerAffiliation" : "https://www.example.org/48a433eb-1b06-4bec-8757-755355025e5b"
+    "owner" : "nlWOi7oJCL",
+    "ownerAffiliation" : "https://www.example.org/90bc21b0-29ce-45b2-8a4a-4fefc5c19a43"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b24919f7-4c58-4c79-8e88-a518edcfe38f"
+    "id" : "https://www.example.org/f8de7576-45b7-45c6-8e7f-8e926806388b"
   },
-  "createdDate" : "1980-05-11T11:31:20.280Z",
-  "modifiedDate" : "2016-01-19T16:46:52.564Z",
-  "publishedDate" : "2004-11-04T15:04:16.818Z",
-  "indexedDate" : "1993-11-02T12:57:49.992Z",
-  "handle" : "https://www.example.org/16c1aafc-5f8b-4341-a8ec-9e0e5fef2600",
-  "doi" : "https://doi.org/10.1234/error",
-  "link" : "https://www.example.org/04187fb5-01d8-4676-9215-beb78e22e481",
+  "createdDate" : "1986-04-22T13:59:26.935Z",
+  "modifiedDate" : "1984-12-02T01:45:18.985Z",
+  "publishedDate" : "2014-07-07T17:05:17.367Z",
+  "indexedDate" : "2018-10-24T08:20:26.415Z",
+  "handle" : "https://www.example.org/e82a3cb3-b4f3-402d-a5c7-15a47ed9980d",
+  "doi" : "https://doi.org/10.1234/libero",
+  "link" : "https://www.example.org/9089592a-10bd-4ec8-b721-5b9daec4c957",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "coCAAKMbGkT4gYZ0",
+    "mainTitle" : "0epdn6FkuJ1AE3WL",
     "alternativeTitles" : {
-      "se" : "In81MkF8UN"
+      "fr" : "ie25sQFHRE5DKCSLFT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Y8ld3cARDyVbvwP",
-      "month" : "vrK4WqJwsArt3RR",
-      "day" : "xTXEDPZCZyRi6DH"
+      "year" : "abu67QBIdpI7",
+      "month" : "b7D3kXPccBoEoh2VgQ",
+      "day" : "5cawN0j7rztkTcXxt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8765c11d-f558-48f0-8f8d-3e0921ad6c9f",
-        "name" : "bgGx9mDvF94AMS",
-        "nameType" : "Organizational",
-        "orcId" : "IAvKJyasfx",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/9efac940-79cf-4e28-b3e4-62c1b1b09f6c",
+        "name" : "EPCjrXPCtPD7y",
+        "nameType" : "Personal",
+        "orcId" : "5qhe4V255i1tDtMK",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "c740hCVlMViMM3",
-          "value" : "1E3T7q7Pzn16L"
+          "sourceName" : "MIosulBnThUU",
+          "value" : "XqhPlQ2SAf3tyF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sdC7TtDO2BkD5O",
-          "value" : "HLiB5OGpar"
+          "sourceName" : "jZ69xcHFHkiAra3ZY",
+          "value" : "qSbBE6bI1whA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a7160c98-afa5-4436-83e6-09e84c746df6"
+        "id" : "https://www.example.org/566c8588-d6ee-441f-b2ed-c5df4f4d3a11"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94b6c968-2b8f-4d32-81e3-5ccde4abda79",
-        "name" : "NM65vhtBSf9i",
-        "nameType" : "Personal",
-        "orcId" : "yIBbvLody469CD",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e028f63e-54a7-43cc-93fc-dd279d95f3f6",
+        "name" : "6UG54ivlYThMHuMG",
+        "nameType" : "Organizational",
+        "orcId" : "OPH5BDWc2zzqeRyof",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ehg5GRrfNmYjutk12c",
-          "value" : "TupTPbDglMprfNt"
+          "sourceName" : "GvvdNd4Y1BdB",
+          "value" : "iKmKWcmFMx6VnqDYt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ElHCsY2YLLR82fRev9",
-          "value" : "0UbDq3XCQ7DAU"
+          "sourceName" : "qO29hMii9DDGDFuZ",
+          "value" : "d2sT8VAjEUQ5p"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/625f9b80-82ca-4df8-96bb-c389b1f1d084"
+        "id" : "https://www.example.org/98bfb4b2-7a38-416d-89bf-beda4dfda3ba"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "xveP0X9PRc"
+      "da" : "W5imyyr9CuRPfZ8i"
     },
-    "npiSubjectHeading" : "IDP1HQLP9nLjz",
-    "tags" : [ "hNB2j8bOMhBXVSLAT9" ],
-    "description" : "RRJZAdDVLXXN5d3J81K",
+    "npiSubjectHeading" : "80NgQn6t76p",
+    "tags" : [ "zkB0K7miimb2HK3ell" ],
+    "description" : "P61pnUDDTxW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0eba3045-2578-4335-819b-489f4c25a590"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1f99c744-7f8b-418e-bf5e-ff330238eeac"
       },
-      "doi" : "https://www.example.org/8ce0026d-6d4e-480b-a5b2-cec8d99824dc",
+      "doi" : "https://www.example.org/b908cc01-97aa-49e6-b970-4eced623e8b5",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "lRW41F3B8q",
-          "end" : "SQDgMSaqu4fjZUO3el"
+          "begin" : "GJFGBtFPRuNKd1",
+          "end" : "pCnfelGswj3AO"
         },
-        "volume" : "Lvwfg8NDnD",
-        "issue" : "AB8gVbKyxH",
-        "articleNumber" : "Ky9Ub8TuX8RDF"
+        "volume" : "NVgoy29Ydq7q5j4E",
+        "issue" : "oDWlpNuoYbMEzq",
+        "articleNumber" : "Sibx13L6McYqO4bl"
       }
     },
-    "metadataSource" : "https://www.example.org/1aee204a-e9fc-40d8-aeeb-5c93d7f1e152",
-    "abstract" : "HCjuG0r0E5"
+    "metadataSource" : "https://www.example.org/41d2f03b-ddd1-46ba-9acb-fe2c4f198453",
+    "abstract" : "2abWJX6ZRSwxo0Ae"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fc19b875-61a3-4ebb-83df-a88a564f0a45",
-    "name" : "cx6m6Qgx4tvf6",
+    "id" : "https://www.example.org/af1e4b1f-796c-4159-983c-ba6d8e86dbc4",
+    "name" : "hnny1QOAvfpz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-03-04T20:45:19.170Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1990-07-14T03:27:12.552Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "sfdHrcT4IpQeaZx7bpA"
+      "applicationCode" : "3RZ3T2CxrCK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d4ea7281-507a-4f89-98c2-765433015347",
-    "identifier" : "UtL0gsx0ojsUtb3e7L",
+    "source" : "https://www.example.org/708ca0e1-791a-4d20-8bae-9bbb55c08b7d",
+    "identifier" : "OIiwAMzhv339EjSEUlR",
     "labels" : {
-      "da" : "kGJXl93rwvdt7"
+      "fr" : "ywu5RETNMURxOm"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2145096093
+      "amount" : 1968142348
     },
-    "activeFrom" : "2012-05-13T02:59:52.194Z",
-    "activeTo" : "2022-12-10T13:28:11.259Z"
+    "activeFrom" : "2014-03-19T22:03:38.530Z",
+    "activeTo" : "2019-02-13T21:01:21.051Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/74cf2907-8b72-4474-bbcc-a7b45090b5de",
-    "id" : "https://www.example.org/11795294-da5f-4b60-8b6f-a9170c284ce4",
-    "identifier" : "s5i6wHNDOM",
+    "source" : "https://www.example.org/24ccd4c4-c3c4-4c49-8e49-103c90e5a3ae",
+    "id" : "https://www.example.org/66f78746-f9e6-4229-bcfe-8190501a19df",
+    "identifier" : "rHjoQmBq9bR",
     "labels" : {
-      "fr" : "LF25NoxbOf"
+      "zh" : "rTwGmtAT6ROCj2ffrVC"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 721092800
+      "amount" : 1589781901
     },
-    "activeFrom" : "2023-04-29T05:11:39.505Z",
-    "activeTo" : "2023-06-11T04:14:42.125Z"
+    "activeFrom" : "2016-05-25T03:15:48.152Z",
+    "activeTo" : "2019-04-07T14:29:08.778Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c7b14616-a40d-4608-8954-2ca465293149" ],
+  "subjects" : [ "https://www.example.org/201e7a2a-5e68-457a-a144-a77ab6198095" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c008ab07-05b9-48bb-af24-33bc3f2e8fce",
-    "name" : "n3XFVoLgkqCta",
-    "mimeType" : "zgpngBfx3ZX6OV0i",
-    "size" : 1465330705,
-    "license" : "https://www.example.com/2nhiqke173o",
+    "identifier" : "93011966-95d3-4540-9214-c574b29e8abb",
+    "name" : "Jq6puifpvDmad9",
+    "mimeType" : "SvwfdBdFTfc9",
+    "size" : 822030002,
+    "license" : "https://www.example.com/alvdty75zhsaztcly",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "hlnOokXLIlr5"
+      "overriddenBy" : "p8i8HGO8MTG2cPzz"
     },
-    "legalNote" : "IAJ1QFw6W3mNqz",
-    "publishedDate" : "1976-06-18T12:12:06.283Z",
+    "legalNote" : "n5zbUzCXcAtZpAoYyb",
+    "publishedDate" : "1991-04-28T15:00:12.403Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "x60MVSSmJa6",
-      "uploadedDate" : "2015-11-21T04:51:30.168Z"
+      "uploadedBy" : "UXCzv7hVVTiKX",
+      "uploadedDate" : "2022-10-03T02:53:45.802Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/yzu67BW1NAaumHsvkAP",
-    "name" : "h312JhLvcCyAZCyGkxg",
-    "description" : "Z6OOHkO3T5bH"
+    "id" : "https://www.example.com/W9bVlVBViL49O1yQQ",
+    "name" : "jbBzO7LhyApjaTGT3wa",
+    "description" : "F6qBigLNgwfVIa"
   } ],
-  "rightsHolder" : "H6urxUZBr9GBzBseWdY",
-  "duplicateOf" : "https://www.example.org/26e1aa53-90c9-4be6-8200-2ddf36968278",
+  "rightsHolder" : "Laal1Qv2Igi9sKx",
+  "duplicateOf" : "https://www.example.org/f386ef45-db5e-4283-a0d0-6b08d6314472",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "rXhkzpWvDsbvYlf7JRs"
+    "note" : "Ih6Sxg3nkgTYfQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "giRQLULcm1IkM",
-    "createdBy" : "XXy4YnwNWVh4l4oJe",
-    "createdDate" : "2005-10-28T11:16:27.809Z"
+    "note" : "9R1eC8IOb4",
+    "createdBy" : "QgeQ7Bb5u93qT8sYo2",
+    "createdDate" : "1993-09-09T00:33:56.794Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2e617efd-6aa8-498c-9338-f5e429d43caf" ],
+  "curatingInstitutions" : [ "https://www.example.org/1e133a48-90d2-448b-869f-4ac1712cdd38" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "wZ7Gsiiu5fwbdM1eDS",
-    "ownerAffiliation" : "https://www.example.org/08e45490-12e7-42a5-a753-bcc87e0fb763"
+    "owner" : "hAImGtvcoH8",
+    "ownerAffiliation" : "https://www.example.org/76d6c9b1-2bf0-4f7b-a9ea-bf933e229290"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cc678c1d-bf4e-4fc2-a5fb-ae89b446846d"
+    "id" : "https://www.example.org/14d13913-6c9d-4ee1-980a-67fc4a48b1cc"
   },
-  "createdDate" : "1987-02-13T14:13:46.055Z",
-  "modifiedDate" : "2023-09-09T11:04:49.839Z",
-  "publishedDate" : "2011-12-12T15:31:09.449Z",
-  "indexedDate" : "2009-12-28T17:55:19.582Z",
-  "handle" : "https://www.example.org/d1e7ac69-e77c-4871-b336-1e416dfc4f6e",
-  "doi" : "https://doi.org/10.1234/labore",
-  "link" : "https://www.example.org/9799bf69-fb2b-4175-bcc4-db120f8f96c1",
+  "createdDate" : "2001-03-24T01:10:59.237Z",
+  "modifiedDate" : "2003-02-21T14:26:43.309Z",
+  "publishedDate" : "2012-04-21T02:33:43.309Z",
+  "indexedDate" : "2021-05-06T16:19:49.729Z",
+  "handle" : "https://www.example.org/b0893df9-3462-4d95-8ddf-0089aebb4009",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/c196118e-db96-41fe-8d63-c3da1b916476",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IbJ0Whj1E2",
+    "mainTitle" : "WCbgP55KrvppJjDv7",
     "alternativeTitles" : {
-      "ru" : "bVON8hoB8MbZ"
+      "cs" : "hzS6nxMLzPgN4Ja"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "YDEO0IRY05",
-      "month" : "wxCkdhHQHz",
-      "day" : "5jJmBBqXVHs69"
+      "year" : "IsGGfJH9Cru",
+      "month" : "n3tqExHsHFyoOp",
+      "day" : "VhnMyxdEEtEmWd1V7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fd198c0d-cfe2-4c78-85c3-f4231d1d8ed9",
-        "name" : "ItAf8C3zLW6O",
+        "id" : "https://www.example.org/1ccc9447-64cb-4e84-897a-85024032a1e3",
+        "name" : "2oMfcrnNFB",
         "nameType" : "Organizational",
-        "orcId" : "WqzSkYtLGfCTDh",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "y5NYS9bNmc",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gwKRtUnVy5sd4h",
-          "value" : "KXBS83JA7WL3a"
+          "sourceName" : "xVCBJAow7YW",
+          "value" : "weBwEbMv0sCOdmYRe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lEmVDlj3jWUfU8mI",
-          "value" : "SPpodIPonJjJ"
+          "sourceName" : "wFAqGu4tnw594",
+          "value" : "SNLB58XVa8F"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/349d9c92-9072-4d77-9b39-bc703674ae5e"
+        "id" : "https://www.example.org/d6538516-5869-4167-8cd4-ac053ae8b779"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c2817a0f-55d9-410e-ae29-67fce049ae2d",
-        "name" : "VqrH7o6ZbDiEw",
-        "nameType" : "Organizational",
-        "orcId" : "oK2KvfLvpoSiiCnIa",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/787a6c7d-64f1-47bc-88bd-fe69c54963b2",
+        "name" : "KH0F99MejDA3",
+        "nameType" : "Personal",
+        "orcId" : "pw8i7OvY7L",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DDSyKLzcQHe0ZiH",
-          "value" : "VaFlHhspCb16"
+          "sourceName" : "jHkKqv8YtSs9",
+          "value" : "6P7R2yiSYuCv6Se3f"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FlHkM4hEt2XCWc1jYS",
-          "value" : "6jGjmb5cZk"
+          "sourceName" : "9W41yyNTP1xmoUcN",
+          "value" : "P6AZvhqnkbyl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f103f6b-c5b5-4389-b893-d4b1ad418766"
+        "id" : "https://www.example.org/c8ae3a0e-9ad3-4293-b037-7586c00b7d48"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "dMu16ToTdn2cCjAs0"
+      "it" : "mHAct01FtnrP46I6T0"
     },
-    "npiSubjectHeading" : "NlkZNI3dAqQaNe",
-    "tags" : [ "60PXK37Djg" ],
-    "description" : "nLSXiRw3biS1UNdpFKp",
+    "npiSubjectHeading" : "aFpvM7UueA6CDCgdn",
+    "tags" : [ "bOdxLEs8iMZUcTkMy" ],
+    "description" : "YUosFuPJwVFdT8ec3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/d2HyrTHjG0ZhNDHp"
+        "id" : "https://www.example.com/d31l5erZPDW"
       },
-      "doi" : "https://www.example.org/94131de0-4cfb-48fa-b369-d0dd828d720f",
+      "doi" : "https://www.example.org/c8a2d7d3-6b45-4ce3-9f23-be0f74533ba4",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "3hbztunK0a7Gb",
-          "end" : "E0wKsfjfEp10e9dx"
+          "begin" : "DSX7bmmGzZivWqj0q",
+          "end" : "SgplEeauKm"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/279bf99d-d5da-4d16-b038-b78ae68a4291",
-    "abstract" : "6pUazO3rqF"
+    "metadataSource" : "https://www.example.org/0e8fab71-3452-4f0e-b3ce-4b06d24d11e7",
+    "abstract" : "G9CfxyTVHVF2ij"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3bd7e332-28d8-46e6-810a-f232b3c783e5",
-    "name" : "KuAsG3CMD3Cy7v",
+    "id" : "https://www.example.org/4cd536de-ba9d-4bd0-96bf-e2eb703daf3a",
+    "name" : "3HGu5HpKxtjOBClA47",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-11-12T11:10:36.754Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "4kqV538Jyifn"
+      "approvalDate" : "1989-03-19T17:49:20.656Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "OCBaDLUKzu6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1f7c756e-bbc5-4f4a-b307-c583717c5006",
-    "identifier" : "MNjBTSYw0WxQyurDys0",
+    "source" : "https://www.example.org/5cb51585-3062-418a-a34f-223d75e1e7ae",
+    "identifier" : "gY4F37Yq9y1EsjR",
     "labels" : {
-      "nn" : "pq7fNap20sa8NeYcA78"
+      "el" : "sPL7Dgkyjn"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 452560759
+      "currency" : "USD",
+      "amount" : 408356544
     },
-    "activeFrom" : "1995-10-17T19:07:10.104Z",
-    "activeTo" : "2010-10-18T14:05:45.021Z"
+    "activeFrom" : "1981-09-04T07:26:27.632Z",
+    "activeTo" : "1992-04-18T00:51:24.135Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f0d87800-0e3a-4e37-8099-ad481b4a524a",
-    "id" : "https://www.example.org/8f9e5509-a7ad-4ede-9595-066b22a66aab",
-    "identifier" : "aPqnaRUibhLSmja7M",
+    "source" : "https://www.example.org/c0f48e2b-aeca-4bd0-ae86-2ac87872de9b",
+    "id" : "https://www.example.org/0576709d-2bfa-48d3-8dbe-0f7caf2ca4a2",
+    "identifier" : "zxcqbA3l0w4",
     "labels" : {
-      "pl" : "bCEIoYNm07t"
+      "is" : "64UdTjpHl6YDfb84K"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 709377320
+      "currency" : "NOK",
+      "amount" : 63333590
     },
-    "activeFrom" : "1975-12-17T22:13:31.818Z",
-    "activeTo" : "1983-09-20T09:13:26.542Z"
+    "activeFrom" : "1993-01-02T11:28:33.616Z",
+    "activeTo" : "2011-03-13T13:30:44.444Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9c608ea0-f429-4d6d-ac1c-968dc603e773" ],
+  "subjects" : [ "https://www.example.org/6bcca0b8-97ea-4d7b-935f-56ba2d69dc46" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "33e1d0b5-1fef-48ec-947f-de50682113b4",
-    "name" : "uQV1zhuorPMs",
-    "mimeType" : "ExztQXuRsVN0",
-    "size" : 1916826418,
-    "license" : "https://www.example.com/hwsdowhzyqtat9lmo",
+    "identifier" : "13b27181-eab5-49e5-884d-1e3e4058cba8",
+    "name" : "lSVDWqRC3vJ0Vphn",
+    "mimeType" : "GHCd4LVFhTWq",
+    "size" : 754511323,
+    "license" : "https://www.example.com/ts8rqmhdrkfxrsug",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "GlXCAtEaAkH009S",
-    "publishedDate" : "2002-10-16T09:33:09.861Z",
+    "legalNote" : "h0INO30k9YM",
+    "publishedDate" : "1980-10-19T13:41:09.201Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "lkB69AE3Nc7d1O",
-      "uploadedDate" : "2023-07-31T16:37:19.367Z"
+      "uploadedBy" : "DRyqmtFEOcxZSr",
+      "uploadedDate" : "2022-10-03T13:31:17.334Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/B6qxiC4kDK97oy5N42P",
-    "name" : "0pHerjnSYeNOozxN",
-    "description" : "hbImpfMAUNnT3GKP"
+    "id" : "https://www.example.com/klPApc3GKOSXP",
+    "name" : "Tdpr6BwANqkb3r",
+    "description" : "BEYlbJobzxvqLvB"
   } ],
-  "rightsHolder" : "hV15gQGpoa",
-  "duplicateOf" : "https://www.example.org/f4917a66-00e8-4d88-a795-2d882883f13c",
+  "rightsHolder" : "00Wvd7Ksmx",
+  "duplicateOf" : "https://www.example.org/15645188-98ae-45b4-8755-1cba324a5705",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bqvykEF0kOySkfk0"
+    "note" : "xPwyJToup9u14tDrS"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vXAIGAvuCJZnTWbwqN8",
-    "createdBy" : "pVdqZYDRcC44bnIEf",
-    "createdDate" : "1988-02-03T06:32:15.722Z"
+    "note" : "JzQz4Vx1X1J",
+    "createdBy" : "ICqtcnKBCSTHdH4W",
+    "createdDate" : "1971-08-16T05:46:46.414Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/311d7824-6984-406c-87aa-d134d7031ffa" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/c810a8fc-7d80-4a81-86d3-9c5f0af59930" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "hAImGtvcoH8",
-    "ownerAffiliation" : "https://www.example.org/76d6c9b1-2bf0-4f7b-a9ea-bf933e229290"
+    "owner" : "5TyZnwuZaXvSc",
+    "ownerAffiliation" : "https://www.example.org/350b56d8-70b7-4739-ad89-5f301b415d27"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/14d13913-6c9d-4ee1-980a-67fc4a48b1cc"
+    "id" : "https://www.example.org/e6c18993-61bd-4f9c-9272-609467fe4d01"
   },
-  "createdDate" : "2001-03-24T01:10:59.237Z",
-  "modifiedDate" : "2003-02-21T14:26:43.309Z",
-  "publishedDate" : "2012-04-21T02:33:43.309Z",
-  "indexedDate" : "2021-05-06T16:19:49.729Z",
-  "handle" : "https://www.example.org/b0893df9-3462-4d95-8ddf-0089aebb4009",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/c196118e-db96-41fe-8d63-c3da1b916476",
+  "createdDate" : "2007-04-02T04:33:27.814Z",
+  "modifiedDate" : "1990-12-09T07:48:02.117Z",
+  "publishedDate" : "1991-02-01T00:34:56.616Z",
+  "indexedDate" : "1977-04-01T15:27:54.971Z",
+  "handle" : "https://www.example.org/c214b29b-f39b-428d-ae91-8e2897bcac66",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/297f99ac-1acf-4d68-b713-10eeefd9c893",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WCbgP55KrvppJjDv7",
+    "mainTitle" : "XW8JDV8HnmXgaZEfon",
     "alternativeTitles" : {
-      "cs" : "hzS6nxMLzPgN4Ja"
+      "pt" : "KmetOSYFld4wel"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "IsGGfJH9Cru",
-      "month" : "n3tqExHsHFyoOp",
-      "day" : "VhnMyxdEEtEmWd1V7"
+      "year" : "4uGCZumH9CXZ772TgT",
+      "month" : "f0wvAtIE2RYS",
+      "day" : "pjcJDFFAT7g2AVaZXgY"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1ccc9447-64cb-4e84-897a-85024032a1e3",
-        "name" : "2oMfcrnNFB",
+        "id" : "https://www.example.org/946818f7-3cf5-45b4-9e57-f58a9e46d88c",
+        "name" : "RSw4EeDQchjp4C",
         "nameType" : "Organizational",
-        "orcId" : "y5NYS9bNmc",
+        "orcId" : "QkgFUJNkjUmxfrRXw3",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xVCBJAow7YW",
-          "value" : "weBwEbMv0sCOdmYRe"
+          "sourceName" : "Il6hUQRETmKw3KMgyj",
+          "value" : "OSM2Cf6Cny2mL9Ka4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wFAqGu4tnw594",
-          "value" : "SNLB58XVa8F"
+          "sourceName" : "ewfQOPrpuZ",
+          "value" : "IcFpMcYn3Cxg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d6538516-5869-4167-8cd4-ac053ae8b779"
+        "id" : "https://www.example.org/ae0c8df5-d392-4040-bfb9-2b6f81004c24"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/787a6c7d-64f1-47bc-88bd-fe69c54963b2",
-        "name" : "KH0F99MejDA3",
+        "id" : "https://www.example.org/573905a7-c0fb-4a0d-ba16-0557338c889e",
+        "name" : "o22QNDs7D1KK",
         "nameType" : "Personal",
-        "orcId" : "pw8i7OvY7L",
+        "orcId" : "SME8Fswfz9GihWiRE",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jHkKqv8YtSs9",
-          "value" : "6P7R2yiSYuCv6Se3f"
+          "sourceName" : "jHC4d7qpjHQElLLbrbF",
+          "value" : "QY40nry9syrPm9H6i3G"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9W41yyNTP1xmoUcN",
-          "value" : "P6AZvhqnkbyl"
+          "sourceName" : "YUtLx0gNnW",
+          "value" : "njJo8OZtLJkuuP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c8ae3a0e-9ad3-4293-b037-7586c00b7d48"
+        "id" : "https://www.example.org/4718725b-9bed-4c6b-8c0f-6cdbdeb4d6a4"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "mHAct01FtnrP46I6T0"
+      "is" : "wfMvwjE4vxTmxfY"
     },
-    "npiSubjectHeading" : "aFpvM7UueA6CDCgdn",
-    "tags" : [ "bOdxLEs8iMZUcTkMy" ],
-    "description" : "YUosFuPJwVFdT8ec3",
+    "npiSubjectHeading" : "q2oRBz30hu07",
+    "tags" : [ "ILfwQpsDj6X4BCWP" ],
+    "description" : "zU2NHLlfNSUg7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/d31l5erZPDW"
+        "id" : "https://www.example.com/nPSLLXAVpK0"
       },
-      "doi" : "https://www.example.org/c8a2d7d3-6b45-4ce3-9f23-be0f74533ba4",
+      "doi" : "https://www.example.org/df527c6b-061b-4a40-82c8-29ea00e8fdb4",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "DSX7bmmGzZivWqj0q",
-          "end" : "SgplEeauKm"
+          "begin" : "2uwghhR5up0eUuzPU",
+          "end" : "xQDMc3Tn1ootbhtS"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0e8fab71-3452-4f0e-b3ce-4b06d24d11e7",
-    "abstract" : "G9CfxyTVHVF2ij"
+    "metadataSource" : "https://www.example.org/02b5f8ce-16e9-4cbd-853c-a6af629aa643",
+    "abstract" : "W3SC8SqfnZ9VzanE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4cd536de-ba9d-4bd0-96bf-e2eb703daf3a",
-    "name" : "3HGu5HpKxtjOBClA47",
+    "id" : "https://www.example.org/0aea83b6-1d5c-44ef-affc-f6561801176d",
+    "name" : "0ozWBXZD0WNmFMlCz4M",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1989-03-19T17:49:20.656Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "OCBaDLUKzu6"
+      "approvalDate" : "2002-02-02T03:37:11.487Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Lt7ETWzUHtvMr"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5cb51585-3062-418a-a34f-223d75e1e7ae",
-    "identifier" : "gY4F37Yq9y1EsjR",
+    "source" : "https://www.example.org/5c918973-09ea-4525-a5bc-9aedb59a5756",
+    "identifier" : "vkWYg2hfOsTHedM",
     "labels" : {
-      "el" : "sPL7Dgkyjn"
+      "se" : "OOA90HXnwiP3p"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 408356544
+      "amount" : 1786040619
     },
-    "activeFrom" : "1981-09-04T07:26:27.632Z",
-    "activeTo" : "1992-04-18T00:51:24.135Z"
+    "activeFrom" : "1983-05-31T13:48:25.847Z",
+    "activeTo" : "2012-01-27T22:03:53.112Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c0f48e2b-aeca-4bd0-ae86-2ac87872de9b",
-    "id" : "https://www.example.org/0576709d-2bfa-48d3-8dbe-0f7caf2ca4a2",
-    "identifier" : "zxcqbA3l0w4",
+    "source" : "https://www.example.org/604fb3b5-4320-4ccd-b0e0-54553879407e",
+    "id" : "https://www.example.org/5b501669-56db-4888-aaee-2e04cfd99bba",
+    "identifier" : "mqc0GTXdzBwlIUYMWj",
     "labels" : {
-      "is" : "64UdTjpHl6YDfb84K"
+      "is" : "AJEQt2SRtHrR"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 63333590
+      "currency" : "USD",
+      "amount" : 1308141330
     },
-    "activeFrom" : "1993-01-02T11:28:33.616Z",
-    "activeTo" : "2011-03-13T13:30:44.444Z"
+    "activeFrom" : "1996-05-03T03:20:18.112Z",
+    "activeTo" : "2013-03-24T23:33:55.276Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6bcca0b8-97ea-4d7b-935f-56ba2d69dc46" ],
+  "subjects" : [ "https://www.example.org/2ce10010-b1c5-4bdb-a9fb-c17b57703cd1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "13b27181-eab5-49e5-884d-1e3e4058cba8",
-    "name" : "lSVDWqRC3vJ0Vphn",
-    "mimeType" : "GHCd4LVFhTWq",
-    "size" : 754511323,
-    "license" : "https://www.example.com/ts8rqmhdrkfxrsug",
+    "identifier" : "9f509695-3638-45c2-9c93-71297df7b505",
+    "name" : "MBYi3fifMfP8",
+    "mimeType" : "TQE98HlNUFUBcf",
+    "size" : 550438522,
+    "license" : "https://www.example.com/bipyfvbtng6",
     "administrativeAgreement" : false,
-    "publisherVersion" : "UpdatedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "h0INO30k9YM",
-    "publishedDate" : "1980-10-19T13:41:09.201Z",
+    "legalNote" : "glW6JjGTaMrCX7MVklw",
+    "publishedDate" : "1986-01-03T07:47:06.065Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DRyqmtFEOcxZSr",
-      "uploadedDate" : "2022-10-03T13:31:17.334Z"
+      "uploadedBy" : "WSeEu1XISKNoSbZy",
+      "uploadedDate" : "2008-08-22T17:55:24.728Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/klPApc3GKOSXP",
-    "name" : "Tdpr6BwANqkb3r",
-    "description" : "BEYlbJobzxvqLvB"
+    "id" : "https://www.example.com/iEevrtFon9OKsDN6jZ",
+    "name" : "TX71bfT8Zot",
+    "description" : "Qi8PuIgan8"
   } ],
-  "rightsHolder" : "00Wvd7Ksmx",
-  "duplicateOf" : "https://www.example.org/15645188-98ae-45b4-8755-1cba324a5705",
+  "rightsHolder" : "0xjk9Oz7OPtPXYN",
+  "duplicateOf" : "https://www.example.org/843c214f-7d8c-448b-a3d5-31a77cc09267",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xPwyJToup9u14tDrS"
+    "note" : "ZQz8FGLDkuaLc2WXST"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "JzQz4Vx1X1J",
-    "createdBy" : "ICqtcnKBCSTHdH4W",
-    "createdDate" : "1971-08-16T05:46:46.414Z"
+    "note" : "czqCPAYQlLP",
+    "createdBy" : "enCQNZFSfpc",
+    "createdDate" : "1980-10-20T10:23:13.996Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c810a8fc-7d80-4a81-86d3-9c5f0af59930" ],
+  "curatingInstitutions" : [ "https://www.example.org/5b6b1e18-e797-455b-a0e0-4f3a5cbcfc3a" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "WReYg5LSYYI",
-    "ownerAffiliation" : "https://www.example.org/c2a99b12-fa28-4cdf-bfec-4cf9435811d3"
+    "owner" : "ytnCDgVZ2x7A0pc",
+    "ownerAffiliation" : "https://www.example.org/b690ab5f-4d12-468a-883f-dfa72b33548a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e52ac67f-0a95-43dd-9b81-1f723fd1aafa"
+    "id" : "https://www.example.org/325a2c36-1fd5-4c9e-a940-4f130bc9b1ef"
   },
-  "createdDate" : "2000-12-15T07:46:46.730Z",
-  "modifiedDate" : "1991-08-30T13:28:43.760Z",
-  "publishedDate" : "1982-11-11T06:46:41.320Z",
-  "indexedDate" : "2003-10-10T07:37:28.336Z",
-  "handle" : "https://www.example.org/40f28f2d-ccb0-4d56-bba2-aa105f45e3ce",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/f8aa0e39-b40b-4372-bf68-8f8ecc3fe553",
+  "createdDate" : "2013-09-20T09:58:13.201Z",
+  "modifiedDate" : "2002-04-05T19:05:07.378Z",
+  "publishedDate" : "1989-01-06T12:55:05.517Z",
+  "indexedDate" : "2012-10-25T18:48:12.368Z",
+  "handle" : "https://www.example.org/b584e7c4-92bb-437c-9089-fc67b87b9f38",
+  "doi" : "https://doi.org/10.1234/provident",
+  "link" : "https://www.example.org/39ae9388-fe74-4d43-b9b6-06d02d2f8b06",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Dgc1KF3q6fQ",
+    "mainTitle" : "vwlrKZ1KdtAxQ7",
     "alternativeTitles" : {
-      "zh" : "xibegwMGzSnA"
+      "fi" : "0KemrLDd2G"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "rHJ0s8GaR2p98C7h",
-      "month" : "WxIFmOA7eWzOo6NxUc1",
-      "day" : "iivX6QJHg1M"
+      "year" : "pGrFAsWnQ0r5i",
+      "month" : "rPJDykWmMF",
+      "day" : "DG1phpbw9PqpQ0gezTV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4ad785bd-d06a-46e9-bb29-3e9cd6260291",
-        "name" : "zviA6FvcNnK",
-        "nameType" : "Personal",
-        "orcId" : "JSrq1S4vQpJaDc79",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/0ab87ae4-51cb-4b57-a011-3f326f72642a",
+        "name" : "0Dct1Kr6S1J8Bamj5D",
+        "nameType" : "Organizational",
+        "orcId" : "hQY051pWfP",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hsf3y8quuiqQSOUthX",
-          "value" : "18i2WKn3pu6VLzUznO"
+          "sourceName" : "SJVBBftLqjh",
+          "value" : "viJv947Gub"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oWwhXZssQ13dRWCxn",
-          "value" : "qsPLGFI3cUoNQNnmhkp"
+          "sourceName" : "wePkwLNY60",
+          "value" : "9oCFc3vjM3FJ5oEsZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c4cb140d-8b33-4662-975d-7170dafb5e47"
+        "id" : "https://www.example.org/15b34dec-bdc7-4867-a795-b05c9e956b9f"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/96f8604d-2963-4745-9275-f8ac2c73e6fd",
-        "name" : "UsVQAYXKKXUHKr",
-        "nameType" : "Personal",
-        "orcId" : "HjP3dtG0Eis",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/127544bc-c322-40f6-950b-77badb42fe2a",
+        "name" : "dcZjO1oT4VraV8URgq",
+        "nameType" : "Organizational",
+        "orcId" : "2bDMWcybf5jtelz5",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5EoRZTqTRvjPgJiLg",
-          "value" : "9rnvA0ET2pSslAskCy0"
+          "sourceName" : "qY1f5LBVpz",
+          "value" : "c5ROMPCQKxRfioh4wcu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zWZKnmFpsAWCUCDvL",
-          "value" : "rj15p9a5ID"
+          "sourceName" : "K9wyKTsVmP6vmEr4v9X",
+          "value" : "wsyxU4LSafDb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/68998de2-1066-434f-b374-ac85b6b7c4da"
+        "id" : "https://www.example.org/8476fe19-df1d-4c21-a001-cd6718db274a"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "fvEPnSiaSYGAp3iHhE"
+      "hu" : "MU4AuMcIsQu0rd"
     },
-    "npiSubjectHeading" : "5upRWCa3387Gj7JG2nc",
-    "tags" : [ "dA5RBAH0YbA" ],
-    "description" : "HivulC5pnork3Jq",
+    "npiSubjectHeading" : "6F8XQT7i45wgea6X1",
+    "tags" : [ "euCjYigS5MGQAZgMJIm" ],
+    "description" : "jZ4dc9VSsEz7f3A15o",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/352b3c53-7841-4df2-843c-fe01caef2c73"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/602cd380-8cc3-4650-819d-bb94bd197de4"
       },
-      "doi" : "https://www.example.org/940402e1-1204-4cb4-9cbd-9937f8b6845f",
+      "doi" : "https://www.example.org/73dac1b6-b638-4a1d-80ee-da2f88c6fc0e",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "7yHjqJdMY5BC",
-          "end" : "7nIncZhVebzhN"
+          "begin" : "hct6KeVs1C1A",
+          "end" : "PCEVwIcY4r"
         },
-        "volume" : "YA4f5CA7bJtqc",
-        "issue" : "HHaRoLdF9j",
-        "articleNumber" : "MFRyiHjYrbG7"
+        "volume" : "Zk3gas7xUoScCR5HZ",
+        "issue" : "4rwamYYng0S4LxwXnLk",
+        "articleNumber" : "RDrt8WDiQsFTIu1YPj"
       }
     },
-    "metadataSource" : "https://www.example.org/81193cd4-44b0-4678-9511-36c99d4ab851",
-    "abstract" : "vlfYi5xOzhnBGxUVAue"
+    "metadataSource" : "https://www.example.org/e52d214c-1326-4ad1-b3c3-b8c1c594baae",
+    "abstract" : "Dm0YLWHNsBh0uwz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e0665951-d981-485d-b8c3-d612cb260aad",
-    "name" : "QrsbXj7Lt39EErWA1",
+    "id" : "https://www.example.org/76c5aab8-6930-42eb-be0b-0063356fecf5",
+    "name" : "UZIBadFHt2Y",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-01-23T21:26:08.912Z",
+      "approvalDate" : "1977-03-24T19:37:02.495Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "LT9KBLprQ3"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "jHTpTbMFI7I2XGJp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/60b02de2-72fa-4364-acba-c9a69d7d5fc3",
-    "identifier" : "eT9c8gz9LuQ",
+    "source" : "https://www.example.org/ed6c9646-7dce-4f61-8448-41a45b97a3f8",
+    "identifier" : "BRCh96bN3P3S8",
     "labels" : {
-      "nb" : "m9FmGagjbvfvhOcjs1l"
+      "fi" : "idqO5CnLwKDs"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1880822027
+      "currency" : "NOK",
+      "amount" : 263501885
     },
-    "activeFrom" : "1971-07-09T07:19:22.901Z",
-    "activeTo" : "1998-02-06T16:53:54.308Z"
+    "activeFrom" : "2011-05-17T14:43:32.105Z",
+    "activeTo" : "2013-09-25T11:49:30.172Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/92b862a0-4a11-46bc-a064-a9a741c1d04d",
-    "id" : "https://www.example.org/3be44d22-6e6f-494c-bdde-0af579991da1",
-    "identifier" : "9i1BYgdhRslm87o4",
+    "source" : "https://www.example.org/de0c55eb-0c45-4d02-a4a5-5a776bdebe51",
+    "id" : "https://www.example.org/e341feab-e661-4c83-a3bc-e3ee290f8f1a",
+    "identifier" : "32YIDripgaR6bV",
     "labels" : {
-      "fr" : "i4CiCne3wX5llwpYed"
+      "en" : "z15hzsUk1bhFI"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2014276929
+      "amount" : 1333736033
     },
-    "activeFrom" : "2000-08-26T17:36:34.606Z",
-    "activeTo" : "2018-10-18T20:53:17.401Z"
+    "activeFrom" : "2019-02-19T03:18:18.157Z",
+    "activeTo" : "2019-12-31T07:40:06.704Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0b1bcdf7-56ed-4694-a1e0-c6e361652564" ],
+  "subjects" : [ "https://www.example.org/a181095c-aced-462e-9fed-fb5eb396533f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3d73a431-dc60-42c5-aeec-1881c3099bb8",
-    "name" : "V4n8jbeMMQi",
-    "mimeType" : "VFbumPHsXy",
-    "size" : 1476440545,
-    "license" : "https://www.example.com/jzkxcx9fen",
+    "identifier" : "71b7ce54-1719-4862-a37c-c3eb30811393",
+    "name" : "bREyrFgvOgQbejYWvGi",
+    "mimeType" : "10Ynla9akykQ3HvuSy",
+    "size" : 318325874,
+    "license" : "https://www.example.com/hb4irbh5qrdyy7uv",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Ld2cKojCpOt",
-    "publishedDate" : "1983-11-11T23:25:20.425Z",
+    "legalNote" : "FmsAgV9VzZsW0MdUcu",
+    "publishedDate" : "1981-08-07T14:19:41.374Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "w7WzdNITDURtj3D50M5",
-      "uploadedDate" : "1982-05-05T21:42:29.798Z"
+      "uploadedBy" : "lTiiMosVVVDgCEP",
+      "uploadedDate" : "2003-05-07T11:02:17.746Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/eU3nGAcDiUHo012G",
-    "name" : "RGTrqN1FOpY4cEPqVy",
-    "description" : "fj0U5oojAtd7WQ"
+    "id" : "https://www.example.com/pi04tWi0Uw4090oheJ",
+    "name" : "KgTyoJUhI0Fz",
+    "description" : "3SM21MstBX4QEcTp"
   } ],
-  "rightsHolder" : "oz2kWSVKLXOk7Nf0B",
-  "duplicateOf" : "https://www.example.org/4d360791-0d7f-4e15-98d7-2aa5ac97e89d",
+  "rightsHolder" : "0ORp5BonBowlvq",
+  "duplicateOf" : "https://www.example.org/fee2c304-cfa6-440a-866d-0e8878729eae",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "1UAFI1PSD5sNIRtCQG"
+    "note" : "OOFHzMAF1BywurCA"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "UZUGaVZaGJmqWCpk7zX",
-    "createdBy" : "lpFlK3k0wy",
-    "createdDate" : "1996-03-31T19:54:13.980Z"
+    "note" : "lTX6YORLnn82",
+    "createdBy" : "ExQbFnox55P8",
+    "createdDate" : "2020-11-05T17:06:26.186Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3dacbbe5-838e-411e-8245-217478e84352" ],
+  "curatingInstitutions" : [ "https://www.example.org/ac6f50bf-5feb-4db1-97eb-81561120d27a" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "ohr40KUjh8x6Vok",
-    "ownerAffiliation" : "https://www.example.org/12c8ae1a-06c5-429f-88b3-d5c49ef3e113"
+    "owner" : "WReYg5LSYYI",
+    "ownerAffiliation" : "https://www.example.org/c2a99b12-fa28-4cdf-bfec-4cf9435811d3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3ddee188-d00a-48db-a054-92d6174e329f"
+    "id" : "https://www.example.org/e52ac67f-0a95-43dd-9b81-1f723fd1aafa"
   },
-  "createdDate" : "2012-01-28T00:38:06.339Z",
-  "modifiedDate" : "2022-02-16T05:21:59.491Z",
-  "publishedDate" : "1973-05-09T22:52:24.865Z",
-  "indexedDate" : "1995-03-16T17:35:33.975Z",
-  "handle" : "https://www.example.org/78b05c38-6c99-4339-9b9d-15cc70c553ae",
-  "doi" : "https://doi.org/10.1234/quae",
-  "link" : "https://www.example.org/19eb80a8-89ca-4e99-b8a2-aa915fdf2586",
+  "createdDate" : "2000-12-15T07:46:46.730Z",
+  "modifiedDate" : "1991-08-30T13:28:43.760Z",
+  "publishedDate" : "1982-11-11T06:46:41.320Z",
+  "indexedDate" : "2003-10-10T07:37:28.336Z",
+  "handle" : "https://www.example.org/40f28f2d-ccb0-4d56-bba2-aa105f45e3ce",
+  "doi" : "https://doi.org/10.1234/praesentium",
+  "link" : "https://www.example.org/f8aa0e39-b40b-4372-bf68-8f8ecc3fe553",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vmHx7YJNXzl",
+    "mainTitle" : "Dgc1KF3q6fQ",
     "alternativeTitles" : {
-      "nl" : "isTCR6TnMaFpI"
+      "zh" : "xibegwMGzSnA"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7NP7v4IrFPKTI",
-      "month" : "yQQP4BayTCOcm",
-      "day" : "K4x2KpV8HC3Kt9Bdcw"
+      "year" : "rHJ0s8GaR2p98C7h",
+      "month" : "WxIFmOA7eWzOo6NxUc1",
+      "day" : "iivX6QJHg1M"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9de96343-ca36-4661-8186-3b70ae07ba6f",
-        "name" : "SeUDSTdK6q",
-        "nameType" : "Organizational",
-        "orcId" : "InlgpmhOE0GETW",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/4ad785bd-d06a-46e9-bb29-3e9cd6260291",
+        "name" : "zviA6FvcNnK",
+        "nameType" : "Personal",
+        "orcId" : "JSrq1S4vQpJaDc79",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8tQfez8aEiZN56ST",
-          "value" : "caCvPeA6Q65I1B"
+          "sourceName" : "Hsf3y8quuiqQSOUthX",
+          "value" : "18i2WKn3pu6VLzUznO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3320pRVwG3N0osBC",
-          "value" : "eeKPI1D2FPiEWUw6v"
+          "sourceName" : "oWwhXZssQ13dRWCxn",
+          "value" : "qsPLGFI3cUoNQNnmhkp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/337eefa2-5efc-4325-ae33-46636bc44bd3"
+        "id" : "https://www.example.org/c4cb140d-8b33-4662-975d-7170dafb5e47"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/69d8c9c0-c1e5-47a6-a5cd-a77cb465dd0b",
-        "name" : "dTl6uHagC6DSSL",
-        "nameType" : "Organizational",
-        "orcId" : "IQoSwe0QDcUwlFAR",
+        "id" : "https://www.example.org/96f8604d-2963-4745-9275-f8ac2c73e6fd",
+        "name" : "UsVQAYXKKXUHKr",
+        "nameType" : "Personal",
+        "orcId" : "HjP3dtG0Eis",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pc7I5letFLR",
-          "value" : "GQG6Onj7iV"
+          "sourceName" : "5EoRZTqTRvjPgJiLg",
+          "value" : "9rnvA0ET2pSslAskCy0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "93Zc2bmGEL6mMieyh34",
-          "value" : "X7w3KABp3CvN"
+          "sourceName" : "zWZKnmFpsAWCUCDvL",
+          "value" : "rj15p9a5ID"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/729122c5-3316-41bb-b3ca-0548f0cacfcb"
+        "id" : "https://www.example.org/68998de2-1066-434f-b374-ac85b6b7c4da"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "LightDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "PBKlTjwYkAL"
+      "pl" : "fvEPnSiaSYGAp3iHhE"
     },
-    "npiSubjectHeading" : "LIDLrcwOFQ9K6S4",
-    "tags" : [ "thvBLOcWmaCFwiObD" ],
-    "description" : "ExVgob4l4obl",
+    "npiSubjectHeading" : "5upRWCa3387Gj7JG2nc",
+    "tags" : [ "dA5RBAH0YbA" ],
+    "description" : "HivulC5pnork3Jq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b3b9f9da-cefe-470f-831a-04bdaf8e6d68"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/352b3c53-7841-4df2-843c-fe01caef2c73"
       },
-      "doi" : "https://www.example.org/9837631c-42eb-4b37-badb-74d9596054c8",
+      "doi" : "https://www.example.org/940402e1-1204-4cb4-9cbd-9937f8b6845f",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "bWeFcPDj66KOBzOpPTj",
-          "end" : "0upiSzKbqERc"
+          "begin" : "7yHjqJdMY5BC",
+          "end" : "7nIncZhVebzhN"
         },
-        "volume" : "7OhPNOWTAuXnKfk5g1u",
-        "issue" : "yzseHhxS3hp9QK",
-        "articleNumber" : "0PuYKG8JHns"
+        "volume" : "YA4f5CA7bJtqc",
+        "issue" : "HHaRoLdF9j",
+        "articleNumber" : "MFRyiHjYrbG7"
       }
     },
-    "metadataSource" : "https://www.example.org/4811638e-6231-42cc-9521-0e84302bb339",
-    "abstract" : "XSfHa2oE5KMxzuKCNN"
+    "metadataSource" : "https://www.example.org/81193cd4-44b0-4678-9511-36c99d4ab851",
+    "abstract" : "vlfYi5xOzhnBGxUVAue"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8efe3474-d150-490b-a35e-43a7d3126cd5",
-    "name" : "J7qUGjtoYvalf0HDMm",
+    "id" : "https://www.example.org/e0665951-d981-485d-b8c3-d612cb260aad",
+    "name" : "QrsbXj7Lt39EErWA1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-01-17T01:37:50.669Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "bFVZZX8z3wv7"
+      "approvalDate" : "2020-01-23T21:26:08.912Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "LT9KBLprQ3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/78de323d-95df-449f-9dbc-da4309b3464a",
-    "identifier" : "8fUGL3ti0iioW5Znlo0",
+    "source" : "https://www.example.org/60b02de2-72fa-4364-acba-c9a69d7d5fc3",
+    "identifier" : "eT9c8gz9LuQ",
     "labels" : {
-      "it" : "k5EwJ4y2ZyZwwCzG9w"
+      "nb" : "m9FmGagjbvfvhOcjs1l"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 465169970
+      "currency" : "USD",
+      "amount" : 1880822027
     },
-    "activeFrom" : "1985-07-01T22:04:22.743Z",
-    "activeTo" : "1999-08-13T19:14:46.570Z"
+    "activeFrom" : "1971-07-09T07:19:22.901Z",
+    "activeTo" : "1998-02-06T16:53:54.308Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f79e4c04-45af-4757-8517-304beaae9990",
-    "id" : "https://www.example.org/4890a989-62e8-4268-bded-5a9dc1fa7973",
-    "identifier" : "iN8CqLc3SU",
+    "source" : "https://www.example.org/92b862a0-4a11-46bc-a064-a9a741c1d04d",
+    "id" : "https://www.example.org/3be44d22-6e6f-494c-bdde-0af579991da1",
+    "identifier" : "9i1BYgdhRslm87o4",
     "labels" : {
-      "fr" : "rCNU8W0LSXgP9dC6u"
+      "fr" : "i4CiCne3wX5llwpYed"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1597426491
+      "amount" : 2014276929
     },
-    "activeFrom" : "1979-02-07T07:27:27.764Z",
-    "activeTo" : "1997-08-17T06:05:30.754Z"
+    "activeFrom" : "2000-08-26T17:36:34.606Z",
+    "activeTo" : "2018-10-18T20:53:17.401Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c4b41ed1-79d2-4aee-ba02-03ed73c2d76e" ],
+  "subjects" : [ "https://www.example.org/0b1bcdf7-56ed-4694-a1e0-c6e361652564" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "737af139-d10a-422e-bcc7-4040f3b56ffc",
-    "name" : "EUszaUy6ZKJt4",
-    "mimeType" : "WrZ84eoMcxnYr",
-    "size" : 750347487,
-    "license" : "https://www.example.com/2hcl0ulf0otak1nji",
+    "identifier" : "3d73a431-dc60-42c5-aeec-1881c3099bb8",
+    "name" : "V4n8jbeMMQi",
+    "mimeType" : "VFbumPHsXy",
+    "size" : 1476440545,
+    "license" : "https://www.example.com/jzkxcx9fen",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "5BIuZXIx7UpBnA",
-    "publishedDate" : "1982-08-07T01:06:39.686Z",
+    "legalNote" : "Ld2cKojCpOt",
+    "publishedDate" : "1983-11-11T23:25:20.425Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "NXBkjXR8N6",
-      "uploadedDate" : "1984-05-14T15:08:01.885Z"
+      "uploadedBy" : "w7WzdNITDURtj3D50M5",
+      "uploadedDate" : "1982-05-05T21:42:29.798Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2NYdJTxN2H",
-    "name" : "3SHZZXCsAZUwEtHE",
-    "description" : "jWuvusFFB382qrH"
+    "id" : "https://www.example.com/eU3nGAcDiUHo012G",
+    "name" : "RGTrqN1FOpY4cEPqVy",
+    "description" : "fj0U5oojAtd7WQ"
   } ],
-  "rightsHolder" : "5kmk932vP1sJd3eimJa",
-  "duplicateOf" : "https://www.example.org/c50adfa3-ca75-4859-854a-b8bdd27d2f6f",
+  "rightsHolder" : "oz2kWSVKLXOk7Nf0B",
+  "duplicateOf" : "https://www.example.org/4d360791-0d7f-4e15-98d7-2aa5ac97e89d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zYIeAclAsJNJ3cK"
+    "note" : "1UAFI1PSD5sNIRtCQG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "W4nh72FLJsG4n6q2",
-    "createdBy" : "ew5uqM3hgb9",
-    "createdDate" : "2015-11-17T11:58:26.636Z"
+    "note" : "UZUGaVZaGJmqWCpk7zX",
+    "createdBy" : "lpFlK3k0wy",
+    "createdDate" : "1996-03-31T19:54:13.980Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/48510336-3218-4dfd-8802-3fc4b3c33c28" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/3dacbbe5-838e-411e-8245-217478e84352" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "RME7HIfF3QD",
-    "ownerAffiliation" : "https://www.example.org/3e78c8fc-04d6-410c-9436-2cf3ee18016b"
+    "owner" : "5AQU9XBlhc8z",
+    "ownerAffiliation" : "https://www.example.org/e94d10d6-a9a6-4458-aca4-07c109239007"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/04cef113-ecae-44a7-a3e4-1e8b38b126d4"
+    "id" : "https://www.example.org/0e204ffa-da63-4f3b-81e4-018be8598890"
   },
-  "createdDate" : "1978-08-17T01:18:19.682Z",
-  "modifiedDate" : "2001-10-13T01:41:59.128Z",
-  "publishedDate" : "1984-03-14T20:07:53.307Z",
-  "indexedDate" : "1998-11-19T11:08:34.861Z",
-  "handle" : "https://www.example.org/2c3178ab-2929-4729-9b64-d64f374ae11a",
-  "doi" : "https://doi.org/10.1234/culpa",
-  "link" : "https://www.example.org/004853bc-e7d3-4774-b578-428ab389c1ac",
+  "createdDate" : "1971-06-20T18:45:49.739Z",
+  "modifiedDate" : "1985-02-20T12:52:01.722Z",
+  "publishedDate" : "2003-05-30T06:54:59.393Z",
+  "indexedDate" : "2011-02-02T10:15:13.059Z",
+  "handle" : "https://www.example.org/b09d1aa5-9f35-4c93-b8ab-b75f885c6a31",
+  "doi" : "https://doi.org/10.1234/eaque",
+  "link" : "https://www.example.org/ef74c6b5-97a9-4c7e-89e4-4b512563ba9d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BOHuw2hIgNVLjU",
+    "mainTitle" : "8SHTLtkDi1pvUCb",
     "alternativeTitles" : {
-      "ru" : "e0ETeA3IbF1i"
+      "af" : "TMsmgjwwA8RH9Q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "X2pqDHnNSET1VGuC",
-      "month" : "kodN7s0Iic",
-      "day" : "9K0q39wUJ9LNmuqb"
+      "year" : "xFZ8IUmaf2kKmkM",
+      "month" : "YWYcGUw6fGSvjw6F",
+      "day" : "vt1tjXNSy1btSSoH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e4e09fc4-3036-4dc9-bfca-07290e377bd9",
-        "name" : "XNLYcq1NHG3",
-        "nameType" : "Personal",
-        "orcId" : "TI92CkhHNiGk3Vl",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/5bac22aa-df4d-4c2d-ab8a-8875d526c483",
+        "name" : "QKX3ZIPdTPC9VuE4g5",
+        "nameType" : "Organizational",
+        "orcId" : "OrSaepchc3Yk",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "62lOcEa4oaUeVY2Iy6",
-          "value" : "CvAmHcivm7hxFLr0Dfx"
+          "sourceName" : "lz0pPNiHKynx4rs",
+          "value" : "DInBN8FNyI8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YhXAk26kKuKwxELf",
-          "value" : "8NRDwCRpfckcZigDH8"
+          "sourceName" : "SMgCOKxUF6n",
+          "value" : "58M0iGANvB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/aade37ed-576b-408d-adad-1a636dd36e27"
+        "id" : "https://www.example.org/84f4f93f-072e-49a8-a876-3e6e1c955db6"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a3d2a048-ad0f-49c2-9364-e0995b6cd8d5",
-        "name" : "TKFK9j57syLsOdY",
-        "nameType" : "Organizational",
-        "orcId" : "AXlgkRPNQD6kc",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/0af751db-cb93-40ce-88c7-78f3f80d6727",
+        "name" : "EPtrUf9bCXf",
+        "nameType" : "Personal",
+        "orcId" : "PA6lnsGUOUlzzHF",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p2yU5r46rqgKw",
-          "value" : "pmrJLKdd7lLiz0"
+          "sourceName" : "EIW8ryXUBu",
+          "value" : "grJ15SqOieG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Mbe52H7TE4VMo",
-          "value" : "77AG02OfK1"
+          "sourceName" : "va0aaZZFPxE2suX",
+          "value" : "gL4uzkfRE72"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/613caed1-ae6a-44d4-a45c-d18ad80d0297"
+        "id" : "https://www.example.org/00f3dec9-3a2f-4f0b-83bb-b0a3bf497a67"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "Artist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "zeE8rcUZYdLgaHN"
+      "pl" : "8gaQgO1pvr5w"
     },
-    "npiSubjectHeading" : "Pd4EBKY2yJBKh",
-    "tags" : [ "ixw07jRRcAxiPYSJ25" ],
-    "description" : "IklWYGQNKia",
+    "npiSubjectHeading" : "H6F7x639pjPuyjfgTi",
+    "tags" : [ "SRR7IyDu5kAhDaYQ82T" ],
+    "description" : "tD9t520i0gN6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b21c2a36-7614-40ff-a704-10765887b942"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e16b0a34-b70c-46c7-99a0-bfc62653dc8e"
         },
-        "seriesNumber" : "T3ULjgFFAP13i93hiH2",
+        "seriesNumber" : "0qF0gaQ94V",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/53acdcc5-5712-4e48-932f-75d26cbaa977",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9c003ab3-f445-4115-a625-811623ce1205",
           "valid" : true
         },
-        "isbnList" : [ "9781037942471", "9781887400886" ],
+        "isbnList" : [ "9791254750766", "9780025222069" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1887400885"
+          "value" : "0025222066"
         } ]
       },
-      "doi" : "https://www.example.org/543d755f-bf7d-4802-8861-c2dd17e81d08",
+      "doi" : "https://www.example.org/6e1d2c87-94d4-496d-9453-f3725cd8276a",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "fRWC6Blclmo",
-            "end" : "BbzDvvKG0jwJSn"
+            "begin" : "CdYrmUvjShgSv",
+            "end" : "tAPCE0kWgFeBLID4R"
           },
-          "pages" : "bl4Titnd3QoU61",
-          "illustrated" : true
+          "pages" : "nG6ECclwDz6IPNNv",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4c5eefe6-a6d5-4dbe-b539-39ffd787ae1a",
-    "abstract" : "okztVny7wzmIM"
+    "metadataSource" : "https://www.example.org/9756918d-10c0-4669-8928-009cbfd6b7f3",
+    "abstract" : "Zat4VlagdKJBc9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c95e63bf-eedc-4471-aeb5-52d200169ca6",
-    "name" : "JoQfyqfSQ0GU",
+    "id" : "https://www.example.org/57c4ab29-039b-40ba-b044-91c3b6b5cf85",
+    "name" : "YNj1t5gLjD24f",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-08-15T16:41:05.705Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "OaBDNKd4CLmqsmTEH5"
+      "approvalDate" : "2015-03-23T19:41:21.756Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "mQwnj4aDT8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e2029c16-d981-40fa-bb82-d055b8ab48e9",
-    "identifier" : "QpdC5cBSTJJ",
+    "source" : "https://www.example.org/ca27a720-5191-4402-95fe-98c370149612",
+    "identifier" : "N7ywYwioko9",
     "labels" : {
-      "sv" : "qFfkbT5JTfthwXN"
+      "bg" : "ALTMOwtfgrw9"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1135110668
+    },
+    "activeFrom" : "1971-04-12T17:39:03.278Z",
+    "activeTo" : "1974-06-06T03:33:38.253Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/e01b7234-9b6b-4c7b-9f87-efdd51553fc8",
+    "id" : "https://www.example.org/7fad4759-93cb-457a-99ef-9cb90213c36c",
+    "identifier" : "QL3t8480Qp",
+    "labels" : {
+      "cs" : "YDYGNqC0eTRyE6ct"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1895977277
+      "amount" : 993128707
     },
-    "activeFrom" : "1986-04-12T16:17:32.309Z",
-    "activeTo" : "1995-08-05T07:43:45.259Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7f8635de-757b-4e27-b776-069608c64617",
-    "id" : "https://www.example.org/0298b398-3199-4259-85dd-0ef18136c54e",
-    "identifier" : "CcorbFuToTqi1ZkAzf4",
-    "labels" : {
-      "pt" : "WM9tPFzRhDD7yfHH"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 451718003
-    },
-    "activeFrom" : "2006-04-24T04:23:34.957Z",
-    "activeTo" : "2007-08-23T06:18:12.422Z"
+    "activeFrom" : "1989-09-04T00:22:49.797Z",
+    "activeTo" : "2010-08-15T08:39:46.421Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/36e47362-e3a4-42ea-b614-081aa87524c0" ],
+  "subjects" : [ "https://www.example.org/f944a474-fd0d-4f71-846b-2630daf844e1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "061a8360-2a34-4324-adb4-d01e157d3326",
-    "name" : "yhOgMz85u4",
-    "mimeType" : "Dsz97OqpyPU",
-    "size" : 800587770,
-    "license" : "https://www.example.com/qicuiakp4iyskhp",
+    "identifier" : "c21b3c2f-4945-49b3-8246-038a51c2c889",
+    "name" : "kkBoK59H2gNZ4DBHIp",
+    "mimeType" : "Iv2kH3Bb82G9OLBJ",
+    "size" : 2027967793,
+    "license" : "https://www.example.com/9jcyzmtpzzgqbe0ev",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "Unmc23ajGU96vtBO"
+      "overriddenBy" : "LragfRUYO5CB"
     },
-    "legalNote" : "vjtZJboR4CVRFC",
-    "publishedDate" : "2005-12-05T00:41:32.421Z",
+    "legalNote" : "9WqyVRTfVOCCpj",
+    "publishedDate" : "2022-08-03T09:55:33.608Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3NeKqcKzZlVjdZ",
-      "uploadedDate" : "2016-01-25T01:32:01.554Z"
+      "uploadedBy" : "yyu23R7Q8iiYBZuuIOY",
+      "uploadedDate" : "2021-12-29T01:23:03.304Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/IBRe30NyGFSre2RkM",
-    "name" : "zQGiJ7Zg3g",
-    "description" : "2VfB5hLHayWDiQV1"
+    "id" : "https://www.example.com/hyFWGbIcLoVurBgo3R",
+    "name" : "ofNCNZtpNb7",
+    "description" : "0qK8Ly7uPrQdQpFrP"
   } ],
-  "rightsHolder" : "SzJ86Ve2nmihl",
-  "duplicateOf" : "https://www.example.org/5c413553-f725-412f-8d05-908ba2ba0516",
+  "rightsHolder" : "XgU7PLDOuK",
+  "duplicateOf" : "https://www.example.org/fb8debf9-4c3a-4fdb-9419-62091a97c16a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "IxXTz1QRY7kQ5NC6LG7"
+    "note" : "0KsmsEgguCEe"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "yHo30wAYc3G",
-    "createdBy" : "vLJM787wai7Q6tqTXwm",
-    "createdDate" : "1991-02-07T08:31:05.313Z"
+    "note" : "Bmkla9HX4SRn3ZI",
+    "createdBy" : "bOz5KnpdAZ31",
+    "createdDate" : "1997-12-19T21:01:27.174Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5d4eb232-b69a-4037-93cc-06e019fd57bb" ],
+  "curatingInstitutions" : [ "https://www.example.org/db39025f-9ae8-4553-b0e0-76fb9e428446" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "lRs0YNofvZMTLC",
-    "ownerAffiliation" : "https://www.example.org/e79a428a-835e-4f71-a827-fe9b8eb08765"
+    "owner" : "RME7HIfF3QD",
+    "ownerAffiliation" : "https://www.example.org/3e78c8fc-04d6-410c-9436-2cf3ee18016b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aa825d4d-f481-49bc-be1c-0b8202230425"
+    "id" : "https://www.example.org/04cef113-ecae-44a7-a3e4-1e8b38b126d4"
   },
-  "createdDate" : "2017-04-04T22:13:05.984Z",
-  "modifiedDate" : "1978-01-25T02:24:13.636Z",
-  "publishedDate" : "1975-01-18T03:16:25.519Z",
-  "indexedDate" : "1998-04-03T07:15:36.399Z",
-  "handle" : "https://www.example.org/c4db8fa4-a8be-42c5-829a-0471cf63d87a",
-  "doi" : "https://doi.org/10.1234/sit",
-  "link" : "https://www.example.org/bfeb2c95-ce60-4d36-98c8-769a7cbce153",
+  "createdDate" : "1978-08-17T01:18:19.682Z",
+  "modifiedDate" : "2001-10-13T01:41:59.128Z",
+  "publishedDate" : "1984-03-14T20:07:53.307Z",
+  "indexedDate" : "1998-11-19T11:08:34.861Z",
+  "handle" : "https://www.example.org/2c3178ab-2929-4729-9b64-d64f374ae11a",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/004853bc-e7d3-4774-b578-428ab389c1ac",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WH07OVW6SMLnqCUpw82",
+    "mainTitle" : "BOHuw2hIgNVLjU",
     "alternativeTitles" : {
-      "pt" : "gTbslJ8w613"
+      "ru" : "e0ETeA3IbF1i"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JUmUrrcjEc3GpXSaRa",
-      "month" : "1CHF4jpst5msypJcZg",
-      "day" : "7ViLMyUNhg2gDJYSF"
+      "year" : "X2pqDHnNSET1VGuC",
+      "month" : "kodN7s0Iic",
+      "day" : "9K0q39wUJ9LNmuqb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2d320d52-7e29-47bc-94a6-d9deb625291a",
-        "name" : "WoBlkdhJsCrBduOc",
+        "id" : "https://www.example.org/e4e09fc4-3036-4dc9-bfca-07290e377bd9",
+        "name" : "XNLYcq1NHG3",
         "nameType" : "Personal",
-        "orcId" : "cJ2P50slqeSprGeC",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "TI92CkhHNiGk3Vl",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w3hjHv5ep1GJM",
-          "value" : "GFQCS3i85KCeq"
+          "sourceName" : "62lOcEa4oaUeVY2Iy6",
+          "value" : "CvAmHcivm7hxFLr0Dfx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v4OU39waCqY8zLX",
-          "value" : "aN2re9UR8ATPMlZt2"
+          "sourceName" : "YhXAk26kKuKwxELf",
+          "value" : "8NRDwCRpfckcZigDH8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9abea8ed-4561-4153-a4a5-8982adcb7aa3"
+        "id" : "https://www.example.org/aade37ed-576b-408d-adad-1a636dd36e27"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d4b44f5c-d21f-42e9-9652-6373f7141b3d",
-        "name" : "rHKvpvlirkFy",
-        "nameType" : "Personal",
-        "orcId" : "tnvFuzYu3H4USkl4",
+        "id" : "https://www.example.org/a3d2a048-ad0f-49c2-9364-e0995b6cd8d5",
+        "name" : "TKFK9j57syLsOdY",
+        "nameType" : "Organizational",
+        "orcId" : "AXlgkRPNQD6kc",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qYbeUAx6sDDLjNYr0F",
-          "value" : "MEje0DVHyGIdlRUD"
+          "sourceName" : "p2yU5r46rqgKw",
+          "value" : "pmrJLKdd7lLiz0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hpb2j2w3zPSjIoE7",
-          "value" : "JHNrhkm63Aj"
+          "sourceName" : "Mbe52H7TE4VMo",
+          "value" : "77AG02OfK1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/76662447-bb9e-4f18-8c88-bd4399f1a331"
+        "id" : "https://www.example.org/613caed1-ae6a-44d4-a45c-d18ad80d0297"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "SoundDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "Kdp1Td4Xjx9F1jcWS"
+      "de" : "zeE8rcUZYdLgaHN"
     },
-    "npiSubjectHeading" : "1ILXHoj2mD4Nz",
-    "tags" : [ "f7PYbDufd0lp3C38Ra" ],
-    "description" : "QU24yR4bViLZaOXFPS",
+    "npiSubjectHeading" : "Pd4EBKY2yJBKh",
+    "tags" : [ "ixw07jRRcAxiPYSJ25" ],
+    "description" : "IklWYGQNKia",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bd024331-3763-4635-aa60-ac9d516d75c9"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b21c2a36-7614-40ff-a704-10765887b942"
         },
-        "seriesNumber" : "w8F8mh3cRV6SJiKk5kp",
+        "seriesNumber" : "T3ULjgFFAP13i93hiH2",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a36c6ccf-21a0-4c12-ba3c-8989c2f9df94",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/53acdcc5-5712-4e48-932f-75d26cbaa977",
           "valid" : true
         },
-        "isbnList" : [ "9791928410064" ],
+        "isbnList" : [ "9781037942471", "9781887400886" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "9saXw4g5N2yeJ05gntM"
+          "value" : "1887400885"
         } ]
       },
-      "doi" : "https://www.example.org/773cb0c3-4448-4271-a8cf-bd2ba30a105c",
+      "doi" : "https://www.example.org/543d755f-bf7d-4802-8861-c2dd17e81d08",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "PIFVs9PkQBqKlm",
-            "end" : "Luh2cchaTGyVYx"
+            "begin" : "fRWC6Blclmo",
+            "end" : "BbzDvvKG0jwJSn"
           },
-          "pages" : "FT4HAsxaSZT",
-          "illustrated" : false
+          "pages" : "bl4Titnd3QoU61",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f9e81793-fa09-4b5a-ac79-9485cae77b13",
-    "abstract" : "rP1h6pV4Sb2WcChSa"
+    "metadataSource" : "https://www.example.org/4c5eefe6-a6d5-4dbe-b539-39ffd787ae1a",
+    "abstract" : "okztVny7wzmIM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8404bddc-c99a-4b2a-bf83-bb646ab81f49",
-    "name" : "zybUasTpQO1",
+    "id" : "https://www.example.org/c95e63bf-eedc-4471-aeb5-52d200169ca6",
+    "name" : "JoQfyqfSQ0GU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-06-15T03:52:17.944Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "grFWxGKDywawiAp9AhB"
+      "approvalDate" : "2016-08-15T16:41:05.705Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "OaBDNKd4CLmqsmTEH5"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ae826906-4bed-4574-875a-b603454ced1b",
-    "identifier" : "JFXOBgGdvRB",
+    "source" : "https://www.example.org/e2029c16-d981-40fa-bb82-d055b8ab48e9",
+    "identifier" : "QpdC5cBSTJJ",
     "labels" : {
-      "es" : "fa48wi1rshtBpvaE1"
+      "sv" : "qFfkbT5JTfthwXN"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 858745537
+      "amount" : 1895977277
     },
-    "activeFrom" : "2002-02-16T07:51:58.391Z",
-    "activeTo" : "2006-08-11T08:38:45.854Z"
+    "activeFrom" : "1986-04-12T16:17:32.309Z",
+    "activeTo" : "1995-08-05T07:43:45.259Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/fe39c32c-3142-438e-a863-f612cafef518",
-    "id" : "https://www.example.org/77264a14-96b2-4673-98d2-5532f2f0692b",
-    "identifier" : "QDrIJqB2SA",
+    "source" : "https://www.example.org/7f8635de-757b-4e27-b776-069608c64617",
+    "id" : "https://www.example.org/0298b398-3199-4259-85dd-0ef18136c54e",
+    "identifier" : "CcorbFuToTqi1ZkAzf4",
     "labels" : {
-      "zh" : "CkD7vVXwajfD2N"
+      "pt" : "WM9tPFzRhDD7yfHH"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1565772361
+      "amount" : 451718003
     },
-    "activeFrom" : "2008-12-20T15:10:55.417Z",
-    "activeTo" : "2018-07-23T19:17:32.723Z"
+    "activeFrom" : "2006-04-24T04:23:34.957Z",
+    "activeTo" : "2007-08-23T06:18:12.422Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ab2bcc28-dc0e-452d-ad97-0d71228c4d3c" ],
+  "subjects" : [ "https://www.example.org/36e47362-e3a4-42ea-b614-081aa87524c0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b4c03329-7520-49a3-bb78-90afef31be73",
-    "name" : "tBtv7m7MFfH",
-    "mimeType" : "sPeX7OlzeXy2",
-    "size" : 60140639,
-    "license" : "https://www.example.com/ugfpx0qos4",
+    "identifier" : "061a8360-2a34-4324-adb4-d01e157d3326",
+    "name" : "yhOgMz85u4",
+    "mimeType" : "Dsz97OqpyPU",
+    "size" : 800587770,
+    "license" : "https://www.example.com/qicuiakp4iyskhp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Unmc23ajGU96vtBO"
     },
-    "legalNote" : "SWu39Cj68BWZyQVZ",
-    "publishedDate" : "2005-08-13T14:57:30.591Z",
+    "legalNote" : "vjtZJboR4CVRFC",
+    "publishedDate" : "2005-12-05T00:41:32.421Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "tVeYZIOb8m21z",
-      "uploadedDate" : "2015-03-15T06:53:25.142Z"
+      "uploadedBy" : "3NeKqcKzZlVjdZ",
+      "uploadedDate" : "2016-01-25T01:32:01.554Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/CbP0pQJ0FBFTOeA8l",
-    "name" : "phiYBwdLLAex5X",
-    "description" : "WokfPGp103eNiR3ZQX"
+    "id" : "https://www.example.com/IBRe30NyGFSre2RkM",
+    "name" : "zQGiJ7Zg3g",
+    "description" : "2VfB5hLHayWDiQV1"
   } ],
-  "rightsHolder" : "5sLRfW7PYTh",
-  "duplicateOf" : "https://www.example.org/238a42c1-3226-4603-9438-923d8ac3bd0f",
+  "rightsHolder" : "SzJ86Ve2nmihl",
+  "duplicateOf" : "https://www.example.org/5c413553-f725-412f-8d05-908ba2ba0516",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ybC8HVcCnG7"
+    "note" : "IxXTz1QRY7kQ5NC6LG7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "r66jlViAFRruFHNt",
-    "createdBy" : "W8whYLA4jWd5n",
-    "createdDate" : "2021-05-05T22:26:44.734Z"
+    "note" : "yHo30wAYc3G",
+    "createdBy" : "vLJM787wai7Q6tqTXwm",
+    "createdDate" : "1991-02-07T08:31:05.313Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/954ca5dc-e066-44a4-bd29-a39541bc179f" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/5d4eb232-b69a-4037-93cc-06e019fd57bb" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "JE8e34pJbi",
-    "ownerAffiliation" : "https://www.example.org/aabaf260-4a3b-4b0f-af3a-dc026f9fc9c3"
+    "owner" : "vY1SkroD6KY8St",
+    "ownerAffiliation" : "https://www.example.org/ff9d36e3-2577-4352-b413-6063fd409d4b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5ce8ac14-9059-4383-aae5-327c7b28d743"
+    "id" : "https://www.example.org/0ea5b6bd-e4f1-4f15-9dd2-4b2b3798c37b"
   },
-  "createdDate" : "1978-12-18T07:10:12.456Z",
-  "modifiedDate" : "1980-11-09T14:28:59.984Z",
-  "publishedDate" : "2004-10-10T01:27:24.495Z",
-  "indexedDate" : "2003-01-15T11:44:45.484Z",
-  "handle" : "https://www.example.org/8221346f-0498-49c2-beb9-af116c80cbaa",
-  "doi" : "https://doi.org/10.1234/vitae",
-  "link" : "https://www.example.org/8f771f48-e76a-4d19-9637-a699e6836e08",
+  "createdDate" : "2002-12-18T01:00:29.264Z",
+  "modifiedDate" : "1979-06-28T06:23:29.746Z",
+  "publishedDate" : "2015-01-23T14:44:42.911Z",
+  "indexedDate" : "2020-01-17T18:30:38.459Z",
+  "handle" : "https://www.example.org/37ad9382-0122-4b97-b5a7-3c5d863808eb",
+  "doi" : "https://doi.org/10.1234/expedita",
+  "link" : "https://www.example.org/6a2240ba-4c3f-4087-ba22-8377021c6261",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kUvQd6BfdjvLqZ",
+    "mainTitle" : "kZvZbPrrtjx",
     "alternativeTitles" : {
-      "pl" : "sp0QQlytnKhBE9"
+      "fr" : "dLPYc38eCONpM"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bN9INzjzyav2Fsxbq",
-      "month" : "Zc70WLpUW2ONuWhs00",
-      "day" : "i0WJ3UjHgY66tCwJD"
+      "year" : "2zOHWgWWxZ85",
+      "month" : "FviVBrKOGStIGlAbjh",
+      "day" : "vSvRXEVWlysSE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9f7fe569-6a37-465a-8a3d-677d85d70bc3",
-        "name" : "f2N1tPlwjnx",
-        "nameType" : "Organizational",
-        "orcId" : "njrQy2J4qqPpiaWq",
+        "id" : "https://www.example.org/a0978c96-7a21-48fd-8444-5be2e66526d5",
+        "name" : "gmrxYqy8gnf",
+        "nameType" : "Personal",
+        "orcId" : "JTawvhPLiTmgC2",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "coyZRzzUluGZOgGy",
-          "value" : "Y40J87uf7pDnT"
+          "sourceName" : "dRqiQeyBJi",
+          "value" : "8jvHJhQcZzc3XS2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iabchptNH7QOqAy3L",
-          "value" : "b6kedPALZ43zS0dEB1k"
+          "sourceName" : "y9nTSoMA7BuMQjLk",
+          "value" : "aHvKe7Q7OnsocyJ3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/862a3b09-3ac9-4c3a-88e4-608c521542b7"
+        "id" : "https://www.example.org/81c277d3-1267-49e0-bede-9b07f3cab0a6"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,188 +62,189 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6ca2b39f-bddd-449a-8914-a86a45017afa",
-        "name" : "r1Nv5mGjUBzy",
-        "nameType" : "Personal",
-        "orcId" : "Va2vnPhRb4rTE",
+        "id" : "https://www.example.org/70c41720-11f7-4605-89fc-ca5fb4836c77",
+        "name" : "kwUpiKtHmX38yAr5lwI",
+        "nameType" : "Organizational",
+        "orcId" : "dHqk1LI4SeNBixGF",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z5j1Vr1RUI",
-          "value" : "F9pjzG9HFpdm4"
+          "sourceName" : "OSOos6mh255K88Vmvt4",
+          "value" : "2SgQqfh9Ka"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VxTtq8cBAhPdJR",
-          "value" : "XEErCDSxf66Y"
+          "sourceName" : "2Kvgs5ZXnTJehJ8h",
+          "value" : "Y3SPtmBku9OEN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d1763f08-2087-4a95-8215-540ef7e401ba"
+        "id" : "https://www.example.org/991cac1d-3713-4cb5-b754-314b7b976d20"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "jKYNbxS29M0CMFlUHQ"
+      "de" : "A1dLhEaq7R9xIR4Pxt2"
     },
-    "npiSubjectHeading" : "Cv1PgcDMEQk0j",
-    "tags" : [ "PEDqt7AUebfpdQUD" ],
-    "description" : "qXzT8DsWA4sRoK55",
+    "npiSubjectHeading" : "TYgJAeIWm4",
+    "tags" : [ "SZyQ0cVkxs" ],
+    "description" : "0918bqMsGfz5oIvR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/123d5251-66fa-4db1-b4e9-af3c15711b72",
+      "doi" : "https://www.example.org/a26014f0-15d7-46be-b727-a75d2be3e4fb",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "PlanningProposal"
+          "type" : "LandscapeArchitecture"
         },
-        "description" : "yRQkdagW5ElkJhC4B",
+        "description" : "GMb4dlIVD8vgQRTVSB",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "WnZZ8SEOTaA",
-          "description" : "kwKHNSy4LSS",
+          "name" : "mN83SQshsGD2e9GCZP8",
+          "description" : "gIbtx33Yo90pPvqf",
           "date" : {
             "type" : "Instant",
-            "value" : "2007-08-22T00:46:07.027Z"
+            "value" : "2024-01-06T10:59:54.455Z"
           },
-          "sequence" : 45790207
+          "sequence" : 948694967
         }, {
           "type" : "MentionInPublication",
-          "title" : "El3gmMrhbHU4ewb",
-          "issue" : "CkbFQpdRe5f",
+          "title" : "2DlBgFBNH0Ctbl",
+          "issue" : "XLwnVWoFslwzql9TZpu",
           "date" : {
             "type" : "Instant",
-            "value" : "2021-01-03T04:37:18.060Z"
+            "value" : "1993-11-20T07:28:38.170Z"
           },
-          "otherInformation" : "kM1k6Y7ljaXGIFo7pD",
-          "sequence" : 2112723822
+          "otherInformation" : "4XCK3gU3rZxAsGwCQnn",
+          "sequence" : 305652168
         }, {
           "type" : "Award",
-          "name" : "q8SKVH3eV2E",
-          "organizer" : "HlEvRrBtp2gCLPr",
+          "name" : "TuLxFOXS90cJ7",
+          "organizer" : "7oaQ8FAdf6e1LbJSF",
           "date" : {
             "type" : "Instant",
-            "value" : "1973-07-03T07:01:12.341Z"
+            "value" : "2011-05-15T08:34:21.897Z"
           },
-          "ranking" : 930048976,
-          "otherInformation" : "oQLc2lBFEP2o",
-          "sequence" : 188299426
+          "ranking" : 359318297,
+          "otherInformation" : "aenUy4fy9mUVob",
+          "sequence" : 125824269
         }, {
           "type" : "Exhibition",
-          "name" : "ZhSfJCoZsI3hwD",
+          "name" : "l3g9rw12IsXIkhp",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "T7KzbKx1gDwdUqQVIk",
-            "country" : "XNeMbjDILdLm"
+            "label" : "4mvpMHiTk9S1ldIvi",
+            "country" : "dsiTSf6SQLK7UTh"
           },
-          "organizer" : "Jb0TVv6cpY",
+          "organizer" : "dxiy9grWuD",
           "date" : {
             "type" : "Period",
-            "from" : "2019-05-19T00:41:40.877Z",
-            "to" : "2023-11-30T11:27:19.621Z"
+            "from" : "1984-05-13T06:22:53.994Z",
+            "to" : "2002-03-07T08:52:10.426Z"
           },
-          "otherInformation" : "C11UuBwH17Px2oTKbF",
-          "sequence" : 122076468
+          "otherInformation" : "hf01Xnk9DNqR",
+          "sequence" : 109926465
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/886d6757-e6f4-4854-837e-7be2c0add576",
-    "abstract" : "t12U3cO7Xx5uJvq4qG"
+    "metadataSource" : "https://www.example.org/6cc5e053-0ac6-4467-bde4-6c210db0503c",
+    "abstract" : "JqWoqnBcIjUW5NH6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/60022afa-359a-4806-8e1f-626adea3e228",
-    "name" : "3bmryRFpjt991E7PQs",
+    "id" : "https://www.example.org/5845fddf-5bcd-4069-8038-9d4ab08700f8",
+    "name" : "a6kDz97zFh5HZgN",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-08-06T17:44:22.431Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "SAm0KM0Jl0ipcEV8"
+      "approvalDate" : "2015-03-01T16:57:00.190Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "jHSq2sEG1qT69T"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c2786841-2072-467e-a661-ada6dbef7ba2",
-    "identifier" : "Qy5usY1FLTVgn3C",
+    "source" : "https://www.example.org/b5f90ba7-9a42-4f7d-b5e9-41ecc358fb84",
+    "identifier" : "SWz8W4iduDQCAOzhVf2",
     "labels" : {
-      "zh" : "bG6yyRHIzfVYfrfy"
+      "ru" : "lwUjQPUw5wV48Pg"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 869989135
+      "currency" : "GBP",
+      "amount" : 544114364
     },
-    "activeFrom" : "2009-09-08T14:23:15.937Z",
-    "activeTo" : "2017-06-10T16:06:23.375Z"
+    "activeFrom" : "1974-05-08T19:52:21.524Z",
+    "activeTo" : "2024-03-18T23:02:26.593Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/698593c0-04d8-46a4-a76b-ec7514a7c3a9",
-    "id" : "https://www.example.org/e6a01351-3984-46ff-aa43-c6eb973f1efe",
-    "identifier" : "7TlTlwRjWqGiR9e",
+    "source" : "https://www.example.org/ccfde097-501f-46ab-97dd-4bb4d4a2e693",
+    "id" : "https://www.example.org/9a4e68c2-c4ad-4fbe-81b4-8acd7661ad8e",
+    "identifier" : "QKQ9VXP6KG6Ai7NkOOg",
     "labels" : {
-      "cs" : "wUipZ6YGxba"
+      "pl" : "w9a5gN2ufVgrDw"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1376185807
+      "amount" : 272568762
     },
-    "activeFrom" : "1984-04-15T05:18:50.697Z",
-    "activeTo" : "1999-01-30T02:44:02.815Z"
+    "activeFrom" : "2016-01-14T23:31:30.611Z",
+    "activeTo" : "2019-11-05T07:38:08.784Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a4b374bd-0c68-445a-a381-59256a8b3c74" ],
+  "subjects" : [ "https://www.example.org/b4985565-4609-43fc-89c3-f2f8bb51b2d1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a9904c97-93f8-4054-a986-674bed07a658",
-    "name" : "twkzmg2HE8aj7YcTd",
-    "mimeType" : "ZESJj2nijPjJM",
-    "size" : 701309467,
-    "license" : "https://www.example.com/lfdvupgekvcaoksrx2u",
+    "identifier" : "0179e54e-756a-4795-baca-7e2ffe8d25bf",
+    "name" : "1M3mBpc4U12bp0WT",
+    "mimeType" : "Fm1FCplARsd9uV",
+    "size" : 1507401203,
+    "license" : "https://www.example.com/xoywlshlorwffm4cpb",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "u1LYr5fkbiySI"
     },
-    "legalNote" : "sNPKkq1zSTdhN",
-    "publishedDate" : "2012-11-30T18:37:19.846Z",
+    "legalNote" : "XkoIhD3BT9s2pB5kKt",
+    "publishedDate" : "1984-01-28T02:13:48.004Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "B4pfGjEo8Szca",
-      "uploadedDate" : "1994-05-23T03:28:48.603Z"
+      "uploadedBy" : "4Jkc9jem2xAtXs",
+      "uploadedDate" : "1994-12-29T14:23:32.614Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/F2dczTiK6yznsF",
-    "name" : "hMTNfgMsvHY3xb9",
-    "description" : "U6gIwprkuPUFBMdwJp"
+    "id" : "https://www.example.com/4jOmkHiEaapIcwy1",
+    "name" : "yJ5Tjicavioth",
+    "description" : "MQ8JKdrFYQLz"
   } ],
-  "rightsHolder" : "2NtJVrJOPxagGzlhALu",
-  "duplicateOf" : "https://www.example.org/6f745b4f-05bd-416f-9c6e-52f8d3127392",
+  "rightsHolder" : "agepuB4SUAKdn6WR",
+  "duplicateOf" : "https://www.example.org/ab6dc081-c21c-47b3-a9e6-03788cd49734",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "8evYHnhULqXEIb"
+    "note" : "kxbgwXMk16nlz70Cts1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "lLXHQCtA49CVZC29U8P",
-    "createdBy" : "7TJlUGoxgk",
-    "createdDate" : "1999-05-07T21:37:20.541Z"
+    "note" : "wS78cDBGi72WurzJ6",
+    "createdBy" : "DVHfLraoDN9mN",
+    "createdDate" : "1983-03-26T20:37:03.592Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f731b8fe-98f9-461c-ae77-c367e92472d7" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/fc4fc3d0-7d13-48c4-8d04-ea352122525d" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "vY1SkroD6KY8St",
-    "ownerAffiliation" : "https://www.example.org/ff9d36e3-2577-4352-b413-6063fd409d4b"
+    "owner" : "vUg71le8akxF2E1B",
+    "ownerAffiliation" : "https://www.example.org/8c1441ed-5824-43a8-96ec-d2b19ead32ef"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0ea5b6bd-e4f1-4f15-9dd2-4b2b3798c37b"
+    "id" : "https://www.example.org/b9ed80b2-ae10-45a4-8601-131797c0c923"
   },
-  "createdDate" : "2002-12-18T01:00:29.264Z",
-  "modifiedDate" : "1979-06-28T06:23:29.746Z",
-  "publishedDate" : "2015-01-23T14:44:42.911Z",
-  "indexedDate" : "2020-01-17T18:30:38.459Z",
-  "handle" : "https://www.example.org/37ad9382-0122-4b97-b5a7-3c5d863808eb",
-  "doi" : "https://doi.org/10.1234/expedita",
-  "link" : "https://www.example.org/6a2240ba-4c3f-4087-ba22-8377021c6261",
+  "createdDate" : "1999-12-21T22:36:00.812Z",
+  "modifiedDate" : "2021-02-22T10:08:35.940Z",
+  "publishedDate" : "2021-10-27T16:03:25Z",
+  "indexedDate" : "1999-12-27T02:55:23.583Z",
+  "handle" : "https://www.example.org/8e63828e-64ee-4227-ac2b-879ec6226295",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/0f9a3715-8c3f-49fe-bb8d-07ed953dfc7b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kZvZbPrrtjx",
+    "mainTitle" : "YIG7JqzEmVlIEPtPr",
     "alternativeTitles" : {
-      "fr" : "dLPYc38eCONpM"
+      "ru" : "6wfsJm0W9Gkvoln0s"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "2zOHWgWWxZ85",
-      "month" : "FviVBrKOGStIGlAbjh",
-      "day" : "vSvRXEVWlysSE"
+      "year" : "0F6UGU8JHNUW",
+      "month" : "G6TneDZcc87fApT",
+      "day" : "1LDO9K6oZXgD6kRksx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a0978c96-7a21-48fd-8444-5be2e66526d5",
-        "name" : "gmrxYqy8gnf",
+        "id" : "https://www.example.org/63ec8c58-fe25-4090-b221-b55943a64861",
+        "name" : "c25kbmaCUEqp3p1VC6",
         "nameType" : "Personal",
-        "orcId" : "JTawvhPLiTmgC2",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "qaPoo9tCeg",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dRqiQeyBJi",
-          "value" : "8jvHJhQcZzc3XS2"
+          "sourceName" : "vAIW17iBrEuOHobQW",
+          "value" : "iYqa7WjWk9UHur"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "y9nTSoMA7BuMQjLk",
-          "value" : "aHvKe7Q7OnsocyJ3"
+          "sourceName" : "g0HjMA9Gl2fQd00S6z",
+          "value" : "v7weMzUUC9J"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/81c277d3-1267-49e0-bede-9b07f3cab0a6"
+        "id" : "https://www.example.org/d6190acf-5bcd-4fbd-a403-85be85fea5de"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,189 +62,188 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/70c41720-11f7-4605-89fc-ca5fb4836c77",
-        "name" : "kwUpiKtHmX38yAr5lwI",
+        "id" : "https://www.example.org/8fe75c7d-1670-463b-9869-c495c4ed0604",
+        "name" : "21CJPN04BF",
         "nameType" : "Organizational",
-        "orcId" : "dHqk1LI4SeNBixGF",
+        "orcId" : "wbjjNAEeFefwd7r",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OSOos6mh255K88Vmvt4",
-          "value" : "2SgQqfh9Ka"
+          "sourceName" : "e5nDOKZook",
+          "value" : "EVMxdw9Uk2UtFdC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2Kvgs5ZXnTJehJ8h",
-          "value" : "Y3SPtmBku9OEN"
+          "sourceName" : "hP9QrNbHGyN8hIb5",
+          "value" : "YrrUwCuqlL9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/991cac1d-3713-4cb5-b754-314b7b976d20"
+        "id" : "https://www.example.org/15dbeb57-5dc2-4d36-9150-6197ce38b021"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "A1dLhEaq7R9xIR4Pxt2"
+      "hu" : "Qm0YZ2fUyTEZ"
     },
-    "npiSubjectHeading" : "TYgJAeIWm4",
-    "tags" : [ "SZyQ0cVkxs" ],
-    "description" : "0918bqMsGfz5oIvR",
+    "npiSubjectHeading" : "CX7aDEpxXfcQ2HEb",
+    "tags" : [ "xuGDGKBmmy" ],
+    "description" : "pBa5XUokJquF3wdGuqL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/a26014f0-15d7-46be-b727-a75d2be3e4fb",
+      "doi" : "https://www.example.org/efe78c03-d842-41f7-9a76-5ca8d7bc2872",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "LandscapeArchitecture"
+          "type" : "PlanningProposal"
         },
-        "description" : "GMb4dlIVD8vgQRTVSB",
+        "description" : "MvKM7izhQKlHE",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "mN83SQshsGD2e9GCZP8",
-          "description" : "gIbtx33Yo90pPvqf",
+          "name" : "Wle5QzBajMds",
+          "description" : "Ltaom3UeJhaW",
           "date" : {
             "type" : "Instant",
-            "value" : "2024-01-06T10:59:54.455Z"
+            "value" : "1991-08-10T02:29:57.548Z"
           },
-          "sequence" : 948694967
+          "sequence" : 681510478
         }, {
           "type" : "MentionInPublication",
-          "title" : "2DlBgFBNH0Ctbl",
-          "issue" : "XLwnVWoFslwzql9TZpu",
+          "title" : "hPBMBZF75EWt8",
+          "issue" : "MCTHAfa86VsH",
           "date" : {
             "type" : "Instant",
-            "value" : "1993-11-20T07:28:38.170Z"
+            "value" : "1988-03-16T09:19:55.510Z"
           },
-          "otherInformation" : "4XCK3gU3rZxAsGwCQnn",
-          "sequence" : 305652168
+          "otherInformation" : "3YkG6SjTNh",
+          "sequence" : 2085515315
         }, {
           "type" : "Award",
-          "name" : "TuLxFOXS90cJ7",
-          "organizer" : "7oaQ8FAdf6e1LbJSF",
+          "name" : "RqmeNyFjGSxmFs",
+          "organizer" : "2FUNHp1fB8",
           "date" : {
             "type" : "Instant",
-            "value" : "2011-05-15T08:34:21.897Z"
+            "value" : "1992-12-01T06:40:52.675Z"
           },
-          "ranking" : 359318297,
-          "otherInformation" : "aenUy4fy9mUVob",
-          "sequence" : 125824269
+          "ranking" : 195850191,
+          "otherInformation" : "xWE2NocDt7w",
+          "sequence" : 1914576126
         }, {
           "type" : "Exhibition",
-          "name" : "l3g9rw12IsXIkhp",
+          "name" : "XhjSWQzBI8536o",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "4mvpMHiTk9S1ldIvi",
-            "country" : "dsiTSf6SQLK7UTh"
+            "label" : "5ZxUlYhJ9btavzWevgU",
+            "country" : "91dK2ZkaioHDXyy"
           },
-          "organizer" : "dxiy9grWuD",
+          "organizer" : "v6rn2ssu8SGsCKd",
           "date" : {
             "type" : "Period",
-            "from" : "1984-05-13T06:22:53.994Z",
-            "to" : "2002-03-07T08:52:10.426Z"
+            "from" : "1975-07-22T12:43:41.622Z",
+            "to" : "2022-02-24T04:36:00.286Z"
           },
-          "otherInformation" : "hf01Xnk9DNqR",
-          "sequence" : 109926465
+          "otherInformation" : "xjC8KqUhZrX",
+          "sequence" : 1637750142
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6cc5e053-0ac6-4467-bde4-6c210db0503c",
-    "abstract" : "JqWoqnBcIjUW5NH6"
+    "metadataSource" : "https://www.example.org/970a5c66-2197-447b-9ebe-07b6ecaa0d4a",
+    "abstract" : "Bx9xT6L69kMgL9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5845fddf-5bcd-4069-8038-9d4ab08700f8",
-    "name" : "a6kDz97zFh5HZgN",
+    "id" : "https://www.example.org/e06d210e-a5a1-449f-9d2d-407165a5d1a5",
+    "name" : "qb6lK3ZCxqg3NWop",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-03-01T16:57:00.190Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "jHSq2sEG1qT69T"
+      "approvalDate" : "2011-04-22T14:13:07.537Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "7OpD7rx1AGjx8p6S"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b5f90ba7-9a42-4f7d-b5e9-41ecc358fb84",
-    "identifier" : "SWz8W4iduDQCAOzhVf2",
+    "source" : "https://www.example.org/a20f048a-ed47-49d3-90a8-d5f04ceeb08c",
+    "identifier" : "tCugArEArPZiCG06E6",
     "labels" : {
-      "ru" : "lwUjQPUw5wV48Pg"
+      "de" : "nRPEYdJhlpgIbV"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 544114364
+      "amount" : 415166794
     },
-    "activeFrom" : "1974-05-08T19:52:21.524Z",
-    "activeTo" : "2024-03-18T23:02:26.593Z"
+    "activeFrom" : "1995-02-16T07:47:58.669Z",
+    "activeTo" : "2022-03-14T00:56:37.246Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ccfde097-501f-46ab-97dd-4bb4d4a2e693",
-    "id" : "https://www.example.org/9a4e68c2-c4ad-4fbe-81b4-8acd7661ad8e",
-    "identifier" : "QKQ9VXP6KG6Ai7NkOOg",
+    "source" : "https://www.example.org/0e52df41-7f0f-4ae6-8a08-108bfc5997be",
+    "id" : "https://www.example.org/92bd1469-0532-4e93-b64c-d31da4ca0bd6",
+    "identifier" : "XZAqlkbEWG4Tmcwpqc",
     "labels" : {
-      "pl" : "w9a5gN2ufVgrDw"
+      "en" : "QmfvFOvkZIlzWHvhGX"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 272568762
+      "amount" : 603293022
     },
-    "activeFrom" : "2016-01-14T23:31:30.611Z",
-    "activeTo" : "2019-11-05T07:38:08.784Z"
+    "activeFrom" : "1989-09-04T05:25:41.684Z",
+    "activeTo" : "2020-08-31T23:29:15.730Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b4985565-4609-43fc-89c3-f2f8bb51b2d1" ],
+  "subjects" : [ "https://www.example.org/1b624b4b-6745-4060-8041-a291c91e46b0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0179e54e-756a-4795-baca-7e2ffe8d25bf",
-    "name" : "1M3mBpc4U12bp0WT",
-    "mimeType" : "Fm1FCplARsd9uV",
-    "size" : 1507401203,
-    "license" : "https://www.example.com/xoywlshlorwffm4cpb",
+    "identifier" : "ab3b1b83-6885-4208-b8b1-441c24a537b2",
+    "name" : "GaO9I44lqqU",
+    "mimeType" : "oIpiBOv8UtmrboaGtH",
+    "size" : 1292217881,
+    "license" : "https://www.example.com/facilx88ezihnoadcyt",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "u1LYr5fkbiySI"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "XkoIhD3BT9s2pB5kKt",
-    "publishedDate" : "1984-01-28T02:13:48.004Z",
+    "legalNote" : "yGTHkHs6n0fmLhu",
+    "publishedDate" : "1998-07-19T07:44:09.947Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "4Jkc9jem2xAtXs",
-      "uploadedDate" : "1994-12-29T14:23:32.614Z"
+      "uploadedBy" : "xMUvgmHgghSJGcFeZ",
+      "uploadedDate" : "1974-07-19T10:54:02.409Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/4jOmkHiEaapIcwy1",
-    "name" : "yJ5Tjicavioth",
-    "description" : "MQ8JKdrFYQLz"
+    "id" : "https://www.example.com/nj7I8vqBnZk4",
+    "name" : "dAEJx8lbrRzR2VV27H",
+    "description" : "E30mAeAKPw"
   } ],
-  "rightsHolder" : "agepuB4SUAKdn6WR",
-  "duplicateOf" : "https://www.example.org/ab6dc081-c21c-47b3-a9e6-03788cd49734",
+  "rightsHolder" : "jtktwooihWRJB",
+  "duplicateOf" : "https://www.example.org/1feb83af-6e6a-4d78-804b-23ca88ee4c0e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kxbgwXMk16nlz70Cts1"
+    "note" : "tPFURS35Tg2looA"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "wS78cDBGi72WurzJ6",
-    "createdBy" : "DVHfLraoDN9mN",
-    "createdDate" : "1983-03-26T20:37:03.592Z"
+    "note" : "3Vi8iOgPnVJabVvUg",
+    "createdBy" : "5B6BMGjjNpzvvnIW",
+    "createdDate" : "1977-05-22T06:12:50.605Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fc4fc3d0-7d13-48c4-8d04-ea352122525d" ],
+  "curatingInstitutions" : [ "https://www.example.org/1c749770-b36d-4910-8e34-2b63558e1314" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "XhlkmHLZKxoxBAidiY2",
-    "ownerAffiliation" : "https://www.example.org/77bd2e24-73e1-496d-baa9-48952492a176"
+    "owner" : "RoN1ygiyHvCGb4",
+    "ownerAffiliation" : "https://www.example.org/1c54cf48-1f37-499a-b9a6-7df5822fd309"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/928f7691-7a74-4639-9ba4-8b4fe826cb5f"
+    "id" : "https://www.example.org/b86fc292-9657-4198-afda-159691afa014"
   },
-  "createdDate" : "2019-12-23T07:46:21.604Z",
-  "modifiedDate" : "1987-05-07T08:38:19.318Z",
-  "publishedDate" : "2021-01-09T21:09:59.372Z",
-  "indexedDate" : "1998-12-12T09:40:45.367Z",
-  "handle" : "https://www.example.org/f6b8599a-9779-40df-bcf8-5c219b852cd9",
-  "doi" : "https://doi.org/10.1234/animi",
-  "link" : "https://www.example.org/4e9c3f3e-2612-40bc-923a-5053d9364b53",
+  "createdDate" : "1996-11-30T15:57:41.543Z",
+  "modifiedDate" : "1990-06-28T20:13:23.252Z",
+  "publishedDate" : "2021-04-12T06:50:46.310Z",
+  "indexedDate" : "1990-03-15T15:22:35.793Z",
+  "handle" : "https://www.example.org/0467b2f9-c4bd-41be-93d6-802c5f32f7bf",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/f2147491-2daf-4b25-9e56-8f52a24cca35",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6OOFn7JuOsEgxAoXAd",
+    "mainTitle" : "u83qbTUc289j7e",
     "alternativeTitles" : {
-      "el" : "fl8hn1itPHd"
+      "sv" : "trEJYo5gBEnPX6TR"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1zuIhnzZro9LfgikbD",
-      "month" : "cQX3z5zpg0OgeDyn98",
-      "day" : "DhqCmRjWnosbPmJY"
+      "year" : "klKcjW4tXxN2VYlP",
+      "month" : "qNHjojUEQWSFt",
+      "day" : "XjNo6vUrnICABITrN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c1080e34-adc1-444f-93c8-8675070fa84c",
-        "name" : "QOnTlLviwcmhXC1HXG",
+        "id" : "https://www.example.org/f2012029-d07d-419c-85d1-6146fbbf5e0f",
+        "name" : "u0RbyR7rc36",
         "nameType" : "Organizational",
-        "orcId" : "CCn9Gs2CHCbqq2K2bn",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "JaEBwjQFpAUcXbeuV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pQU0Pt4dMb4Et",
-          "value" : "Gh7sKeeytyMzZPZy"
+          "sourceName" : "fiNNlujs94xdsyzD9",
+          "value" : "Z3IGBqTcJ4HS0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "95MiylUSbGQdc",
-          "value" : "4NRo0N85p7ugFwNVFc"
+          "sourceName" : "vGi6FLSRuW744l",
+          "value" : "S7zTUNFIaelcCUapSJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/eddb8c54-1b43-4e6f-8f27-676c2063d758"
+        "id" : "https://www.example.org/c0e1a449-b193-46d4-8720-e619dd62ec0d"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/40e22fbc-bf64-41c2-ae72-d9dc44227a12",
-        "name" : "a79dqdhyf5mTi1HwJ",
-        "nameType" : "Personal",
-        "orcId" : "NfpvRDVY55PUi",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/6a6ead76-54d9-49fc-ad71-18c0a2118f4d",
+        "name" : "vEp6R72q8flEM0R",
+        "nameType" : "Organizational",
+        "orcId" : "Blpw20hjApAKjLpv",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UFcSMpXIOL7dag6sGh",
-          "value" : "iF4qcXGVbf9"
+          "sourceName" : "xSonBh7ZpZo0x",
+          "value" : "Yxg3TkBn4vKajNnSx3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oodzc5fXWm",
-          "value" : "Schwa1nWbjWRrO6cSM"
+          "sourceName" : "wOaw9mrWHpG2I7B",
+          "value" : "c119jCIZ9X15s"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/97c89337-2fd7-4492-8ee0-909e0825c0fe"
+        "id" : "https://www.example.org/321e23e8-cfbb-4e27-b8ba-edefd37bf49e"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "DOYHgLmR47f0jxjt"
+      "hu" : "x1eEEPBANan0gSG"
     },
-    "npiSubjectHeading" : "Ft072lEHsW4GxBYQlj6",
-    "tags" : [ "jhmuOBqMZfFHM0A" ],
-    "description" : "RrAFOCgkmn79s",
+    "npiSubjectHeading" : "r5XUSiHFPQD0UjiQ",
+    "tags" : [ "dzJnqujEgtSE8OJ" ],
+    "description" : "8aYBJwU1IUvUpw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/8d5be61f-1849-4826-802b-5aeb04dc7285",
+      "doi" : "https://www.example.org/63078ec0-669e-4eef-bde6-981fa74b7097",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ClothingDesign"
+          "type" : "InteriorDesign"
         },
-        "description" : "G9R80v3xVOVsyTcasU",
+        "description" : "J1GzClPhLs4LJTy",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "jAd1YivTMTATnyTSX",
-            "country" : "LupfR1rG0767QY769j"
+            "label" : "zMa2oOyG67hpY2sht",
+            "country" : "RJTMCFaL12rE"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2008-12-30T09:31:50.439Z",
-            "to" : "2024-02-01T09:39:59.939Z"
+            "from" : "1980-08-17T04:52:27.872Z",
+            "to" : "2005-06-23T00:27:49.442Z"
           },
-          "sequence" : 1231665274
+          "sequence" : 888491354
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "8cpoEoxHSpaGr02qX4Y",
-            "country" : "UgZL5ev9t5F4J3J"
+            "label" : "WYLFtAadut8eW6L",
+            "country" : "sZZWTBZYzryQVLU"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2013-01-30T13:05:09.101Z",
-            "to" : "2017-08-04T04:33:00.514Z"
+            "from" : "1984-07-31T02:14:52.006Z",
+            "to" : "2020-01-06T08:41:16.829Z"
           },
-          "sequence" : 1043163048
+          "sequence" : 610369247
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6038eaaa-3bd4-41e6-b16f-3615709863a4",
-    "abstract" : "sZdbjFtRAu6RaReV"
+    "metadataSource" : "https://www.example.org/db27be2c-b5e5-43fc-b535-c8b73c018725",
+    "abstract" : "uTJNPY2RPbwQQHC71Q"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f84f1a1f-ecf7-4377-9599-41e4b416ad09",
-    "name" : "f2G9jdOpd9UbuI5KhkL",
+    "id" : "https://www.example.org/eef8e7c8-962e-435a-9c4a-38e3ca2862a0",
+    "name" : "yxZd1Iat8oysOutL8tC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-11-20T23:07:04.956Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "rG5CQG6Cd1LBIkgb"
+      "approvalDate" : "2000-07-26T20:45:02.652Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "zcnjvB99Nca441H2u"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/78a7649d-0356-45f6-a299-3b97c645ed0e",
-    "identifier" : "P2LdrCHUGZ5k39nnO4e",
+    "source" : "https://www.example.org/82c762b2-72eb-48ff-bdb3-6ef65c0a27c2",
+    "identifier" : "sJGASWR6GVYCvPC",
     "labels" : {
-      "hu" : "ZZnWYOz6FolZyelD"
+      "cs" : "Hwl0jWe6wd"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2087208798
+      "amount" : 1205171284
     },
-    "activeFrom" : "2019-11-28T19:19:35.222Z",
-    "activeTo" : "2020-04-24T12:52:09.642Z"
+    "activeFrom" : "2022-12-10T12:31:42.708Z",
+    "activeTo" : "2023-01-09T11:53:02.414Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1c589a40-1813-4add-8bdf-bf305981e0ac",
-    "id" : "https://www.example.org/e97efc1b-ccd4-4877-8c32-a1ee7e3b4b32",
-    "identifier" : "iWCSdkLYIptc7TWrOQk",
+    "source" : "https://www.example.org/7719b118-b8e0-45d9-a277-d2f6eba00aad",
+    "id" : "https://www.example.org/2f5fd9f4-6307-4624-804e-df08262ff126",
+    "identifier" : "5G6DnI1ULSin4RWdzI",
     "labels" : {
-      "zh" : "I3SJTYo3sV5S"
+      "el" : "3cBZU8hTlV8n2w6RR4"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 455538920
+      "currency" : "GBP",
+      "amount" : 810633969
     },
-    "activeFrom" : "1999-08-06T14:13:55.376Z",
-    "activeTo" : "2010-06-16T23:40:03.973Z"
+    "activeFrom" : "2006-05-30T04:21:14.636Z",
+    "activeTo" : "2010-07-11T02:57:06.152Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a473702b-b977-4eaa-80e9-a93911ab7c23" ],
+  "subjects" : [ "https://www.example.org/5875dcae-5aa3-4812-b82d-55fb5ba88a89" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "adad06ae-2a96-488f-a423-47736151b324",
-    "name" : "udwhTf8tmE",
-    "mimeType" : "Vgvqy0ervwnZH8Bj",
-    "size" : 3504925,
-    "license" : "https://www.example.com/rep0pcev18sqidx5r",
+    "identifier" : "8b09174f-f7e6-46f4-9379-14bcee4d02fc",
+    "name" : "lU2TgMnplSrpNUe",
+    "mimeType" : "aKQahGoXt3Ed3sGGJ",
+    "size" : 88022626,
+    "license" : "https://www.example.com/cyfvy4adx8rmmgwxz",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QL8B5P7i0Rfh4Gjk98k",
-    "publishedDate" : "1983-06-26T07:50:44.042Z",
+    "legalNote" : "e84Np9OXKjlA",
+    "publishedDate" : "2017-09-28T13:36:41.492Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "XcA6cjJcjYdRvsiFw",
-      "uploadedDate" : "1985-10-22T17:15:27.753Z"
+      "uploadedBy" : "8iMUYPELUVWoOVtRr4Z",
+      "uploadedDate" : "1985-03-13T09:24:22.189Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/vrUeVUVu3QJCNMG2w",
-    "name" : "qX1K4gsP0LEp7v",
-    "description" : "vsz3uui96mBkcj"
+    "id" : "https://www.example.com/nCmPFjCPdW84IfAS",
+    "name" : "ndJi9Dvp1UBzsO",
+    "description" : "PFu2cC7dGWP2"
   } ],
-  "rightsHolder" : "IUWp32nnuFsY8I",
-  "duplicateOf" : "https://www.example.org/70bfeaf2-5935-431e-81c6-233553578951",
+  "rightsHolder" : "DZfBXOi8kAj",
+  "duplicateOf" : "https://www.example.org/76117233-e934-4a39-82f2-62def41c90b5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "NxD91MWgZuDXLl46fe"
+    "note" : "SaJ7F97dxgbeIRtF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GXIAvpjQDC4A",
-    "createdBy" : "mR74F3ObgZmcTaCT",
-    "createdDate" : "2009-04-02T04:32:46.611Z"
+    "note" : "VvVgQN1sFTmbBS",
+    "createdBy" : "zFpuUzxgicErfaf",
+    "createdDate" : "1983-04-22T14:32:29.927Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1d8d3788-a301-499a-9405-bc39334d605e" ],
+  "curatingInstitutions" : [ "https://www.example.org/9bfefc97-efd7-4c7c-8355-c70f7010cbb1" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "H2e3tGKTpQZ",
-    "ownerAffiliation" : "https://www.example.org/86fb17bb-3ff3-466b-b71b-739ba71e2217"
+    "owner" : "XhlkmHLZKxoxBAidiY2",
+    "ownerAffiliation" : "https://www.example.org/77bd2e24-73e1-496d-baa9-48952492a176"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8c206795-cf9e-4f0d-ab74-04965336c934"
+    "id" : "https://www.example.org/928f7691-7a74-4639-9ba4-8b4fe826cb5f"
   },
-  "createdDate" : "2010-12-12T16:47:38.151Z",
-  "modifiedDate" : "1992-05-16T23:56:06.926Z",
-  "publishedDate" : "1977-03-03T13:15:40.404Z",
-  "indexedDate" : "2018-11-20T08:09:53.201Z",
-  "handle" : "https://www.example.org/885c1964-3755-45b6-967e-0e2a670a5cf9",
+  "createdDate" : "2019-12-23T07:46:21.604Z",
+  "modifiedDate" : "1987-05-07T08:38:19.318Z",
+  "publishedDate" : "2021-01-09T21:09:59.372Z",
+  "indexedDate" : "1998-12-12T09:40:45.367Z",
+  "handle" : "https://www.example.org/f6b8599a-9779-40df-bcf8-5c219b852cd9",
   "doi" : "https://doi.org/10.1234/animi",
-  "link" : "https://www.example.org/ee07a254-d931-4450-b3f0-5575d9a87829",
+  "link" : "https://www.example.org/4e9c3f3e-2612-40bc-923a-5053d9364b53",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IBXR0hW7UyA",
+    "mainTitle" : "6OOFn7JuOsEgxAoXAd",
     "alternativeTitles" : {
-      "fr" : "66MgvhBqz8aKs"
+      "el" : "fl8hn1itPHd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iL0QF3iLbElWv",
-      "month" : "W5hhNYm4HALZDZ1tke",
-      "day" : "vsc3JNZ97ge"
+      "year" : "1zuIhnzZro9LfgikbD",
+      "month" : "cQX3z5zpg0OgeDyn98",
+      "day" : "DhqCmRjWnosbPmJY"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d4f5987a-2747-4381-962e-19ff1d39b027",
-        "name" : "vmkYvvMwja0elu",
+        "id" : "https://www.example.org/c1080e34-adc1-444f-93c8-8675070fa84c",
+        "name" : "QOnTlLviwcmhXC1HXG",
         "nameType" : "Organizational",
-        "orcId" : "3OiB8xF4S6",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "CCn9Gs2CHCbqq2K2bn",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WEIyoJXYDSB",
-          "value" : "nxGNTwcdf4NDS1zJHq8"
+          "sourceName" : "pQU0Pt4dMb4Et",
+          "value" : "Gh7sKeeytyMzZPZy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "P3Ysk2SKn4YqtVFj",
-          "value" : "K6XqptNcYdGdtP"
+          "sourceName" : "95MiylUSbGQdc",
+          "value" : "4NRo0N85p7ugFwNVFc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7ce9d58f-6a10-4402-8436-a6a2157bc8e2"
+        "id" : "https://www.example.org/eddb8c54-1b43-4e6f-8f27-676c2063d758"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "LightDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,169 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b24d07c5-1b94-4cd4-b076-af7af58491cb",
-        "name" : "PuI35CWXd2",
+        "id" : "https://www.example.org/40e22fbc-bf64-41c2-ae72-d9dc44227a12",
+        "name" : "a79dqdhyf5mTi1HwJ",
         "nameType" : "Personal",
-        "orcId" : "lchPzvGz6G2FLbI9Ez6",
+        "orcId" : "NfpvRDVY55PUi",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nYSiTdSWgVpxGhD",
-          "value" : "AdpT6SNDsVKbB"
+          "sourceName" : "UFcSMpXIOL7dag6sGh",
+          "value" : "iF4qcXGVbf9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6C2RO1bcMdcccWmb8h7",
-          "value" : "UvMiqCllPUlDQUB5"
+          "sourceName" : "oodzc5fXWm",
+          "value" : "Schwa1nWbjWRrO6cSM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6f27c4fe-ec36-4013-9219-d4542fc4c8f0"
+        "id" : "https://www.example.org/97c89337-2fd7-4492-8ee0-909e0825c0fe"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Composer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "Ak4J0gPIcoNy"
+      "hu" : "DOYHgLmR47f0jxjt"
     },
-    "npiSubjectHeading" : "0AMfRyV8jWCkSYXti2n",
-    "tags" : [ "cVJN4SPsnsMksIz" ],
-    "description" : "lpqHGOLYw4ZsKzlck",
+    "npiSubjectHeading" : "Ft072lEHsW4GxBYQlj6",
+    "tags" : [ "jhmuOBqMZfFHM0A" ],
+    "description" : "RrAFOCgkmn79s",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/84ec9c3b-fe74-41f4-8292-9849cc99fde1",
+      "doi" : "https://www.example.org/8d5be61f-1849-4826-802b-5aeb04dc7285",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ProductDesign"
+          "type" : "ClothingDesign"
         },
-        "description" : "WeD7e40cIagw5Cyg4V",
+        "description" : "G9R80v3xVOVsyTcasU",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "JT1nwOIjoq7uxvB4E",
-            "country" : "wZ3Tvtg2medy"
+            "label" : "jAd1YivTMTATnyTSX",
+            "country" : "LupfR1rG0767QY769j"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1977-07-17T04:59:08.327Z",
-            "to" : "1999-01-07T19:03:00.385Z"
+            "from" : "2008-12-30T09:31:50.439Z",
+            "to" : "2024-02-01T09:39:59.939Z"
           },
-          "sequence" : 22709631
+          "sequence" : 1231665274
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "GaQwRzPmJScZ",
-            "country" : "fCMQoVGcGCImKDd"
+            "label" : "8cpoEoxHSpaGr02qX4Y",
+            "country" : "UgZL5ev9t5F4J3J"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1976-03-11T18:39:05.251Z",
-            "to" : "1995-07-06T02:57:24.149Z"
+            "from" : "2013-01-30T13:05:09.101Z",
+            "to" : "2017-08-04T04:33:00.514Z"
           },
-          "sequence" : 243559284
+          "sequence" : 1043163048
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b759a072-050f-4a9b-9212-eefc4417ead2",
-    "abstract" : "JdxD0SGd8l"
+    "metadataSource" : "https://www.example.org/6038eaaa-3bd4-41e6-b16f-3615709863a4",
+    "abstract" : "sZdbjFtRAu6RaReV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/89478cfd-445c-4bc1-bfd3-1176781a0da9",
-    "name" : "lTATUatDbr4rvKQP",
+    "id" : "https://www.example.org/f84f1a1f-ecf7-4377-9599-41e4b416ad09",
+    "name" : "f2G9jdOpd9UbuI5KhkL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-12-06T21:40:52.017Z",
+      "approvalDate" : "2011-11-20T23:07:04.956Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "JyJakeLwsNtVBg"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "rG5CQG6Cd1LBIkgb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/515a1c38-c3ec-4ea4-8daa-f5033e86f397",
-    "identifier" : "IYqrLLaRoV41Y1tSaD",
+    "source" : "https://www.example.org/78a7649d-0356-45f6-a299-3b97c645ed0e",
+    "identifier" : "P2LdrCHUGZ5k39nnO4e",
     "labels" : {
-      "is" : "xqP2bVLXJkCix5t5Fz"
+      "hu" : "ZZnWYOz6FolZyelD"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 440869655
+      "currency" : "EUR",
+      "amount" : 2087208798
     },
-    "activeFrom" : "1989-12-09T14:34:17.707Z",
-    "activeTo" : "2019-03-17T15:18:51.698Z"
+    "activeFrom" : "2019-11-28T19:19:35.222Z",
+    "activeTo" : "2020-04-24T12:52:09.642Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/63dbbbfe-54e2-4a74-97f5-5955df48c505",
-    "id" : "https://www.example.org/1062b372-9336-4e95-a8de-831194c44641",
-    "identifier" : "wTnUxTtSLFHUxI",
+    "source" : "https://www.example.org/1c589a40-1813-4add-8bdf-bf305981e0ac",
+    "id" : "https://www.example.org/e97efc1b-ccd4-4877-8c32-a1ee7e3b4b32",
+    "identifier" : "iWCSdkLYIptc7TWrOQk",
     "labels" : {
-      "pl" : "Tzv79gWNQYjuhTLw03i"
+      "zh" : "I3SJTYo3sV5S"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2116901867
+      "amount" : 455538920
     },
-    "activeFrom" : "1977-12-28T02:20:46.913Z",
-    "activeTo" : "2000-02-17T05:22:30.293Z"
+    "activeFrom" : "1999-08-06T14:13:55.376Z",
+    "activeTo" : "2010-06-16T23:40:03.973Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dd3486a1-323c-4459-85c2-d5cfd31c6abb" ],
+  "subjects" : [ "https://www.example.org/a473702b-b977-4eaa-80e9-a93911ab7c23" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "59753438-c1e4-4e0a-b8b8-a99c36379f53",
-    "name" : "V8HzjXRFaUhzs",
-    "mimeType" : "h297EaGpBu35tKe6gMc",
-    "size" : 1311151562,
-    "license" : "https://www.example.com/c4u44x7jwhbqpkbyg7j",
+    "identifier" : "adad06ae-2a96-488f-a423-47736151b324",
+    "name" : "udwhTf8tmE",
+    "mimeType" : "Vgvqy0ervwnZH8Bj",
+    "size" : 3504925,
+    "license" : "https://www.example.com/rep0pcev18sqidx5r",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "lqx3f00gJ9"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "u9ZrQ8ZgwVpva7",
-    "publishedDate" : "2010-11-28T19:34:58.844Z",
+    "legalNote" : "QL8B5P7i0Rfh4Gjk98k",
+    "publishedDate" : "1983-06-26T07:50:44.042Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "nTU9ZQnHaA",
-      "uploadedDate" : "2000-05-30T14:33:23.522Z"
+      "uploadedBy" : "XcA6cjJcjYdRvsiFw",
+      "uploadedDate" : "1985-10-22T17:15:27.753Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gVUg1zxEk3OkHz",
-    "name" : "KI2ltreuX03LB",
-    "description" : "EI6KgJvPYObPMbs"
+    "id" : "https://www.example.com/vrUeVUVu3QJCNMG2w",
+    "name" : "qX1K4gsP0LEp7v",
+    "description" : "vsz3uui96mBkcj"
   } ],
-  "rightsHolder" : "BR3EzUix9hMxt49JPi",
-  "duplicateOf" : "https://www.example.org/7233dd10-bf4b-471e-bc48-8c8e18e62c31",
+  "rightsHolder" : "IUWp32nnuFsY8I",
+  "duplicateOf" : "https://www.example.org/70bfeaf2-5935-431e-81c6-233553578951",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7tFZlbl0rniw1zxn4k"
+    "note" : "NxD91MWgZuDXLl46fe"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hGv4A3qtMhaiXpKGxzo",
-    "createdBy" : "ojmg3atM3vl7JDH",
-    "createdDate" : "1999-05-19T09:39:56.197Z"
+    "note" : "GXIAvpjQDC4A",
+    "createdBy" : "mR74F3ObgZmcTaCT",
+    "createdDate" : "2009-04-02T04:32:46.611Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2ee43e62-d870-454f-a11e-e14205374205" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/1d8d3788-a301-499a-9405-bc39334d605e" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "sB2oReiMo6p6K9bR",
-    "ownerAffiliation" : "https://www.example.org/ab8f48ee-3c51-4d5a-9f1b-6ddffac62bef"
+    "owner" : "YCss5CQCvqL",
+    "ownerAffiliation" : "https://www.example.org/0ce4abd8-a4d6-4d8b-a7c3-1c479a7c10cc"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/65c5ab8c-d11e-48d5-8b52-7dd5aa7c17a8"
+    "id" : "https://www.example.org/a3c2f19a-2e51-427a-87df-332a5ba4dded"
   },
-  "createdDate" : "2018-01-05T17:00:28.002Z",
-  "modifiedDate" : "1984-06-11T22:42:58.845Z",
-  "publishedDate" : "1993-08-13T15:33:50.763Z",
-  "indexedDate" : "1995-03-15T07:45:28.732Z",
-  "handle" : "https://www.example.org/ebe36b0f-2b5e-4fa1-9f7c-f5c6ba2929a5",
-  "doi" : "https://doi.org/10.1234/sunt",
-  "link" : "https://www.example.org/206d1f76-121d-409c-ad0c-64fc1957f6c9",
+  "createdDate" : "2010-10-03T06:51:33.986Z",
+  "modifiedDate" : "2005-02-28T18:48:00.142Z",
+  "publishedDate" : "2018-01-11T23:55:59.386Z",
+  "indexedDate" : "2016-02-01T21:34:29.461Z",
+  "handle" : "https://www.example.org/9c445122-4af6-4409-93a1-e8b967633b6a",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/32dc0368-8088-4bfa-a11b-1b5adaa82784",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "qm6spH6WzuWu",
+    "mainTitle" : "L2uZ1xDyODmt3Wim9Z",
     "alternativeTitles" : {
-      "ru" : "bOjCg8A9B833C"
+      "ru" : "G0lVWNIuYcYSOEG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qXq3fMxGfDxJdPE",
-      "month" : "3iiDozrZL7feC",
-      "day" : "TYlzIH8lgfuC0ov"
+      "year" : "Mz6egvfNOX9PcgysyR",
+      "month" : "5JIWuK1NS0TuObkYsEU",
+      "day" : "b97dCtCcujdF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5371f30b-de77-45ca-86b5-108e7a349567",
-        "name" : "Fo5NUpUPHpa5vR",
+        "id" : "https://www.example.org/f7222a04-9ed6-4d86-ba0a-8d192c4549d3",
+        "name" : "691UFTGLDZNQ2uh",
         "nameType" : "Personal",
-        "orcId" : "PUsG0Fbh4JHYhNi",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "VKHHQ10S7ia1HbD3Y",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mDam6VD4lD",
-          "value" : "93tq3LfNGsle1DNwps"
+          "sourceName" : "UynmsG84AlJHn",
+          "value" : "Jn9OfRSQWGtFUPZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qDGvkQ3Rfhqw4",
-          "value" : "MkZ4b43NmqMkN"
+          "sourceName" : "Hz4TBRK3xInKxi",
+          "value" : "QBCLsCzZb9IijtbW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a4b887ed-228f-466b-982a-7129ed6360dc"
+        "id" : "https://www.example.org/1c287d91-c0ea-4615-8eaa-073a23f13b44"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4008a8f4-043c-457b-822a-e230b8227dbd",
-        "name" : "5Pv5h6Eq8VGgKhsm",
-        "nameType" : "Organizational",
-        "orcId" : "D8WTEvX6tU0bik",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2a989fb3-cd92-4b63-b9f2-2b0a9321fea3",
+        "name" : "D25vThehOa",
+        "nameType" : "Personal",
+        "orcId" : "IgmviVAT1y1H",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Q1v4YhyMWXxzHLct",
-          "value" : "2P3ilbhWVYU0x48rV"
+          "sourceName" : "8x2Qg8mDfruE3fjZwO",
+          "value" : "cCtLlMZ4UrW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "E1WJLTeNpIL",
-          "value" : "FPCSQACOeVjqEwUR1"
+          "sourceName" : "DAPiE6doAiDUSUfQcoS",
+          "value" : "HD5or2ImPvjVNrwo7T2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1dea9eb4-5a0d-4644-a28f-a5fb1440b788"
+        "id" : "https://www.example.org/87dc401f-82ea-46e6-85b3-ec0aa821cd21"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "RelatedPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "6X6fwOi6sE"
+      "bg" : "jF6OMnvz61CnUcZgFV"
     },
-    "npiSubjectHeading" : "fCFJfYTQRHH3OsP",
-    "tags" : [ "orRmF7cKRzOa3wHLg" ],
-    "description" : "ldeYNz0RyMewSyXqeG",
+    "npiSubjectHeading" : "sUTscxZ8J85Vpa",
+    "tags" : [ "qLzS7QKYqyV" ],
+    "description" : "86YToIHQoZCg9StX0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f7fed1ca-89af-434f-9cf6-e104c3e367aa"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7c0a4c22-f70c-4adf-a7bd-126ec63b81f0"
         },
-        "seriesNumber" : "zUjcR9z3bTF9wX",
+        "seriesNumber" : "T7IR15BqArpgzeNq0X",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f7c1edc6-a3c2-4d30-8b49-e819b4259402",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ec808fd5-b9da-475d-a1b9-002c8d125ec8",
           "valid" : true
         },
-        "isbnList" : [ "9781369426823" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781022998636", "9780724826100" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "BjpaAjJzwPUTImWvrMm"
+          "value" : "0724826106"
         } ]
       },
-      "doi" : "https://www.example.org/00835764-3b33-40db-8cfd-364ad83e3017",
+      "doi" : "https://www.example.org/ff9bf2f4-7fe4-499b-bcfe-323a552afd8a",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "4bYo1F4a5Q",
-            "end" : "EW4xdaUwz22uAJptX"
+            "begin" : "YFwyKw7Pw76KC",
+            "end" : "f8k5ghQMS786sAi"
           },
-          "pages" : "LzI3Py1YoSUdS6A",
-          "illustrated" : true
+          "pages" : "DgoXUULubffB",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b38d0c76-787a-42dc-a2f6-7683a738fb21",
-    "abstract" : "ptTQBPQwB4"
+    "metadataSource" : "https://www.example.org/de8abbca-f315-4631-acff-f8e172081ede",
+    "abstract" : "YvtzQZ091GaOjfQ2V7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5fdb433d-ae2e-4275-8a5f-f502a2da479c",
-    "name" : "LxCPO7a7cXYSIQqG",
+    "id" : "https://www.example.org/18f0c287-e84d-429b-9161-97934e737333",
+    "name" : "aRreRxTijYWn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-05-03T11:21:37.263Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "PtOy2WZ59IHv"
+      "approvalDate" : "1975-02-21T10:24:32.207Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "8XP0yAKpf9Oegc"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1309fb63-8c08-43d8-8577-48b675906a45",
-    "identifier" : "Y55a9HUsAlcrR",
+    "source" : "https://www.example.org/7339fdcc-6209-4c95-9518-4ebba9ad0805",
+    "identifier" : "7fiEcpJ9nDz3W1EB",
     "labels" : {
-      "en" : "R0hpvRFVVkb9XiYha5"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 699574035
-    },
-    "activeFrom" : "2010-05-07T20:10:45.673Z",
-    "activeTo" : "2023-03-03T18:55:32.898Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c45f53fd-e1f0-4801-9d9e-cc06cf6e31c8",
-    "id" : "https://www.example.org/549afb37-8cd8-4dc6-ab8f-21a81cc772e5",
-    "identifier" : "yYzwTF0WKx6uJsKe",
-    "labels" : {
-      "it" : "8jQi4jKJY0YWIt"
+      "nn" : "QfOAJrhO6yuJdoEYK"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2043380988
+      "amount" : 995297708
     },
-    "activeFrom" : "2006-12-24T12:49:22.575Z",
-    "activeTo" : "2023-02-09T17:10:13.717Z"
+    "activeFrom" : "2007-03-27T02:27:26.832Z",
+    "activeTo" : "2018-12-01T21:06:39.348Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/2cfed173-3a9a-42be-8143-cf4f98275d9c",
+    "id" : "https://www.example.org/812a1629-fef5-468a-ad79-67a2d6c3c4f2",
+    "identifier" : "Dd52as8NPSkg9N",
+    "labels" : {
+      "se" : "4lQ6BNneGOV6GneE0D"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1422444915
+    },
+    "activeFrom" : "1995-05-31T18:11:29.935Z",
+    "activeTo" : "2016-08-24T02:14:22.365Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f9dfc8d5-ed31-47b8-b0fe-6f943568791e" ],
+  "subjects" : [ "https://www.example.org/c5186150-3cfd-4251-9545-848f535fc040" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fb570f47-6325-4dfe-988a-7af578206157",
-    "name" : "pBQFLeJv41eF7bx",
-    "mimeType" : "F06D2F64dSK",
-    "size" : 940330812,
-    "license" : "https://www.example.com/hwjqffhu7gm",
+    "identifier" : "7ccb95b3-f689-42c5-9a42-25bb32b73cf4",
+    "name" : "2nsTklyFa0",
+    "mimeType" : "pguu0MN934",
+    "size" : 1495079634,
+    "license" : "https://www.example.com/lsnvsnjrzjk",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "0ZWnEsqXXhi52dy4K"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "vYMYykrQlIp",
-    "publishedDate" : "2015-07-20T11:19:44.065Z",
+    "legalNote" : "HoALA1B3Ho7bg",
+    "publishedDate" : "1998-04-16T02:23:59.274Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "UmmiXWy1bmR82P",
-      "uploadedDate" : "1999-12-30T09:40:16.116Z"
+      "uploadedBy" : "dVPtYbhYQwq19",
+      "uploadedDate" : "2004-11-29T07:14:01.640Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Fs7bXqTViu",
-    "name" : "cbtY9lv1UGR",
-    "description" : "nDTN1RxwOO"
+    "id" : "https://www.example.com/Gyf0hHk2Hw1",
+    "name" : "pbvDhSZYBpUOsMCIK1I",
+    "description" : "nn8u3xq7hBvu"
   } ],
-  "rightsHolder" : "gS5A0zpryeb",
-  "duplicateOf" : "https://www.example.org/f1cddb3f-7753-4b61-b04a-7b3518828a51",
+  "rightsHolder" : "IEEIMCJcTlRUT4",
+  "duplicateOf" : "https://www.example.org/3a0371d1-1d35-46af-b709-57d843e85d08",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "X9buuUeUk09ro1jYk4m"
+    "note" : "8sZoWrf0jr0vRfZ3VSO"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2DHidRQ4TmC4Gs",
-    "createdBy" : "uVEX5yQqi4LUx",
-    "createdDate" : "2000-03-05T08:40:31.866Z"
+    "note" : "WdIC60DV2Yt",
+    "createdBy" : "RBf6AbW4nvkz",
+    "createdDate" : "2019-10-05T04:57:25.519Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5aeb6cd0-31c5-4310-9ffe-a84dd8978fba" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/613f45eb-df98-479e-b19f-bce7d86a655e" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "YCss5CQCvqL",
-    "ownerAffiliation" : "https://www.example.org/0ce4abd8-a4d6-4d8b-a7c3-1c479a7c10cc"
+    "owner" : "7xMbg9GoTZ",
+    "ownerAffiliation" : "https://www.example.org/f7392628-5969-4934-98f4-c966a1068a0f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a3c2f19a-2e51-427a-87df-332a5ba4dded"
+    "id" : "https://www.example.org/dd9805b2-c8e5-446a-84e2-d9b464da551a"
   },
-  "createdDate" : "2010-10-03T06:51:33.986Z",
-  "modifiedDate" : "2005-02-28T18:48:00.142Z",
-  "publishedDate" : "2018-01-11T23:55:59.386Z",
-  "indexedDate" : "2016-02-01T21:34:29.461Z",
-  "handle" : "https://www.example.org/9c445122-4af6-4409-93a1-e8b967633b6a",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/32dc0368-8088-4bfa-a11b-1b5adaa82784",
+  "createdDate" : "2006-02-05T21:52:26.946Z",
+  "modifiedDate" : "2021-09-07T05:35:15.690Z",
+  "publishedDate" : "2000-03-29T07:53:27.676Z",
+  "indexedDate" : "1974-10-08T23:24:49.369Z",
+  "handle" : "https://www.example.org/e8ea6d81-5464-42ea-aea7-dbd4dfb1f189",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/8bcd8f90-9051-4263-9e16-005727f11bcf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "L2uZ1xDyODmt3Wim9Z",
+    "mainTitle" : "hzAEM6VMu3kNdYDY",
     "alternativeTitles" : {
-      "ru" : "G0lVWNIuYcYSOEG"
+      "nl" : "eTpcLuHi9s5NP"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Mz6egvfNOX9PcgysyR",
-      "month" : "5JIWuK1NS0TuObkYsEU",
-      "day" : "b97dCtCcujdF"
+      "year" : "HYZ6BjBjHi3x33xw5",
+      "month" : "OsUYWfGR5yVwQ",
+      "day" : "tZLPzwSU1v4v2XC72"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f7222a04-9ed6-4d86-ba0a-8d192c4549d3",
-        "name" : "691UFTGLDZNQ2uh",
-        "nameType" : "Personal",
-        "orcId" : "VKHHQ10S7ia1HbD3Y",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2b70b7fd-6218-4e11-b21f-aac1c0ab301e",
+        "name" : "UujskQRtBr9qDVH3",
+        "nameType" : "Organizational",
+        "orcId" : "FHwezkwRhooNvWe",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UynmsG84AlJHn",
-          "value" : "Jn9OfRSQWGtFUPZ"
+          "sourceName" : "SkIrEHckFiro",
+          "value" : "CT73QWaO5jCKGLZQP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hz4TBRK3xInKxi",
-          "value" : "QBCLsCzZb9IijtbW"
+          "sourceName" : "27fvqtNPeKRVSUBaN",
+          "value" : "ngZwYgCkEUnVRS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1c287d91-c0ea-4615-8eaa-073a23f13b44"
+        "id" : "https://www.example.org/08d092b2-ccdc-495d-859d-fd6ebfdb8810"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2a989fb3-cd92-4b63-b9f2-2b0a9321fea3",
-        "name" : "D25vThehOa",
-        "nameType" : "Personal",
-        "orcId" : "IgmviVAT1y1H",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/00930523-a109-4db6-b955-a11ad05fe240",
+        "name" : "S2cgyJrOnKKB",
+        "nameType" : "Organizational",
+        "orcId" : "6SfSl0XHTISAqY",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8x2Qg8mDfruE3fjZwO",
-          "value" : "cCtLlMZ4UrW"
+          "sourceName" : "rkl6JRSgtz7DI",
+          "value" : "Ywk76ur2AM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DAPiE6doAiDUSUfQcoS",
-          "value" : "HD5or2ImPvjVNrwo7T2"
+          "sourceName" : "E59bDOU9TbTzvBt",
+          "value" : "WKikRf0xUqFPndFN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/87dc401f-82ea-46e6-85b3-ec0aa821cd21"
+        "id" : "https://www.example.org/0a22c199-0255-4dae-aeb4-b083cb3b981a"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "jF6OMnvz61CnUcZgFV"
+      "nl" : "02kGVq8YP1lSIDCy"
     },
-    "npiSubjectHeading" : "sUTscxZ8J85Vpa",
-    "tags" : [ "qLzS7QKYqyV" ],
-    "description" : "86YToIHQoZCg9StX0",
+    "npiSubjectHeading" : "cL6n3ftNhlXon8hG",
+    "tags" : [ "yHfDIcQd45V3t6cRL" ],
+    "description" : "J18MbL15kSNWe3zkN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7c0a4c22-f70c-4adf-a7bd-126ec63b81f0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5769747a-c8bf-4355-9e7f-c8993a7d99dc"
         },
-        "seriesNumber" : "T7IR15BqArpgzeNq0X",
+        "seriesNumber" : "hQto8ze6CmTYRAlcLw",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ec808fd5-b9da-475d-a1b9-002c8d125ec8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bb455852-e2da-4725-8c8a-84c12b754edc",
           "valid" : true
         },
-        "isbnList" : [ "9781022998636", "9780724826100" ],
+        "isbnList" : [ "9791958004905", "9781893563605" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0724826106"
+          "value" : "189356360X"
         } ]
       },
-      "doi" : "https://www.example.org/ff9bf2f4-7fe4-499b-bcfe-323a552afd8a",
+      "doi" : "https://www.example.org/09c6eba0-a7e7-4abb-a712-67f440e34ebd",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "YFwyKw7Pw76KC",
-            "end" : "f8k5ghQMS786sAi"
+            "begin" : "1t8Ceir7yHYB38",
+            "end" : "ldT9WKIi9VguFYAx4"
           },
-          "pages" : "DgoXUULubffB",
+          "pages" : "VIGOAEJVgeN1d6",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/de8abbca-f315-4631-acff-f8e172081ede",
-    "abstract" : "YvtzQZ091GaOjfQ2V7"
+    "metadataSource" : "https://www.example.org/c9b18a56-2d80-4ba6-a1fc-f294d2d29f2c",
+    "abstract" : "utn1MbAEkitxUZCvH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/18f0c287-e84d-429b-9161-97934e737333",
-    "name" : "aRreRxTijYWn",
+    "id" : "https://www.example.org/ebb1233f-e346-489d-b60b-48f9869a80b7",
+    "name" : "YIVM658c2Lbd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-02-21T10:24:32.207Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "8XP0yAKpf9Oegc"
+      "approvalDate" : "2009-10-21T04:52:34.866Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Z2PvqHLFEgLw6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7339fdcc-6209-4c95-9518-4ebba9ad0805",
-    "identifier" : "7fiEcpJ9nDz3W1EB",
+    "source" : "https://www.example.org/1822ccaf-72d6-4850-b095-720c33cdca1b",
+    "identifier" : "5qKmEjuHyJIWH",
     "labels" : {
-      "nn" : "QfOAJrhO6yuJdoEYK"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 995297708
-    },
-    "activeFrom" : "2007-03-27T02:27:26.832Z",
-    "activeTo" : "2018-12-01T21:06:39.348Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2cfed173-3a9a-42be-8143-cf4f98275d9c",
-    "id" : "https://www.example.org/812a1629-fef5-468a-ad79-67a2d6c3c4f2",
-    "identifier" : "Dd52as8NPSkg9N",
-    "labels" : {
-      "se" : "4lQ6BNneGOV6GneE0D"
+      "fi" : "etufPi7gsOSpt0LM"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1422444915
+      "amount" : 1774927517
     },
-    "activeFrom" : "1995-05-31T18:11:29.935Z",
-    "activeTo" : "2016-08-24T02:14:22.365Z"
+    "activeFrom" : "2007-04-07T03:50:37.998Z",
+    "activeTo" : "2016-04-12T06:52:20.884Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/1c79b381-0d4e-4b94-9353-8c48f80b383a",
+    "id" : "https://www.example.org/6a6da23a-0180-42e2-9c48-36530b13546e",
+    "identifier" : "lbVGHGGyxgMQzsQ",
+    "labels" : {
+      "pt" : "jfKB23STwhI5pb"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 29198792
+    },
+    "activeFrom" : "1997-05-27T22:22:45.912Z",
+    "activeTo" : "2014-10-31T08:52:37.412Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c5186150-3cfd-4251-9545-848f535fc040" ],
+  "subjects" : [ "https://www.example.org/1c1673b3-959e-4c7b-ba06-ec17170d4db0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7ccb95b3-f689-42c5-9a42-25bb32b73cf4",
-    "name" : "2nsTklyFa0",
-    "mimeType" : "pguu0MN934",
-    "size" : 1495079634,
-    "license" : "https://www.example.com/lsnvsnjrzjk",
+    "identifier" : "c79227a7-d074-4bd0-9d4e-0fd6f5b427b8",
+    "name" : "wTITMPoQXxuJ",
+    "mimeType" : "kWpWGMIKUOnbbzN",
+    "size" : 1644783597,
+    "license" : "https://www.example.com/mbx4aaqcce4",
     "administrativeAgreement" : false,
     "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "HoALA1B3Ho7bg",
-    "publishedDate" : "1998-04-16T02:23:59.274Z",
+    "legalNote" : "weelgJvMKojx",
+    "publishedDate" : "1999-10-17T06:56:08.511Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dVPtYbhYQwq19",
-      "uploadedDate" : "2004-11-29T07:14:01.640Z"
+      "uploadedBy" : "QBkfnawuvaKYI",
+      "uploadedDate" : "2008-08-28T18:28:25.678Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Gyf0hHk2Hw1",
-    "name" : "pbvDhSZYBpUOsMCIK1I",
-    "description" : "nn8u3xq7hBvu"
+    "id" : "https://www.example.com/VD8ZLDWfewA0pQlB9Ml",
+    "name" : "F7A5FapUFC",
+    "description" : "FYo0OKLujSLcXXChGHR"
   } ],
-  "rightsHolder" : "IEEIMCJcTlRUT4",
-  "duplicateOf" : "https://www.example.org/3a0371d1-1d35-46af-b709-57d843e85d08",
+  "rightsHolder" : "f4KnjtwMJZwZ",
+  "duplicateOf" : "https://www.example.org/38408b9b-0161-4138-bd99-e59380e78be9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "8sZoWrf0jr0vRfZ3VSO"
+    "note" : "Yb726WKg2wUMdznk"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WdIC60DV2Yt",
-    "createdBy" : "RBf6AbW4nvkz",
-    "createdDate" : "2019-10-05T04:57:25.519Z"
+    "note" : "wHTqLjq2mbw9",
+    "createdBy" : "nexPmdTL1kmTf7A",
+    "createdDate" : "2020-05-29T15:23:03.620Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/613f45eb-df98-479e-b19f-bce7d86a655e" ],
+  "curatingInstitutions" : [ "https://www.example.org/93ab49de-b305-43ce-93ac-7dff3a715d2f" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "PbKDmHSK3hSx",
-    "ownerAffiliation" : "https://www.example.org/b1f44452-e279-4909-bee4-3755f001977c"
+    "owner" : "jK8iaHXWcE9MkJPVi",
+    "ownerAffiliation" : "https://www.example.org/d6116dcd-4eeb-4ae8-b2d5-609235541d42"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c00c2123-bc5f-41f6-8570-c59d4aefc637"
+    "id" : "https://www.example.org/d2bac3a4-47e3-4cdc-82bd-6e6a60a2cf33"
   },
-  "createdDate" : "2020-03-30T15:22:51.637Z",
-  "modifiedDate" : "1977-11-30T21:11:32.111Z",
-  "publishedDate" : "1978-09-23T19:34:20.898Z",
-  "indexedDate" : "2023-02-13T16:59:12.086Z",
-  "handle" : "https://www.example.org/a5b40df6-2549-48e2-aba4-c689ac288183",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/f6d19f29-206b-4f52-be39-8f54a4ec3c20",
+  "createdDate" : "2003-09-15T06:13:12.153Z",
+  "modifiedDate" : "2007-01-05T16:42:19.276Z",
+  "publishedDate" : "1972-08-01T04:31:11.821Z",
+  "indexedDate" : "2018-11-24T21:16:50.513Z",
+  "handle" : "https://www.example.org/9ef89e56-d904-4e66-80ac-be370bdf4a5c",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/27d8e9df-d039-4e47-8f51-7c8d8514b6a1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Xa0k50VLhg",
+    "mainTitle" : "wubv8uQQqHPUc2F",
     "alternativeTitles" : {
-      "fi" : "W8MqdCK9IxrdN"
+      "el" : "tjBCSAnZvs5TMOY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Af1S3NrjdZhWQrHuY",
-      "month" : "h5s8OG79rVAEa3",
-      "day" : "me2wTY3ShoVj9WjVj"
+      "year" : "RUNBQwoxxIIN474DN",
+      "month" : "Bjc7t8mAWj83cKzJ",
+      "day" : "B1kvaMIxDkWuKj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8561985d-6e3f-4f8a-ade2-bccb7b8351e5",
-        "name" : "gnsPnSU7KGl9EfdliM",
+        "id" : "https://www.example.org/7eedece3-8d08-442a-be21-7b81c3739756",
+        "name" : "gpWKE9gusbL63",
         "nameType" : "Personal",
-        "orcId" : "xVygWSeEk7MzSL7oH",
-        "verificationStatus" : "Verified",
+        "orcId" : "uTDqShLsT0jS",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MalLRR6DnU",
-          "value" : "GfNKtkev0H45G2p0A"
+          "sourceName" : "rM5yaw6tTLLBq",
+          "value" : "7Tc7r6iaTf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2aInfPz8CLWVN",
-          "value" : "vHH9xQiqS1Vrb"
+          "sourceName" : "TfQRbZcqZ0tGUaQ",
+          "value" : "2JodHBY6a8ddfKlG6ds"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/98d7aa62-f26c-47e0-a696-79e1ffaf6ce8"
+        "id" : "https://www.example.org/0d66be25-2803-4396-928d-10b055f2a68f"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/602304fe-7f61-409f-b127-206fa8674727",
-        "name" : "GADTVtX4y2Z8",
-        "nameType" : "Personal",
-        "orcId" : "vKxge0uZFqNwk",
+        "id" : "https://www.example.org/71c0478a-ed05-45d9-9e37-2a7e494a2ac3",
+        "name" : "O4Wdny5o8IcfbkeZLmB",
+        "nameType" : "Organizational",
+        "orcId" : "xXGQio3mXUyFY",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nM8Z65AjaEKk450wrs",
-          "value" : "AwcUp4Mp1zigR"
+          "sourceName" : "MbqlFFG77ztHV",
+          "value" : "ML8TYTWod2J"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xpl0Y8xDiRKO",
-          "value" : "sXAgp2cJkJ13eZ7"
+          "sourceName" : "g4jYsXwQ0380StIWk",
+          "value" : "D5gA8yKRwtC1DW7Ct"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/73ced124-53cd-4d24-9215-42e8af23cd65"
+        "id" : "https://www.example.org/a7597f50-794f-4d7a-bbf5-f486754076fe"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "bIDmloePYhWXItl1fO"
+      "sv" : "vQzdI6pYhpME"
     },
-    "npiSubjectHeading" : "d6eQDtCXO8",
-    "tags" : [ "0Jz1J5v4AHiDhI" ],
-    "description" : "pKhMECGlziz4j",
+    "npiSubjectHeading" : "d60APRrOmALQLbH",
+    "tags" : [ "I8kgSjbloa" ],
+    "description" : "vm0uyf0zRYw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f9fac4ce-4627-41dc-b20a-e25beee47e13"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f3834528-51e9-4008-938a-d1e3b2c3b87d"
       },
-      "doi" : "https://www.example.org/c5ee8ad5-6359-4f7b-8c79-beb6b4bd4791",
+      "doi" : "https://www.example.org/84f8ace2-5159-4f38-853a-777b3942e885",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "VyGrxkwi48newXiN",
-          "end" : "rSUygYjDHz"
+          "begin" : "sgFdYtwknJLKY",
+          "end" : "MUP9EdCbdKF"
         },
-        "volume" : "uJF0LEdzdn6",
-        "issue" : "jqmhZXmdx1GWQdRuend",
-        "articleNumber" : "62pi5q6AVOSkNw"
+        "volume" : "Q1VSnqDhbtbl7d",
+        "issue" : "kCyLUeAaNJcod2T",
+        "articleNumber" : "bsStqDZTPZFnR"
       }
     },
-    "metadataSource" : "https://www.example.org/5aed4868-b7a2-4bce-9679-a9196a5b5671",
-    "abstract" : "EolNW9gSzB7oK49YUqD"
+    "metadataSource" : "https://www.example.org/309200ad-878d-4a16-85d2-f990ca41333e",
+    "abstract" : "9glWcz7pM8g896o"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0822d64c-f90a-4d71-9317-9090612792ad",
-    "name" : "YItMY6vHOaV",
+    "id" : "https://www.example.org/bbc866df-f50f-4581-be2b-eabc94185aac",
+    "name" : "zuYnZucaXfl7Ukw",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-11-04T23:15:24.710Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "dnWARlZwB7uFDIts"
+      "approvalDate" : "2018-07-29T23:27:49.389Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "IX7MN190FypLcB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5b06f9fe-b6cc-49f8-a60b-2705250bed15",
-    "identifier" : "tdMe2GhbsxaHsNUSPfS",
+    "source" : "https://www.example.org/a208b566-95d6-4188-9a3b-69d829c15f66",
+    "identifier" : "RnuFBgUV1DBpe",
     "labels" : {
-      "sv" : "tFyPxW2NsGKzlci5fG"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1078409611
-    },
-    "activeFrom" : "1984-09-12T18:15:51.984Z",
-    "activeTo" : "2009-04-14T08:07:49.479Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/63f7bc1b-dc60-4ce5-a309-abe139810006",
-    "id" : "https://www.example.org/046b5d5a-34e5-43d9-a5f1-8d249d07c7b9",
-    "identifier" : "8FaKMNZLCQ3ne",
-    "labels" : {
-      "is" : "i5uABIiYJL29BWUDF"
+      "pt" : "fCmDLieFn1Aroa8FDWh"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1614283582
+      "amount" : 807480057
     },
-    "activeFrom" : "1976-09-19T21:40:48.244Z",
-    "activeTo" : "2016-12-04T16:24:50.418Z"
+    "activeFrom" : "1993-06-03T20:51:11.144Z",
+    "activeTo" : "2002-02-19T17:20:34.386Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/83ed2de6-6cec-45bb-9953-cb2ae833a714",
+    "id" : "https://www.example.org/73ec953b-341c-4c35-9318-452cf37eb7ff",
+    "identifier" : "nfMsUrOmQxzi",
+    "labels" : {
+      "fr" : "mFiOQHtumNLLkeDXTR6"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 421395064
+    },
+    "activeFrom" : "1995-01-29T16:18:58.763Z",
+    "activeTo" : "2005-08-06T11:42:16.433Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c0b3da17-c89b-43b4-b6bd-3710ea637988" ],
+  "subjects" : [ "https://www.example.org/fe6d8817-5520-4be6-9099-11eb3598b030" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7eea76b5-58e6-4990-aaad-93e31ff2e71b",
-    "name" : "oeq7DFBobHW8nho",
-    "mimeType" : "fmTHy4vHda0cBEw",
-    "size" : 271303583,
-    "license" : "https://www.example.com/zh1onqte9nrbx7ykoml",
+    "identifier" : "fd21d037-88f2-4039-b3c2-069e59b88e42",
+    "name" : "SZzyGskkPsy",
+    "mimeType" : "KegUwjnphm",
+    "size" : 11674911,
+    "license" : "https://www.example.com/gj9zgrssyz",
     "administrativeAgreement" : false,
-    "publisherVersion" : "UpdatedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "y7LtLwknd0KGCgrda"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "kQHrRsCWIk",
-    "publishedDate" : "2020-08-24T15:04:39.931Z",
+    "legalNote" : "aDjHWeSBn16NTxL",
+    "publishedDate" : "1972-06-18T13:55:12.435Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uOT749ECuHVt9",
-      "uploadedDate" : "2000-03-15T17:22:53.390Z"
+      "uploadedBy" : "FFRiAVRGr4Ip",
+      "uploadedDate" : "2024-01-15T06:18:04.824Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PVMGFAKOcFg5mwVf",
-    "name" : "g9qtjolebkzP43",
-    "description" : "7L79Eum8HbQQfdOwP"
+    "id" : "https://www.example.com/ynrWGMBvFm",
+    "name" : "DcfX1nQC5YEgd",
+    "description" : "41F3R1U7TVUxXxlZf"
   } ],
-  "rightsHolder" : "1H7cIFdyiZ2m",
-  "duplicateOf" : "https://www.example.org/dd518824-c2ca-476e-8e77-6d14e638d9ab",
+  "rightsHolder" : "c8osVmyiuDNnvWu",
+  "duplicateOf" : "https://www.example.org/53176c7a-1411-4987-b19a-a88bd6d2e3be",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xZDrpajUmKx8T"
+    "note" : "D4pQeiGaE6qc1K0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xdtS7yuaa4biYObz5",
-    "createdBy" : "pwIXmmJx1cJEVOA",
-    "createdDate" : "2019-08-13T03:45:40.451Z"
+    "note" : "QL1s9kTYVm",
+    "createdBy" : "sttJ9AU25oVXVAB6xe",
+    "createdDate" : "1982-01-05T00:20:59.785Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b4bedc1a-883e-49ee-a1b2-f66105d6e224" ],
+  "curatingInstitutions" : [ "https://www.example.org/27e559f3-ad7d-4ed2-86da-87d434617562" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "t1ygrOv04Vm0DOcYF",
-    "ownerAffiliation" : "https://www.example.org/11ed466b-213e-49a7-9ea1-73d930d51a44"
+    "owner" : "PbKDmHSK3hSx",
+    "ownerAffiliation" : "https://www.example.org/b1f44452-e279-4909-bee4-3755f001977c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/02108cdc-91de-4f3d-8285-854e7392481d"
+    "id" : "https://www.example.org/c00c2123-bc5f-41f6-8570-c59d4aefc637"
   },
-  "createdDate" : "1989-03-06T18:25:56.046Z",
-  "modifiedDate" : "1975-03-30T14:45:40.187Z",
-  "publishedDate" : "2009-06-10T23:06:52.869Z",
-  "indexedDate" : "1996-05-13T01:32:23.388Z",
-  "handle" : "https://www.example.org/9c569a8d-403d-4974-b3e7-d20bced718a8",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/b852a677-01f1-44cc-b0d0-cf19ae76de73",
+  "createdDate" : "2020-03-30T15:22:51.637Z",
+  "modifiedDate" : "1977-11-30T21:11:32.111Z",
+  "publishedDate" : "1978-09-23T19:34:20.898Z",
+  "indexedDate" : "2023-02-13T16:59:12.086Z",
+  "handle" : "https://www.example.org/a5b40df6-2549-48e2-aba4-c689ac288183",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/f6d19f29-206b-4f52-be39-8f54a4ec3c20",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "R3QF1sRQ5azIkXAzp",
+    "mainTitle" : "Xa0k50VLhg",
     "alternativeTitles" : {
-      "it" : "8qHwMz63eDqc2FUoHX"
+      "fi" : "W8MqdCK9IxrdN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "D8Qi2237asJN237Io",
-      "month" : "ah16JTV3eu",
-      "day" : "E1eW8bn5En4M"
+      "year" : "Af1S3NrjdZhWQrHuY",
+      "month" : "h5s8OG79rVAEa3",
+      "day" : "me2wTY3ShoVj9WjVj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/16c66ee6-0558-4ccd-a9dd-b35acc4462c9",
-        "name" : "9NYt2XhO9K",
-        "nameType" : "Organizational",
-        "orcId" : "hAd1NrxpOUvzCFyN9K",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/8561985d-6e3f-4f8a-ade2-bccb7b8351e5",
+        "name" : "gnsPnSU7KGl9EfdliM",
+        "nameType" : "Personal",
+        "orcId" : "xVygWSeEk7MzSL7oH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VNeITXKTTOaQQQFdg",
-          "value" : "Y2KjAyjq0nyaNh"
+          "sourceName" : "MalLRR6DnU",
+          "value" : "GfNKtkev0H45G2p0A"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4ZMulc76lWdPF8X5c4Y",
-          "value" : "Gr4NRLSD7fay"
+          "sourceName" : "2aInfPz8CLWVN",
+          "value" : "vHH9xQiqS1Vrb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/31edf155-7247-4065-8a44-09c46fae96ec"
+        "id" : "https://www.example.org/98d7aa62-f26c-47e0-a696-79e1ffaf6ce8"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b467e58b-5cd3-44d2-9faf-7a51c1270c78",
-        "name" : "9nL97TgcpM8ISWqLI",
+        "id" : "https://www.example.org/602304fe-7f61-409f-b127-206fa8674727",
+        "name" : "GADTVtX4y2Z8",
         "nameType" : "Personal",
-        "orcId" : "PxTKWUOXlsJ1pIO",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "vKxge0uZFqNwk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ohobND7kkQ",
-          "value" : "TZTIrRmu2Tv4Fl"
+          "sourceName" : "nM8Z65AjaEKk450wrs",
+          "value" : "AwcUp4Mp1zigR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qkmU4eL7Om1wwMf9Nx",
-          "value" : "x995flFwyuSvuOv"
+          "sourceName" : "xpl0Y8xDiRKO",
+          "value" : "sXAgp2cJkJ13eZ7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/918c2bad-3ed6-404a-a503-5d6124cf1aa4"
+        "id" : "https://www.example.org/73ced124-53cd-4d24-9215-42e8af23cd65"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "X3gjQe7DKwf"
+      "fr" : "bIDmloePYhWXItl1fO"
     },
-    "npiSubjectHeading" : "0vQDqbVXFDvc8bqOWrk",
-    "tags" : [ "JrsbNamDiPnLxN" ],
-    "description" : "LU1HmUxrlTaQSdo4G8m",
+    "npiSubjectHeading" : "d6eQDtCXO8",
+    "tags" : [ "0Jz1J5v4AHiDhI" ],
+    "description" : "pKhMECGlziz4j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d5fedf21-b239-47cd-9d5e-66b34b235071"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f9fac4ce-4627-41dc-b20a-e25beee47e13"
       },
-      "doi" : "https://www.example.org/6bbd3d7a-d32a-46f5-9fdb-f76365c37309",
+      "doi" : "https://www.example.org/c5ee8ad5-6359-4f7b-8c79-beb6b4bd4791",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "hUTglG8kXR68UVac9u",
-          "end" : "czcj6PnJ7xv"
+          "begin" : "VyGrxkwi48newXiN",
+          "end" : "rSUygYjDHz"
         },
-        "volume" : "MtqU7NARjYB140L",
-        "issue" : "xfr4jkL4yvJnjuNVD",
-        "articleNumber" : "AiTKHSvzFZF1pGs"
+        "volume" : "uJF0LEdzdn6",
+        "issue" : "jqmhZXmdx1GWQdRuend",
+        "articleNumber" : "62pi5q6AVOSkNw"
       }
     },
-    "metadataSource" : "https://www.example.org/afc539ba-60d3-426e-add3-b14ab1af1ff7",
-    "abstract" : "44Ni6FAlAi2"
+    "metadataSource" : "https://www.example.org/5aed4868-b7a2-4bce-9679-a9196a5b5671",
+    "abstract" : "EolNW9gSzB7oK49YUqD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/542f4128-004b-4129-a7e0-55ac7d4539cc",
-    "name" : "2oPJCiWyfNCk",
+    "id" : "https://www.example.org/0822d64c-f90a-4d71-9317-9090612792ad",
+    "name" : "YItMY6vHOaV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-02-14T02:47:35.943Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1974-11-04T23:15:24.710Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "czaf3Acf6YC"
+      "applicationCode" : "dnWARlZwB7uFDIts"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0b4d5539-02a7-4420-81d6-59778dae84e8",
-    "identifier" : "99LahAEMtX",
+    "source" : "https://www.example.org/5b06f9fe-b6cc-49f8-a60b-2705250bed15",
+    "identifier" : "tdMe2GhbsxaHsNUSPfS",
     "labels" : {
-      "fr" : "86TOv4Qej3hX7uu"
+      "sv" : "tFyPxW2NsGKzlci5fG"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2079856026
+      "currency" : "NOK",
+      "amount" : 1078409611
     },
-    "activeFrom" : "2021-11-14T01:26:02.322Z",
-    "activeTo" : "2023-03-31T04:32:49.917Z"
+    "activeFrom" : "1984-09-12T18:15:51.984Z",
+    "activeTo" : "2009-04-14T08:07:49.479Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/22721b30-15ac-4497-9e36-855bbb889870",
-    "id" : "https://www.example.org/44c49c6f-f585-4be0-9097-196fc46b9ddb",
-    "identifier" : "SdoalOFs3hiHn25",
+    "source" : "https://www.example.org/63f7bc1b-dc60-4ce5-a309-abe139810006",
+    "id" : "https://www.example.org/046b5d5a-34e5-43d9-a5f1-8d249d07c7b9",
+    "identifier" : "8FaKMNZLCQ3ne",
     "labels" : {
-      "sv" : "vQNIfUmWND3h"
+      "is" : "i5uABIiYJL29BWUDF"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 484748808
+      "currency" : "USD",
+      "amount" : 1614283582
     },
-    "activeFrom" : "2016-04-23T09:11:00.620Z",
-    "activeTo" : "2019-03-28T19:41:31.465Z"
+    "activeFrom" : "1976-09-19T21:40:48.244Z",
+    "activeTo" : "2016-12-04T16:24:50.418Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f97c3c49-4aab-47bb-b7fa-8e099a9e3557" ],
+  "subjects" : [ "https://www.example.org/c0b3da17-c89b-43b4-b6bd-3710ea637988" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5d93f2bf-97d0-4f81-84f7-f828400beb52",
-    "name" : "J8KZqFLQVeCy",
-    "mimeType" : "VhS8L38VHvx97g5ZON",
-    "size" : 1584049077,
-    "license" : "https://www.example.com/nyyunapt4wvuhv",
+    "identifier" : "7eea76b5-58e6-4990-aaad-93e31ff2e71b",
+    "name" : "oeq7DFBobHW8nho",
+    "mimeType" : "fmTHy4vHda0cBEw",
+    "size" : 271303583,
+    "license" : "https://www.example.com/zh1onqte9nrbx7ykoml",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "y7LtLwknd0KGCgrda"
     },
-    "legalNote" : "A5Ptln3W8Y",
-    "publishedDate" : "2022-07-06T15:53:05.021Z",
+    "legalNote" : "kQHrRsCWIk",
+    "publishedDate" : "2020-08-24T15:04:39.931Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "kKz6EFMm3UF",
-      "uploadedDate" : "2022-02-26T21:57:34.626Z"
+      "uploadedBy" : "uOT749ECuHVt9",
+      "uploadedDate" : "2000-03-15T17:22:53.390Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NuJMyV28pL2LQxJK",
-    "name" : "UmwtnA7t71XKU12",
-    "description" : "UIxZmrFMu49"
+    "id" : "https://www.example.com/PVMGFAKOcFg5mwVf",
+    "name" : "g9qtjolebkzP43",
+    "description" : "7L79Eum8HbQQfdOwP"
   } ],
-  "rightsHolder" : "Lm1nBko0fvmLI",
-  "duplicateOf" : "https://www.example.org/b52286ea-7a32-4c53-b80a-d6f7b9ee3d7e",
+  "rightsHolder" : "1H7cIFdyiZ2m",
+  "duplicateOf" : "https://www.example.org/dd518824-c2ca-476e-8e77-6d14e638d9ab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "BsVV3PNU2vm"
+    "note" : "xZDrpajUmKx8T"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "NAcRKXoi3yI5pLFYQxH",
-    "createdBy" : "0v13Yvp8EHxd",
-    "createdDate" : "2014-01-02T01:55:55.534Z"
+    "note" : "xdtS7yuaa4biYObz5",
+    "createdBy" : "pwIXmmJx1cJEVOA",
+    "createdDate" : "2019-08-13T03:45:40.451Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/986920b7-0a4f-4c38-a07a-60ce07b1f1e9" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/b4bedc1a-883e-49ee-a1b2-f66105d6e224" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "ZrA1oYdZ5j9WE",
-    "ownerAffiliation" : "https://www.example.org/b7853169-468a-4ba5-8559-f5bddcf3cac8"
+    "owner" : "TQZQtuOOinjTpkNgPcl",
+    "ownerAffiliation" : "https://www.example.org/78159c85-14c8-4434-9f63-eb77c7c034ac"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1ca1e946-4cb2-4bee-a6a7-6c6d1bc88a99"
+    "id" : "https://www.example.org/24904571-1b36-41ab-8bc5-b05f4c37a669"
   },
-  "createdDate" : "2023-06-11T22:48:07.518Z",
-  "modifiedDate" : "2018-06-23T00:37:32.095Z",
-  "publishedDate" : "1992-08-10T00:31:03.591Z",
-  "indexedDate" : "2004-08-08T19:17:25.499Z",
-  "handle" : "https://www.example.org/b027dd6f-d037-47b1-989d-35da24cb99b0",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/8609a1a8-1026-43ad-bdd7-49fcf3b2c07f",
+  "createdDate" : "2018-11-21T10:02:39.337Z",
+  "modifiedDate" : "2017-08-18T07:31:17.463Z",
+  "publishedDate" : "1980-06-06T14:01:27.116Z",
+  "indexedDate" : "2014-10-01T22:11:41.030Z",
+  "handle" : "https://www.example.org/bd594bb7-4c80-4808-8d06-abd1564d528b",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/d8883f54-90e8-4ca3-866a-394db411a680",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lYpC2FcfC08kjSlo",
+    "mainTitle" : "Oib0NfKXzx4N8gn",
     "alternativeTitles" : {
-      "es" : "eyVmcAhCk0sF8"
+      "de" : "rJqkgvKB6A"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UaNCXiB3MSpZyuZAzZ",
-      "month" : "ORFFrkRWySFRKu24GI",
-      "day" : "z8ivLrs2G6jcJfHJc"
+      "year" : "dewRXYNYAaaUj1UR",
+      "month" : "GnEF28DVtXZldfgQr",
+      "day" : "kduyjVJRn3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9649d05e-a6c1-446b-bfa4-92a1c93b05e7",
-        "name" : "0IlTJTCGTLz6",
+        "id" : "https://www.example.org/f5ad8148-ab62-457e-a7c5-e82d6bdea139",
+        "name" : "WOmXM30tedbc74rSA2n",
         "nameType" : "Organizational",
-        "orcId" : "X4OqCGCLs4gJ5A",
+        "orcId" : "QxjVP6HIYno1kD6Hjo",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZMTV6TOmYzhzV",
-          "value" : "PJQ0fUYvTrzQs6KZ"
+          "sourceName" : "sDw2M1xdOy",
+          "value" : "lu9MTNcFFLCq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "easpPqh8k8ArN",
-          "value" : "SGBl5yoVg1Fz7PqN"
+          "sourceName" : "MyQPZMuaAaMtUTSB2CK",
+          "value" : "gWQdbnp9K3K0AW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7c2df24b-e53a-4a15-9ad4-96454f37d175"
+        "id" : "https://www.example.org/9448d783-26e2-4772-873a-904549cce4dd"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6009af3f-ebaa-4d0f-b291-0aa78b879ac8",
-        "name" : "G7XF2YGRozp5hiHpIwI",
-        "nameType" : "Personal",
-        "orcId" : "8OXm8CE5bHPIeIbl4vl",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/46f71509-3032-4512-b88c-7b98ce5243a8",
+        "name" : "jr1YD7vJM3SEEb9pj9O",
+        "nameType" : "Organizational",
+        "orcId" : "DbIwi3LgMjBxVxD5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xqDGYnCynVz",
-          "value" : "zPWWRajISxmEM7a"
+          "sourceName" : "Av5Y86tV88fd2dk3El6",
+          "value" : "PTbTH7oGwLw9cH"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o8YDZ65H4lK2Gx",
-          "value" : "UVkmncFzGRJW"
+          "sourceName" : "4j3Em1QI45s6JPl7Ze",
+          "value" : "Ebx5dYFmQkVTFkeJy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a83670f5-27b7-4c92-b1bc-c2b77ecb1be1"
+        "id" : "https://www.example.org/a238f992-81e3-407a-b2cf-dfc4c2bb35d6"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "hoNS2UBRGgfmD9"
+      "nn" : "hDr1tQFe9O"
     },
-    "npiSubjectHeading" : "muZ1LYZhlK5B",
-    "tags" : [ "kYvhfS6NLTT" ],
-    "description" : "Q8xxBXoqcl6h",
+    "npiSubjectHeading" : "xcEnXbVeIrYZ50grqhm",
+    "tags" : [ "7Fw8dAIXoqbUqaDsaEe" ],
+    "description" : "3pN6DRfpUs7g",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/2FfJkPHMKEHjfEe9K"
+        "id" : "https://www.example.com/I8qFq09U4qxiYMUI"
       },
-      "doi" : "https://www.example.org/9c12165d-e24c-408e-983a-830862ab2ac6",
+      "doi" : "https://www.example.org/c838b8ff-5e4d-45eb-9113-0e38470c18a7",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "VGEyRivfwj",
-          "end" : "KRC1QbzsOXmkPeWqX"
+          "begin" : "wfT2slc0uxnOoexoXvc",
+          "end" : "L7fKn2x2NCjHlQ6K"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/940067f5-e3b9-4e80-ac14-dbe4b2fd1856",
-    "abstract" : "36rIcUb1942vJ1"
+    "metadataSource" : "https://www.example.org/ca74b9b6-5709-419d-8dc7-6eb685f5349f",
+    "abstract" : "COAFAHrprP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/65946c5c-9ffe-43da-a0bf-c91b2511dc09",
-    "name" : "lKAFXSeRyvbEaHf",
+    "id" : "https://www.example.org/d94e2cf4-9ff3-4018-9b89-74edf3ccb556",
+    "name" : "eBsqVrbylnqh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-02-26T10:29:54.161Z",
+      "approvalDate" : "1979-08-12T18:17:22.001Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "wRdfReqGKnbyOPqZw"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "iOshGewY8bwf"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/27365342-e69b-4e5a-b64a-c45ff9393e04",
-    "identifier" : "Q1PsQevSrB1CrR9QQ",
+    "source" : "https://www.example.org/1a1cba1d-394c-4954-81c2-3e3d10bb7af0",
+    "identifier" : "OErOrxEdcS0nsRG",
     "labels" : {
-      "fi" : "P5ZIcLlsdjnrQ"
+      "el" : "UohP5Kaye3"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 842184913
+      "amount" : 1367331119
     },
-    "activeFrom" : "2017-05-28T12:05:57.414Z",
-    "activeTo" : "2021-09-03T04:30:06.755Z"
+    "activeFrom" : "2012-11-06T17:47:27.365Z",
+    "activeTo" : "2023-12-30T08:43:31.113Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5b60e9cd-1fd9-4bc0-b670-ca61201182ed",
-    "id" : "https://www.example.org/c8b03bd2-03f5-4c23-a120-8ee2c3daca3b",
-    "identifier" : "ZZyyqRrBrlIHvId",
+    "source" : "https://www.example.org/5f4b3379-5460-4702-bd85-7d7a2aa7af86",
+    "id" : "https://www.example.org/88c2eb98-ab8b-4529-b4ea-d855f5840512",
+    "identifier" : "YZYEL2bJ5rLbwiuhGwQ",
     "labels" : {
-      "pt" : "xZzy1ZbrIKT14pOBXuq"
+      "is" : "KxMleNZtn58"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 812072754
+      "amount" : 1826475920
     },
-    "activeFrom" : "2002-03-11T14:22:22.174Z",
-    "activeTo" : "2006-09-21T14:05:42.834Z"
+    "activeFrom" : "1981-03-19T15:46:11.175Z",
+    "activeTo" : "1998-11-04T21:41:24.908Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8095a0fd-6b5b-4764-a7a4-6e98b8145d36" ],
+  "subjects" : [ "https://www.example.org/ccb2430f-8359-457f-9ab9-7fb6350664b2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dfbcd181-8076-45ba-b5b5-28378d6ad4c9",
-    "name" : "xvUUGTE9lj",
-    "mimeType" : "x7Hra9cSgvsbxsx",
-    "size" : 1341524815,
-    "license" : "https://www.example.com/uzknaao22je9h5zz",
+    "identifier" : "12338e33-bc1f-46b3-a1b7-0e876f382a1f",
+    "name" : "Pos2Hw4TtGSF0nN",
+    "mimeType" : "lJb4xOlBE0",
+    "size" : 1088956407,
+    "license" : "https://www.example.com/smhcy1epldqubviz",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "LTmRQDM80BG"
+      "overriddenBy" : "pjyWQNSTEvYFh"
     },
-    "legalNote" : "EgyNsUFVVyjfYXt",
-    "publishedDate" : "1999-05-31T03:05:27.759Z",
+    "legalNote" : "9sxbzSZGKnxA8R",
+    "publishedDate" : "1994-01-12T01:32:25.279Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "rc9F84zZ2eyFvSLG",
-      "uploadedDate" : "1995-06-22T12:16:06.672Z"
+      "uploadedBy" : "eaWsrENl3EI2U1wP",
+      "uploadedDate" : "2011-07-28T20:21:21.357Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zvPPiHIjthHQthjWB",
-    "name" : "e2ZBsCgzg5Q",
-    "description" : "y7wwNYuRhbN3"
+    "id" : "https://www.example.com/Y9IxmXUEi3zaKiTuJ",
+    "name" : "WhQIk5fCPsaYfC",
+    "description" : "4rMJVpIqM6"
   } ],
-  "rightsHolder" : "sDeoG2VFw21X0G",
-  "duplicateOf" : "https://www.example.org/a95d3570-92a1-485b-b48a-ee3554c6e87e",
+  "rightsHolder" : "8xa8RBRI6usLhpK1OXZ",
+  "duplicateOf" : "https://www.example.org/f9f72779-72a0-4cd7-90e8-4fc60d71b26f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kayij19pTO"
+    "note" : "bkKBNPBq7gqvOp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "j3JPYp0lwDbabV",
-    "createdBy" : "MTMqUzXMT0M6l4zxB",
-    "createdDate" : "2003-11-25T00:39:03.234Z"
+    "note" : "Z4Hr4v3FcfTPPJU",
+    "createdBy" : "m6a1RhtBJlcengTvw",
+    "createdDate" : "1981-12-13T00:21:35.027Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ccec1f2e-e335-4b48-9c08-4b7ae51c1ba8" ],
+  "curatingInstitutions" : [ "https://www.example.org/c9c585ad-40c2-4875-9e27-a3e077f4e8d2" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "l2ndWtd3VuM",
-    "ownerAffiliation" : "https://www.example.org/893076ce-03d2-46da-ba50-560add3fccf4"
+    "owner" : "ZrA1oYdZ5j9WE",
+    "ownerAffiliation" : "https://www.example.org/b7853169-468a-4ba5-8559-f5bddcf3cac8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6862ad70-c7a6-4265-8ecd-6e4b177e0b1b"
+    "id" : "https://www.example.org/1ca1e946-4cb2-4bee-a6a7-6c6d1bc88a99"
   },
-  "createdDate" : "1979-10-09T10:43:31.301Z",
-  "modifiedDate" : "2008-08-07T20:19:34.215Z",
-  "publishedDate" : "1993-12-14T21:40:06.818Z",
-  "indexedDate" : "1971-02-04T08:49:31.540Z",
-  "handle" : "https://www.example.org/6307a5df-fd5a-4238-bbc0-a3c82425d6b8",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/01c63175-df8c-4bfc-a2c6-b6bbcc46a60c",
+  "createdDate" : "2023-06-11T22:48:07.518Z",
+  "modifiedDate" : "2018-06-23T00:37:32.095Z",
+  "publishedDate" : "1992-08-10T00:31:03.591Z",
+  "indexedDate" : "2004-08-08T19:17:25.499Z",
+  "handle" : "https://www.example.org/b027dd6f-d037-47b1-989d-35da24cb99b0",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/8609a1a8-1026-43ad-bdd7-49fcf3b2c07f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bCmug1GNoriB",
+    "mainTitle" : "lYpC2FcfC08kjSlo",
     "alternativeTitles" : {
-      "es" : "dF5a5NgbTKImZk"
+      "es" : "eyVmcAhCk0sF8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Np6nfjiX2FjHws3bf",
-      "month" : "5M1fdih8RBF2MOb5",
-      "day" : "k6bEi7j7fVF6Gh4H"
+      "year" : "UaNCXiB3MSpZyuZAzZ",
+      "month" : "ORFFrkRWySFRKu24GI",
+      "day" : "z8ivLrs2G6jcJfHJc"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/78679800-14c3-4f03-9b3c-07a2f694b0d3",
-        "name" : "MbJBwEBwS7nYH",
+        "id" : "https://www.example.org/9649d05e-a6c1-446b-bfa4-92a1c93b05e7",
+        "name" : "0IlTJTCGTLz6",
         "nameType" : "Organizational",
-        "orcId" : "i0Qz4dUKjA0DgNzlBcq",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "X4OqCGCLs4gJ5A",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gmpu9I8mI1Xff",
-          "value" : "W97XlYn7Owr"
+          "sourceName" : "ZMTV6TOmYzhzV",
+          "value" : "PJQ0fUYvTrzQs6KZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LtfXHECsr19KsO",
-          "value" : "zfI7KXj0RhNmG"
+          "sourceName" : "easpPqh8k8ArN",
+          "value" : "SGBl5yoVg1Fz7PqN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/68071026-b36b-4713-a277-238fa24af2e1"
+        "id" : "https://www.example.org/7c2df24b-e53a-4a15-9ad4-96454f37d175"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0227f240-eddb-433b-b436-f63694393f8a",
-        "name" : "Wpc6MfG79rnyDD4X",
+        "id" : "https://www.example.org/6009af3f-ebaa-4d0f-b291-0aa78b879ac8",
+        "name" : "G7XF2YGRozp5hiHpIwI",
         "nameType" : "Personal",
-        "orcId" : "U59KaVxubv75xPPBWwI",
+        "orcId" : "8OXm8CE5bHPIeIbl4vl",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BTObTnwpdUV2CIT",
-          "value" : "2CQgLeOjKtDQXZ8LboP"
+          "sourceName" : "xqDGYnCynVz",
+          "value" : "zPWWRajISxmEM7a"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2dbOjCiVA2tEOVJ",
-          "value" : "06tYF2rh6YWM1f0in"
+          "sourceName" : "o8YDZ65H4lK2Gx",
+          "value" : "UVkmncFzGRJW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/00e39fc5-d4b8-4c69-a5a8-d526ecc793f7"
+        "id" : "https://www.example.org/a83670f5-27b7-4c92-b1bc-c2b77ecb1be1"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "HQyAUbvBjP4AIw0BZw"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "0DYyywUBR08"
+      "is" : "hoNS2UBRGgfmD9"
     },
-    "npiSubjectHeading" : "hXgzaUrKFk3",
-    "tags" : [ "0xDalmN61LFJbUzu" ],
-    "description" : "p8JcU6BwfKIy",
+    "npiSubjectHeading" : "muZ1LYZhlK5B",
+    "tags" : [ "kYvhfS6NLTT" ],
+    "description" : "Q8xxBXoqcl6h",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/wqXRAQrvbMHqxxq"
+        "id" : "https://www.example.com/2FfJkPHMKEHjfEe9K"
       },
-      "doi" : "https://www.example.org/45b76898-042b-434d-9c52-4fb9ce9c51bd",
+      "doi" : "https://www.example.org/9c12165d-e24c-408e-983a-830862ab2ac6",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "6Ij2dNmkky4YFQLWzV",
-          "end" : "qQ4jwEwzkOloxjOV5"
+          "begin" : "VGEyRivfwj",
+          "end" : "KRC1QbzsOXmkPeWqX"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f2d7a0f1-ed07-4b4b-88eb-860e35e827ab",
-    "abstract" : "9WqOaT5sLJEjFq"
+    "metadataSource" : "https://www.example.org/940067f5-e3b9-4e80-ac14-dbe4b2fd1856",
+    "abstract" : "36rIcUb1942vJ1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/700f5206-94c0-4568-b27d-ddbce417de5a",
-    "name" : "5St9SASm9zKegxtxHxS",
+    "id" : "https://www.example.org/65946c5c-9ffe-43da-a0bf-c91b2511dc09",
+    "name" : "lKAFXSeRyvbEaHf",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-03-27T02:10:09.211Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "7YvZiWF3Z9e"
+      "approvalDate" : "1987-02-26T10:29:54.161Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "wRdfReqGKnbyOPqZw"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/29c0a5b1-10bd-4ff9-b276-831f3abeb769",
-    "identifier" : "MfsmW6nIh17g4B",
+    "source" : "https://www.example.org/27365342-e69b-4e5a-b64a-c45ff9393e04",
+    "identifier" : "Q1PsQevSrB1CrR9QQ",
     "labels" : {
-      "cs" : "70u8dsl4lxB2SofwTQ"
+      "fi" : "P5ZIcLlsdjnrQ"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 501794878
+      "currency" : "GBP",
+      "amount" : 842184913
     },
-    "activeFrom" : "2001-01-17T23:09:27.887Z",
-    "activeTo" : "2023-09-22T18:04:56.374Z"
+    "activeFrom" : "2017-05-28T12:05:57.414Z",
+    "activeTo" : "2021-09-03T04:30:06.755Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f4c718bb-d7a8-40db-b29e-b5107a040cde",
-    "id" : "https://www.example.org/58bbc306-fa20-4cad-8f28-8e4789da66ec",
-    "identifier" : "tiuWNKLZ5e",
+    "source" : "https://www.example.org/5b60e9cd-1fd9-4bc0-b670-ca61201182ed",
+    "id" : "https://www.example.org/c8b03bd2-03f5-4c23-a120-8ee2c3daca3b",
+    "identifier" : "ZZyyqRrBrlIHvId",
     "labels" : {
-      "af" : "9yASGwpk1cdhWtMNuwk"
+      "pt" : "xZzy1ZbrIKT14pOBXuq"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 2073342113
+      "currency" : "EUR",
+      "amount" : 812072754
     },
-    "activeFrom" : "1986-08-09T01:06:14.706Z",
-    "activeTo" : "1989-08-01T02:53:00.813Z"
+    "activeFrom" : "2002-03-11T14:22:22.174Z",
+    "activeTo" : "2006-09-21T14:05:42.834Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0eb09793-6517-48a6-b65f-8adf0f85de5a" ],
+  "subjects" : [ "https://www.example.org/8095a0fd-6b5b-4764-a7a4-6e98b8145d36" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "856e18ce-bd93-49d7-90cd-441df40d25a6",
-    "name" : "ucOKp4XDHVzwYF",
-    "mimeType" : "ZToeOJEyMdKiJDV",
-    "size" : 116485562,
-    "license" : "https://www.example.com/0xb8yddflki",
+    "identifier" : "dfbcd181-8076-45ba-b5b5-28378d6ad4c9",
+    "name" : "xvUUGTE9lj",
+    "mimeType" : "x7Hra9cSgvsbxsx",
+    "size" : 1341524815,
+    "license" : "https://www.example.com/uzknaao22je9h5zz",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "LTmRQDM80BG"
     },
-    "legalNote" : "34VWEHSjnQ",
-    "publishedDate" : "1992-04-21T11:39:09.572Z",
+    "legalNote" : "EgyNsUFVVyjfYXt",
+    "publishedDate" : "1999-05-31T03:05:27.759Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "VaU4RKqvP6M1rGlFYc",
-      "uploadedDate" : "2021-10-26T17:52:57.427Z"
+      "uploadedBy" : "rc9F84zZ2eyFvSLG",
+      "uploadedDate" : "1995-06-22T12:16:06.672Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/9gJUXW5ptp",
-    "name" : "ivEMgwZvUAH32e",
-    "description" : "3h6KJWeuOw03EyXLAt"
+    "id" : "https://www.example.com/zvPPiHIjthHQthjWB",
+    "name" : "e2ZBsCgzg5Q",
+    "description" : "y7wwNYuRhbN3"
   } ],
-  "rightsHolder" : "qdzPPF7FKTcd",
-  "duplicateOf" : "https://www.example.org/7b9deeca-8265-47c5-9dc6-ced2cf6e2396",
+  "rightsHolder" : "sDeoG2VFw21X0G",
+  "duplicateOf" : "https://www.example.org/a95d3570-92a1-485b-b48a-ee3554c6e87e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0wvafPbs0IzvfpouZt"
+    "note" : "kayij19pTO"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Ae2Oz2ndUjUTUYZqXu",
-    "createdBy" : "uROZrOI4vMSnwegZ7Kr",
-    "createdDate" : "1994-12-13T15:18:43.680Z"
+    "note" : "j3JPYp0lwDbabV",
+    "createdBy" : "MTMqUzXMT0M6l4zxB",
+    "createdDate" : "2003-11-25T00:39:03.234Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5e2af7d9-d8ce-4644-a646-2251100563f2" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/ccec1f2e-e335-4b48-9c08-4b7ae51c1ba8" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "d9JSFzKzQ2N4rV",
-    "ownerAffiliation" : "https://www.example.org/e67f76c9-431e-462e-807d-fff3248b9531"
+    "owner" : "w9XyEQ1UWoRFhDjAS",
+    "ownerAffiliation" : "https://www.example.org/93e90c0c-7f42-4537-9ef2-2b9d8395bd8c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/55e60386-02f6-4a5c-a5fe-a52b2356cbbb"
+    "id" : "https://www.example.org/5c3254a4-3757-4aeb-ad18-380540383cc0"
   },
-  "createdDate" : "1987-12-04T08:20:51.146Z",
-  "modifiedDate" : "2006-07-24T13:57:37.077Z",
-  "publishedDate" : "1994-05-20T10:38:55.707Z",
-  "indexedDate" : "2011-12-26T12:01:27.203Z",
-  "handle" : "https://www.example.org/f5bde4dc-787e-4370-8c00-0f7b467647b1",
-  "doi" : "https://doi.org/10.1234/autem",
-  "link" : "https://www.example.org/f6a1b045-5128-43ec-b761-f1a593a85981",
+  "createdDate" : "1992-08-13T09:25:38.912Z",
+  "modifiedDate" : "2009-10-25T15:45:56.397Z",
+  "publishedDate" : "1999-06-18T17:22:57.248Z",
+  "indexedDate" : "2000-12-24T05:17:57.326Z",
+  "handle" : "https://www.example.org/56e5d716-c275-4111-bc43-e82154925203",
+  "doi" : "https://doi.org/10.1234/quasi",
+  "link" : "https://www.example.org/7e2aeb93-2cc1-44f3-99c1-f6a58a2f43dc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Wbjrgv4TB3YWi",
+    "mainTitle" : "oZwq6XkJVyn3",
     "alternativeTitles" : {
-      "se" : "UPFfqvfuzOLzN"
+      "ca" : "FRLrEgp86d"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wp8dFIcLJ6yvUJ",
-      "month" : "VMVyLY4eimZbY",
-      "day" : "FAxPe1Dak7LmWo"
+      "year" : "waQx2o0cD9u",
+      "month" : "KD923DnpLH3u",
+      "day" : "VyTZiS0fUuitK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f5cfe21c-7311-48c6-9525-7e09e707a77e",
-        "name" : "4Q4Z0Kda9Jgm9FiS",
+        "id" : "https://www.example.org/3a12ff52-d3d1-49fc-9400-5a68598b0e60",
+        "name" : "DuIKAVrnyFyJ5hH",
         "nameType" : "Organizational",
-        "orcId" : "63RssjwEsR",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "yjQYdlRCNCzeA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6KdKeCLMRh4Gm6C",
-          "value" : "MsgfAFwJuBlsY"
+          "sourceName" : "xONo0p0LM5VdYV64U",
+          "value" : "D727SzO07V5Ca0iRz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t1j65ceUlUmpjMjD7",
-          "value" : "lk831WS7nyPasKHcZ"
+          "sourceName" : "3wuvbqhZlrcTuE3l",
+          "value" : "oCEsLIdQ8Q8IzMGI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/69f44ed5-212a-4d9a-9b1e-de37c994341f"
+        "id" : "https://www.example.org/392586e0-eed1-4123-a472-59cced45ffea"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "LightDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/840e306f-ef00-47bc-a8bc-75300dc8f3c0",
-        "name" : "vUQ6p14nf4a",
-        "nameType" : "Organizational",
-        "orcId" : "qF8ASiaclCYDE3VrNe",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/fc7e3e11-a82d-4fed-87c6-c58c8ec8bab5",
+        "name" : "fyEeLpE9zr4PwH2t",
+        "nameType" : "Personal",
+        "orcId" : "kPCaDoGT7nXfec",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0pXo4hMPpxfURj",
-          "value" : "Pwoe1IEFNLX2VoCx"
+          "sourceName" : "v3CB1Y2uVk88YVO5b",
+          "value" : "BL2eJQDYJbSyyxHGUHS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "M5cxpqf44ZK3poO9Oj",
-          "value" : "Y7sox0U4QDImA"
+          "sourceName" : "QMH8WJf3Q6okRy0TCn",
+          "value" : "7Wegur7KceGFDV2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bf561be1-9c3c-43a7-af0e-198dfb4985a4"
+        "id" : "https://www.example.org/3ad5552d-4b96-46a3-989e-16d77bc99209"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Artist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "vkZrPcgcSM7"
+      "en" : "PISrPLK1O61"
     },
-    "npiSubjectHeading" : "mNBVMOuoKqxWmXoEpIo",
-    "tags" : [ "T6qXShAujsA" ],
-    "description" : "ct9V0Gimz9iOW8BU",
+    "npiSubjectHeading" : "B0dtZevyBZxXZM73Jg5",
+    "tags" : [ "vF2mqWX33i00e0fsyd" ],
+    "description" : "PpslQULO05Yh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/vlgCdEgt5UVH5Al7fR"
+        "id" : "https://www.example.com/g8l1igX3uOc71ddoT"
       },
-      "doi" : "https://www.example.org/f795460c-c225-46ce-9b39-0925c157005f",
+      "doi" : "https://www.example.org/1c9852ec-cb3d-4a05-82bc-c913f790a4fd",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "SBVTz6D8LNuE2aB7",
-          "end" : "lciBkVJTbR"
+          "begin" : "fyAn6NYR2g0ESp0",
+          "end" : "57klTXotftQdNp"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e4e96108-ed34-4b84-895c-fd2b0c337f2f",
-    "abstract" : "PCwIVNAGa8Jhh"
+    "metadataSource" : "https://www.example.org/c1a9774d-37ea-44a9-be6e-f8488e88bd9b",
+    "abstract" : "txCTt4uwhrqlzSyQ06"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eb9c4103-3a7a-4742-8ce2-09f90a2a2b1c",
-    "name" : "IzPiRfmabYmmlE52",
+    "id" : "https://www.example.org/d6f495fd-9750-44db-95b2-f5f31f06b6d9",
+    "name" : "1Ytf70aHb6qs6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1986-07-02T15:44:40.998Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "qXVlvv8E72mWUeqMo3"
+      "approvalDate" : "1979-10-28T02:28:26.699Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "yOzTgjOiVTvRuxb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a199229b-3062-4015-9bd4-35383ee292a4",
-    "identifier" : "WRL9d11L820gK",
+    "source" : "https://www.example.org/0d9f9a05-ee74-4a0b-82a9-131c759ed547",
+    "identifier" : "tzJ2N4xrSjgsKF6ei",
     "labels" : {
-      "is" : "WB1Wu7hz8P"
+      "de" : "yLFOJgjyVNEndxC6Z"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 607891022
+      "amount" : 1107971461
     },
-    "activeFrom" : "1990-11-11T04:59:04.610Z",
-    "activeTo" : "2002-04-28T16:21:37.729Z"
+    "activeFrom" : "1971-07-09T08:24:18.596Z",
+    "activeTo" : "1985-05-28T01:57:02.629Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6b36ff6b-6d20-41f1-bba3-7736cc26a9e1",
-    "id" : "https://www.example.org/7c9e0c6c-27bc-4ab5-a0a4-e47b78551dcb",
-    "identifier" : "Tit0KjiSlIn4pdJOF2",
+    "source" : "https://www.example.org/a770836c-aa28-4dde-8937-2f21a0b33adc",
+    "id" : "https://www.example.org/e72ef1ae-b38f-47f9-bbd1-0a2b4482c9c0",
+    "identifier" : "af2YHkexZKuFAos",
     "labels" : {
-      "it" : "klait4Z7Ny1rRmicu"
+      "da" : "hiuQnyQnqB4L580u"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 164224093
+      "currency" : "EUR",
+      "amount" : 1851827539
     },
-    "activeFrom" : "2014-06-11T08:26:55.144Z",
-    "activeTo" : "2014-10-30T12:30:00.786Z"
+    "activeFrom" : "1990-09-24T15:23:17.131Z",
+    "activeTo" : "2013-09-29T01:53:26.679Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c2245eb3-9475-48db-bb23-f1977a3668c2" ],
+  "subjects" : [ "https://www.example.org/638d28d0-1818-4b7d-83db-04e8e5807b5d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bf623228-b52c-42d0-91cb-1466567176d5",
-    "name" : "fKlkAmzN8Z5QVYr",
-    "mimeType" : "KaoLkR7YG7bJ",
-    "size" : 1291937294,
-    "license" : "https://www.example.com/owqql1w6xvum",
+    "identifier" : "b5d2bb89-3967-4636-bad8-13f0fd62af3c",
+    "name" : "5rkzxklntyK",
+    "mimeType" : "w4QaTtxbb3",
+    "size" : 1165182804,
+    "license" : "https://www.example.com/xaiz0gdbx8pgcype",
     "administrativeAgreement" : false,
-    "publisherVersion" : "UpdatedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "d1qnHPHXxWjkfQ9",
-    "publishedDate" : "2011-12-08T02:13:27.167Z",
+    "legalNote" : "9GSdxrJkjPbQ2bYX8",
+    "publishedDate" : "2010-06-01T08:51:09.478Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "YRiYFfYajZfujT",
-      "uploadedDate" : "1986-10-17T12:29:47.619Z"
+      "uploadedBy" : "j1tr8bZXpbd4SM",
+      "uploadedDate" : "1975-12-02T23:27:00.979Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/oUsaAEi32Bkw5C6an",
-    "name" : "TmSxVJmVvA55Fw7",
-    "description" : "T3ud0Eo9Nf"
+    "id" : "https://www.example.com/3hwCssKt7O4TOvYlaM",
+    "name" : "zFoHlE25g6iRpzxU61",
+    "description" : "f2eF0tUNy8QD6"
   } ],
-  "rightsHolder" : "tXharuZbFAPua9NZ",
-  "duplicateOf" : "https://www.example.org/2c76bd35-eef8-4bc3-a27e-5c9b2a9a8061",
+  "rightsHolder" : "nxxKHbHj51lQB",
+  "duplicateOf" : "https://www.example.org/281d95c2-5e17-4a3c-9d7f-92c88b8c222b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KNrpOqOykyPqi"
+    "note" : "Kr4DVP0N56YRXko"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "uhNXX3jChsRlB",
-    "createdBy" : "LAqupn6DVPjstPwQjv",
-    "createdDate" : "2015-11-05T03:12:56.986Z"
+    "note" : "VJh7Wf1AjsWvRFUWknj",
+    "createdBy" : "eYJVVKrmeK9rW9i",
+    "createdDate" : "2019-08-06T01:21:14.924Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5a60a03b-8e13-4c9a-b553-a7aab15f686a" ],
+  "curatingInstitutions" : [ "https://www.example.org/4c0b120f-8e85-42d0-9bc4-af3f2630964a" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "XpPvjleOnerjGgYi",
-    "ownerAffiliation" : "https://www.example.org/102b66ae-eac3-4fa9-a0f3-6789a74ef907"
+    "owner" : "d9JSFzKzQ2N4rV",
+    "ownerAffiliation" : "https://www.example.org/e67f76c9-431e-462e-807d-fff3248b9531"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9ecbe5db-7936-46b8-8776-cfa681dde998"
+    "id" : "https://www.example.org/55e60386-02f6-4a5c-a5fe-a52b2356cbbb"
   },
-  "createdDate" : "1989-08-16T06:29:42.707Z",
-  "modifiedDate" : "1997-09-07T01:34:49.722Z",
-  "publishedDate" : "2009-02-16T14:07:05.290Z",
-  "indexedDate" : "2006-10-06T21:35:49.943Z",
-  "handle" : "https://www.example.org/df7961c6-4591-4661-8399-c5d8ba68a29d",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/fcc0995e-5ca7-45e7-82e6-6af4e6c82bb3",
+  "createdDate" : "1987-12-04T08:20:51.146Z",
+  "modifiedDate" : "2006-07-24T13:57:37.077Z",
+  "publishedDate" : "1994-05-20T10:38:55.707Z",
+  "indexedDate" : "2011-12-26T12:01:27.203Z",
+  "handle" : "https://www.example.org/f5bde4dc-787e-4370-8c00-0f7b467647b1",
+  "doi" : "https://doi.org/10.1234/autem",
+  "link" : "https://www.example.org/f6a1b045-5128-43ec-b761-f1a593a85981",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pDeMEPMEIClmMBEngl",
+    "mainTitle" : "Wbjrgv4TB3YWi",
     "alternativeTitles" : {
-      "pt" : "O9KXBKvuGKfbiW2d"
+      "se" : "UPFfqvfuzOLzN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XceQZqWBllZFQldkkeq",
-      "month" : "rtjG0iKOjxyPPo6",
-      "day" : "eWzap5awf63mcKdj7"
+      "year" : "wp8dFIcLJ6yvUJ",
+      "month" : "VMVyLY4eimZbY",
+      "day" : "FAxPe1Dak7LmWo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b807391e-f492-48b0-8fd0-acc5c0322f01",
-        "name" : "nUMBKMO9N9",
-        "nameType" : "Personal",
-        "orcId" : "PADa3gZCN7m20AO28S",
+        "id" : "https://www.example.org/f5cfe21c-7311-48c6-9525-7e09e707a77e",
+        "name" : "4Q4Z0Kda9Jgm9FiS",
+        "nameType" : "Organizational",
+        "orcId" : "63RssjwEsR",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eIchMTIx5z7dRhDMr",
-          "value" : "o5KKqzDubE3L4x"
+          "sourceName" : "6KdKeCLMRh4Gm6C",
+          "value" : "MsgfAFwJuBlsY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WyxpbCXQ56",
-          "value" : "6voFmbcywY7v6g0Kpka"
+          "sourceName" : "t1j65ceUlUmpjMjD7",
+          "value" : "lk831WS7nyPasKHcZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/74586b31-25e2-4474-ad9c-ee7c163d6552"
+        "id" : "https://www.example.org/69f44ed5-212a-4d9a-9b1e-de37c994341f"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7536c6d3-183c-4556-8e01-e40be139542b",
-        "name" : "0hURS6gmRpbU",
-        "nameType" : "Personal",
-        "orcId" : "g2EQ85oI9XZ9hzLL",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/840e306f-ef00-47bc-a8bc-75300dc8f3c0",
+        "name" : "vUQ6p14nf4a",
+        "nameType" : "Organizational",
+        "orcId" : "qF8ASiaclCYDE3VrNe",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "omkc9iVTymeuX6PK",
-          "value" : "PO64Uj41WoFVK"
+          "sourceName" : "0pXo4hMPpxfURj",
+          "value" : "Pwoe1IEFNLX2VoCx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nHnvs1vUJWw6yrCjc",
-          "value" : "LJOPBoL9DKu"
+          "sourceName" : "M5cxpqf44ZK3poO9Oj",
+          "value" : "Y7sox0U4QDImA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/921bb109-ddfd-4b5f-9141-23d7df5372c1"
+        "id" : "https://www.example.org/bf561be1-9c3c-43a7-af0e-198dfb4985a4"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "hu5l10AysuihQ5"
+      "sv" : "vkZrPcgcSM7"
     },
-    "npiSubjectHeading" : "GdauhSQ91oiX4",
-    "tags" : [ "285BcjzC0uOFjwyy8rM" ],
-    "description" : "Povil2FxdSEy44fNZ6",
+    "npiSubjectHeading" : "mNBVMOuoKqxWmXoEpIo",
+    "tags" : [ "T6qXShAujsA" ],
+    "description" : "ct9V0Gimz9iOW8BU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/bZN46D5WNPC"
+        "id" : "https://www.example.com/vlgCdEgt5UVH5Al7fR"
       },
-      "doi" : "https://www.example.org/7122b2b9-ba82-4e8f-bd3b-6c09e306c784",
+      "doi" : "https://www.example.org/f795460c-c225-46ce-9b39-0925c157005f",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "L0uwXjsQByWGvG",
-          "end" : "D0HrpwG8uHE"
+          "begin" : "SBVTz6D8LNuE2aB7",
+          "end" : "lciBkVJTbR"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6860debb-8aee-4290-8656-5b3429c05b3d",
-    "abstract" : "OBGXjLlU0FCjTtxD"
+    "metadataSource" : "https://www.example.org/e4e96108-ed34-4b84-895c-fd2b0c337f2f",
+    "abstract" : "PCwIVNAGa8Jhh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/204088f0-c7cc-4258-8426-71fecbf08a4c",
-    "name" : "XEG3NMkbAu",
+    "id" : "https://www.example.org/eb9c4103-3a7a-4742-8ce2-09f90a2a2b1c",
+    "name" : "IzPiRfmabYmmlE52",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-12-06T14:07:26.772Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "54QsJCtPeJk5"
+      "approvalDate" : "1986-07-02T15:44:40.998Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "qXVlvv8E72mWUeqMo3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9ab2653c-b7d8-44cc-9936-d33258fcd5c9",
-    "identifier" : "UYivQKGLioElZeEYg",
+    "source" : "https://www.example.org/a199229b-3062-4015-9bd4-35383ee292a4",
+    "identifier" : "WRL9d11L820gK",
     "labels" : {
-      "fi" : "HpFdFuDojelHD5k97nR"
+      "is" : "WB1Wu7hz8P"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1832453132
+      "amount" : 607891022
     },
-    "activeFrom" : "1981-08-13T14:48:37.859Z",
-    "activeTo" : "1987-05-14T02:06:18.163Z"
+    "activeFrom" : "1990-11-11T04:59:04.610Z",
+    "activeTo" : "2002-04-28T16:21:37.729Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a52688f1-bc68-4b57-a125-a42417831e13",
-    "id" : "https://www.example.org/3e0da545-f04c-4d02-b3dd-02214ccbea0c",
-    "identifier" : "ZVSM7HhLNhe",
+    "source" : "https://www.example.org/6b36ff6b-6d20-41f1-bba3-7736cc26a9e1",
+    "id" : "https://www.example.org/7c9e0c6c-27bc-4ab5-a0a4-e47b78551dcb",
+    "identifier" : "Tit0KjiSlIn4pdJOF2",
     "labels" : {
-      "is" : "d7VPULzdsTqSjQ6KHm"
+      "it" : "klait4Z7Ny1rRmicu"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1495401066
+      "currency" : "NOK",
+      "amount" : 164224093
     },
-    "activeFrom" : "2011-03-23T19:29:10.058Z",
-    "activeTo" : "2011-05-18T12:32:01.548Z"
+    "activeFrom" : "2014-06-11T08:26:55.144Z",
+    "activeTo" : "2014-10-30T12:30:00.786Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/90827111-d305-424a-801b-8358a86858ec" ],
+  "subjects" : [ "https://www.example.org/c2245eb3-9475-48db-bb23-f1977a3668c2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a24b812a-37dc-4f8b-a125-cef5d36ebcd9",
-    "name" : "klqPMgda7uLG68wSCk",
-    "mimeType" : "Y5akhcfCAAvYDVIZ5",
-    "size" : 1312578087,
-    "license" : "https://www.example.com/edrtbcquwdiw",
+    "identifier" : "bf623228-b52c-42d0-91cb-1466567176d5",
+    "name" : "fKlkAmzN8Z5QVYr",
+    "mimeType" : "KaoLkR7YG7bJ",
+    "size" : 1291937294,
+    "license" : "https://www.example.com/owqql1w6xvum",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "XFHgLi2ombul",
-    "publishedDate" : "1988-02-22T12:41:22.272Z",
+    "legalNote" : "d1qnHPHXxWjkfQ9",
+    "publishedDate" : "2011-12-08T02:13:27.167Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "lmNh6SmojN8koYBJ7Vg",
-      "uploadedDate" : "2015-07-05T18:01:39.843Z"
+      "uploadedBy" : "YRiYFfYajZfujT",
+      "uploadedDate" : "1986-10-17T12:29:47.619Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XhvDpfW6iADDnfzh4",
-    "name" : "AJxklNNVHUVeteSW8",
-    "description" : "11cSLnXaf5dfYdBEKc"
+    "id" : "https://www.example.com/oUsaAEi32Bkw5C6an",
+    "name" : "TmSxVJmVvA55Fw7",
+    "description" : "T3ud0Eo9Nf"
   } ],
-  "rightsHolder" : "HgXvPgQd5SfiyN",
-  "duplicateOf" : "https://www.example.org/e9ca59d1-af51-466d-8393-6e2054839692",
+  "rightsHolder" : "tXharuZbFAPua9NZ",
+  "duplicateOf" : "https://www.example.org/2c76bd35-eef8-4bc3-a27e-5c9b2a9a8061",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0fY1PSWcio9ZXezX"
+    "note" : "KNrpOqOykyPqi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "g8NYqF1xFqVxn9AlLM",
-    "createdBy" : "1BHYGD2LmfIVzn",
-    "createdDate" : "1996-10-04T02:48:55.118Z"
+    "note" : "uhNXX3jChsRlB",
+    "createdBy" : "LAqupn6DVPjstPwQjv",
+    "createdDate" : "2015-11-05T03:12:56.986Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/43aec1d7-4d53-4f66-a240-1ca50c50567c" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/5a60a03b-8e13-4c9a-b553-a7aab15f686a" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "gUuyuLit3DcSgdHfcY",
-    "ownerAffiliation" : "https://www.example.org/580c58d8-e0a0-4aac-a581-d89e9cdda1d2"
+    "owner" : "j3iIA6aQ0cLd",
+    "ownerAffiliation" : "https://www.example.org/73d9d3ac-6e37-4443-81b6-051c325a176b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4ab49160-89ff-492f-8b98-115d5820f290"
+    "id" : "https://www.example.org/f33ccf76-5b8e-4f40-ba36-c5c60afa178a"
   },
-  "createdDate" : "1999-10-07T12:04:49.164Z",
-  "modifiedDate" : "2002-03-03T21:41:16.754Z",
-  "publishedDate" : "1985-05-09T23:13:15.952Z",
-  "indexedDate" : "2017-04-26T17:01:55.585Z",
-  "handle" : "https://www.example.org/b63d0c1d-948d-44c8-a4f7-81d80a785a1e",
-  "doi" : "https://doi.org/10.1234/illo",
-  "link" : "https://www.example.org/ce64546b-2f58-4b72-8e0a-b28176b28034",
+  "createdDate" : "2006-10-23T03:29:16.074Z",
+  "modifiedDate" : "1984-04-06T04:50:53.724Z",
+  "publishedDate" : "2008-06-04T08:36:17.316Z",
+  "indexedDate" : "1995-07-25T10:07:44.441Z",
+  "handle" : "https://www.example.org/440fb027-4409-4b99-bb45-2b5c139f35a3",
+  "doi" : "https://doi.org/10.1234/quod",
+  "link" : "https://www.example.org/b5eb9f6f-63b8-44a6-b5b4-b6c5bc7b4af3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LgDjQEsuDj",
+    "mainTitle" : "OWSld9Yhap",
     "alternativeTitles" : {
-      "fi" : "fyYk7Uz9NWl8bvW9i9K"
+      "bg" : "61I3HHl9VxxBfPj"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Cp6H0E2YTS",
-      "month" : "Z66eKZOuYORppUn",
-      "day" : "oItsrUToKax"
+      "year" : "rR4W4NdNPh7Dcrl",
+      "month" : "E8St0hL21qJOZ2",
+      "day" : "cDHGmue00AIle2fAhX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0d9a00de-2b92-4896-b92c-aa90ff397727",
-        "name" : "9jdRM4LCnh53qq",
-        "nameType" : "Organizational",
-        "orcId" : "oUCSUI2ygVEDbb7",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/384c5e6b-3ecf-4a08-9c67-abdd82d1bdaa",
+        "name" : "Cr4rWZnkQvjwSJ6M",
+        "nameType" : "Personal",
+        "orcId" : "CThr2SDVBntI7x7ag",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "N2a7hNPC9k4jY24",
-          "value" : "NuYydsgZlPA6"
+          "sourceName" : "RkxEIAjBHtM6q5E7dxw",
+          "value" : "VXrRWFRx6asGJ82y2o"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2MEGzgQiDM8KufYb51",
-          "value" : "P59dhJHmj3JS9vdZ2fy"
+          "sourceName" : "0VV2rr2hqkLt21nR8",
+          "value" : "3Jr8EPSgsf5h"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2e43da36-4209-43e3-935f-7ad92b7d3fa9"
+        "id" : "https://www.example.org/862991b4-9f69-4f13-a48f-55f4cc43ca8b"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/df11ebe8-26f6-4191-8cb1-0c52d3f689d2",
-        "name" : "XTGWOHibT3",
-        "nameType" : "Personal",
-        "orcId" : "9H0Puvs8C9oR",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1326ba09-db21-4ae3-b66e-f3ba9f06882f",
+        "name" : "n8oHncsUBPkya",
+        "nameType" : "Organizational",
+        "orcId" : "t7HGW1JLJzkapyLyjS",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BUe1FT8sFK2YVOj",
-          "value" : "RdDVe7jxXTAh9OkdV"
+          "sourceName" : "ktfjObe47q6HSf84",
+          "value" : "rR6WWYpp2Xsc9M"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IbiLpnjoLm8C",
-          "value" : "soSIl2axTphl4"
+          "sourceName" : "g7TTQR4DF4yMnbD5CXj",
+          "value" : "RG6v3hOGhwfUjMWg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2c09c02e-71e5-4dea-ab63-361fea0884c0"
+        "id" : "https://www.example.org/2aff3469-4a38-4813-bf30-00c52f98a276"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "WAVdwvn0yjgHIJDe"
+      "sv" : "S8uwOli66a3aV1jf"
     },
-    "npiSubjectHeading" : "nUAJof5cxXxwEtYCUG",
-    "tags" : [ "9HNVLwOz4vmhuYp9aG" ],
-    "description" : "NvthXcAGZ9bcxaBA",
+    "npiSubjectHeading" : "S0UstYHmWMj5kuoZ",
+    "tags" : [ "fnuXdcIDouU" ],
+    "description" : "n0cE1dC2A5VyDNvnS8s",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/788134a9-a5d4-47ec-8873-479ccd69c428"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3040f5c0-3e62-4fe0-ab83-632ca41f22af"
       },
-      "doi" : "https://www.example.org/8efc9b23-f4a7-41db-bd35-b496858c76e1",
+      "doi" : "https://www.example.org/793681ba-1f4b-456c-8235-d5db08f576d3",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "9iuAi8JKUhV8nyo",
-        "issue" : "OSBb2mAED2gGCcr",
-        "articleNumber" : "7D3kv4hP19xozOTUoZr",
+        "volume" : "WiKRlbn9wUxj4",
+        "issue" : "OxSaALy1fXj8viJvO",
+        "articleNumber" : "JL2K9Y3simVKYDu",
         "pages" : {
           "type" : "Range",
-          "begin" : "eiUw7QDYQYGSYw0dv",
-          "end" : "N13ezlhekU"
+          "begin" : "8SGJOQyxrCj",
+          "end" : "SXcIZTLsnb"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/96d43252-da46-41ee-a614-3df94e666549",
-    "abstract" : "LfR8wJ9njpnX"
+    "metadataSource" : "https://www.example.org/ce69fe28-ebb9-4ed6-8b49-b230f89f459b",
+    "abstract" : "NxRzo6dOYDXX3gnRqa"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c32ccbf4-ac55-48fe-889a-88dbf333d7ef",
-    "name" : "ov0nqbeDY6Qy",
+    "id" : "https://www.example.org/d7dc3582-107c-4ea6-bdde-7c12dc4c7de0",
+    "name" : "JGvhYpYSCH39",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-03-31T19:03:49.824Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1991-07-08T19:34:05.808Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "l4As1GQjwicMLVI"
+      "applicationCode" : "vrL7A5w0xLD2OKpR2Wc"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c654be82-87b4-4a69-88a1-35298889e1a3",
-    "identifier" : "ESm5JfCApT",
+    "source" : "https://www.example.org/08d049dc-1464-4395-8d61-10a5a6acfbac",
+    "identifier" : "C7YEbgCa5p",
     "labels" : {
-      "fr" : "WfJEzZZDNYI"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 524934266
-    },
-    "activeFrom" : "1980-11-23T18:50:27.739Z",
-    "activeTo" : "2011-06-14T19:29:21.717Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8e3a101c-0327-4988-8741-f607801abf61",
-    "id" : "https://www.example.org/c421d270-4b9a-4302-b4dc-ef2761fa3aac",
-    "identifier" : "zeqrT66vO7dHQZoTA14",
-    "labels" : {
-      "nl" : "kVo1zI59l7z"
+      "fr" : "gmitH8DN7nfL134zW"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1937323589
+      "amount" : 1548554869
     },
-    "activeFrom" : "1992-10-14T00:39:51.745Z",
-    "activeTo" : "1995-12-24T07:09:24.540Z"
+    "activeFrom" : "1993-03-15T04:23:18.421Z",
+    "activeTo" : "2015-11-02T06:51:33.506Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/dd09f8b3-6ed9-4380-a277-d9d9e63a0e87",
+    "id" : "https://www.example.org/86bca2db-6afc-431e-9650-73cd779bc3e0",
+    "identifier" : "bL7Oya0swxso2",
+    "labels" : {
+      "nl" : "rq7IlfW1y24L1KA2"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1548467436
+    },
+    "activeFrom" : "1981-03-17T11:13:36.987Z",
+    "activeTo" : "1993-12-11T02:45:55.879Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2a569545-4ec2-4139-b4d6-9cbccffc2a85" ],
+  "subjects" : [ "https://www.example.org/8d4ac203-7d08-47ad-a711-fa39c956e114" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5471469c-f4cf-41ab-b503-93e0026f8822",
-    "name" : "4iEU0tSrrJiR9WbcvC",
-    "mimeType" : "ZLB4xAGyzSAP",
-    "size" : 1501793756,
-    "license" : "https://www.example.com/7vglczuuaav",
+    "identifier" : "9a995ff3-0a94-4501-9c63-f0813e983831",
+    "name" : "82n1EKjcOUofH4bfWr",
+    "mimeType" : "IYD38uvQleo",
+    "size" : 1915156956,
+    "license" : "https://www.example.com/ibgtoxj3z4",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Pv6ygInfmbnMP0qJO"
     },
-    "legalNote" : "9BwBUsH4tDdVAfrUfO",
-    "publishedDate" : "2012-09-29T04:08:35.444Z",
+    "legalNote" : "GhWpsLwNQuY",
+    "publishedDate" : "1971-07-02T16:59:07.862Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "oCjUkYRf7kRGnvWKG8w",
-      "uploadedDate" : "2007-02-10T17:40:30.353Z"
+      "uploadedBy" : "69Ozhc5oCkN",
+      "uploadedDate" : "1972-12-22T22:11:06.651Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/g9KqVsC96sjflYm",
-    "name" : "Wcj4JqcqiT",
-    "description" : "xQU5XFtuKhNCzWqjmX"
+    "id" : "https://www.example.com/odcNwqUTC5c",
+    "name" : "yYV1GG9RjG",
+    "description" : "P0EBdpM7Xwa7QxJzE"
   } ],
-  "rightsHolder" : "4I5e8ZP6bCn",
-  "duplicateOf" : "https://www.example.org/606fc3f8-7190-4575-bee7-ceaff106fc08",
+  "rightsHolder" : "odadezunW1aatBFZLWP",
+  "duplicateOf" : "https://www.example.org/18726293-e534-4781-a4e7-674b57191e6f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "HiIuvjbcHzWb"
+    "note" : "pJzdLP8umhBtcs1zck"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "5pYpuGA3UmYTCntBo5",
-    "createdBy" : "cyh5wHvEEzDg06Pulu",
-    "createdDate" : "2013-01-19T13:09:56.979Z"
+    "note" : "U0Un6i8VC9QcGucYgm0",
+    "createdBy" : "vuePtQRigR",
+    "createdDate" : "2014-11-10T21:36:37.080Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/396d75a2-e4ef-429c-8f66-e65afc0138f0" ],
+  "curatingInstitutions" : [ "https://www.example.org/ab3fe96b-3b98-47f3-8851-a15dd0aa68bb" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "5Xyra1JRgh",
-    "ownerAffiliation" : "https://www.example.org/4c63c5b5-a444-4cf3-8471-8a57c1b69ef7"
+    "owner" : "gUuyuLit3DcSgdHfcY",
+    "ownerAffiliation" : "https://www.example.org/580c58d8-e0a0-4aac-a581-d89e9cdda1d2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9f0f6a4e-aa22-4662-a3bc-d5febc37d428"
+    "id" : "https://www.example.org/4ab49160-89ff-492f-8b98-115d5820f290"
   },
-  "createdDate" : "2018-12-04T07:04:36.863Z",
-  "modifiedDate" : "1976-08-12T18:25:27.288Z",
-  "publishedDate" : "2013-05-02T19:29:03.417Z",
-  "indexedDate" : "2017-11-20T08:07:55.128Z",
-  "handle" : "https://www.example.org/d452cb83-8c5a-42a1-a875-2f54f26f9a32",
-  "doi" : "https://doi.org/10.1234/molestias",
-  "link" : "https://www.example.org/cddf29a2-5d8a-4a3c-8d27-850108d52700",
+  "createdDate" : "1999-10-07T12:04:49.164Z",
+  "modifiedDate" : "2002-03-03T21:41:16.754Z",
+  "publishedDate" : "1985-05-09T23:13:15.952Z",
+  "indexedDate" : "2017-04-26T17:01:55.585Z",
+  "handle" : "https://www.example.org/b63d0c1d-948d-44c8-a4f7-81d80a785a1e",
+  "doi" : "https://doi.org/10.1234/illo",
+  "link" : "https://www.example.org/ce64546b-2f58-4b72-8e0a-b28176b28034",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ArbUXA4gGM6Cdp",
+    "mainTitle" : "LgDjQEsuDj",
     "alternativeTitles" : {
-      "ca" : "ZjsyMQwFrgYXAt6dZqo"
+      "fi" : "fyYk7Uz9NWl8bvW9i9K"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wfxVxirJ20ZqQeYW",
-      "month" : "M6k0eUZ5mIe",
-      "day" : "c2PEJAP2vr15Jm6"
+      "year" : "Cp6H0E2YTS",
+      "month" : "Z66eKZOuYORppUn",
+      "day" : "oItsrUToKax"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3afc2326-68e0-47db-9a15-9948999a90aa",
-        "name" : "eTgTf6CExoGxTOuN5oP",
-        "nameType" : "Personal",
-        "orcId" : "l8iyEtvBUb0",
+        "id" : "https://www.example.org/0d9a00de-2b92-4896-b92c-aa90ff397727",
+        "name" : "9jdRM4LCnh53qq",
+        "nameType" : "Organizational",
+        "orcId" : "oUCSUI2ygVEDbb7",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0n7ZbcKP5k0eAs",
-          "value" : "o85PK9OmW5CES7on"
+          "sourceName" : "N2a7hNPC9k4jY24",
+          "value" : "NuYydsgZlPA6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TQs69SVZBkbeBkV",
-          "value" : "LHNKFG9BCq0ERLJ9"
+          "sourceName" : "2MEGzgQiDM8KufYb51",
+          "value" : "P59dhJHmj3JS9vdZ2fy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7ee6efc4-4daf-4082-b149-dff37e5c314e"
+        "id" : "https://www.example.org/2e43da36-4209-43e3-935f-7ad92b7d3fa9"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,24 +62,24 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/29a9f789-51c4-4c0d-8e61-de5e809761e2",
-        "name" : "mI0i6X5NQr52BV6jH",
+        "id" : "https://www.example.org/df11ebe8-26f6-4191-8cb1-0c52d3f689d2",
+        "name" : "XTGWOHibT3",
         "nameType" : "Personal",
-        "orcId" : "gp23EWNw8bO",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "9H0Puvs8C9oR",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YJxv9I3rZW44bHQ",
-          "value" : "UEynoZG1WAXb9ZQRj"
+          "sourceName" : "BUe1FT8sFK2YVOj",
+          "value" : "RdDVe7jxXTAh9OkdV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YqCwldC4I79",
-          "value" : "HvGbFyfnKD"
+          "sourceName" : "IbiLpnjoLm8C",
+          "value" : "soSIl2axTphl4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/93861741-016e-4b55-b78d-8cc7b358e775"
+        "id" : "https://www.example.org/2c09c02e-71e5-4dea-ab63-361fea0884c0"
       } ],
       "role" : {
         "type" : "ContactPerson"
@@ -88,117 +88,117 @@
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "unykQkJwpFgj"
+      "af" : "WAVdwvn0yjgHIJDe"
     },
-    "npiSubjectHeading" : "LiaNdBETwB983YtV",
-    "tags" : [ "LONFZ3mLNW" ],
-    "description" : "QriboOFcUGK",
+    "npiSubjectHeading" : "nUAJof5cxXxwEtYCUG",
+    "tags" : [ "9HNVLwOz4vmhuYp9aG" ],
+    "description" : "NvthXcAGZ9bcxaBA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b81637a5-b50f-4d6c-b480-072be486d89b"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/788134a9-a5d4-47ec-8873-479ccd69c428"
       },
-      "doi" : "https://www.example.org/5b14d897-8778-487f-babd-7770fb321d08",
+      "doi" : "https://www.example.org/8efc9b23-f4a7-41db-bd35-b496858c76e1",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "QUWAEiQIpTeBP",
-        "issue" : "axVfW0RxlkEK",
-        "articleNumber" : "eYtcAjhsWAp",
+        "volume" : "9iuAi8JKUhV8nyo",
+        "issue" : "OSBb2mAED2gGCcr",
+        "articleNumber" : "7D3kv4hP19xozOTUoZr",
         "pages" : {
           "type" : "Range",
-          "begin" : "kUfhJIVynZlg9",
-          "end" : "1YAMszFo1X"
+          "begin" : "eiUw7QDYQYGSYw0dv",
+          "end" : "N13ezlhekU"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1eb154a2-a7fc-4847-90df-054f260a1455",
-    "abstract" : "snYcGfouXJDr"
+    "metadataSource" : "https://www.example.org/96d43252-da46-41ee-a614-3df94e666549",
+    "abstract" : "LfR8wJ9njpnX"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5e5495f7-09ac-4936-9229-64493b2193c9",
-    "name" : "YcBwC60wu26gwPLXd3M",
+    "id" : "https://www.example.org/c32ccbf4-ac55-48fe-889a-88dbf333d7ef",
+    "name" : "ov0nqbeDY6Qy",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-03-29T04:53:39.982Z",
+      "approvalDate" : "2007-03-31T19:03:49.824Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "WIrC1EUmx3XIB2V"
+      "applicationCode" : "l4As1GQjwicMLVI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ce19ec7d-dd9c-42aa-901e-38b33999e1c5",
-    "identifier" : "3m7zRGXPJand",
+    "source" : "https://www.example.org/c654be82-87b4-4a69-88a1-35298889e1a3",
+    "identifier" : "ESm5JfCApT",
     "labels" : {
-      "es" : "pzWnnEzipx84Kh3Ud"
+      "fr" : "WfJEzZZDNYI"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2061563963
+      "amount" : 524934266
     },
-    "activeFrom" : "1990-06-18T09:38:34.957Z",
-    "activeTo" : "1997-12-25T17:51:35.195Z"
+    "activeFrom" : "1980-11-23T18:50:27.739Z",
+    "activeTo" : "2011-06-14T19:29:21.717Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6c2598ef-6648-479d-ae08-d5aa73ed3c51",
-    "id" : "https://www.example.org/db604509-add0-416c-9b75-27603dfa05fb",
-    "identifier" : "SqXEKUbLPoT8Ttvk",
+    "source" : "https://www.example.org/8e3a101c-0327-4988-8741-f607801abf61",
+    "id" : "https://www.example.org/c421d270-4b9a-4302-b4dc-ef2761fa3aac",
+    "identifier" : "zeqrT66vO7dHQZoTA14",
     "labels" : {
-      "en" : "T1YKEgpmrdfQws"
+      "nl" : "kVo1zI59l7z"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1311354274
+      "amount" : 1937323589
     },
-    "activeFrom" : "2010-11-06T17:28:07.701Z",
-    "activeTo" : "2013-10-21T04:24:02.155Z"
+    "activeFrom" : "1992-10-14T00:39:51.745Z",
+    "activeTo" : "1995-12-24T07:09:24.540Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a1c6196a-44fe-4fdf-a369-1168517bf3b4" ],
+  "subjects" : [ "https://www.example.org/2a569545-4ec2-4139-b4d6-9cbccffc2a85" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "39f0406e-1ddc-4182-9231-2086fa006a37",
-    "name" : "c58VHnoM8ULnMMj",
-    "mimeType" : "OZvtq6N1EMVVFR",
-    "size" : 933123851,
-    "license" : "https://www.example.com/rgiqctbja6ci",
+    "identifier" : "5471469c-f4cf-41ab-b503-93e0026f8822",
+    "name" : "4iEU0tSrrJiR9WbcvC",
+    "mimeType" : "ZLB4xAGyzSAP",
+    "size" : 1501793756,
+    "license" : "https://www.example.com/7vglczuuaav",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "NiG6FFXC7Fejq",
-    "publishedDate" : "1996-10-03T22:25:21.612Z",
+    "legalNote" : "9BwBUsH4tDdVAfrUfO",
+    "publishedDate" : "2012-09-29T04:08:35.444Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "HaJxgy3DzcdCDzgEvR",
-      "uploadedDate" : "1974-11-08T23:56:38.063Z"
+      "uploadedBy" : "oCjUkYRf7kRGnvWKG8w",
+      "uploadedDate" : "2007-02-10T17:40:30.353Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/La5SbGhZlFejFHkr",
-    "name" : "yinJZvdvtGH13Q",
-    "description" : "HDOFhfpdbKRcoXrXmeY"
+    "id" : "https://www.example.com/g9KqVsC96sjflYm",
+    "name" : "Wcj4JqcqiT",
+    "description" : "xQU5XFtuKhNCzWqjmX"
   } ],
-  "rightsHolder" : "iQqlk1pMw8",
-  "duplicateOf" : "https://www.example.org/bd85cf1a-fe15-4189-b7bf-e603dada44cb",
+  "rightsHolder" : "4I5e8ZP6bCn",
+  "duplicateOf" : "https://www.example.org/606fc3f8-7190-4575-bee7-ceaff106fc08",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "r5PF1N3n8BXjbu"
+    "note" : "HiIuvjbcHzWb"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "HKUui5KBXw",
-    "createdBy" : "cmsG21hnlTFuQPo",
-    "createdDate" : "1979-05-07T21:19:18.586Z"
+    "note" : "5pYpuGA3UmYTCntBo5",
+    "createdBy" : "cyh5wHvEEzDg06Pulu",
+    "createdDate" : "2013-01-19T13:09:56.979Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/70b73b13-0690-41ee-9a15-25c8779509e5" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/396d75a2-e4ef-429c-8f66-e65afc0138f0" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "M6LletbMlBKEpdilUl",
-    "ownerAffiliation" : "https://www.example.org/e198370e-dfa2-41b7-a11a-1847685cf108"
+    "owner" : "eSwPOJuZmRHKjpYYjsO",
+    "ownerAffiliation" : "https://www.example.org/f6d9e88e-3cae-4086-a211-4c8190101eac"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6e0238a0-ed2a-4d84-94a6-ed9506ff7289"
+    "id" : "https://www.example.org/a1fdc6cd-fa78-4619-9901-34e15d28bfe8"
   },
-  "createdDate" : "2014-09-12T14:20:28.641Z",
-  "modifiedDate" : "2000-10-24T20:07:43.229Z",
-  "publishedDate" : "2014-11-29T19:33:09.098Z",
-  "indexedDate" : "2014-03-28T17:54:46.947Z",
-  "handle" : "https://www.example.org/bc979670-fe0c-447b-97ea-fac205403f22",
-  "doi" : "https://doi.org/10.1234/natus",
-  "link" : "https://www.example.org/d258c2e8-0e85-4c37-8c47-14778796056f",
+  "createdDate" : "2024-04-12T16:36:58.847Z",
+  "modifiedDate" : "2003-09-13T00:28:15.261Z",
+  "publishedDate" : "2017-11-18T07:30:17.217Z",
+  "indexedDate" : "1996-01-18T04:44:44.068Z",
+  "handle" : "https://www.example.org/d8160d6b-5435-460a-a89c-848e492c3a27",
+  "doi" : "https://doi.org/10.1234/vitae",
+  "link" : "https://www.example.org/ef120997-4155-4aa9-aa25-e8633dc14ed6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "C6BpcKu4rZTAeDBCb8",
+    "mainTitle" : "ThQI5Nax0ZTPaKXh",
     "alternativeTitles" : {
-      "bg" : "JolZcdVkSj"
+      "en" : "0m1GRSyQefY93nD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "8rANayjJP1wPy",
-      "month" : "PIYb9UM6Ktp6",
-      "day" : "gZdPiJktuTflW75B0"
+      "year" : "cgP4qqzGnKjBft6SxK",
+      "month" : "I7MCGuGOOh",
+      "day" : "AWQEjBamgJG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/294465b0-2c2a-46ee-b035-2b247c1b7a7a",
-        "name" : "T3jxv7zY9WPKCMC",
-        "nameType" : "Organizational",
-        "orcId" : "kQ7to1I31CURVyVOU",
+        "id" : "https://www.example.org/cadd4aba-20d1-43d1-b358-572508a0f2bb",
+        "name" : "KeQtzjnLzJmY8k",
+        "nameType" : "Personal",
+        "orcId" : "NlxWMivewVD",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iMlGuA6KDzEzI0zN",
-          "value" : "eUFXj4grqwZBYxT"
+          "sourceName" : "jjUhZkgUM1x9S",
+          "value" : "r5sl2fKCmrP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nCDcRYo3QrMYQ",
-          "value" : "T2c6b7vk0W4q"
+          "sourceName" : "2ciOE60YvZ47W",
+          "value" : "nPVSlxMIZzQZh9h"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6e02d157-7bae-4d60-8a8a-99b81d40b59f"
+        "id" : "https://www.example.org/8dca901b-1d0b-42dd-a1be-cb479d76e2a1"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/97c571a6-e60f-4b5b-979f-62564fee9d76",
-        "name" : "HAXWGQOIhv",
-        "nameType" : "Personal",
-        "orcId" : "O6hh0NtpCwTIm1mO",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e60d4f63-3624-45c4-bee5-08620c9f3959",
+        "name" : "mQZKelPHRJJ",
+        "nameType" : "Organizational",
+        "orcId" : "txWCyX4obAjUR",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qmfooXAGZPjre",
-          "value" : "7mz239ZlxHn"
+          "sourceName" : "cmykf9XrVGA",
+          "value" : "i56aavYzDn5tMxz7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UXAgdIS35ZrvgxPwVA",
-          "value" : "jzCVISL2VkNXy"
+          "sourceName" : "DdWX36eN1MtLG",
+          "value" : "xPWTkTUR9Fr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/70c1d832-2a5d-46a0-b54b-fa2a3136d128"
+        "id" : "https://www.example.org/591cf3ba-1ddf-4926-9cdf-21daff8a3ea1"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "WPCrflbICFFWBL"
+      "zh" : "1fqv9g5ScE96w5Ey"
     },
-    "npiSubjectHeading" : "wMaCjRzC3lQy",
-    "tags" : [ "Ob3SAiuq9oHMz" ],
-    "description" : "jQcJklyWi8lRtBMV",
+    "npiSubjectHeading" : "HiGe051Ds6rqiOUbu1",
+    "tags" : [ "Urao0kEzivHCbqI" ],
+    "description" : "ModZpNh2EyxOmm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "WOlKDSAEi7",
+        "label" : "O3JwnT4NceFWqmouZF",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "vWzvtenKHV",
-          "country" : "GcybOs8HjleXn"
+          "label" : "0X3FY4y370lOtQBlyLF",
+          "country" : "SfSOrl7omJSH9ev"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1996-05-31T23:16:43.444Z",
-          "to" : "2014-10-23T02:23:19.188Z"
+          "from" : "2002-02-27T17:20:37.977Z",
+          "to" : "2011-11-20T11:51:27.641Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/PEOiKYux27Lzir"
+          "id" : "https://www.example.com/WUA3nzZCQCGVlq"
         },
-        "product" : "https://www.example.com/3rtLcbwUKDfAJO"
+        "product" : "https://www.example.com/ODwcCb5fVxr39TOlOxL"
       },
-      "doi" : "https://www.example.org/17a06c14-f51d-4700-bd66-15b27e076550",
+      "doi" : "https://www.example.org/8248dd32-51aa-4d22-8fa7-748f698fa60b",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -122,93 +122,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/54d96044-a699-42f5-a6b9-c6e12378707e",
-    "abstract" : "9KYEVe6AfWgf3n7"
+    "metadataSource" : "https://www.example.org/b4fe55f7-ac05-4ff4-94b0-3b4132eb0d57",
+    "abstract" : "q554YApzs5TuSpq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/da543163-cc98-40c1-944a-03ca2095f867",
-    "name" : "HtAkAZZMCfvHMka",
+    "id" : "https://www.example.org/adaf5728-bc81-4957-a217-6bcc303f6dc5",
+    "name" : "i1LCOvZ7XUk94D4T7z",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-09-19T12:57:24.186Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "egTQaRJ2rGPTSVgE2fT"
+      "approvalDate" : "1978-08-16T08:41:23.216Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "17YTNaSas6VCn2Xd"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/099538d4-a867-4cad-b49f-36e2ca933994",
-    "identifier" : "fpLxgv3IRO1JP5sx",
+    "source" : "https://www.example.org/8162370a-6f11-4474-95d7-732b733f06c9",
+    "identifier" : "YoPAfsqKhLax",
     "labels" : {
-      "sv" : "9BecPF0nE2DtN"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1726492360
-    },
-    "activeFrom" : "1979-11-30T20:38:07.321Z",
-    "activeTo" : "1993-03-19T14:21:36.008Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b009a5ef-7d47-4716-b1d1-7dc571209639",
-    "id" : "https://www.example.org/efd23e37-f757-4ecd-8bdd-2e7867460038",
-    "identifier" : "5VSLcIzDAv7LRffOwrY",
-    "labels" : {
-      "af" : "xltr1TFcqQ4lCkY64"
+      "nl" : "sokWjanbK2szPe"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2040845554
+      "amount" : 376721845
     },
-    "activeFrom" : "1983-07-06T13:38:42.840Z",
-    "activeTo" : "2000-11-01T12:57:01.129Z"
+    "activeFrom" : "2019-05-28T08:09:34.832Z",
+    "activeTo" : "2022-04-15T03:08:31.889Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/7ea54f05-0ed2-4301-9324-a5d9b63a6438",
+    "id" : "https://www.example.org/62a14b47-782c-4ef2-9397-248943fb430a",
+    "identifier" : "pXGV366IP0oQCXwTV0",
+    "labels" : {
+      "nb" : "55nC8ZJncrrAC"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 312909363
+    },
+    "activeFrom" : "1971-10-29T04:32:57.928Z",
+    "activeTo" : "1999-02-18T07:49:52.855Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/304757e3-0f00-4f38-ad14-6591611c5ff6" ],
+  "subjects" : [ "https://www.example.org/47e0109a-2cf2-4d6c-8fed-5051882fc41b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7af081b0-ceb0-49b4-bbeb-bec8e847ffc0",
-    "name" : "2ABlOWQ7ftw",
-    "mimeType" : "8qgrYpbwzi8BQCO7lc",
-    "size" : 1172391492,
-    "license" : "https://www.example.com/hzlbztsudsdwj4",
+    "identifier" : "1f9d5834-0f25-4cc3-a578-68ce3fbcfeda",
+    "name" : "7Cx6g5lQ0Au1",
+    "mimeType" : "G3ylhHJBHdNgaSAck",
+    "size" : 1067114749,
+    "license" : "https://www.example.com/jqv4p1okmkvstjyo",
     "administrativeAgreement" : false,
     "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "EGZQkifWG3TbopcfWVO",
-    "publishedDate" : "2009-03-04T21:39:28.662Z",
+    "legalNote" : "Dd6MKZfgXUl",
+    "publishedDate" : "1991-05-08T01:15:12.573Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TMf1k8GrHIhAaJEFxlo",
-      "uploadedDate" : "1991-01-02T00:03:33.648Z"
+      "uploadedBy" : "0Gr5bvkIo4vLqn1Q",
+      "uploadedDate" : "1996-05-18T16:11:36.992Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YQWaYqtd3Xawd3P0kK",
-    "name" : "mJSwJ8klbZfg4",
-    "description" : "FBpqR6fkOwO"
+    "id" : "https://www.example.com/z8PCq8rBShZfbW3or2L",
+    "name" : "BVsHVGD6mCnTp9btw",
+    "description" : "c0hmEYIP6N1mbiB"
   } ],
-  "rightsHolder" : "L8UedtvYeds",
-  "duplicateOf" : "https://www.example.org/cd9e831a-f6b5-4f3c-a25c-dc3e4c0d02af",
+  "rightsHolder" : "8AqdSU5kEMCEaT",
+  "duplicateOf" : "https://www.example.org/2aeba989-5755-49c0-9f33-c7c8f6b70ca4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zylGMqggBViF"
+    "note" : "oXxD0YT2asz3KVRK9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "de7gluBTW5wRC",
-    "createdBy" : "mbDcUEXxhyOUI8",
-    "createdDate" : "2012-10-04T12:21:15.839Z"
+    "note" : "6UmqbgozDIbm5o",
+    "createdBy" : "zzlaj4KNNJobv",
+    "createdDate" : "2001-02-04T12:05:05.796Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6c0a45bd-d83b-40e9-9b37-3b1509c080d0" ],
+  "curatingInstitutions" : [ "https://www.example.org/fc61bf6a-8e0e-465b-a2e6-c6878da54da7" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "UvuZ3ySfUw8uA7Fk",
-    "ownerAffiliation" : "https://www.example.org/5039083e-2018-46d3-a8c3-9f02851a2dc8"
+    "owner" : "M6LletbMlBKEpdilUl",
+    "ownerAffiliation" : "https://www.example.org/e198370e-dfa2-41b7-a11a-1847685cf108"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/249dee5b-08f2-4d68-a2f4-3a29259de62e"
+    "id" : "https://www.example.org/6e0238a0-ed2a-4d84-94a6-ed9506ff7289"
   },
-  "createdDate" : "2022-01-31T09:08:43.873Z",
-  "modifiedDate" : "2004-04-29T04:22:48.156Z",
-  "publishedDate" : "1975-12-03T03:24:49.587Z",
-  "indexedDate" : "1985-08-23T01:05:35.307Z",
-  "handle" : "https://www.example.org/f5dd3e6e-1f46-48a7-8efa-9bebd4d5ebac",
-  "doi" : "https://doi.org/10.1234/nisi",
-  "link" : "https://www.example.org/6965da34-1f34-4ab9-ac82-42229ecce0cc",
+  "createdDate" : "2014-09-12T14:20:28.641Z",
+  "modifiedDate" : "2000-10-24T20:07:43.229Z",
+  "publishedDate" : "2014-11-29T19:33:09.098Z",
+  "indexedDate" : "2014-03-28T17:54:46.947Z",
+  "handle" : "https://www.example.org/bc979670-fe0c-447b-97ea-fac205403f22",
+  "doi" : "https://doi.org/10.1234/natus",
+  "link" : "https://www.example.org/d258c2e8-0e85-4c37-8c47-14778796056f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Zatba0zwjoPZ4DGzUAA",
+    "mainTitle" : "C6BpcKu4rZTAeDBCb8",
     "alternativeTitles" : {
-      "it" : "a54qCWjTv30zBB"
+      "bg" : "JolZcdVkSj"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Edmafmxz8gVvFx",
-      "month" : "fQIifISQVkp",
-      "day" : "M0SyFc9Y0hX0JHCX"
+      "year" : "8rANayjJP1wPy",
+      "month" : "PIYb9UM6Ktp6",
+      "day" : "gZdPiJktuTflW75B0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0925f326-a94e-4c4f-adbe-3a7618011886",
-        "name" : "W8idvNQkNn",
+        "id" : "https://www.example.org/294465b0-2c2a-46ee-b035-2b247c1b7a7a",
+        "name" : "T3jxv7zY9WPKCMC",
         "nameType" : "Organizational",
-        "orcId" : "IRB1LGr6VoL0xMp",
+        "orcId" : "kQ7to1I31CURVyVOU",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oGv6oaWIbn41u78J",
-          "value" : "3jkCNBc9bdpS"
+          "sourceName" : "iMlGuA6KDzEzI0zN",
+          "value" : "eUFXj4grqwZBYxT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3kfL2EHhlD8gkCR",
-          "value" : "8RjyVbAOgU"
+          "sourceName" : "nCDcRYo3QrMYQ",
+          "value" : "T2c6b7vk0W4q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5960ad81-d2af-4f0e-bde5-0fcf9d58154b"
+        "id" : "https://www.example.org/6e02d157-7bae-4d60-8a8a-99b81d40b59f"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a715b6ce-3b9e-479d-a60d-4bec0cafa1d3",
-        "name" : "N1cngvIdjJg",
-        "nameType" : "Organizational",
-        "orcId" : "0QgJ4We7wrEk",
+        "id" : "https://www.example.org/97c571a6-e60f-4b5b-979f-62564fee9d76",
+        "name" : "HAXWGQOIhv",
+        "nameType" : "Personal",
+        "orcId" : "O6hh0NtpCwTIm1mO",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "764kxnpJj8",
-          "value" : "59To1XzI0edKib2"
+          "sourceName" : "qmfooXAGZPjre",
+          "value" : "7mz239ZlxHn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sBSMUIvCecarbdxwUWG",
-          "value" : "4MhLsYCyuHhvm6tY"
+          "sourceName" : "UXAgdIS35ZrvgxPwVA",
+          "value" : "jzCVISL2VkNXy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/02a8671c-df6a-4134-8a2e-0661260b6320"
+        "id" : "https://www.example.org/70c1d832-2a5d-46a0-b54b-fa2a3136d128"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "TF5PEgwYL4csLFC"
+        "type" : "SoundDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "gvV5DI7xKuFe"
+      "sv" : "WPCrflbICFFWBL"
     },
-    "npiSubjectHeading" : "71PMp9ZtRbZw1lHddq",
-    "tags" : [ "1pT0ckVJCJ" ],
-    "description" : "W61XLsFAbhlW",
+    "npiSubjectHeading" : "wMaCjRzC3lQy",
+    "tags" : [ "Ob3SAiuq9oHMz" ],
+    "description" : "jQcJklyWi8lRtBMV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "dxkTeKQC2u9NN",
+        "label" : "WOlKDSAEi7",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "RsLida3meJDk",
-          "country" : "vArWcss2wwcWyej"
+          "label" : "vWzvtenKHV",
+          "country" : "GcybOs8HjleXn"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2016-06-30T18:43:15.173Z"
+          "type" : "Period",
+          "from" : "1996-05-31T23:16:43.444Z",
+          "to" : "2014-10-23T02:23:19.188Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/2A8vkQiOhG"
+          "id" : "https://www.example.com/PEOiKYux27Lzir"
         },
-        "product" : "https://www.example.com/dw30acsRDZZfS"
+        "product" : "https://www.example.com/3rtLcbwUKDfAJO"
       },
-      "doi" : "https://www.example.org/fb474df1-5ab5-4119-ba85-e9793fa0cecb",
+      "doi" : "https://www.example.org/17a06c14-f51d-4700-bd66-15b27e076550",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -122,93 +122,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ee40fc37-abd6-4fb4-a8d4-f6287063e3c6",
-    "abstract" : "1mfNBLk52rGWYeO4G"
+    "metadataSource" : "https://www.example.org/54d96044-a699-42f5-a6b9-c6e12378707e",
+    "abstract" : "9KYEVe6AfWgf3n7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f0f7e8f9-04bf-4e0c-bc52-63c1f00519a0",
-    "name" : "GVU3M3zlMcqrAT8",
+    "id" : "https://www.example.org/da543163-cc98-40c1-944a-03ca2095f867",
+    "name" : "HtAkAZZMCfvHMka",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1989-01-16T10:13:51.277Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2015-09-19T12:57:24.186Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "54Vx9YFdtgF"
+      "applicationCode" : "egTQaRJ2rGPTSVgE2fT"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f801f4ae-8118-44ee-b537-a27b30bc9035",
-    "identifier" : "eAiwyR0nNI3F",
+    "source" : "https://www.example.org/099538d4-a867-4cad-b49f-36e2ca933994",
+    "identifier" : "fpLxgv3IRO1JP5sx",
     "labels" : {
-      "en" : "TjGZajkmru"
+      "sv" : "9BecPF0nE2DtN"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 579047616
+      "amount" : 1726492360
     },
-    "activeFrom" : "1996-10-06T03:24:04.582Z",
-    "activeTo" : "2015-03-22T08:39:50.095Z"
+    "activeFrom" : "1979-11-30T20:38:07.321Z",
+    "activeTo" : "1993-03-19T14:21:36.008Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f4ec8b16-6a9b-4c19-aa35-9419e7ca62f4",
-    "id" : "https://www.example.org/a27db170-c4b6-40d7-857b-cfa185d27317",
-    "identifier" : "wNTsU3rmgjQeLjewt",
+    "source" : "https://www.example.org/b009a5ef-7d47-4716-b1d1-7dc571209639",
+    "id" : "https://www.example.org/efd23e37-f757-4ecd-8bdd-2e7867460038",
+    "identifier" : "5VSLcIzDAv7LRffOwrY",
     "labels" : {
-      "sv" : "4L0KTC5ECT34PrH"
+      "af" : "xltr1TFcqQ4lCkY64"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1922094950
+      "currency" : "USD",
+      "amount" : 2040845554
     },
-    "activeFrom" : "2008-04-10T12:26:39.789Z",
-    "activeTo" : "2021-04-05T12:47:26.504Z"
+    "activeFrom" : "1983-07-06T13:38:42.840Z",
+    "activeTo" : "2000-11-01T12:57:01.129Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/42573676-10b7-4df8-8a12-52108918ce28" ],
+  "subjects" : [ "https://www.example.org/304757e3-0f00-4f38-ad14-6591611c5ff6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8d9cb996-7718-4a12-94df-08ffb29ae689",
-    "name" : "LG50GbymBReLa",
-    "mimeType" : "2SRMlRhkqs30e4Z7t3",
-    "size" : 1733622582,
-    "license" : "https://www.example.com/nyli85sustaxvwupg",
+    "identifier" : "7af081b0-ceb0-49b4-bbeb-bec8e847ffc0",
+    "name" : "2ABlOWQ7ftw",
+    "mimeType" : "8qgrYpbwzi8BQCO7lc",
+    "size" : 1172391492,
+    "license" : "https://www.example.com/hzlbztsudsdwj4",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Iq2v86XM0ttJ",
-    "publishedDate" : "1989-03-12T18:14:42.378Z",
+    "legalNote" : "EGZQkifWG3TbopcfWVO",
+    "publishedDate" : "2009-03-04T21:39:28.662Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "413sWg1hYnI",
-      "uploadedDate" : "2013-04-20T16:04:20.228Z"
+      "uploadedBy" : "TMf1k8GrHIhAaJEFxlo",
+      "uploadedDate" : "1991-01-02T00:03:33.648Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/9GQKp18wqpAbwf6JRf9",
-    "name" : "fRVwbahdf5Zqe7",
-    "description" : "OS5md5ZLgUcRh"
+    "id" : "https://www.example.com/YQWaYqtd3Xawd3P0kK",
+    "name" : "mJSwJ8klbZfg4",
+    "description" : "FBpqR6fkOwO"
   } ],
-  "rightsHolder" : "NsFyFZ47h94",
-  "duplicateOf" : "https://www.example.org/9c77aec8-e3c7-4600-b649-b11b203e18d9",
+  "rightsHolder" : "L8UedtvYeds",
+  "duplicateOf" : "https://www.example.org/cd9e831a-f6b5-4f3c-a25c-dc3e4c0d02af",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "qevssGPuK0dO"
+    "note" : "zylGMqggBViF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1sxiT4lNelQ",
-    "createdBy" : "0xlJTu9dlthYsE",
-    "createdDate" : "1996-05-28T08:54:44.142Z"
+    "note" : "de7gluBTW5wRC",
+    "createdBy" : "mbDcUEXxhyOUI8",
+    "createdDate" : "2012-10-04T12:21:15.839Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/82128c74-120c-4511-9af7-2f617a2b3501" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/6c0a45bd-d83b-40e9-9b37-3b1509c080d0" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "B2vY89FDPv3YCLim25U",
-    "ownerAffiliation" : "https://www.example.org/c4ab0320-8e84-411b-96e2-724287912519"
+    "owner" : "B06Ss0outu2cKV15",
+    "ownerAffiliation" : "https://www.example.org/ccd6b6c1-d376-43ff-ab11-6281e76ad74f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3bfa06db-70cc-4c4b-ad41-fd6e23a403b0"
+    "id" : "https://www.example.org/f0ca1e9c-f5e1-40b9-aea9-5756fff9f775"
   },
-  "createdDate" : "1993-09-06T08:43:39.977Z",
-  "modifiedDate" : "2016-10-11T18:54:47.470Z",
-  "publishedDate" : "1978-11-20T10:49:35.074Z",
-  "indexedDate" : "1987-11-06T04:52:31.405Z",
-  "handle" : "https://www.example.org/8ff155ff-6a30-49a2-9891-b2ea6aaf2142",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/2a662743-66de-4c16-9dcf-1189123466f9",
+  "createdDate" : "2003-10-21T04:47:06.924Z",
+  "modifiedDate" : "2009-05-17T14:16:21.834Z",
+  "publishedDate" : "1980-05-26T03:03:55.442Z",
+  "indexedDate" : "1992-02-01T16:29:18.102Z",
+  "handle" : "https://www.example.org/c63c5837-1014-42f1-af9c-fe4e3aa1c3bf",
+  "doi" : "https://doi.org/10.1234/recusandae",
+  "link" : "https://www.example.org/342bd913-b2c9-4b7d-9863-703f926175c7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eBBnlQP1PLyZ",
+    "mainTitle" : "is4INhqpUkiim",
     "alternativeTitles" : {
-      "de" : "DuB1wlYaT704OrE"
+      "bg" : "qpcvHvTAS9iJqvBNK6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dCPM02Rd4r1XTHyV8n",
-      "month" : "cL33invcJdMIhlT",
-      "day" : "uSmVZSUY1ZcMAQvAB2p"
+      "year" : "OXsqY3nXSUnc5",
+      "month" : "IpNQpuE2DzhYaNmQO1",
+      "day" : "TfZopzaT8qlt4xVdSPw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fdd557f1-6b24-46be-b13e-9c08cc9b88e9",
-        "name" : "M3C8v0lybpbCj9GLk",
-        "nameType" : "Personal",
-        "orcId" : "IFXJXwQ5lFgy",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/339632e7-19bc-4cd1-9139-ede1534ade46",
+        "name" : "lewR3QyJl3g7P",
+        "nameType" : "Organizational",
+        "orcId" : "Ft2J2KXhmtFAla7Sj",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dk3AycYUqxZsu",
-          "value" : "9FhV1uZ1JvRWztT5yNY"
+          "sourceName" : "QQsadeylK2",
+          "value" : "iHrtJkKqPhbGgtDr9eO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "I0qHwzNwpeZdvsu",
-          "value" : "WsTvNCRjSfhQIA4Y3u"
+          "sourceName" : "CNSeFhm19cuwnARWWuP",
+          "value" : "C15dsYGxrCU9gFL0p3s"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ced55a22-bad7-42f1-9310-abc4db1eeff6"
+        "id" : "https://www.example.org/6e290072-43a2-4d7c-b637-9dc199cc9ebf"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/587543c5-2d02-4e13-ba51-86469ebe4e8f",
-        "name" : "o7A7QGUrWife",
+        "id" : "https://www.example.org/30c46eab-9aaf-4ee4-976d-7ddabe8f7ded",
+        "name" : "u9qOUoTReHpc",
         "nameType" : "Personal",
-        "orcId" : "YDVQi1yMvck",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "FLTQoAHycn6WWnEk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VaSBXNqC0TG59g",
-          "value" : "I3jbi8W8ebgY6"
+          "sourceName" : "z1g8zgw9LolkaUsXxIj",
+          "value" : "i5QyYIiW7eb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "leeXsyLhcmJl",
-          "value" : "GzYGEyZ2DD"
+          "sourceName" : "hCwSX3BcmE6",
+          "value" : "HazDIToEm6Q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dd495ca9-292e-46e9-a253-7833537c232b"
+        "id" : "https://www.example.org/63cb0a0c-afd3-4ef8-9411-499271d85618"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "bq33I4mGFDCl"
+      "zh" : "Wdabdpk7qWIIeM"
     },
-    "npiSubjectHeading" : "UI7D2l5DUG0MOmst3E",
-    "tags" : [ "8mprnXBfxDE" ],
-    "description" : "0gDf48Y1cCjiMuO",
+    "npiSubjectHeading" : "Qhp3K7xmJ7Fs4Sb",
+    "tags" : [ "LF2zlr4JL13j" ],
+    "description" : "VcZJD8lY44xFzEV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "nnJcbZBxDr",
+        "label" : "SFChZoL4AXsFUW",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "SRLkyvl1yK7xLb",
-          "country" : "BnuswUaMKLu"
+          "label" : "31CakGoOSnK",
+          "country" : "1K94S908kMEmeQn"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "1988-02-29T11:07:22.025Z",
-          "to" : "2005-10-08T05:17:19.368Z"
+          "type" : "Instant",
+          "value" : "2001-02-04T02:31:35.014Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/9ji8szUiE8adRynxq"
+          "id" : "https://www.example.com/aNEWpd7Nbs0"
         },
-        "product" : "https://www.example.com/eDXJzXsmgmJkUfj"
+        "product" : "https://www.example.com/pzdmxPpMREdcU"
       },
-      "doi" : "https://www.example.org/ecdb50c9-cd4e-4c32-be1c-455716d104e7",
+      "doi" : "https://www.example.org/6e9a3d68-3011-413a-bb40-fdf078da4b45",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -122,94 +121,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/526ad1e9-abff-4133-907a-e1aff8c2d9a4",
-    "abstract" : "SK8Ew1oau2zpDImo"
+    "metadataSource" : "https://www.example.org/86f40dfa-24a3-4135-b6e6-6c0976c789b4",
+    "abstract" : "FEuq9j57S0cMsklIv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e2d5d570-c41c-4292-92b1-0586d21c76f5",
-    "name" : "EvUqhT4GBraT",
+    "id" : "https://www.example.org/9207379e-785a-4ab3-844b-102cc4c14aa0",
+    "name" : "aDruy31VqgvMH1c",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-09-11T12:59:26.963Z",
+      "approvalDate" : "1994-11-26T05:45:19.553Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "v2qNZFnzyO"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "SCHcOjV46G3Mi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8410cf04-37f5-425f-a3c9-e97eb8537064",
-    "identifier" : "7dmmjtLh0KsVi",
+    "source" : "https://www.example.org/c4c82a8a-5fe7-4ed3-86e0-af686b5bfa5c",
+    "identifier" : "d6cKcSU2w11FOF",
     "labels" : {
-      "es" : "sHLps3shy0Zmjo"
+      "sv" : "Mvbl6n3IJJ"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1063700804
+      "currency" : "NOK",
+      "amount" : 17939177
     },
-    "activeFrom" : "1991-09-05T02:47:08.236Z",
-    "activeTo" : "1998-08-31T21:38:10.398Z"
+    "activeFrom" : "2022-07-12T15:30:18.723Z",
+    "activeTo" : "2023-11-24T19:20:17.787Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/aa718dac-88a5-4c01-b170-e668da70860a",
-    "id" : "https://www.example.org/ca3173fd-588c-43b2-b051-9d1741ca5476",
-    "identifier" : "7hI73ihmd13HGg",
+    "source" : "https://www.example.org/452a52b3-3061-49b0-8f8a-255588181402",
+    "id" : "https://www.example.org/cf61eaf1-d1f3-4460-881f-60ab16ca5195",
+    "identifier" : "JBQIhsoj7Z3xQ",
     "labels" : {
-      "nl" : "XKkamCBApq7Bp"
+      "af" : "hKleCKHGWmYWx6qhvE"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1720217658
+      "amount" : 1760968566
     },
-    "activeFrom" : "1982-12-07T19:11:38.218Z",
-    "activeTo" : "1988-12-26T07:14:31.573Z"
+    "activeFrom" : "1972-09-02T11:10:37.318Z",
+    "activeTo" : "2022-11-30T14:58:35.888Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1648ec7c-27ca-4dc2-943b-d93714b6f625" ],
+  "subjects" : [ "https://www.example.org/07afae80-c045-495f-91fb-b9a9721ab702" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "444707b1-16ba-4da3-9428-17dd5086ec35",
-    "name" : "xTPOZfnSXpDTaZ0",
-    "mimeType" : "Wtb28Zpa0A",
-    "size" : 1295191397,
-    "license" : "https://www.example.com/gsvmn6nh8xteb8ooq",
+    "identifier" : "d091a5f3-e349-4861-b003-1924688bc3be",
+    "name" : "vTFjXsasHScqLr1MrjO",
+    "mimeType" : "yiSRLsOTxST",
+    "size" : 1791440651,
+    "license" : "https://www.example.com/7l3k7kyesysk7",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "txbUWqqCnHotCN"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "VW0hF2412UXdKp4",
-    "publishedDate" : "2007-09-23T05:14:49.657Z",
+    "legalNote" : "dhYVsqMO0clDFmiuQJ",
+    "publishedDate" : "2013-10-12T22:33:28.774Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DVxuNS3OOlPZ",
-      "uploadedDate" : "1985-07-21T07:12:48.941Z"
+      "uploadedBy" : "eL0NYDmaUydjSiEfi",
+      "uploadedDate" : "1979-09-10T06:29:50.014Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/f2Wum05Bd7P",
-    "name" : "VxYkgGXtMcz",
-    "description" : "GXNjsKRdnbF3Q0It"
+    "id" : "https://www.example.com/Q9a4rEJ77OJAG",
+    "name" : "Wbe2T5jhuIWf",
+    "description" : "QdVmEuGwgwX0"
   } ],
-  "rightsHolder" : "PF4LqPR9cqyMIt",
-  "duplicateOf" : "https://www.example.org/2de84d24-88de-4d3d-86d0-ae96b0861eca",
+  "rightsHolder" : "vsvQuLn9qO",
+  "duplicateOf" : "https://www.example.org/77fa6164-bfae-4fae-84a4-d04930f64f2f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vpxprL0yJkuJpE"
+    "note" : "TLiK3BhjA8DcSjsZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vjU1yQZZqyFUUxWfVB",
-    "createdBy" : "4kbH9d3NLb",
-    "createdDate" : "1998-04-30T23:15:26.039Z"
+    "note" : "M7QXCDT6jEN0kriznm",
+    "createdBy" : "npjyKhLHPGM9tQ5jeVn",
+    "createdDate" : "2007-02-22T07:23:37.232Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7ee93f0a-2374-415e-b069-10d72a3dd8be" ],
+  "curatingInstitutions" : [ "https://www.example.org/b4922e81-be03-466c-9f36-50d1b5d02086" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "sHUB22fQPDcLR3q6fl",
-    "ownerAffiliation" : "https://www.example.org/512fbe94-e5b5-4901-bc82-3cb8eaabd60c"
+    "owner" : "B2vY89FDPv3YCLim25U",
+    "ownerAffiliation" : "https://www.example.org/c4ab0320-8e84-411b-96e2-724287912519"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/35df4d16-6565-425d-8e88-28eb316f55b1"
+    "id" : "https://www.example.org/3bfa06db-70cc-4c4b-ad41-fd6e23a403b0"
   },
-  "createdDate" : "2016-10-10T14:48:12.994Z",
-  "modifiedDate" : "2004-02-18T06:55:15.415Z",
-  "publishedDate" : "2007-08-31T11:26:55.717Z",
-  "indexedDate" : "1998-03-07T21:49:48.897Z",
-  "handle" : "https://www.example.org/cf2fc71a-26c3-4c8b-ac46-a465c28f0246",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/3a303c74-4391-4146-b770-6c369cd297c5",
+  "createdDate" : "1993-09-06T08:43:39.977Z",
+  "modifiedDate" : "2016-10-11T18:54:47.470Z",
+  "publishedDate" : "1978-11-20T10:49:35.074Z",
+  "indexedDate" : "1987-11-06T04:52:31.405Z",
+  "handle" : "https://www.example.org/8ff155ff-6a30-49a2-9891-b2ea6aaf2142",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/2a662743-66de-4c16-9dcf-1189123466f9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GkGlUtqWXLvGW",
+    "mainTitle" : "eBBnlQP1PLyZ",
     "alternativeTitles" : {
-      "cs" : "SXvwbcjHKSu0bf"
+      "de" : "DuB1wlYaT704OrE"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "58g49YbbOBpgxeWeKk",
-      "month" : "b2gRire3f92Yq",
-      "day" : "LXVPEKsbSIYC3d1zK"
+      "year" : "dCPM02Rd4r1XTHyV8n",
+      "month" : "cL33invcJdMIhlT",
+      "day" : "uSmVZSUY1ZcMAQvAB2p"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fc174081-34d9-4cff-8e34-90917212ce56",
-        "name" : "h6XP7Cfuey",
-        "nameType" : "Organizational",
-        "orcId" : "WfYDwMqnRcQ",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/fdd557f1-6b24-46be-b13e-9c08cc9b88e9",
+        "name" : "M3C8v0lybpbCj9GLk",
+        "nameType" : "Personal",
+        "orcId" : "IFXJXwQ5lFgy",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0x9ShiQqOSBN8WONwZ",
-          "value" : "ePzbpnWXF9"
+          "sourceName" : "dk3AycYUqxZsu",
+          "value" : "9FhV1uZ1JvRWztT5yNY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GZBBoyhmRHaaFOg",
-          "value" : "bRtpOsLOxn"
+          "sourceName" : "I0qHwzNwpeZdvsu",
+          "value" : "WsTvNCRjSfhQIA4Y3u"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6ffc7085-3d42-4318-9dfb-6952ac734709"
+        "id" : "https://www.example.org/ced55a22-bad7-42f1-9310-abc4db1eeff6"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/25a6f75d-70fd-4e13-bcd6-828cf655a7f9",
-        "name" : "80oTxfdFh0gQJCWU",
+        "id" : "https://www.example.org/587543c5-2d02-4e13-ba51-86469ebe4e8f",
+        "name" : "o7A7QGUrWife",
         "nameType" : "Personal",
-        "orcId" : "XMkJCaxfFiIaeA5it",
-        "verificationStatus" : "Verified",
+        "orcId" : "YDVQi1yMvck",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hyrPAbmNchbM",
-          "value" : "kPYe1ERTAtK"
+          "sourceName" : "VaSBXNqC0TG59g",
+          "value" : "I3jbi8W8ebgY6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lbPS4jryqpE",
-          "value" : "rUkgieEf0Zu4"
+          "sourceName" : "leeXsyLhcmJl",
+          "value" : "GzYGEyZ2DD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/da972d7b-b9f6-40d2-9613-8fd79ccdcb04"
+        "id" : "https://www.example.org/dd495ca9-292e-46e9-a253-7833537c232b"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "imDcx9ZSd9"
+      "de" : "bq33I4mGFDCl"
     },
-    "npiSubjectHeading" : "SkyOHM8fE4cFV",
-    "tags" : [ "J9yIKCpZuqseckV" ],
-    "description" : "D6tMkCLaKEJ",
+    "npiSubjectHeading" : "UI7D2l5DUG0MOmst3E",
+    "tags" : [ "8mprnXBfxDE" ],
+    "description" : "0gDf48Y1cCjiMuO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "Vq8e2DwULPpZje",
+        "label" : "nnJcbZBxDr",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "fd4tjeDbxd",
-          "country" : "N17GBYQz5p0"
+          "label" : "SRLkyvl1yK7xLb",
+          "country" : "BnuswUaMKLu"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1979-12-31T19:08:51.781Z",
-          "to" : "2009-02-14T17:19:46.181Z"
+          "from" : "1988-02-29T11:07:22.025Z",
+          "to" : "2005-10-08T05:17:19.368Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/Vdgm9B5AXJK8yRnahHX"
+          "id" : "https://www.example.com/9ji8szUiE8adRynxq"
         },
-        "product" : "https://www.example.com/ZLH4qdnDr6e7CFC"
+        "product" : "https://www.example.com/eDXJzXsmgmJkUfj"
       },
-      "doi" : "https://www.example.org/f0370dee-485c-4bd2-888c-d3ab90d75710",
+      "doi" : "https://www.example.org/ecdb50c9-cd4e-4c32-be1c-455716d104e7",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -122,93 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/34b09125-7acc-4486-804e-c0cad1aa8c2f",
-    "abstract" : "TxN9W8cddgE"
+    "metadataSource" : "https://www.example.org/526ad1e9-abff-4133-907a-e1aff8c2d9a4",
+    "abstract" : "SK8Ew1oau2zpDImo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6a6c20de-3492-4713-b13c-c81b729a1551",
-    "name" : "ZcaWqO0UzpIs0DlyMY",
+    "id" : "https://www.example.org/e2d5d570-c41c-4292-92b1-0586d21c76f5",
+    "name" : "EvUqhT4GBraT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2003-03-06T10:50:36.498Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "kzIXhugH7uEDhxv"
+      "approvalDate" : "1985-09-11T12:59:26.963Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "v2qNZFnzyO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e4747b37-e6d5-4059-8d52-0c655b007892",
-    "identifier" : "zxGKSmAcUf7",
+    "source" : "https://www.example.org/8410cf04-37f5-425f-a3c9-e97eb8537064",
+    "identifier" : "7dmmjtLh0KsVi",
     "labels" : {
-      "fi" : "0g1Mzm5cg3J4"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 367945112
-    },
-    "activeFrom" : "2018-08-19T17:11:37.168Z",
-    "activeTo" : "2021-02-25T22:18:13.681Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/61c69d02-f925-4d01-818d-7c25664779a9",
-    "id" : "https://www.example.org/e2953588-b91a-498d-b8f2-38d2d58142a2",
-    "identifier" : "UuPH2IBOyV5",
-    "labels" : {
-      "pt" : "KjHXplKNk7pZVu3aTv6"
+      "es" : "sHLps3shy0Zmjo"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1975144392
+      "amount" : 1063700804
     },
-    "activeFrom" : "2007-03-21T04:20:34.066Z",
-    "activeTo" : "2017-08-10T01:40:55.825Z"
+    "activeFrom" : "1991-09-05T02:47:08.236Z",
+    "activeTo" : "1998-08-31T21:38:10.398Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/aa718dac-88a5-4c01-b170-e668da70860a",
+    "id" : "https://www.example.org/ca3173fd-588c-43b2-b051-9d1741ca5476",
+    "identifier" : "7hI73ihmd13HGg",
+    "labels" : {
+      "nl" : "XKkamCBApq7Bp"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1720217658
+    },
+    "activeFrom" : "1982-12-07T19:11:38.218Z",
+    "activeTo" : "1988-12-26T07:14:31.573Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/219581b8-dffe-416e-9e90-be5113488eac" ],
+  "subjects" : [ "https://www.example.org/1648ec7c-27ca-4dc2-943b-d93714b6f625" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8d24d7de-ae5b-4723-a9e5-8a445c6243b3",
-    "name" : "UrxR4pRkeHn",
-    "mimeType" : "qp6TFpBPYa2",
-    "size" : 83546459,
-    "license" : "https://www.example.com/0wrsfff09zey",
+    "identifier" : "444707b1-16ba-4da3-9428-17dd5086ec35",
+    "name" : "xTPOZfnSXpDTaZ0",
+    "mimeType" : "Wtb28Zpa0A",
+    "size" : 1295191397,
+    "license" : "https://www.example.com/gsvmn6nh8xteb8ooq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "txbUWqqCnHotCN"
     },
-    "legalNote" : "ds3wr3Ya4KabRg",
-    "publishedDate" : "1996-02-23T01:21:29.971Z",
+    "legalNote" : "VW0hF2412UXdKp4",
+    "publishedDate" : "2007-09-23T05:14:49.657Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "eKMpFjvDVqY27K",
-      "uploadedDate" : "1976-11-18T07:43:08.534Z"
+      "uploadedBy" : "DVxuNS3OOlPZ",
+      "uploadedDate" : "1985-07-21T07:12:48.941Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/84qVHrwS4ZpUQyrVC4",
-    "name" : "x1iwMXwGCFkm92g5a",
-    "description" : "YmtZdG2I1w6mGxy"
+    "id" : "https://www.example.com/f2Wum05Bd7P",
+    "name" : "VxYkgGXtMcz",
+    "description" : "GXNjsKRdnbF3Q0It"
   } ],
-  "rightsHolder" : "ybitGjktCR5XKbHYfF",
-  "duplicateOf" : "https://www.example.org/970c6a93-e74b-46cf-9579-83a5bb5461fa",
+  "rightsHolder" : "PF4LqPR9cqyMIt",
+  "duplicateOf" : "https://www.example.org/2de84d24-88de-4d3d-86d0-ae96b0861eca",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vlVNzunnkR"
+    "note" : "vpxprL0yJkuJpE"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "PhGsEZXY0C6Q",
-    "createdBy" : "dyBys944RXXkAbyYs",
-    "createdDate" : "2016-01-21T05:17:29.801Z"
+    "note" : "vjU1yQZZqyFUUxWfVB",
+    "createdBy" : "4kbH9d3NLb",
+    "createdDate" : "1998-04-30T23:15:26.039Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/df601374-4923-4145-8028-e23b0d4cccfb" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/7ee93f0a-2374-415e-b069-10d72a3dd8be" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "N2X8yAOkTyJCMZxWJc",
-    "ownerAffiliation" : "https://www.example.org/0ffd346b-3940-44a5-ac6b-b3b36d12c770"
+    "owner" : "AU6qKiIcuMz",
+    "ownerAffiliation" : "https://www.example.org/f12b30ef-933a-4073-a046-e2523964a223"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/77a4a8ea-a687-41df-8ceb-20aa04c74230"
+    "id" : "https://www.example.org/10fc317b-8983-4343-b876-182a96072867"
   },
-  "createdDate" : "2003-04-15T17:56:09.657Z",
-  "modifiedDate" : "1986-12-28T22:01:37.238Z",
-  "publishedDate" : "1990-10-27T05:00:20.643Z",
-  "indexedDate" : "2019-05-10T08:28:19.657Z",
-  "handle" : "https://www.example.org/1f7aa5dd-3678-4436-a095-89d170cb2034",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/1a325ed5-b980-4fba-bc77-8a7a73b02d80",
+  "createdDate" : "2000-04-14T17:46:55.305Z",
+  "modifiedDate" : "1992-09-28T00:30:44.060Z",
+  "publishedDate" : "2019-04-15T21:18:54.358Z",
+  "indexedDate" : "2008-06-06T01:25:10.181Z",
+  "handle" : "https://www.example.org/63c6fca7-4b38-4b4a-b2e2-606122bf356d",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/7f8beedb-0989-4547-9433-1ac9ae7529cb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RQkeAUfhVJxvpo",
+    "mainTitle" : "2mjcK21SJOwD5FT0",
     "alternativeTitles" : {
-      "en" : "LPMIuqGlWas7"
+      "fi" : "fW5mcbuwBSMa"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7PtkHUDcasTwRphw7",
-      "month" : "PGCGK8QpM0RvdxK7",
-      "day" : "j9PJN7kLWdTenwuG6AV"
+      "year" : "MC0rAW9Pd2QFXnBFe",
+      "month" : "Xeq34rpgSQqaOBaRfJ",
+      "day" : "1TwNJBUd3MJu72fx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0a339c0d-2eb4-4f53-a1e5-e11085bc2f18",
-        "name" : "GNsBmbcZvu",
+        "id" : "https://www.example.org/55420f4e-5f13-40a4-9902-8b98b6955a7d",
+        "name" : "ZRPDZot9uTFraOW0o49",
         "nameType" : "Organizational",
-        "orcId" : "OVT5dtjfdX1K",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "GOKNPSvfQppqXLAVGdk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z1dK4Oi53Vw",
-          "value" : "G4PPKZLFx5OTFd"
+          "sourceName" : "bd6wjbLI0qAW",
+          "value" : "vaONPqTPPmrUmQi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iONxt4NCzBknGoZ4",
-          "value" : "XZXSekZ65u"
+          "sourceName" : "k9Y63b47cOY1quVJxC",
+          "value" : "wKsREQYLeWR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ff3edc0c-0d68-4cbc-b8d9-f5c6f5f195f9"
+        "id" : "https://www.example.org/f0218b02-2b36-492a-b8cf-c52f16016a5c"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fcae6b56-0ae8-484a-af09-6d87d71c951b",
-        "name" : "aG1dZMZWBNvF9m5",
+        "id" : "https://www.example.org/af8e45a4-803e-4929-9853-884eff978ca0",
+        "name" : "vAgFKIHHbtX0CazVunQ",
         "nameType" : "Personal",
-        "orcId" : "fybMRsK7GkPc",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "r8pk0ZqQGjeoRmG",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "upSjOGWB581Bu21ZJ",
-          "value" : "4CveIx2wSTfo6Me7w"
+          "sourceName" : "u8Pc79fjneRXwjUHhq7",
+          "value" : "5hqKSEwcBqILy2Qd2E"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YeKZKQZNpxYZic",
-          "value" : "pOHenkmU2IR"
+          "sourceName" : "ZIh86nMP4NgMiOJ",
+          "value" : "t2uIMwFncrW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/66782418-79b9-49d2-99b7-0c97f3046821"
+        "id" : "https://www.example.org/2329f362-436a-46d3-bb96-0114d6a8c13d"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "bR5oxJPOih"
+      "bg" : "E0Cqr8oD0hjY"
     },
-    "npiSubjectHeading" : "cYLxrzGeA3BMVjt",
-    "tags" : [ "D2v5zEWfIeEqgHMZ" ],
-    "description" : "YjeUKzgW21M8Y82XYv",
+    "npiSubjectHeading" : "9XLxlypCNOYbCn7",
+    "tags" : [ "dqrlT32TDWHtzsA" ],
+    "description" : "PuKC7ekhuanxc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f980415f-a948-4a20-82ed-a9c234772a13"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9b771724-a991-4200-8b48-b70e6989eb02"
         },
-        "seriesNumber" : "C0hICwcz8gf",
+        "seriesNumber" : "XMHL5s3sHRz",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/51237458-fd4c-4754-93ed-677b43a51542",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a800049e-df21-4600-8aa2-0925b32dc81f",
           "valid" : true
         },
-        "isbnList" : [ "9790994360105" ],
+        "isbnList" : [ "9780750477796", "9781009372596" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "dUvqSOIQWKx5z"
+          "value" : "1009372599"
         } ]
       },
-      "doi" : "https://www.example.org/5596f649-edf3-49ac-a253-f7736c0a50b7",
+      "doi" : "https://www.example.org/0ee5da13-fe47-464a-9ce6-46fdf7ae9103",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "LB7kEQ9YlWXdYK",
-            "end" : "tLzgaqHeKTPEhQ"
+            "begin" : "NaTQiBStLlYd",
+            "end" : "4R68AJjIx2vOf7YYgTy"
           },
-          "pages" : "Crflb9Z09eiu1",
-          "illustrated" : false
+          "pages" : "JZOrJDe21WM",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6788b3f0-50f4-4eb9-9be0-94399a8ec86f",
-    "abstract" : "ueh5zZttQCV"
+    "metadataSource" : "https://www.example.org/629052e6-ce05-407e-b900-69722e4dc56c",
+    "abstract" : "ooE4EDhBZQ4dYB"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9f98445f-6afc-4cde-8a79-ac0e633dce41",
-    "name" : "lQ6h5CuTabyC8xiVn",
+    "id" : "https://www.example.org/7c127a20-c59d-4f58-9cc1-3295a558fe0e",
+    "name" : "FUOlxrPa0ty",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-11-26T20:14:58.783Z",
+      "approvalDate" : "1986-07-15T21:13:34.370Z",
       "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ywHFYe9yHqH9f4U"
+      "applicationCode" : "fTDNwXN7JgLi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/177a61bb-4ba7-424e-8a38-66d284fec971",
-    "identifier" : "hxq5KyuJqD2yENYRdH",
+    "source" : "https://www.example.org/aa7bface-31b4-4386-9d09-e4f07b1a6513",
+    "identifier" : "QW0pPHXuAfDuEy0",
     "labels" : {
-      "ca" : "jz72j8206pLvd6vitCr"
+      "nl" : "hBdTZFgETrRNOuS"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1488356567
+      "currency" : "EUR",
+      "amount" : 506153719
     },
-    "activeFrom" : "2003-08-23T20:51:39.144Z",
-    "activeTo" : "2014-09-13T13:15:30.131Z"
+    "activeFrom" : "2013-04-18T07:34:21.813Z",
+    "activeTo" : "2020-04-27T15:49:51.160Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7f4c6994-6b8b-4477-b440-8886f9ad4f19",
-    "id" : "https://www.example.org/e52705be-d802-4d11-aa2e-86203db6668c",
-    "identifier" : "2hgPtwaxlC19200",
+    "source" : "https://www.example.org/73459a17-da3f-4df1-83e3-c497299f3945",
+    "id" : "https://www.example.org/2bf52f22-f1e0-463f-8e3f-c0e247ae3f5c",
+    "identifier" : "J2W1N13YUuAa",
     "labels" : {
-      "en" : "KjRRjSunzsxKisA3L6"
+      "nn" : "hGZahodubD4Az"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 573418590
+      "currency" : "EUR",
+      "amount" : 275002210
     },
-    "activeFrom" : "2017-04-30T01:55:09.083Z",
-    "activeTo" : "2024-04-18T05:41:41.507Z"
+    "activeFrom" : "2017-10-20T06:37:45.597Z",
+    "activeTo" : "2021-11-06T18:05:50.017Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bcd5b297-1c8c-4108-b1ed-3b0fec6649d1" ],
+  "subjects" : [ "https://www.example.org/507b16a5-2d5a-42bc-8ed0-1fa403480d0d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "757fc6aa-5c2a-4bb0-83b9-0c108971540b",
-    "name" : "wCuwZ43ggm7",
-    "mimeType" : "kR1WcXCKdP",
-    "size" : 290769447,
-    "license" : "https://www.example.com/5kjjybduqqdpbfvs",
+    "identifier" : "330554c0-e659-4b68-a756-6787bc070b55",
+    "name" : "i5fAf2ksirbyV8c5",
+    "mimeType" : "Ek8S6qsxy24KGrYMvK",
+    "size" : 258213037,
+    "license" : "https://www.example.com/zao6iixetmcbgk",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "xVszAkuRiQmjTQSR",
-    "publishedDate" : "1995-06-08T23:43:31.550Z",
+    "legalNote" : "fMrJuCmgAVnlyNtv4",
+    "publishedDate" : "1972-07-13T02:52:46.100Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "aqjHHzOfGDCVRbaCPuq",
-      "uploadedDate" : "1977-01-04T00:04:05.344Z"
+      "uploadedBy" : "3JsuUf92KoYsT6ARM",
+      "uploadedDate" : "1995-06-24T03:58:57.799Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7dhVFOa7qme68K",
-    "name" : "G8o019qANGGU1l6FtPd",
-    "description" : "hzerBY9XI2K5Gu"
+    "id" : "https://www.example.com/7ShB5CwTIn",
+    "name" : "vSkoo8dR3V1tv",
+    "description" : "uOfKhNWVeW"
   } ],
-  "rightsHolder" : "rjH2YTRU9J1iowPEvaV",
-  "duplicateOf" : "https://www.example.org/04706707-f44a-4bd7-b53d-08abc3e48b31",
+  "rightsHolder" : "nxinzmQ4s7PH",
+  "duplicateOf" : "https://www.example.org/7cd87a6a-378a-4f29-82a7-ec3b7a4d5fcc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "nJOpiONDwgeXvNTg"
+    "note" : "oaEhMMVDgZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sMQfVhcpiMyh5BXQmd",
-    "createdBy" : "XGfTvPPgWZRMtgKBpr",
-    "createdDate" : "1985-11-06T06:22:51.912Z"
+    "note" : "aUFrwAv4TwBF8R4PvM",
+    "createdBy" : "yyZ8gc8dIoH",
+    "createdDate" : "1977-02-13T13:50:23.700Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9e63b883-c60c-42a2-a560-a9fcf5ba02f2" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/13561209-f6d6-4dbd-ac43-d3e399964330" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "AU6qKiIcuMz",
-    "ownerAffiliation" : "https://www.example.org/f12b30ef-933a-4073-a046-e2523964a223"
+    "owner" : "5TQY3yaU2OUkDM",
+    "ownerAffiliation" : "https://www.example.org/ac6b7b8f-74dc-4ef9-b50f-b8b40fc26e55"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/10fc317b-8983-4343-b876-182a96072867"
+    "id" : "https://www.example.org/a2f3bf0a-67e6-4d82-b1dd-3fd07e723f3b"
   },
-  "createdDate" : "2000-04-14T17:46:55.305Z",
-  "modifiedDate" : "1992-09-28T00:30:44.060Z",
-  "publishedDate" : "2019-04-15T21:18:54.358Z",
-  "indexedDate" : "2008-06-06T01:25:10.181Z",
-  "handle" : "https://www.example.org/63c6fca7-4b38-4b4a-b2e2-606122bf356d",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/7f8beedb-0989-4547-9433-1ac9ae7529cb",
+  "createdDate" : "1972-12-30T19:34:34.455Z",
+  "modifiedDate" : "1996-05-05T11:53:32.950Z",
+  "publishedDate" : "2024-01-12T00:45:30.575Z",
+  "indexedDate" : "2022-02-12T07:43:45.634Z",
+  "handle" : "https://www.example.org/fd32cb58-9f9f-4b62-bb96-98d8e6d3321e",
+  "doi" : "https://doi.org/10.1234/eos",
+  "link" : "https://www.example.org/2077e860-7964-4364-a1aa-548330324210",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2mjcK21SJOwD5FT0",
+    "mainTitle" : "WSIO0H7kGMrPRT40dkF",
     "alternativeTitles" : {
-      "fi" : "fW5mcbuwBSMa"
+      "es" : "AAjfmTWMq6aDBLIh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "MC0rAW9Pd2QFXnBFe",
-      "month" : "Xeq34rpgSQqaOBaRfJ",
-      "day" : "1TwNJBUd3MJu72fx"
+      "year" : "1ZCM0hNe4xOkW5MK",
+      "month" : "ZkPfuFlTXc",
+      "day" : "af6p9CetKmHeOOLjE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/55420f4e-5f13-40a4-9902-8b98b6955a7d",
-        "name" : "ZRPDZot9uTFraOW0o49",
-        "nameType" : "Organizational",
-        "orcId" : "GOKNPSvfQppqXLAVGdk",
+        "id" : "https://www.example.org/a08b7cf0-67e4-41d0-9cb0-dca77214984b",
+        "name" : "TJl8f2OCVoNdt",
+        "nameType" : "Personal",
+        "orcId" : "wsGwjnXNAW42n633J4Y",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bd6wjbLI0qAW",
-          "value" : "vaONPqTPPmrUmQi"
+          "sourceName" : "m373i3GT097fdqE",
+          "value" : "HSumuhU3PO9lbm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "k9Y63b47cOY1quVJxC",
-          "value" : "wKsREQYLeWR"
+          "sourceName" : "d3rFG9e10lrdTd41X5G",
+          "value" : "VGQehX5VDPIJXlWU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f0218b02-2b36-492a-b8cf-c52f16016a5c"
+        "id" : "https://www.example.org/b79c1ca7-ef0d-4045-b928-9d094f7f9586"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Advisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/af8e45a4-803e-4929-9853-884eff978ca0",
-        "name" : "vAgFKIHHbtX0CazVunQ",
-        "nameType" : "Personal",
-        "orcId" : "r8pk0ZqQGjeoRmG",
+        "id" : "https://www.example.org/e40921be-5cce-4c5f-a7ec-2497dc9440e1",
+        "name" : "ExVGFnLVBfapE",
+        "nameType" : "Organizational",
+        "orcId" : "lUlEehv1GgDSd4L7",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "u8Pc79fjneRXwjUHhq7",
-          "value" : "5hqKSEwcBqILy2Qd2E"
+          "sourceName" : "XLvglChJdUcQ",
+          "value" : "M3TZyhIjBQDZ8UM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZIh86nMP4NgMiOJ",
-          "value" : "t2uIMwFncrW"
+          "sourceName" : "7NHp4E6ZqO17",
+          "value" : "GmCNOsAER3DNX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2329f362-436a-46d3-bb96-0114d6a8c13d"
+        "id" : "https://www.example.org/c9f8f60f-11ec-44dc-bd88-f96715c3ed1b"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "E0Cqr8oD0hjY"
+      "it" : "e2qUTgW2BGJzubO0"
     },
-    "npiSubjectHeading" : "9XLxlypCNOYbCn7",
-    "tags" : [ "dqrlT32TDWHtzsA" ],
-    "description" : "PuKC7ekhuanxc",
+    "npiSubjectHeading" : "9M3e1qbXcdW7m",
+    "tags" : [ "vWJn6iYepKCfwSG" ],
+    "description" : "d8eQOM1DKM",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9b771724-a991-4200-8b48-b70e6989eb02"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0a714a76-9ae6-4ba9-b12c-1a7e85317a51"
         },
-        "seriesNumber" : "XMHL5s3sHRz",
+        "seriesNumber" : "DmNQ2cb175OV7mRZkE4",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a800049e-df21-4600-8aa2-0925b32dc81f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f1bf17e1-b047-41c7-9a8f-ae939508dfca",
           "valid" : true
         },
-        "isbnList" : [ "9780750477796", "9781009372596" ],
+        "isbnList" : [ "9791883857461", "9781782037101" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1009372599"
+          "value" : "1782037101"
         } ]
       },
-      "doi" : "https://www.example.org/0ee5da13-fe47-464a-9ce6-46fdf7ae9103",
+      "doi" : "https://www.example.org/a8486f01-4cf1-4000-a9ab-24266103004f",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "NaTQiBStLlYd",
-            "end" : "4R68AJjIx2vOf7YYgTy"
+            "begin" : "uZxQyDacL30v",
+            "end" : "ig16VsM4ogZ9R9"
           },
-          "pages" : "JZOrJDe21WM",
+          "pages" : "4H2M8iHQe8onMyG",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/629052e6-ce05-407e-b900-69722e4dc56c",
-    "abstract" : "ooE4EDhBZQ4dYB"
+    "metadataSource" : "https://www.example.org/3e523ce3-ece8-4876-86c3-535d724f790d",
+    "abstract" : "6DmPRDzypU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7c127a20-c59d-4f58-9cc1-3295a558fe0e",
-    "name" : "FUOlxrPa0ty",
+    "id" : "https://www.example.org/0170a7b2-4ada-451a-9de2-d5d2f444fc45",
+    "name" : "DSBYMZI11XZ47x8Km",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1986-07-15T21:13:34.370Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "fTDNwXN7JgLi"
+      "approvalDate" : "2012-01-31T00:44:51.805Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "qclW6PrxNibyzf48Gc5"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/aa7bface-31b4-4386-9d09-e4f07b1a6513",
-    "identifier" : "QW0pPHXuAfDuEy0",
+    "source" : "https://www.example.org/95112608-1065-46b4-8a43-51bdc6096732",
+    "identifier" : "Eir5G81rhs6a",
     "labels" : {
-      "nl" : "hBdTZFgETrRNOuS"
+      "pl" : "aGXqe8OvSYEHFcfhwj"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 506153719
+      "currency" : "USD",
+      "amount" : 888444067
     },
-    "activeFrom" : "2013-04-18T07:34:21.813Z",
-    "activeTo" : "2020-04-27T15:49:51.160Z"
+    "activeFrom" : "2004-11-19T08:00:08.290Z",
+    "activeTo" : "2010-02-20T03:42:26.688Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/73459a17-da3f-4df1-83e3-c497299f3945",
-    "id" : "https://www.example.org/2bf52f22-f1e0-463f-8e3f-c0e247ae3f5c",
-    "identifier" : "J2W1N13YUuAa",
+    "source" : "https://www.example.org/2e619773-3790-4cb0-9719-adc61af95b48",
+    "id" : "https://www.example.org/3d9af1b0-2d8d-47bd-a758-115f02df12b3",
+    "identifier" : "mSEmjG5LzG3TAQhYSI",
     "labels" : {
-      "nn" : "hGZahodubD4Az"
+      "ru" : "pLnD9Uxn1P9nExmyIpH"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 275002210
+      "amount" : 1934156391
     },
-    "activeFrom" : "2017-10-20T06:37:45.597Z",
-    "activeTo" : "2021-11-06T18:05:50.017Z"
+    "activeFrom" : "2023-06-09T19:02:23.388Z",
+    "activeTo" : "2023-07-21T13:02:51.129Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/507b16a5-2d5a-42bc-8ed0-1fa403480d0d" ],
+  "subjects" : [ "https://www.example.org/ac713edb-59da-4576-b7d5-6bdfd26593dc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "330554c0-e659-4b68-a756-6787bc070b55",
-    "name" : "i5fAf2ksirbyV8c5",
-    "mimeType" : "Ek8S6qsxy24KGrYMvK",
-    "size" : 258213037,
-    "license" : "https://www.example.com/zao6iixetmcbgk",
+    "identifier" : "1762899d-5707-44e3-a15e-23fa7c1578d3",
+    "name" : "hcMbZgWbzyWYBDis",
+    "mimeType" : "0D58XRiUv1tnYRhETby",
+    "size" : 1056960186,
+    "license" : "https://www.example.com/571smbkcnof5ngmwe3p",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "2mlqkZJ2Q6dPh"
     },
-    "legalNote" : "fMrJuCmgAVnlyNtv4",
-    "publishedDate" : "1972-07-13T02:52:46.100Z",
+    "legalNote" : "Shg4fKflqynU",
+    "publishedDate" : "2011-04-12T03:03:45.591Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3JsuUf92KoYsT6ARM",
-      "uploadedDate" : "1995-06-24T03:58:57.799Z"
+      "uploadedBy" : "fC6pgOruBT7x",
+      "uploadedDate" : "2014-04-11T04:12:53.756Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7ShB5CwTIn",
-    "name" : "vSkoo8dR3V1tv",
-    "description" : "uOfKhNWVeW"
+    "id" : "https://www.example.com/S7nEw0vibetCp",
+    "name" : "Gr0vUG4yffCqAiyH",
+    "description" : "5qgEBAGznwhVHhVCXWT"
   } ],
-  "rightsHolder" : "nxinzmQ4s7PH",
-  "duplicateOf" : "https://www.example.org/7cd87a6a-378a-4f29-82a7-ec3b7a4d5fcc",
+  "rightsHolder" : "CLsWVCsqwICNlFT1aC",
+  "duplicateOf" : "https://www.example.org/4f5828c3-7d3a-4715-8887-de71a4e78010",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "oaEhMMVDgZ"
+    "note" : "EFxDoHxHH0HH"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "aUFrwAv4TwBF8R4PvM",
-    "createdBy" : "yyZ8gc8dIoH",
-    "createdDate" : "1977-02-13T13:50:23.700Z"
+    "note" : "ITCieKp8fN",
+    "createdBy" : "sdZJs7Q0NzEU30n",
+    "createdDate" : "1990-09-02T23:05:23.452Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/13561209-f6d6-4dbd-ac43-d3e399964330" ],
+  "curatingInstitutions" : [ "https://www.example.org/6719a92c-bc60-4118-9fb8-e2275ff1139d" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "ynjc2XWXc2NXlAxfXBR",
-    "ownerAffiliation" : "https://www.example.org/d0ae22ed-4711-482b-874d-7fba7410984a"
+    "owner" : "SC4OBot33e0zjnqeADR",
+    "ownerAffiliation" : "https://www.example.org/d8686892-337f-4359-b93b-1ae925fd407b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d1e97119-9c23-4559-86fc-040ecf03472f"
+    "id" : "https://www.example.org/15087b9a-ad0c-4110-be4b-4d31b0ca85fc"
   },
-  "createdDate" : "2000-03-10T11:58:20.339Z",
-  "modifiedDate" : "2010-08-25T04:56:26.556Z",
-  "publishedDate" : "1987-11-21T00:23:48.313Z",
-  "indexedDate" : "2002-07-06T10:04:16.967Z",
-  "handle" : "https://www.example.org/3a9820cf-014d-4881-ac01-0e4277381cec",
-  "doi" : "https://doi.org/10.1234/temporibus",
-  "link" : "https://www.example.org/ea9e3555-adcf-4cc2-9b36-ae09d824c2ed",
+  "createdDate" : "2009-02-17T14:26:03.638Z",
+  "modifiedDate" : "1977-05-08T18:38:45.824Z",
+  "publishedDate" : "2004-07-13T06:49:03.841Z",
+  "indexedDate" : "2002-02-27T18:47:36.464Z",
+  "handle" : "https://www.example.org/86576c4c-5cd6-47e6-9a92-ab35315d3dd8",
+  "doi" : "https://doi.org/10.1234/magnam",
+  "link" : "https://www.example.org/c811d2b3-8426-43f5-a37f-de6fee0b3c34",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "q6C6WtcCcUh5n",
+    "mainTitle" : "06RXULlhSmA3skOK",
     "alternativeTitles" : {
-      "es" : "5cWWUbMvNMjZq"
+      "cs" : "sA91qHQc2Y"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "8rCMsOuYEsP",
-      "month" : "HXQ4neZaiLQCj",
-      "day" : "eUeWjSAdxRsUmfe"
+      "year" : "3ZblSGgePM6xTZr",
+      "month" : "DX3JjRuuA7eRjv",
+      "day" : "hOUFssKyuoD4UhU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a5e7743a-9ed2-467e-9c39-1b5f79c89252",
-        "name" : "qjNiRIP5v0",
+        "id" : "https://www.example.org/77b78580-d8f1-4cbd-99da-e7fd4776d033",
+        "name" : "UlxjUk21FyL8DBK",
         "nameType" : "Organizational",
-        "orcId" : "MsliZaXvmG",
+        "orcId" : "cQLv6FqfA5B",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MJfJQ2sc5M9I4",
-          "value" : "fYrI6MX2Req"
+          "sourceName" : "CO5eFrS4lwz",
+          "value" : "JTrzi4AhGBsHdVdV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jPxy11JaF4S5tF8B2",
-          "value" : "KaprZdmULVzIMfieT"
+          "sourceName" : "vzYTR5K2nnwlSkahx6",
+          "value" : "UIvHO119mq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2416716e-ba03-4562-8881-716486b08770"
+        "id" : "https://www.example.org/9f08ca6e-f76d-4fbc-9331-4d13861da6de"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a47fc11-75b0-4059-88af-bdc804fa2831",
-        "name" : "kaJxRWoFGDz6B",
-        "nameType" : "Personal",
-        "orcId" : "BLGeRnKFE8oyneBt1C",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1f548d0a-9cb7-436e-aa18-e4aded8f5d21",
+        "name" : "7FclWkE61O8pnh",
+        "nameType" : "Organizational",
+        "orcId" : "JCTxPOA7xC98cD",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xMlzw2W3KxwxpjO",
-          "value" : "PoZfLt9rMOx5"
+          "sourceName" : "AsCfUc9Ltj5eXSDZdPE",
+          "value" : "1ppr7L5PV4JVyvKl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4e1JdhJxEbrJ1gp",
-          "value" : "41aviRZTUcr2"
+          "sourceName" : "s5FTsqfPtyOSfE",
+          "value" : "UFzEqTJouLN9i"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/256ea829-99da-47d2-a7dd-827c8da4508b"
+        "id" : "https://www.example.org/04cc032e-8fef-4fe8-a548-fd1750e000cd"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "RoleOther",
+        "description" : "39k09zsU9RYkZ"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "6e1bIFKlww07NpwxX"
+      "nn" : "Xrt9cWrZI7PzguJmJr4"
     },
-    "npiSubjectHeading" : "TJRrWesK9Wd",
-    "tags" : [ "OI3RaP0ZmKn0Bp0Z" ],
-    "description" : "sgnqD06Th7mBmLp9Rc",
+    "npiSubjectHeading" : "6mGWRsnJH4c0YkvSG",
+    "tags" : [ "za3w2SfN7Ts1Sna" ],
+    "description" : "rwlvEh4hQRP5E",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f956d30d-36f4-47e8-8aed-83c709a313db",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1b2adf7f-0ddb-4c2a-ac45-67da12c712f8",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/29fb2a36-b52b-4101-897d-c75d53ea51cf",
+      "doi" : "https://www.example.org/ed231419-d28b-4ee0-a3c1-8a246f580525",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "x9SPcHyEgNBah"
+          "text" : "y98cw3Rww2"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "StwqLGUmH0zH",
-            "end" : "KQsCq8I7CwNKuFv4"
+            "begin" : "GQ5L4jCwAJ9gSkpITyq",
+            "end" : "Hpuk5r2VZucW33"
           },
-          "pages" : "ysdHghZbJzjvfU7",
-          "illustrated" : false
+          "pages" : "vm0QaKGpleuaPCxfxS",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ff859930-31b7-42ce-8b38-2917cc01dabc",
-    "abstract" : "faHr8b62HCw"
+    "metadataSource" : "https://www.example.org/a8083d57-d5bc-432e-ad3f-d16e5cc4c276",
+    "abstract" : "nnGOqGPx53Ce8A3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2df867ae-711b-44ac-834b-f00ff0a98a8e",
-    "name" : "8Ju3ZD5S9JmDM5Ir4",
+    "id" : "https://www.example.org/f2734ed4-a079-4b49-8975-1da9083f44da",
+    "name" : "03HmOm2kRRp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2014-04-11T18:55:05.698Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "cDVeXmHCBKcGlVkY"
+      "approvalDate" : "2022-03-30T02:18:02.689Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "2yJ4IfR6GvMin"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e1ad8c86-b2f1-4be1-ac22-c20457d8de99",
-    "identifier" : "ap2HZpQp39b",
+    "source" : "https://www.example.org/7ae94e98-2479-4c42-b2d5-ea102631a5dd",
+    "identifier" : "UgBZnrprlcnCp0MFN",
     "labels" : {
-      "sv" : "zW8aUpV3rJYf"
+      "se" : "gVKksViHh0fTzv7D4We"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 214583304
+    },
+    "activeFrom" : "1995-09-03T23:48:41.952Z",
+    "activeTo" : "2004-03-28T02:20:37.761Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/3d8443f5-c840-491f-94a8-d40f950d02da",
+    "id" : "https://www.example.org/8dc34542-a0d9-418a-b77f-5a70e5199b45",
+    "identifier" : "gApmds1RP56VcDcPD",
+    "labels" : {
+      "en" : "jbxWcTxHp5etQNe"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 94824649
+      "amount" : 2098780901
     },
-    "activeFrom" : "2001-08-13T19:42:54.552Z",
-    "activeTo" : "2023-06-17T09:07:32.106Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/753424be-b2a1-4b3a-9abf-b3900e9b32e2",
-    "id" : "https://www.example.org/022353e6-04ab-4c52-aa7d-caca9809915e",
-    "identifier" : "83RDn5QSoJBOz1vj",
-    "labels" : {
-      "af" : "zEkXZmKcoG"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 117287634
-    },
-    "activeFrom" : "1999-10-22T23:44:59.819Z",
-    "activeTo" : "2022-10-01T16:30:22.696Z"
+    "activeFrom" : "2003-11-26T11:58:16.834Z",
+    "activeTo" : "2021-04-16T22:41:07.289Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/208d6ebd-f916-4173-a9fa-1d0ace55f4aa" ],
+  "subjects" : [ "https://www.example.org/7bb48494-c940-4094-85c0-90248522496e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "60397ba0-1dcd-4bec-aade-26cc64fdc0b2",
-    "name" : "udhsaxe9qDaE",
-    "mimeType" : "Sb8Q11iYVpp2gDYeJa7",
-    "size" : 1717898591,
-    "license" : "https://www.example.com/db60so53jeeehwk",
+    "identifier" : "a6563e51-ee46-45e2-a987-8ffd21ebfa59",
+    "name" : "oLsiTlZi1i8pcOvVsuK",
+    "mimeType" : "HKoxzrmc96vsEwtHMu",
+    "size" : 61742577,
+    "license" : "https://www.example.com/cumjdkbv7gjq",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "8972Hlhl6VQn",
-    "publishedDate" : "2005-09-28T07:17:24.849Z",
+    "legalNote" : "gNFx3aE7AnQ",
+    "publishedDate" : "1989-11-16T10:56:44.460Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "6kncPWoKbqvpVMUFFM5",
-      "uploadedDate" : "1988-01-16T01:10:23.123Z"
+      "uploadedBy" : "iZXTsy54FCb0",
+      "uploadedDate" : "2023-09-02T05:12:51.292Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YQ6yBwBXEqi6",
-    "name" : "xxDFjTcCk3F9",
-    "description" : "13uzKnMGnFu6LmXfx2"
+    "id" : "https://www.example.com/fHgFvKaC1lsMwZAF",
+    "name" : "yVd5Irxy2s8C",
+    "description" : "jAmjcOmiq5ZgwGV"
   } ],
-  "rightsHolder" : "gTuHVPabkD5m3",
-  "duplicateOf" : "https://www.example.org/bc2bedd9-9e21-44da-b5d2-c255d47fad6c",
+  "rightsHolder" : "IQzcwbFZmn",
+  "duplicateOf" : "https://www.example.org/70babc08-c5e0-481d-9fee-803cf0eb822b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "JuD2z8ctI8v"
+    "note" : "vBmFPdsKD1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "5GVoU6YNlJA94naTl",
-    "createdBy" : "CluEsBecPyAjJZn",
-    "createdDate" : "2014-06-11T13:53:38.789Z"
+    "note" : "YgivrDLSeplGBzbO",
+    "createdBy" : "W3V7v5Nhtc",
+    "createdDate" : "1983-12-21T14:48:37.173Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a7994124-ae1d-4702-8126-b280e29d99bc" ],
+  "curatingInstitutions" : [ "https://www.example.org/c649838a-3c85-400c-8714-2afb9eb1b07e" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "l0T4xp2rBSAzck",
-    "ownerAffiliation" : "https://www.example.org/6097e4a6-373b-4b12-80ef-d282c381ba3f"
+    "owner" : "ynjc2XWXc2NXlAxfXBR",
+    "ownerAffiliation" : "https://www.example.org/d0ae22ed-4711-482b-874d-7fba7410984a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/58fe6982-5599-486f-ad05-91e863c1dcfe"
+    "id" : "https://www.example.org/d1e97119-9c23-4559-86fc-040ecf03472f"
   },
-  "createdDate" : "2022-07-16T01:34:02.891Z",
-  "modifiedDate" : "2019-10-11T01:17:40.983Z",
-  "publishedDate" : "1992-09-27T04:04:39.836Z",
-  "indexedDate" : "2011-08-30T00:11:59.528Z",
-  "handle" : "https://www.example.org/9556adc7-815d-4c31-b5fd-e361fc8f46f3",
-  "doi" : "https://doi.org/10.1234/adipisci",
-  "link" : "https://www.example.org/5c76a044-e660-40a0-abed-ea665096c8d1",
+  "createdDate" : "2000-03-10T11:58:20.339Z",
+  "modifiedDate" : "2010-08-25T04:56:26.556Z",
+  "publishedDate" : "1987-11-21T00:23:48.313Z",
+  "indexedDate" : "2002-07-06T10:04:16.967Z",
+  "handle" : "https://www.example.org/3a9820cf-014d-4881-ac01-0e4277381cec",
+  "doi" : "https://doi.org/10.1234/temporibus",
+  "link" : "https://www.example.org/ea9e3555-adcf-4cc2-9b36-ae09d824c2ed",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7xyr8E5Be8iQTB",
+    "mainTitle" : "q6C6WtcCcUh5n",
     "alternativeTitles" : {
-      "nn" : "jQfnqQFQMEU0AGTgb"
+      "es" : "5cWWUbMvNMjZq"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "oxVVrD19Tu8P9xXG",
-      "month" : "M6IlvvVCgMqoY",
-      "day" : "CMYb8CL4p4ZuF"
+      "year" : "8rCMsOuYEsP",
+      "month" : "HXQ4neZaiLQCj",
+      "day" : "eUeWjSAdxRsUmfe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/24a59505-1bb7-445c-a203-0fc493d2fdfb",
-        "name" : "iDGa8m6eajleXasOcC",
-        "nameType" : "Personal",
-        "orcId" : "JPZQSg17RGbhewbkPE",
+        "id" : "https://www.example.org/a5e7743a-9ed2-467e-9c39-1b5f79c89252",
+        "name" : "qjNiRIP5v0",
+        "nameType" : "Organizational",
+        "orcId" : "MsliZaXvmG",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tjm4EwaEaMYYCy5Y2",
-          "value" : "gn4LRYnZnHX5sQ4"
+          "sourceName" : "MJfJQ2sc5M9I4",
+          "value" : "fYrI6MX2Req"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "f4A4aCEu9Qa",
-          "value" : "LlNnl0VodF"
+          "sourceName" : "jPxy11JaF4S5tF8B2",
+          "value" : "KaprZdmULVzIMfieT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f3c02d5f-8b08-41f6-bf48-ad322ca456b5"
+        "id" : "https://www.example.org/2416716e-ba03-4562-8881-716486b08770"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e32c114-d0d9-490a-a8fc-e0c2af2cbb91",
-        "name" : "sU1HloGYzy32",
+        "id" : "https://www.example.org/8a47fc11-75b0-4059-88af-bdc804fa2831",
+        "name" : "kaJxRWoFGDz6B",
         "nameType" : "Personal",
-        "orcId" : "RXt2lprVu7mVKXNGZh",
-        "verificationStatus" : "Verified",
+        "orcId" : "BLGeRnKFE8oyneBt1C",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V8qZpUistO64X18CZ7",
-          "value" : "WmFt5UYM3bUL4glD"
+          "sourceName" : "xMlzw2W3KxwxpjO",
+          "value" : "PoZfLt9rMOx5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pLHIKeUfP5J1",
-          "value" : "th4nEgd2agmn1MmEj"
+          "sourceName" : "4e1JdhJxEbrJ1gp",
+          "value" : "41aviRZTUcr2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/52c86322-ae81-46d6-92a8-f53b15bb24e4"
+        "id" : "https://www.example.org/256ea829-99da-47d2-a7dd-827c8da4508b"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "s95TA0RTZA"
+      "bg" : "6e1bIFKlww07NpwxX"
     },
-    "npiSubjectHeading" : "vjZqtNz0TBtKm7r",
-    "tags" : [ "unQVa2SltftY" ],
-    "description" : "uG2u3b5grANcwB",
+    "npiSubjectHeading" : "TJRrWesK9Wd",
+    "tags" : [ "OI3RaP0ZmKn0Bp0Z" ],
+    "description" : "sgnqD06Th7mBmLp9Rc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/10d839fa-fb56-4ec5-b3a8-176bd7e5fd50",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f956d30d-36f4-47e8-8aed-83c709a313db",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/75ae97c7-0c22-47a1-b564-b48154af5aff",
+      "doi" : "https://www.example.org/29fb2a36-b52b-4101-897d-c75d53ea51cf",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "UoW10gBZTa"
+          "text" : "x9SPcHyEgNBah"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rx1oh17fzvhMSG",
-            "end" : "lvzE7cjiAkroO1S"
+            "begin" : "StwqLGUmH0zH",
+            "end" : "KQsCq8I7CwNKuFv4"
           },
-          "pages" : "0qvzG5SVKvGRHs",
+          "pages" : "ysdHghZbJzjvfU7",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/99f24fd1-8f76-48d7-8a8f-ce5979430373",
-    "abstract" : "nLiPyhs3EYo4zIFb8F"
+    "metadataSource" : "https://www.example.org/ff859930-31b7-42ce-8b38-2917cc01dabc",
+    "abstract" : "faHr8b62HCw"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7d349ba7-ca2a-469b-ade0-88ce6da045d6",
-    "name" : "XFYxbDZmrvqediRwY5V",
+    "id" : "https://www.example.org/2df867ae-711b-44ac-834b-f00ff0a98a8e",
+    "name" : "8Ju3ZD5S9JmDM5Ir4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-03-16T20:25:14.231Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2014-04-11T18:55:05.698Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "ggYIxn9y2p"
+      "applicationCode" : "cDVeXmHCBKcGlVkY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/38ce228a-db09-4900-9a77-2b46edfa588e",
-    "identifier" : "EZ31pJKqBBpq0y2B7eZ",
+    "source" : "https://www.example.org/e1ad8c86-b2f1-4be1-ac22-c20457d8de99",
+    "identifier" : "ap2HZpQp39b",
     "labels" : {
-      "en" : "g1TuYYfu6qiSi2D3"
+      "sv" : "zW8aUpV3rJYf"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1454820755
+      "currency" : "EUR",
+      "amount" : 94824649
     },
-    "activeFrom" : "2018-07-17T03:15:27.783Z",
-    "activeTo" : "2019-09-23T06:31:20.478Z"
+    "activeFrom" : "2001-08-13T19:42:54.552Z",
+    "activeTo" : "2023-06-17T09:07:32.106Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a09c53e2-b65c-4e5b-8cfe-8147d549e7d9",
-    "id" : "https://www.example.org/58a9a355-ace6-43ba-837a-79c0ba1929cb",
-    "identifier" : "G5wEhfHgyOXquy",
+    "source" : "https://www.example.org/753424be-b2a1-4b3a-9abf-b3900e9b32e2",
+    "id" : "https://www.example.org/022353e6-04ab-4c52-aa7d-caca9809915e",
+    "identifier" : "83RDn5QSoJBOz1vj",
     "labels" : {
-      "ru" : "4WtbFlkFgymFxD"
+      "af" : "zEkXZmKcoG"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1547909933
+      "amount" : 117287634
     },
-    "activeFrom" : "2022-07-18T11:50:19.872Z",
-    "activeTo" : "2023-09-27T17:42:28.190Z"
+    "activeFrom" : "1999-10-22T23:44:59.819Z",
+    "activeTo" : "2022-10-01T16:30:22.696Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5d24e7d0-ea5c-4d7c-8f1e-1cc59ff652d9" ],
+  "subjects" : [ "https://www.example.org/208d6ebd-f916-4173-a9fa-1d0ace55f4aa" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e985ffaa-efa0-46de-a15a-d8033d08df17",
-    "name" : "Zo7Twpqok4uYbaS9xYZ",
-    "mimeType" : "J5S6HZBRVUM0M",
-    "size" : 1620604793,
-    "license" : "https://www.example.com/fkkisfaykvvawcwdu",
+    "identifier" : "60397ba0-1dcd-4bec-aade-26cc64fdc0b2",
+    "name" : "udhsaxe9qDaE",
+    "mimeType" : "Sb8Q11iYVpp2gDYeJa7",
+    "size" : 1717898591,
+    "license" : "https://www.example.com/db60so53jeeehwk",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "G9EDVcPxtQeJb2G2v",
-    "publishedDate" : "2013-08-11T00:53:17.520Z",
+    "legalNote" : "8972Hlhl6VQn",
+    "publishedDate" : "2005-09-28T07:17:24.849Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ILRm6HwPFgxungm6M",
-      "uploadedDate" : "1980-02-08T05:41:27.780Z"
+      "uploadedBy" : "6kncPWoKbqvpVMUFFM5",
+      "uploadedDate" : "1988-01-16T01:10:23.123Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7v5gDJkJ8EiLp6ZTce1",
-    "name" : "wad9LunxQWeb10SmP",
-    "description" : "H8jNEdXFrO"
+    "id" : "https://www.example.com/YQ6yBwBXEqi6",
+    "name" : "xxDFjTcCk3F9",
+    "description" : "13uzKnMGnFu6LmXfx2"
   } ],
-  "rightsHolder" : "nsyWPD80NUJfz58Fto",
-  "duplicateOf" : "https://www.example.org/ea312add-049a-4e07-af49-44b4e422c343",
+  "rightsHolder" : "gTuHVPabkD5m3",
+  "duplicateOf" : "https://www.example.org/bc2bedd9-9e21-44da-b5d2-c255d47fad6c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vqrJa8WAWE"
+    "note" : "JuD2z8ctI8v"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "5z2J6Ec0JzN5",
-    "createdBy" : "WUfZEs5UI215eO",
-    "createdDate" : "2014-04-28T22:33:16.836Z"
+    "note" : "5GVoU6YNlJA94naTl",
+    "createdBy" : "CluEsBecPyAjJZn",
+    "createdDate" : "2014-06-11T13:53:38.789Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e7812c50-f41e-42cc-bc6d-ccb6ce6dfc08" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/a7994124-ae1d-4702-8126-b280e29d99bc" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Qm65K6xhPZ27k5UmfF",
-    "ownerAffiliation" : "https://www.example.org/df3185c1-237e-4a03-b2dd-36416fc1fd1e"
+    "owner" : "US7Dsxx8s5QRYoIc",
+    "ownerAffiliation" : "https://www.example.org/4d3b2e24-d1c9-42a8-9e32-7b62d3cf9b22"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/af068d96-cfc8-4bfa-9b92-8ee919bdf018"
+    "id" : "https://www.example.org/3b5eca3b-dbe0-4d0d-aec2-4d06eb69a6ee"
   },
-  "createdDate" : "2010-12-07T10:43:13.988Z",
-  "modifiedDate" : "2007-07-16T04:53:48.106Z",
-  "publishedDate" : "1978-02-14T18:49:37.064Z",
-  "indexedDate" : "1988-01-18T06:50:44.892Z",
-  "handle" : "https://www.example.org/3b226e26-2640-49c0-984d-a96acb9bf0dc",
-  "doi" : "https://doi.org/10.1234/sed",
-  "link" : "https://www.example.org/38194d3b-33f8-4708-81c9-e39c6d56dbaf",
+  "createdDate" : "2000-10-04T23:48:15.292Z",
+  "modifiedDate" : "2021-03-16T16:39:48.094Z",
+  "publishedDate" : "1975-10-28T10:56:14.156Z",
+  "indexedDate" : "2000-08-16T14:38:36.704Z",
+  "handle" : "https://www.example.org/1f527b08-abf9-4e05-852c-b1b2a5dbf728",
+  "doi" : "https://doi.org/10.1234/neque",
+  "link" : "https://www.example.org/ded406f2-34b3-4c50-8acb-90cd8efb93af",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ViehQ2fnOCzpU",
+    "mainTitle" : "rApM6AtScTP58l9Sy",
     "alternativeTitles" : {
-      "nl" : "zEGP2XIBjR8c"
+      "en" : "asL5f1OKeE6UQT2iOd9"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TFmwDr1jFSP6wU",
-      "month" : "vzl3gs6coTCNP9VkIF",
-      "day" : "Kx5gdAAYqqBB6217PVq"
+      "year" : "KjsLzHdyx9VCulgaF",
+      "month" : "b6auCvE0A1bvY1",
+      "day" : "1MobQGyObvo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6049b947-a772-4a93-83b1-273f75279a1c",
-        "name" : "lzm4Ku2SdQRTrk",
-        "nameType" : "Organizational",
-        "orcId" : "e82Ot2kkQAj1",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/8a764e3f-7100-4d75-83b4-ce747a5585ab",
+        "name" : "LSgXXwpvFoFd",
+        "nameType" : "Personal",
+        "orcId" : "7t6nG9M8b2Zu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p4DIYcPTLTOBmIH",
-          "value" : "Zv6en7RkoyKxg"
+          "sourceName" : "GAI5Gr5SPuFvcJb",
+          "value" : "ej9tBTn0NFLq272x39"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hGFsGdfB7Gm",
-          "value" : "6Ud3aGLEHNXgsOyZaN"
+          "sourceName" : "hWDrG1Wf3WhB1m",
+          "value" : "xdjBwIpQlfGFXq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/23fbb92f-3113-4587-ab25-15ec920c7e01"
+        "id" : "https://www.example.org/2a8f138c-d943-4b4f-a4f2-96faca08a172"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,154 +62,153 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fecc5bcb-4d41-4192-97cc-391bb71ae3ad",
-        "name" : "LVj3JwHwcluym",
+        "id" : "https://www.example.org/720f2492-fe6c-4277-8056-70561115a3cd",
+        "name" : "GtQClIqmkznIbkOOXf",
         "nameType" : "Organizational",
-        "orcId" : "9ksgEwD2Bi8mH9S",
+        "orcId" : "TjsBZNtbYL2Rzi8vL",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ghwI6UPzgBPWM",
-          "value" : "5oVnovgVFxYOs"
+          "sourceName" : "e7rdFPVm2J4",
+          "value" : "8zjuMUQK3RlhHXG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Jys5BCOBPXg1lx",
-          "value" : "9syd8MRHcO"
+          "sourceName" : "T4FEs2SewZDtdD1L",
+          "value" : "h3jLMpXzAbHnX7B8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5532b2e1-2c9e-4814-915d-1284af7ab7f9"
+        "id" : "https://www.example.org/3ca1707c-e491-410e-860b-6b0c0fead2d6"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "Scenographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "J0pPfIAQzrWC"
+      "sv" : "ySj8Ka2OZLEs"
     },
-    "npiSubjectHeading" : "p6toFP1Ao9b",
-    "tags" : [ "BJU3Tnxyon" ],
-    "description" : "ubKOU3Pv8UVL",
+    "npiSubjectHeading" : "wBQnxFfs9jZSfdR4Pj",
+    "tags" : [ "snWZtntGepF7" ],
+    "description" : "55sg9cGU5dd16by",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/da6b2880-7127-49db-98b0-4333f889451f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9e73678a-1926-4517-ab87-2f870480d37d",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/8be21ebd-ef71-4f96-a026-5d2d845bcb88",
+      "doi" : "https://www.example.org/456934c7-a8ca-4b23-9bab-438296c3310d",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : true,
+        "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "KGwGBQU1jSgrc"
+          "description" : "YHpDHn9j0E"
         },
-        "referencedBy" : [ "https://www.example.com/b7INMqOLSDgVD7pvrK" ],
+        "referencedBy" : [ "https://www.example.com/QjtXhTM6F7G0yM2tQjj" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "jNEUnIFWauABC4"
+          "text" : "Xv1iV5KxCsAdYVhf4hB"
         } ],
-        "compliesWith" : [ "https://www.example.com/0ORKp5rsHRB" ],
+        "compliesWith" : [ "https://www.example.com/dPE0BTDZMtK4FIX9JyC" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e0320dff-65dc-4f3b-89fe-4e53f7d8c228",
-    "abstract" : "kGFawBQ0NaeALgw"
+    "metadataSource" : "https://www.example.org/b3594cb3-f432-4a7d-934f-8819961e0c72",
+    "abstract" : "zDUHsx0oI1vgvmvOFxS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/aa6c9a3a-192a-4879-b7a2-56d5cc0876a3",
-    "name" : "CFAocOK6R1",
+    "id" : "https://www.example.org/f7b19e4a-4c28-4319-828b-ae0fa600622c",
+    "name" : "kDNNQMSdxd8AD66UCK",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-10-22T01:01:44.412Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "JMlWz5dUziO1"
+      "approvalDate" : "2000-08-21T04:45:16.673Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "eseGxCFLm9eFo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6c4b5df7-42e2-4fd0-bdab-c515baedebcb",
-    "identifier" : "seyvEAR02emoX",
+    "source" : "https://www.example.org/fe9d4826-9176-4f4e-985f-fae8307dfad0",
+    "identifier" : "pu1JurdVNgI",
     "labels" : {
-      "ru" : "TTQvEQZfI7srA"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 485932724
-    },
-    "activeFrom" : "1988-03-23T06:24:18.271Z",
-    "activeTo" : "1994-04-02T09:21:06.179Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5d8cc8de-22cf-474a-b341-09f4fb097cc6",
-    "id" : "https://www.example.org/73d86c1d-c405-413a-bc39-4f01cd832bd9",
-    "identifier" : "pEnYTCNHAxUu",
-    "labels" : {
-      "el" : "DiuJttVaZfGJIaOin"
+      "sv" : "rnnfJxflnB"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 386913254
+      "amount" : 1105999249
     },
-    "activeFrom" : "1986-08-14T07:38:55.677Z",
-    "activeTo" : "1992-05-18T23:47:00.725Z"
+    "activeFrom" : "2001-05-16T06:56:28.482Z",
+    "activeTo" : "2004-02-27T20:45:10.704Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d2f16351-42e7-4151-8a62-73eaf73a829a",
+    "id" : "https://www.example.org/6ccdf5c1-b01d-4396-9bf1-77ef60e161c5",
+    "identifier" : "MAHWIj51Fj",
+    "labels" : {
+      "hu" : "0QdI9PlyloDyMp4x40"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 2061477781
+    },
+    "activeFrom" : "1975-06-09T07:23:02.391Z",
+    "activeTo" : "2018-03-24T07:51:14.909Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b7dda677-526d-4dfd-8952-c4b43d6ea4dd" ],
+  "subjects" : [ "https://www.example.org/f7d597cb-dcd0-4058-8168-9e500e581bb7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "875a67f7-2313-4e26-9c1d-236863ddb83d",
-    "name" : "YPZQld76VscVWcw",
-    "mimeType" : "CsZVyUrq1e2q",
-    "size" : 990093763,
-    "license" : "https://www.example.com/gtl6sq1ruaii4",
+    "identifier" : "d1847bba-3092-4b19-b1c9-08967c18966a",
+    "name" : "cIA8emYiFFskqJvfkg",
+    "mimeType" : "OGB2U8CSeY3NIX",
+    "size" : 79434645,
+    "license" : "https://www.example.com/1d8nsfwksgbxb4o",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "2ZQNgU4aTl"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "YEMY7qof3JXTH9E",
-    "publishedDate" : "2018-07-12T00:38:45.635Z",
+    "legalNote" : "ypWzwh8aZnFqzL457X",
+    "publishedDate" : "2019-05-19T15:22:25.502Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "9InmCrtho3FteQtrQL",
-      "uploadedDate" : "1974-06-08T21:47:20.036Z"
+      "uploadedBy" : "fHv5LFcXldWAio",
+      "uploadedDate" : "2000-11-10T05:33:29.868Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/p6giEvZyKdxBeSHKMk",
-    "name" : "mxcQ4O5zwsKiaw0v",
-    "description" : "oieydvZ2Ztd9GQFtl"
+    "id" : "https://www.example.com/ZXOMY85AvKxcA",
+    "name" : "0ANkSPjmB7t",
+    "description" : "C5IDUuPIhmL46LflO"
   } ],
-  "rightsHolder" : "fvCrJt5Q9ZTLo",
-  "duplicateOf" : "https://www.example.org/76d1b5a7-a0f3-4247-81c5-0fa14bb0e205",
+  "rightsHolder" : "1lIH2gy3aRwfOn8URAu",
+  "duplicateOf" : "https://www.example.org/e675d737-a219-4430-ab7e-bb5185e28aa0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "6bMYtoZD7A2GFSfCNr"
+    "note" : "bCnsPUqXvtia5tw6"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "FH0cwnmurSTZWXaYJ",
-    "createdBy" : "j7tJsdr6RhfH",
-    "createdDate" : "1981-08-07T13:04:33.218Z"
+    "note" : "MAWkyIxVVOqTaY",
+    "createdBy" : "6Nri8l1xh30",
+    "createdDate" : "2010-04-04T14:12:49.088Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fff7b501-004d-4a88-8a01-0fb973719dc9" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/873e7ca5-81e9-4762-9a39-1a6b09195092" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "US7Dsxx8s5QRYoIc",
-    "ownerAffiliation" : "https://www.example.org/4d3b2e24-d1c9-42a8-9e32-7b62d3cf9b22"
+    "owner" : "YVeiL28ZJWi79QWxULB",
+    "ownerAffiliation" : "https://www.example.org/3f815519-0885-4a4c-8a65-ce3072c77334"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3b5eca3b-dbe0-4d0d-aec2-4d06eb69a6ee"
+    "id" : "https://www.example.org/cb10e795-d1cc-4904-ba3f-ca46da3d9861"
   },
-  "createdDate" : "2000-10-04T23:48:15.292Z",
-  "modifiedDate" : "2021-03-16T16:39:48.094Z",
-  "publishedDate" : "1975-10-28T10:56:14.156Z",
-  "indexedDate" : "2000-08-16T14:38:36.704Z",
-  "handle" : "https://www.example.org/1f527b08-abf9-4e05-852c-b1b2a5dbf728",
-  "doi" : "https://doi.org/10.1234/neque",
-  "link" : "https://www.example.org/ded406f2-34b3-4c50-8acb-90cd8efb93af",
+  "createdDate" : "1977-01-07T04:43:44.469Z",
+  "modifiedDate" : "1997-10-28T15:52:19.562Z",
+  "publishedDate" : "2021-09-09T23:24:47.064Z",
+  "indexedDate" : "2015-03-09T22:36:02.676Z",
+  "handle" : "https://www.example.org/26ee0d2b-9d40-4b5c-88f9-af7db308ddbc",
+  "doi" : "https://doi.org/10.1234/laboriosam",
+  "link" : "https://www.example.org/cdd7fbc3-b313-4c6c-beb4-19484587be0f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rApM6AtScTP58l9Sy",
+    "mainTitle" : "DyY5MyOU6XPzPSUzpD",
     "alternativeTitles" : {
-      "en" : "asL5f1OKeE6UQT2iOd9"
+      "hu" : "xk6Af2WpkVPYx"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KjsLzHdyx9VCulgaF",
-      "month" : "b6auCvE0A1bvY1",
-      "day" : "1MobQGyObvo"
+      "year" : "cSDSjt6DyQCR4UWoWWM",
+      "month" : "HSRciiiZ13OcEyj",
+      "day" : "WOhbXlYAJl6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a764e3f-7100-4d75-83b4-ce747a5585ab",
-        "name" : "LSgXXwpvFoFd",
-        "nameType" : "Personal",
-        "orcId" : "7t6nG9M8b2Zu",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/b78ffa1a-c807-4fdb-9a52-5f9e6b9c8a0e",
+        "name" : "xi5M0dIF4OFpeX",
+        "nameType" : "Organizational",
+        "orcId" : "6yKfAiF4R0X9ZdmEq",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GAI5Gr5SPuFvcJb",
-          "value" : "ej9tBTn0NFLq272x39"
+          "sourceName" : "g1rTwjJ5At9b3whx",
+          "value" : "2wcIGkAdCE2dWA3C"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hWDrG1Wf3WhB1m",
-          "value" : "xdjBwIpQlfGFXq"
+          "sourceName" : "NXIBWPgtXgYFJa",
+          "value" : "D21FVhYckHAvs6Zi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a8f138c-d943-4b4f-a4f2-96faca08a172"
+        "id" : "https://www.example.org/1e8145d8-4f40-4d27-8eb1-1ef94c55157e"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/720f2492-fe6c-4277-8056-70561115a3cd",
-        "name" : "GtQClIqmkznIbkOOXf",
+        "id" : "https://www.example.org/e2d01388-0089-4600-9b82-12c87090de85",
+        "name" : "EsyTxHKFJPf9hIXfz",
         "nameType" : "Organizational",
-        "orcId" : "TjsBZNtbYL2Rzi8vL",
+        "orcId" : "5CIbUzGXuxtEZZEO",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e7rdFPVm2J4",
-          "value" : "8zjuMUQK3RlhHXG"
+          "sourceName" : "tXZnMVW9AmHdIsBK",
+          "value" : "an0bHBcsX3YbxHXe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T4FEs2SewZDtdD1L",
-          "value" : "h3jLMpXzAbHnX7B8"
+          "sourceName" : "zEPgkcbKJC8QZvnIz",
+          "value" : "vLN7Jw2zaGwgVzBBKs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3ca1707c-e491-410e-860b-6b0c0fead2d6"
+        "id" : "https://www.example.org/93b848f1-3d74-4bbf-a2ed-1d5545f598b2"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "ySj8Ka2OZLEs"
+      "pt" : "ZL6qGI4ufHv9vFw"
     },
-    "npiSubjectHeading" : "wBQnxFfs9jZSfdR4Pj",
-    "tags" : [ "snWZtntGepF7" ],
-    "description" : "55sg9cGU5dd16by",
+    "npiSubjectHeading" : "IrkikLiBzomj8Cr",
+    "tags" : [ "oS4EKmmBwYrbvsHiida" ],
+    "description" : "ZhM2ry1zwSUX6ua4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9e73678a-1926-4517-ab87-2f870480d37d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/077509bb-a5a8-4bc1-8a04-6083902cfc21",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/456934c7-a8ca-4b23-9bab-438296c3310d",
+      "doi" : "https://www.example.org/efac2cd0-03f1-4df5-8230-348ab694ac5b",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : false,
+        "userAgreesToTermsAndConditions" : true,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "YHpDHn9j0E"
+          "description" : "1wD5CXldt7Kq3ydm"
         },
-        "referencedBy" : [ "https://www.example.com/QjtXhTM6F7G0yM2tQjj" ],
+        "referencedBy" : [ "https://www.example.com/evUOpty08uvt" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "Xv1iV5KxCsAdYVhf4hB"
+          "text" : "oM4HR2jFVEcXcSP"
         } ],
-        "compliesWith" : [ "https://www.example.com/dPE0BTDZMtK4FIX9JyC" ],
+        "compliesWith" : [ "https://www.example.com/NflZHmwzdIDl" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b3594cb3-f432-4a7d-934f-8819961e0c72",
-    "abstract" : "zDUHsx0oI1vgvmvOFxS"
+    "metadataSource" : "https://www.example.org/d03965f9-6d14-48af-b43a-73022d4e4af1",
+    "abstract" : "SRloAAx82W7t"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f7b19e4a-4c28-4319-828b-ae0fa600622c",
-    "name" : "kDNNQMSdxd8AD66UCK",
+    "id" : "https://www.example.org/07ff75e8-35f8-4191-bdfb-f392455bab98",
+    "name" : "lVCMDnN1Cf",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-08-21T04:45:16.673Z",
+      "approvalDate" : "1978-08-07T10:26:40.782Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "eseGxCFLm9eFo"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "p2T50BosSt6gh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/fe9d4826-9176-4f4e-985f-fae8307dfad0",
-    "identifier" : "pu1JurdVNgI",
+    "source" : "https://www.example.org/91a22e0c-0cc4-44a6-84eb-70cfb82a887b",
+    "identifier" : "Y04aZwfatjRrhZ",
     "labels" : {
-      "sv" : "rnnfJxflnB"
+      "fr" : "Ux6bKMVjQINa5Zj"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1105999249
+      "currency" : "GBP",
+      "amount" : 679652530
     },
-    "activeFrom" : "2001-05-16T06:56:28.482Z",
-    "activeTo" : "2004-02-27T20:45:10.704Z"
+    "activeFrom" : "1998-12-21T02:49:38.295Z",
+    "activeTo" : "2007-07-01T04:13:27.152Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d2f16351-42e7-4151-8a62-73eaf73a829a",
-    "id" : "https://www.example.org/6ccdf5c1-b01d-4396-9bf1-77ef60e161c5",
-    "identifier" : "MAHWIj51Fj",
+    "source" : "https://www.example.org/27244d49-9805-4351-8f72-d59edb0cef8c",
+    "id" : "https://www.example.org/93a83c14-683d-4e6f-a629-cc48933b51df",
+    "identifier" : "e8bv32nXXVYRtMn",
     "labels" : {
-      "hu" : "0QdI9PlyloDyMp4x40"
+      "cs" : "cON8VltLMohnXV"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 2061477781
+      "currency" : "GBP",
+      "amount" : 955925221
     },
-    "activeFrom" : "1975-06-09T07:23:02.391Z",
-    "activeTo" : "2018-03-24T07:51:14.909Z"
+    "activeFrom" : "1994-06-20T03:09:49.058Z",
+    "activeTo" : "2001-03-05T23:45:31.248Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f7d597cb-dcd0-4058-8168-9e500e581bb7" ],
+  "subjects" : [ "https://www.example.org/e189f443-8613-48b1-9a6a-73f68df2da6d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d1847bba-3092-4b19-b1c9-08967c18966a",
-    "name" : "cIA8emYiFFskqJvfkg",
-    "mimeType" : "OGB2U8CSeY3NIX",
-    "size" : 79434645,
-    "license" : "https://www.example.com/1d8nsfwksgbxb4o",
+    "identifier" : "c7518544-dbb9-4149-b993-9b104d6161e2",
+    "name" : "yN5FqEGWcJh",
+    "mimeType" : "50a6gVMnx8F412LQ",
+    "size" : 1913993027,
+    "license" : "https://www.example.com/zlqw1uuexzy1kkzi4y",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "9yqx9RGBHcHyWjfHL"
     },
-    "legalNote" : "ypWzwh8aZnFqzL457X",
-    "publishedDate" : "2019-05-19T15:22:25.502Z",
+    "legalNote" : "2KXKwiPMp5NZ82l",
+    "publishedDate" : "1976-01-15T05:34:11.578Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "fHv5LFcXldWAio",
-      "uploadedDate" : "2000-11-10T05:33:29.868Z"
+      "uploadedBy" : "epiCVxZnT8dmu",
+      "uploadedDate" : "2019-06-29T08:58:46.571Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZXOMY85AvKxcA",
-    "name" : "0ANkSPjmB7t",
-    "description" : "C5IDUuPIhmL46LflO"
+    "id" : "https://www.example.com/PmPesvz7FPe",
+    "name" : "yNHKLcCyvubaIsQN1L",
+    "description" : "zvMabcjaLnp0z"
   } ],
-  "rightsHolder" : "1lIH2gy3aRwfOn8URAu",
-  "duplicateOf" : "https://www.example.org/e675d737-a219-4430-ab7e-bb5185e28aa0",
+  "rightsHolder" : "j5gNufatbW95SH",
+  "duplicateOf" : "https://www.example.org/2ef1ed14-8114-4f18-ab77-30cbaf5a03bb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bCnsPUqXvtia5tw6"
+    "note" : "RQuagTJjErzgN7ec"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "MAWkyIxVVOqTaY",
-    "createdBy" : "6Nri8l1xh30",
-    "createdDate" : "2010-04-04T14:12:49.088Z"
+    "note" : "ItcmHOGkMynWah3SV",
+    "createdBy" : "TVWAZpdLPhdK",
+    "createdDate" : "2006-01-24T02:02:54.709Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/873e7ca5-81e9-4762-9a39-1a6b09195092" ],
+  "curatingInstitutions" : [ "https://www.example.org/c8bc7ed1-3349-464a-b59e-0a4e2500c777" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "nNcAQdvCFm9dclFqRX",
-    "ownerAffiliation" : "https://www.example.org/3f937195-3e76-4e31-894c-782e5f808630"
+    "owner" : "0B2C63UmkgZ5dOs",
+    "ownerAffiliation" : "https://www.example.org/e3d337f5-dc5a-4be5-b6e1-c9ce2dad5b4d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/83fda26c-60af-422e-9bf2-13f789a4f582"
+    "id" : "https://www.example.org/7792486b-e52b-47dc-abed-eca88fdc5845"
   },
-  "createdDate" : "1985-02-26T19:43:21.580Z",
-  "modifiedDate" : "2006-03-03T02:34:14.145Z",
-  "publishedDate" : "1997-02-11T09:04:32.868Z",
-  "indexedDate" : "2023-07-26T15:59:40.748Z",
-  "handle" : "https://www.example.org/79f84fce-7167-43b9-8372-0d1968dfcfb5",
-  "doi" : "https://doi.org/10.1234/eaque",
-  "link" : "https://www.example.org/cf985efb-a7dd-4a70-b269-2125de0ea8e3",
+  "createdDate" : "2017-03-14T00:47:44.176Z",
+  "modifiedDate" : "1991-12-31T22:02:42.847Z",
+  "publishedDate" : "2019-11-07T20:41:02.375Z",
+  "indexedDate" : "1984-07-31T18:19:10.343Z",
+  "handle" : "https://www.example.org/d6d5184e-7d02-44c0-9785-c458ec0587a3",
+  "doi" : "https://doi.org/10.1234/rerum",
+  "link" : "https://www.example.org/df778fa2-7264-4f42-8735-e3a5f6b7a719",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "wHCdAdrsZHhUjYMA",
+    "mainTitle" : "7E6cA6O3efZ",
     "alternativeTitles" : {
-      "de" : "PnYl7Oz7Vcc1o"
+      "fi" : "pJbaOQ1Bnn9K1hTzpib"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "lQZ4ujohyv0qT7Gpj3C",
-      "month" : "rqWcXGMpxpdl",
-      "day" : "nuoYMDhpuQ3IZ"
+      "year" : "DJvcUuO4t4",
+      "month" : "wIzj1QSGBswf3MtH",
+      "day" : "sAqTSKdV3LOvlm6IAg"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e89ba3d-3dac-4091-944b-1db8ce630aa1",
-        "name" : "b5tKz7k0Vd3",
+        "id" : "https://www.example.org/7d5e5ab1-0cb6-461c-9018-1bd36bd05796",
+        "name" : "qwGuVFY7OnBa1JQgOBS",
         "nameType" : "Personal",
-        "orcId" : "Yj2ViGm7Cm",
+        "orcId" : "MixCquYF0N",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NJbD7zNL8tkpXh",
-          "value" : "ZZ5ZyBAXxRclLg9c9"
+          "sourceName" : "WnDSgB73j61Mu",
+          "value" : "WaB7RWRhQYJVbD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ncbeouVg2Z6jvQKKkEA",
-          "value" : "uWxUbE91xXcya"
+          "sourceName" : "0JLuGTtXzc2R7Eo2BPP",
+          "value" : "mLNa2OfQJYQuh8e"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c89b1726-54be-4587-aeef-572efe1c0f45"
+        "id" : "https://www.example.org/d7a7936b-b461-4d34-8d2f-d02fb53bbfae"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Composer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/10689289-2b9d-4df4-b267-5feb75de2fa0",
-        "name" : "1tTEn2iKNEgg0qSLGl",
+        "id" : "https://www.example.org/35d37774-2b8f-4761-8738-101c1b8fdb5f",
+        "name" : "wOggeCr2vNT4JHnvYY8",
         "nameType" : "Personal",
-        "orcId" : "gFT3Ewqv0O3H",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "sdixvqHQwhvUU",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EaeAge8NJQzTrrRzIMa",
-          "value" : "YDAHPl9DwpLm"
+          "sourceName" : "LA7rVJv335rPp6",
+          "value" : "tjMuwsNWY6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "D4hauPyGxjm2gYHc",
-          "value" : "QfVgCYfLZOysJ"
+          "sourceName" : "0kc2kFUH6ExG",
+          "value" : "8NqemJueczQGO8UMn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/49d8aaca-df27-477a-b431-5da03376e0c4"
+        "id" : "https://www.example.org/ead7f30c-f9a6-433b-a743-027f108d1ba2"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "VV4N6m0T9Ltp47wU2K2"
+      "sv" : "iVKP2MJiSuqzsJvPV"
     },
-    "npiSubjectHeading" : "nTAIg3guGRIRet",
-    "tags" : [ "tEayUTNXDks" ],
-    "description" : "HoEtK5PCw2",
+    "npiSubjectHeading" : "k9r6ErN27y85yj",
+    "tags" : [ "RVloaGLwywGAr2eq" ],
+    "description" : "3wiNhFdsgVkDuqy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dbce0479-a59e-4f22-9714-703f51604782"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c7fb484a-269b-4192-81dd-16f2956bc604"
         },
-        "seriesNumber" : "DGIAfeoBrEY",
+        "seriesNumber" : "AV9hylVnyR8Nxe",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fd337e58-92b8-42c6-845a-dd7246b24e98",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2d6c97a6-6b80-4831-9172-b4dd8ccc0066",
           "valid" : true
         },
-        "isbnList" : [ "9781960491602" ],
+        "isbnList" : [ "9791069146877", "9781874385936" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "jw0Q3OEXk2qjM7Uxv"
+          "code" : "kIOv5hhOwOq"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "G8U6r4J9IydMm"
+          "value" : "1874385939"
         } ]
       },
-      "doi" : "https://www.example.org/53a531be-73c2-4399-82f8-1f1778fb5075",
+      "doi" : "https://www.example.org/2d524ce3-2c00-40e0-830a-85b4cb09e7e4",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "1gmUeVt7Awu7yn",
-            "end" : "YtJGaWIkUIX1nF2bFK"
+            "begin" : "qNXLzWKatvpahadV",
+            "end" : "S8qWDkTaaLytF9gHakv"
           },
-          "pages" : "DU14Ma1URwtJvEeJdpm",
+          "pages" : "U7rcOoGhJ7p3tqiP4W",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "rHIqo6JOqgcX",
-          "month" : "wfDqWnQjIxsU7LjNj",
-          "day" : "XOuPEFw8NO3XMlKgBr"
+          "year" : "d1vgFX9ewQyyY",
+          "month" : "zaIdDg7swTCkQtEkE",
+          "day" : "vj3gUtLOYWggF7Tvys0"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/dbab3545-5d2f-4da1-9b2e-0f19707dcf39",
-    "abstract" : "byqPlPL1MfU"
+    "metadataSource" : "https://www.example.org/59e99ef5-fd43-49d0-a334-ecf6caca332d",
+    "abstract" : "ITw3Lq3W5uTl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d9bb6267-34da-47bd-b70e-88fec3c51eed",
-    "name" : "iJploUEd7tDDq8NiXx",
+    "id" : "https://www.example.org/fe3ff96c-4ff8-434f-8968-56f2d5f252eb",
+    "name" : "ygLCZjcmKm8",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-03-30T23:14:13.468Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "spWeWX0XyEg3ESg62"
+      "approvalDate" : "2011-05-05T17:53:15.491Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "Bp2yyKg2FYIcdQ3tsYh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5db3d5e7-48c5-4de7-b84e-16cb70d39080",
-    "identifier" : "wnX98zSlzt5sD1lAh1a",
+    "source" : "https://www.example.org/eaf30820-a5b5-410f-9171-c85fe95cc42d",
+    "identifier" : "yTL6edz1nv",
     "labels" : {
-      "ca" : "nCp8Od3Wydo1pmn4LL"
+      "es" : "gxpfdcAUg8K"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1680833978
+      "amount" : 610256082
     },
-    "activeFrom" : "2021-09-04T13:53:15.375Z",
-    "activeTo" : "2022-06-14T04:30:38.012Z"
+    "activeFrom" : "2020-08-04T15:25:14.068Z",
+    "activeTo" : "2021-09-18T04:55:22.394Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/05bfdbe3-2066-4601-945b-460b3f7d3e60",
-    "id" : "https://www.example.org/81db2739-b4da-46ee-b55f-4a01050b8cd3",
-    "identifier" : "0vYXyKIMIwI",
+    "source" : "https://www.example.org/419ad10b-13e7-4109-82cc-84fdcbaa1410",
+    "id" : "https://www.example.org/94e16c66-d2e9-4eaa-9c01-3b1e80d7c6f4",
+    "identifier" : "fNXDAwmEV7Ep",
     "labels" : {
-      "nl" : "9UmHRNnKzL2XJqW"
+      "af" : "TcKJq1rkxNi"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1797150682
+      "currency" : "GBP",
+      "amount" : 957610212
     },
-    "activeFrom" : "2013-09-22T13:58:23.104Z",
-    "activeTo" : "2016-11-20T20:43:57.167Z"
+    "activeFrom" : "2015-03-09T12:36:17.361Z",
+    "activeTo" : "2016-09-21T15:26:19.311Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/392822b4-7486-41d5-b5ca-684fecea18e7" ],
+  "subjects" : [ "https://www.example.org/268825b8-f8ef-4460-88c7-a04e3d1b04cc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "eb434f6b-7590-461f-a571-51bdb45dad3d",
-    "name" : "PBY82hsSUrXawH5EHtq",
-    "mimeType" : "wiTH9RtS3F",
-    "size" : 1889717800,
-    "license" : "https://www.example.com/prhj2ai8vkrlm",
+    "identifier" : "8839583e-1c42-4cd2-a2cb-791b633ca52a",
+    "name" : "QWS69fQYahvkYIK",
+    "mimeType" : "Zr33Nd0D1qHgP7O2b",
+    "size" : 1049051790,
+    "license" : "https://www.example.com/ytftqrgiicy",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "imbGeanXPOEPqDYnD3w",
-    "publishedDate" : "2012-05-15T05:11:44.298Z",
+    "legalNote" : "Sg23769QO57zQyj4",
+    "publishedDate" : "1979-01-26T12:15:26.673Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "oqFjvk3YGN1MCkz16F",
-      "uploadedDate" : "2015-12-29T13:25:18.919Z"
+      "uploadedBy" : "05II9TfBEFbjdSch",
+      "uploadedDate" : "2018-06-04T05:10:38.063Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/mCrXsPCX51BqMmGhA",
-    "name" : "XHXCQA6jlCA6",
-    "description" : "dmV5dyeUSoKlbfX"
+    "id" : "https://www.example.com/edCo7aFQYEGR",
+    "name" : "Cw1XIZ4Dva0zCjT",
+    "description" : "hQtEpeiU6elHoIUYGQV"
   } ],
-  "rightsHolder" : "E6AIYolK7QZDn50",
-  "duplicateOf" : "https://www.example.org/b0882660-7e1a-463b-8ae9-4edfb58d4494",
+  "rightsHolder" : "YklkeabKdTlwn0",
+  "duplicateOf" : "https://www.example.org/33180e23-4b1e-4e60-a855-e4ceec06580d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tZJtVQz91t"
+    "note" : "kqAYg2LrEScTBJ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vACgQS3LJ9UgLn5MTh",
-    "createdBy" : "QSB4WiFp8wP4OZY",
-    "createdDate" : "2021-09-13T11:17:16.242Z"
+    "note" : "14j5NkJN2KRB5S7oPnV",
+    "createdBy" : "cU9mOqmik7eXK2791",
+    "createdDate" : "1977-06-03T08:58:42.367Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2ac1d809-ab40-48d5-bd75-2bb9b600257c" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/769d6a86-853e-4461-9b3b-646f61717144" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "0B2C63UmkgZ5dOs",
-    "ownerAffiliation" : "https://www.example.org/e3d337f5-dc5a-4be5-b6e1-c9ce2dad5b4d"
+    "owner" : "2I6JzNHFTD",
+    "ownerAffiliation" : "https://www.example.org/16696811-5cb0-4055-b7a5-49d56b3c1697"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7792486b-e52b-47dc-abed-eca88fdc5845"
+    "id" : "https://www.example.org/160ea395-c058-4ce9-a88e-39283c27754d"
   },
-  "createdDate" : "2017-03-14T00:47:44.176Z",
-  "modifiedDate" : "1991-12-31T22:02:42.847Z",
-  "publishedDate" : "2019-11-07T20:41:02.375Z",
-  "indexedDate" : "1984-07-31T18:19:10.343Z",
-  "handle" : "https://www.example.org/d6d5184e-7d02-44c0-9785-c458ec0587a3",
-  "doi" : "https://doi.org/10.1234/rerum",
-  "link" : "https://www.example.org/df778fa2-7264-4f42-8735-e3a5f6b7a719",
+  "createdDate" : "1973-02-18T23:38:33.867Z",
+  "modifiedDate" : "2020-01-16T09:25:26.579Z",
+  "publishedDate" : "1996-10-02T05:12:51.812Z",
+  "indexedDate" : "2017-03-04T08:21:02.829Z",
+  "handle" : "https://www.example.org/e44de855-b407-4687-ab57-7c2f5ac92a5b",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/e43b5575-508a-4f49-a88e-3fcd7041100f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7E6cA6O3efZ",
+    "mainTitle" : "DFYXRvNrzJwmPyw",
     "alternativeTitles" : {
-      "fi" : "pJbaOQ1Bnn9K1hTzpib"
+      "pt" : "wbgOEff5mreo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "DJvcUuO4t4",
-      "month" : "wIzj1QSGBswf3MtH",
-      "day" : "sAqTSKdV3LOvlm6IAg"
+      "year" : "H9NSvca8H8I",
+      "month" : "WaeLMrzzACvWFd1lAqZ",
+      "day" : "u4NzUr4MUztjHd9A"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7d5e5ab1-0cb6-461c-9018-1bd36bd05796",
-        "name" : "qwGuVFY7OnBa1JQgOBS",
+        "id" : "https://www.example.org/bf82175f-cab8-4572-98b0-0f26b46fbbe0",
+        "name" : "aV6zgRpj1vNwstG",
         "nameType" : "Personal",
-        "orcId" : "MixCquYF0N",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Y1w74KfVNvjoPBzoy",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WnDSgB73j61Mu",
-          "value" : "WaB7RWRhQYJVbD"
+          "sourceName" : "Uw55R8UAGybaINc0",
+          "value" : "eH4KvKOYuW8prV2DjBX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0JLuGTtXzc2R7Eo2BPP",
-          "value" : "mLNa2OfQJYQuh8e"
+          "sourceName" : "LlKoTtLRYtKd3Q3",
+          "value" : "kIhnGSlNtE4fKXj3L0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d7a7936b-b461-4d34-8d2f-d02fb53bbfae"
+        "id" : "https://www.example.org/4b7fe83c-3823-4351-bf39-5b9d8553723b"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/35d37774-2b8f-4761-8738-101c1b8fdb5f",
-        "name" : "wOggeCr2vNT4JHnvYY8",
-        "nameType" : "Personal",
-        "orcId" : "sdixvqHQwhvUU",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/21c5fa9a-61f9-4e74-bcc6-335cc30db953",
+        "name" : "GoTf18vDdekW0",
+        "nameType" : "Organizational",
+        "orcId" : "vNVpB3Bdg861",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LA7rVJv335rPp6",
-          "value" : "tjMuwsNWY6"
+          "sourceName" : "eAlw00kcblUl6",
+          "value" : "oVMzexN27fmt7v"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0kc2kFUH6ExG",
-          "value" : "8NqemJueczQGO8UMn"
+          "sourceName" : "sja3pcpD2MZD",
+          "value" : "RcDwgZcC8ZcmuA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ead7f30c-f9a6-433b-a743-027f108d1ba2"
+        "id" : "https://www.example.org/51f380b1-5207-4134-9437-531bc97b7a90"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "Creator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "iVKP2MJiSuqzsJvPV"
+      "nn" : "mluZuxBjNPmlZsWOb7R"
     },
-    "npiSubjectHeading" : "k9r6ErN27y85yj",
-    "tags" : [ "RVloaGLwywGAr2eq" ],
-    "description" : "3wiNhFdsgVkDuqy",
+    "npiSubjectHeading" : "LV45hnJHSBmBDR",
+    "tags" : [ "0lFsRkodZN" ],
+    "description" : "LNMmSRiSkqP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c7fb484a-269b-4192-81dd-16f2956bc604"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/534702d9-f052-4a79-ac0c-ee266b59c245"
         },
-        "seriesNumber" : "AV9hylVnyR8Nxe",
+        "seriesNumber" : "FWKOnXkpYHHY",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2d6c97a6-6b80-4831-9172-b4dd8ccc0066",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4f042f1c-7dc9-43c5-8081-ebe764f0d6b2",
           "valid" : true
         },
-        "isbnList" : [ "9791069146877", "9781874385936" ],
+        "isbnList" : [ "9790943593899", "9780032323643" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "kIOv5hhOwOq"
+          "code" : "UuGrufMZLeA2"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1874385939"
+          "value" : "0032323646"
         } ]
       },
-      "doi" : "https://www.example.org/2d524ce3-2c00-40e0-830a-85b4cb09e7e4",
+      "doi" : "https://www.example.org/29f9fd93-cc9c-4e37-880e-dc6fa5b2123a",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "qNXLzWKatvpahadV",
-            "end" : "S8qWDkTaaLytF9gHakv"
+            "begin" : "7cCrByO906qy77WWgV",
+            "end" : "VYMLkB9z7pWe8RwP"
           },
-          "pages" : "U7rcOoGhJ7p3tqiP4W",
-          "illustrated" : false
+          "pages" : "LiEAhf1DRC3V1OjLso",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "d1vgFX9ewQyyY",
-          "month" : "zaIdDg7swTCkQtEkE",
-          "day" : "vj3gUtLOYWggF7Tvys0"
+          "year" : "MGXNYpI1qQXq4u",
+          "month" : "TRf74bVRkprKUgljK",
+          "day" : "Q5cfanglRP3rGiQ0"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/59e99ef5-fd43-49d0-a334-ecf6caca332d",
-    "abstract" : "ITw3Lq3W5uTl"
+    "metadataSource" : "https://www.example.org/d6479569-3230-4f33-b6bb-ac1631654bdc",
+    "abstract" : "PpMWles1ZkaLDW1sdAc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fe3ff96c-4ff8-434f-8968-56f2d5f252eb",
-    "name" : "ygLCZjcmKm8",
+    "id" : "https://www.example.org/a5d170c2-fce2-4cdd-bead-bef29de2fa48",
+    "name" : "eGnjGlH8otzp6pjM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-05-05T17:53:15.491Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Bp2yyKg2FYIcdQ3tsYh"
+      "approvalDate" : "2013-01-10T10:31:40.234Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "bMsvW9fKaI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/eaf30820-a5b5-410f-9171-c85fe95cc42d",
-    "identifier" : "yTL6edz1nv",
+    "source" : "https://www.example.org/f75ed1f5-a664-4f5c-8bdb-9fcb58fcd39b",
+    "identifier" : "Wi8L2LU2iOttNnOo6NO",
     "labels" : {
-      "es" : "gxpfdcAUg8K"
+      "de" : "02zLEZu4GAEd3Gb5rO"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 610256082
+      "currency" : "EUR",
+      "amount" : 383038613
     },
-    "activeFrom" : "2020-08-04T15:25:14.068Z",
-    "activeTo" : "2021-09-18T04:55:22.394Z"
+    "activeFrom" : "1983-12-06T06:12:45.759Z",
+    "activeTo" : "2001-01-22T22:58:23.736Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/419ad10b-13e7-4109-82cc-84fdcbaa1410",
-    "id" : "https://www.example.org/94e16c66-d2e9-4eaa-9c01-3b1e80d7c6f4",
-    "identifier" : "fNXDAwmEV7Ep",
+    "source" : "https://www.example.org/31f0dae4-1b8e-4522-855d-64a359b58f28",
+    "id" : "https://www.example.org/6d9392a8-1315-4774-b4f4-0803a7af7f88",
+    "identifier" : "xWfjpIVXj0NHt9lgBmw",
     "labels" : {
-      "af" : "TcKJq1rkxNi"
+      "nl" : "VwLDZUGcmaCuMKzBz"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 957610212
+      "currency" : "EUR",
+      "amount" : 936239422
     },
-    "activeFrom" : "2015-03-09T12:36:17.361Z",
-    "activeTo" : "2016-09-21T15:26:19.311Z"
+    "activeFrom" : "1973-07-31T10:14:07.671Z",
+    "activeTo" : "1998-07-28T16:24:07.271Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/268825b8-f8ef-4460-88c7-a04e3d1b04cc" ],
+  "subjects" : [ "https://www.example.org/dd568fba-c2e4-4193-9c1d-1c0126b63bb7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8839583e-1c42-4cd2-a2cb-791b633ca52a",
-    "name" : "QWS69fQYahvkYIK",
-    "mimeType" : "Zr33Nd0D1qHgP7O2b",
-    "size" : 1049051790,
-    "license" : "https://www.example.com/ytftqrgiicy",
+    "identifier" : "f26ff583-7d74-408d-b9a8-814d75c1aeee",
+    "name" : "U8Xz8ywJYuOirOCdS9",
+    "mimeType" : "1obQcVK1Qf4Rr9Wqz",
+    "size" : 140736625,
+    "license" : "https://www.example.com/y6zbgwn5bqx",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Sg23769QO57zQyj4",
-    "publishedDate" : "1979-01-26T12:15:26.673Z",
+    "legalNote" : "Fldzq23r0Vcu",
+    "publishedDate" : "1984-07-17T08:33:02.725Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "05II9TfBEFbjdSch",
-      "uploadedDate" : "2018-06-04T05:10:38.063Z"
+      "uploadedBy" : "gsjTQmaOTEsG9a",
+      "uploadedDate" : "2021-07-30T01:48:12.589Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/edCo7aFQYEGR",
-    "name" : "Cw1XIZ4Dva0zCjT",
-    "description" : "hQtEpeiU6elHoIUYGQV"
+    "id" : "https://www.example.com/wzb6rhyES0",
+    "name" : "uETJ8CR995kxIOaOsuI",
+    "description" : "VoouEIpIfO2UBbIxZu"
   } ],
-  "rightsHolder" : "YklkeabKdTlwn0",
-  "duplicateOf" : "https://www.example.org/33180e23-4b1e-4e60-a855-e4ceec06580d",
+  "rightsHolder" : "xX7obPdb4N7yDzIL",
+  "duplicateOf" : "https://www.example.org/37883b17-7d64-4e96-9689-e7ab2f8e71df",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kqAYg2LrEScTBJ"
+    "note" : "MrmQKhNfT0g3DM0WZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "14j5NkJN2KRB5S7oPnV",
-    "createdBy" : "cU9mOqmik7eXK2791",
-    "createdDate" : "1977-06-03T08:58:42.367Z"
+    "note" : "Mc3lQUAJQOoKH",
+    "createdBy" : "3XhWqvR3VWBoPq2I",
+    "createdDate" : "1988-08-15T04:33:06.060Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/769d6a86-853e-4461-9b3b-646f61717144" ],
+  "curatingInstitutions" : [ "https://www.example.org/5fd90b76-4f77-4d86-aff7-d8e06fc8c128" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "RlSRZW6Vb84uX8UEyVb",
-    "ownerAffiliation" : "https://www.example.org/a17434ed-2d62-4e29-ada4-6af206407665"
+    "owner" : "s78RjZjNRuFjU5iX95",
+    "ownerAffiliation" : "https://www.example.org/c374129b-3416-4d8b-a4e8-43171388237d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7d4b4b74-20ff-46aa-a9fa-7e12329edb76"
+    "id" : "https://www.example.org/fc7df527-f905-4378-9dc7-93f0df34ccfe"
   },
-  "createdDate" : "2018-05-28T09:48:56.189Z",
-  "modifiedDate" : "1982-02-22T05:45:04.109Z",
-  "publishedDate" : "1997-02-04T20:47:37.749Z",
-  "indexedDate" : "2010-04-07T04:25:52.171Z",
-  "handle" : "https://www.example.org/cece81d8-746b-4819-b2fb-acd87d02f84d",
-  "doi" : "https://doi.org/10.1234/tenetur",
-  "link" : "https://www.example.org/d0b46360-5e89-4007-90d5-8414add7104a",
+  "createdDate" : "1973-04-18T15:47:25.156Z",
+  "modifiedDate" : "2016-11-13T23:46:40.169Z",
+  "publishedDate" : "2006-12-01T00:11:26.909Z",
+  "indexedDate" : "2020-12-14T20:21:42.621Z",
+  "handle" : "https://www.example.org/f45c9bee-3800-4150-bf1d-1c51bd9b89da",
+  "doi" : "https://doi.org/10.1234/laborum",
+  "link" : "https://www.example.org/32641875-e893-49e4-ac95-810dc9df9c72",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jortJ9BgQws6a",
+    "mainTitle" : "vjKoHQkPEAeJf",
     "alternativeTitles" : {
-      "de" : "JBzujkgw8Lc"
+      "es" : "MWUnUr1w0Vg2n"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vKnEjU3DEbQ",
-      "month" : "5kseqS9iGxvwsy6c",
-      "day" : "whrSmvsb51LFvd"
+      "year" : "OIu1fcYudgf1R",
+      "month" : "hmiC7zU0I1l",
+      "day" : "PxK9CQ1wZhfQYBh79Ys"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e6d853b9-ebdc-46fa-b46e-626d0608541d",
-        "name" : "t6FMPdUofA",
+        "id" : "https://www.example.org/6f6733f2-11b4-4f3b-9186-aecd9db14fdf",
+        "name" : "eh4kCBucCYqKDoszEok",
         "nameType" : "Personal",
-        "orcId" : "xxe1TQVwHPBYKcKPm",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ZVkmNKlFKPLN",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WkrcVimzfmWlUpkQ0hp",
-          "value" : "6KaYho8RZWhH2w2mxw"
+          "sourceName" : "GXaYAOJUfQl37hxjx",
+          "value" : "kG38Rt56oETs1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UxgclZqpO9ylK",
-          "value" : "20wjuK0LfAgJ3p"
+          "sourceName" : "wjUO06VwU7",
+          "value" : "IRCwzl2S4ei"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ee127742-26bd-46c3-a5e9-8b8f745308ab"
+        "id" : "https://www.example.org/38909110-1ebb-4faf-ab53-2f701a07859c"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e837c1df-456f-4759-9202-534d60f51c1e",
-        "name" : "lGbqt4kgMw5",
-        "nameType" : "Organizational",
-        "orcId" : "sP1nlVzCBwfWdPATSR4",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/475e2c83-7cb1-4c6a-b74a-41893e2a87af",
+        "name" : "XDoMYQsDulM5BUc5",
+        "nameType" : "Personal",
+        "orcId" : "CuNPmkdKPuaQ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KoKvPxa8pKkN",
-          "value" : "phclErYUVDyfmyj"
+          "sourceName" : "L6bsXoG8oqng9ooAdt6",
+          "value" : "iOaCDK1LrrwMT7QtL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7FpNpDTXVa",
-          "value" : "ikrwhuNQP9ZRkIlJhAi"
+          "sourceName" : "GyWdvoF0KIzoaURadUO",
+          "value" : "svAYJAua2COaHY5jHrH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/333ee9c7-a662-4cce-879a-ec506280ebf0"
+        "id" : "https://www.example.org/10492bab-9f3e-41c9-a665-cfa00ce33fdb"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "IHXe3oBkkrvejT4"
+      "ca" : "Vqo8VlXG3BM0vDn"
     },
-    "npiSubjectHeading" : "xNML5iyPk43kDJID9",
-    "tags" : [ "Ozf10Dgs9r76L4ybj" ],
-    "description" : "GF16XikIObu2axkZ0RO",
+    "npiSubjectHeading" : "3marxO26SR3AE",
+    "tags" : [ "iFGca6pIFxof15" ],
+    "description" : "QSIWhwuSAt0cI2Uz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/91b3f5b5-21fc-42ae-b4c3-9359f771f3ed"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/75efd032-79fb-41ef-9546-44bff0f25803"
         },
-        "seriesNumber" : "0TBTnH1PfEIfiTh",
+        "seriesNumber" : "8UxGYqvzfHh095",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/726d8640-f411-40e1-9185-188ad90f9780",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3bea8dc5-69c3-4d02-a2e2-1dfaaf2b8bd5",
           "valid" : true
         },
-        "isbnList" : [ "9791924168471" ],
+        "isbnList" : [ "9790922848408", "9781990268632" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "kQFDmDAb8jCu"
+          "code" : "f8TJ906mJCnH"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "9JJDZa02MF5KiQL"
+          "value" : "1990268633"
         } ]
       },
-      "doi" : "https://www.example.org/da07139b-81cc-4701-af50-c56a32e5b622",
+      "doi" : "https://www.example.org/34637e88-29b1-4c18-ba67-2239d3268f0c",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "87PdRPpTgBCVr89",
-            "end" : "sl22XSBjAvTmzGdbh"
+            "begin" : "YbXVG6bIgR3",
+            "end" : "B8d0ECm32cApal4zcC"
           },
-          "pages" : "YdEXBKAd0Uo",
+          "pages" : "j40wgaVHhZX8",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "h21SAC7RNcDcLYjB",
-          "month" : "LsuJvNY020Ou6b4",
-          "day" : "MhtA7tj9WbmZP7"
+          "year" : "BTBDiOUoeVv71",
+          "month" : "WO0yI0bs7LmPvS",
+          "day" : "FaMBHM8v06qFoy"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e29a36cb-b170-41ef-98c0-c1448f0fc849",
-    "abstract" : "VZzcsy5YSX8rnlS"
+    "metadataSource" : "https://www.example.org/db0e7e4d-071b-4422-8fa2-cd7a563afca1",
+    "abstract" : "X0myOILtyF1Q"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/bc9fb459-fd8f-4f70-a564-b6e5f754c56b",
-    "name" : "3M3NDK72L2Epz9ey",
+    "id" : "https://www.example.org/3526511e-76b1-4e36-8676-21b21751070d",
+    "name" : "tnOSJiPfwFfaf",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-05-26T04:23:55.445Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2007-04-03T01:13:55.648Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "9jrVSXlvRfafdeyfE"
+      "applicationCode" : "J2FEnfsxNf7YV"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/651185de-d2b4-4edd-8c07-431f906278f7",
-    "identifier" : "t0BPqu73xwsAi1",
+    "source" : "https://www.example.org/869c1edd-b0c2-4ea3-a077-18001227f498",
+    "identifier" : "iuf23E1aGuXAiHonGH",
     "labels" : {
-      "ru" : "Cguhz7xnMqdD96dMw"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 409284696
-    },
-    "activeFrom" : "2013-08-30T18:21:33.401Z",
-    "activeTo" : "2022-12-18T20:33:59.863Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f956f721-a14e-4d20-ba08-948bf5df1ce0",
-    "id" : "https://www.example.org/54bc7f32-fa80-42d2-91d7-c524fa0f356c",
-    "identifier" : "0AAgtZLeI1",
-    "labels" : {
-      "nb" : "0K1rPKAgSpZriLP9"
+      "af" : "SLsVtpTl1iPntlj"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 7794215
+      "amount" : 1188249756
     },
-    "activeFrom" : "1985-02-02T13:19:16.609Z",
-    "activeTo" : "1990-08-21T22:29:55.939Z"
+    "activeFrom" : "1994-05-10T06:11:48.367Z",
+    "activeTo" : "2020-05-02T18:47:26.415Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/58f803df-1483-41cb-88b6-bd2e910d8350",
+    "id" : "https://www.example.org/824d219f-acdd-4367-a68e-811a08edcd39",
+    "identifier" : "BdZVjj3fkaJIdMq2",
+    "labels" : {
+      "it" : "3PfQbq8TmBj2"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 928006137
+    },
+    "activeFrom" : "1997-08-23T13:24:55.588Z",
+    "activeTo" : "2016-05-02T02:00:33.368Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d8493f02-f3fe-4880-9568-26095ce4436a" ],
+  "subjects" : [ "https://www.example.org/2220b7f7-1942-4d68-9319-9e3214b2b6c2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ed5b6519-722b-424e-bc64-fdb1b8c871ee",
-    "name" : "oyxRTij2CC",
-    "mimeType" : "irxnb5KjEbnSjXjinwC",
-    "size" : 1107075119,
-    "license" : "https://www.example.com/e6m5tmkn7pboc",
+    "identifier" : "c8fd85c7-14f3-4d00-a9f0-42cf9b90711a",
+    "name" : "QnXkfvRlHZF4",
+    "mimeType" : "bnHyAOQUTnGUjpM",
+    "size" : 445990034,
+    "license" : "https://www.example.com/im1i4wsszqt",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ntDn1bfWt9",
-    "publishedDate" : "1972-05-17T05:04:16.922Z",
+    "legalNote" : "Ug4MOJeB4Jxszt7",
+    "publishedDate" : "1988-05-06T22:00:05.096Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "VquibeOgmvThh1Ae8",
-      "uploadedDate" : "1997-06-07T18:04:57.743Z"
+      "uploadedBy" : "TvvgQfVZHuaK",
+      "uploadedDate" : "1985-01-20T15:36:56.219Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3bE75vajKSmFA2hix",
-    "name" : "fSXC2YSWVHiNWU",
-    "description" : "WFNnsdk1kJsYxG"
+    "id" : "https://www.example.com/K59pxT8fJJ3auHP",
+    "name" : "CAOKnyQcQ4Tt",
+    "description" : "n3UdVw0eQFjERL9Q"
   } ],
-  "rightsHolder" : "siDNW8sRA8ixv2a",
-  "duplicateOf" : "https://www.example.org/596ea3c1-f582-4b68-9ecf-0aefc4b8b58b",
+  "rightsHolder" : "vmtR6iBNFhq",
+  "duplicateOf" : "https://www.example.org/439643ac-d8f5-466a-9277-5b926926a450",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Dj4vkkhYobbRa0gbWm"
+    "note" : "txKvOQLwXvSJ0t"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "aEcR0eafEPaFGsFgv",
-    "createdBy" : "CZsYVehnyt1",
-    "createdDate" : "2022-11-19T01:41:53.315Z"
+    "note" : "ly6rQPSrEDP",
+    "createdBy" : "kvvDbTze7pJOBDWe8Wc",
+    "createdDate" : "2020-10-12T21:45:46.804Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8ef9159d-444f-4d20-ad09-a412a4627cbb" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/d2bbf61e-ac7a-47c4-a02d-053945023ec7" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "s78RjZjNRuFjU5iX95",
-    "ownerAffiliation" : "https://www.example.org/c374129b-3416-4d8b-a4e8-43171388237d"
+    "owner" : "wvLHFu274DrkoKcJ",
+    "ownerAffiliation" : "https://www.example.org/c378a279-800c-4dd5-9c7b-85f288f1f055"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fc7df527-f905-4378-9dc7-93f0df34ccfe"
+    "id" : "https://www.example.org/cc50bb83-f8a8-4748-b1fc-4f5af3ed23b8"
   },
-  "createdDate" : "1973-04-18T15:47:25.156Z",
-  "modifiedDate" : "2016-11-13T23:46:40.169Z",
-  "publishedDate" : "2006-12-01T00:11:26.909Z",
-  "indexedDate" : "2020-12-14T20:21:42.621Z",
-  "handle" : "https://www.example.org/f45c9bee-3800-4150-bf1d-1c51bd9b89da",
-  "doi" : "https://doi.org/10.1234/laborum",
-  "link" : "https://www.example.org/32641875-e893-49e4-ac95-810dc9df9c72",
+  "createdDate" : "1984-07-17T06:58:10.953Z",
+  "modifiedDate" : "2014-02-10T14:24:40.374Z",
+  "publishedDate" : "1994-04-21T01:10:42.242Z",
+  "indexedDate" : "2020-02-15T01:39:33.466Z",
+  "handle" : "https://www.example.org/5fed35f0-62be-41c3-955f-db3c43aa9670",
+  "doi" : "https://doi.org/10.1234/molestias",
+  "link" : "https://www.example.org/bec16ec5-9b81-4f92-a899-e02c06c2ead7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vjKoHQkPEAeJf",
+    "mainTitle" : "YjkMlNVxy1OG",
     "alternativeTitles" : {
-      "es" : "MWUnUr1w0Vg2n"
+      "cs" : "1QHpaWy7ODqwmG05Ot"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OIu1fcYudgf1R",
-      "month" : "hmiC7zU0I1l",
-      "day" : "PxK9CQ1wZhfQYBh79Ys"
+      "year" : "R5Ef1q59hWo6btk",
+      "month" : "xiT1x9ISIGBo7cPoW",
+      "day" : "rwymCig50JW5rgzs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6f6733f2-11b4-4f3b-9186-aecd9db14fdf",
-        "name" : "eh4kCBucCYqKDoszEok",
+        "id" : "https://www.example.org/ae988f18-e246-437e-af25-a79a710d6ad9",
+        "name" : "BbKtvoC19tXoL7",
         "nameType" : "Personal",
-        "orcId" : "ZVkmNKlFKPLN",
-        "verificationStatus" : "Verified",
+        "orcId" : "gyMzRfO8vWlAJ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GXaYAOJUfQl37hxjx",
-          "value" : "kG38Rt56oETs1"
+          "sourceName" : "9BQIOpQZ7BBIMO",
+          "value" : "CnJys8aMHqJHExKE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wjUO06VwU7",
-          "value" : "IRCwzl2S4ei"
+          "sourceName" : "jRijjSSdcIbSmO",
+          "value" : "ZDCcHHhcVRxEAZj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/38909110-1ebb-4faf-ab53-2f701a07859c"
+        "id" : "https://www.example.org/0c8815a3-62fd-4b64-b7c2-ad1e569c9234"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,171 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/475e2c83-7cb1-4c6a-b74a-41893e2a87af",
-        "name" : "XDoMYQsDulM5BUc5",
-        "nameType" : "Personal",
-        "orcId" : "CuNPmkdKPuaQ",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/8ef76547-1f11-4a3d-9a6c-d78604273d06",
+        "name" : "cdP3Caa9ZhxdItq",
+        "nameType" : "Organizational",
+        "orcId" : "vNPQCEc5GUY9ABCUR6f",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "L6bsXoG8oqng9ooAdt6",
-          "value" : "iOaCDK1LrrwMT7QtL"
+          "sourceName" : "gYkyLmbmov2",
+          "value" : "903CBTMGCCwP5NPnm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GyWdvoF0KIzoaURadUO",
-          "value" : "svAYJAua2COaHY5jHrH"
+          "sourceName" : "9KZ9seAGmIgum",
+          "value" : "Pt0O5mjHoUFGi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/10492bab-9f3e-41c9-a665-cfa00ce33fdb"
+        "id" : "https://www.example.org/281b972e-22b0-4a27-8858-bb7819514b30"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "Journalist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "Vqo8VlXG3BM0vDn"
+      "ru" : "ZiDOOykz9wkdGZf8"
     },
-    "npiSubjectHeading" : "3marxO26SR3AE",
-    "tags" : [ "iFGca6pIFxof15" ],
-    "description" : "QSIWhwuSAt0cI2Uz",
+    "npiSubjectHeading" : "MugzrWLy1QUAwQOxU",
+    "tags" : [ "b7sXhaDdrE" ],
+    "description" : "lHcCPp2TW8GIlR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/75efd032-79fb-41ef-9546-44bff0f25803"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/580a20e4-4f52-4e19-902d-c88e5ac270f7"
         },
-        "seriesNumber" : "8UxGYqvzfHh095",
+        "seriesNumber" : "susSiikNKfLc7n",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3bea8dc5-69c3-4d02-a2e2-1dfaaf2b8bd5",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/34ce1bbb-6d57-46ae-b3d5-b514e5bb546c",
           "valid" : true
         },
-        "isbnList" : [ "9790922848408", "9781990268632" ],
+        "isbnList" : [ "9791913407727", "9780071582285" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "f8TJ906mJCnH"
+          "code" : "UjPmBTK53HiRQf"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1990268633"
+          "value" : "0071582282"
         } ]
       },
-      "doi" : "https://www.example.org/34637e88-29b1-4c18-ba67-2239d3268f0c",
+      "doi" : "https://www.example.org/a209e591-6c84-42ea-86e7-278dcb156f99",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "YbXVG6bIgR3",
-            "end" : "B8d0ECm32cApal4zcC"
+            "begin" : "vpDW0DALqy",
+            "end" : "xReiZsiubSD8USd"
           },
-          "pages" : "j40wgaVHhZX8",
+          "pages" : "8FkVpbu9Sp3Tj4tr",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "BTBDiOUoeVv71",
-          "month" : "WO0yI0bs7LmPvS",
-          "day" : "FaMBHM8v06qFoy"
+          "year" : "YjcPSzB6ZBf14D",
+          "month" : "Skva8lBoX3OWbezjlC6",
+          "day" : "BtbDx0FLnOia"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/db0e7e4d-071b-4422-8fa2-cd7a563afca1",
-    "abstract" : "X0myOILtyF1Q"
+    "metadataSource" : "https://www.example.org/86fa569e-2997-4a51-a5ad-1f395eb214f6",
+    "abstract" : "BlsTzUsT8Kiy6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3526511e-76b1-4e36-8676-21b21751070d",
-    "name" : "tnOSJiPfwFfaf",
+    "id" : "https://www.example.org/a2a423f1-6d82-4503-bab8-8064fc1517ec",
+    "name" : "APSVJV9oIG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-04-03T01:13:55.648Z",
+      "approvalDate" : "2004-01-29T19:35:03.851Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "J2FEnfsxNf7YV"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "eph16ToJivmh5bVVn"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/869c1edd-b0c2-4ea3-a077-18001227f498",
-    "identifier" : "iuf23E1aGuXAiHonGH",
+    "source" : "https://www.example.org/2d193f5c-7359-4400-87c5-f6d1ec07ce02",
+    "identifier" : "MMPwZvwB4esf",
     "labels" : {
-      "af" : "SLsVtpTl1iPntlj"
+      "es" : "1m6BODF0kKLk9QQ4"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1188249756
+      "currency" : "USD",
+      "amount" : 407370814
     },
-    "activeFrom" : "1994-05-10T06:11:48.367Z",
-    "activeTo" : "2020-05-02T18:47:26.415Z"
+    "activeFrom" : "2002-08-03T05:24:33.947Z",
+    "activeTo" : "2011-03-30T12:42:19.697Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/58f803df-1483-41cb-88b6-bd2e910d8350",
-    "id" : "https://www.example.org/824d219f-acdd-4367-a68e-811a08edcd39",
-    "identifier" : "BdZVjj3fkaJIdMq2",
+    "source" : "https://www.example.org/80c5d510-cc3c-458f-a1ad-0a54d0e15aab",
+    "id" : "https://www.example.org/30d221a6-4eb2-4b48-98d5-4f036fc14276",
+    "identifier" : "CmP0YP7IP1mWeTBgwvj",
     "labels" : {
-      "it" : "3PfQbq8TmBj2"
+      "fr" : "FVvxIMuemIEWPCaa"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 928006137
+      "currency" : "USD",
+      "amount" : 1857918316
     },
-    "activeFrom" : "1997-08-23T13:24:55.588Z",
-    "activeTo" : "2016-05-02T02:00:33.368Z"
+    "activeFrom" : "2018-10-27T06:46:52.776Z",
+    "activeTo" : "2023-12-13T15:11:34.755Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2220b7f7-1942-4d68-9319-9e3214b2b6c2" ],
+  "subjects" : [ "https://www.example.org/c7dd9ea0-8027-4db0-86e9-ca3bbcb3af47" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c8fd85c7-14f3-4d00-a9f0-42cf9b90711a",
-    "name" : "QnXkfvRlHZF4",
-    "mimeType" : "bnHyAOQUTnGUjpM",
-    "size" : 445990034,
-    "license" : "https://www.example.com/im1i4wsszqt",
+    "identifier" : "ddc1c542-ea06-4c45-a3f4-80f496c6841d",
+    "name" : "LBwDGXvdbOOas",
+    "mimeType" : "WScRlqzUTy9bFeA",
+    "size" : 125868919,
+    "license" : "https://www.example.com/idfv6tt7k4tkl7ohld",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "OVNQmVsmo28BANNnY"
     },
-    "legalNote" : "Ug4MOJeB4Jxszt7",
-    "publishedDate" : "1988-05-06T22:00:05.096Z",
+    "legalNote" : "Epe3WaXBXc",
+    "publishedDate" : "1994-06-26T20:01:07.119Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TvvgQfVZHuaK",
-      "uploadedDate" : "1985-01-20T15:36:56.219Z"
+      "uploadedBy" : "lhiCkr6ILKe",
+      "uploadedDate" : "1997-05-08T11:34:27.967Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/K59pxT8fJJ3auHP",
-    "name" : "CAOKnyQcQ4Tt",
-    "description" : "n3UdVw0eQFjERL9Q"
+    "id" : "https://www.example.com/TbIjjT8OyjrfEx6VqT",
+    "name" : "zw1MCEcI6nOpEb",
+    "description" : "7il06v2xmz"
   } ],
-  "rightsHolder" : "vmtR6iBNFhq",
-  "duplicateOf" : "https://www.example.org/439643ac-d8f5-466a-9277-5b926926a450",
+  "rightsHolder" : "Hqrkwu6zP0IC",
+  "duplicateOf" : "https://www.example.org/3ac0b3b5-c0f7-4ac6-b6c6-8e328035cb98",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "txKvOQLwXvSJ0t"
+    "note" : "nfeEeQvTQutT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ly6rQPSrEDP",
-    "createdBy" : "kvvDbTze7pJOBDWe8Wc",
-    "createdDate" : "2020-10-12T21:45:46.804Z"
+    "note" : "PRB8zi4y14fmHo84",
+    "createdBy" : "AI28fy30qLbT1",
+    "createdDate" : "1991-08-08T22:01:19.839Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d2bbf61e-ac7a-47c4-a02d-053945023ec7" ],
+  "curatingInstitutions" : [ "https://www.example.org/5ca5dbeb-e5e9-4c51-8229-3787ee242ebe" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "oLlmowfqGXEJdaa2",
-    "ownerAffiliation" : "https://www.example.org/3eea8fec-4f95-4c21-85a7-20f559b728bf"
+    "owner" : "2CCXQ1YZLAlOa",
+    "ownerAffiliation" : "https://www.example.org/8f369a7a-0686-445d-91fe-096d405c8d2f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f36711cb-5544-4b71-ae74-28a999cafd7c"
+    "id" : "https://www.example.org/d7cc847a-a518-428e-b0bc-7e78374a9dd7"
   },
-  "createdDate" : "2017-11-23T08:13:25.636Z",
-  "modifiedDate" : "1977-04-06T06:43:40.737Z",
-  "publishedDate" : "1991-03-23T22:21:58.148Z",
-  "indexedDate" : "2012-05-27T20:25:21.066Z",
-  "handle" : "https://www.example.org/4e4cc43e-4e56-4a62-b474-073d94a8a996",
-  "doi" : "https://doi.org/10.1234/harum",
-  "link" : "https://www.example.org/2b8e965a-1b58-4fb5-876c-4e481e0d0fa7",
+  "createdDate" : "1986-07-16T13:54:47.445Z",
+  "modifiedDate" : "2007-08-22T05:57:39.720Z",
+  "publishedDate" : "1971-10-20T20:52:42.430Z",
+  "indexedDate" : "2000-01-29T23:27:46.545Z",
+  "handle" : "https://www.example.org/2b46ef3b-d6aa-4f5b-922e-4a63bcd04dab",
+  "doi" : "https://doi.org/10.1234/exercitationem",
+  "link" : "https://www.example.org/af898b5a-0e5c-4f55-8055-aebdbbab83a9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "OA0tDQcRcwn",
+    "mainTitle" : "gXpMrXQfj8g",
     "alternativeTitles" : {
-      "pl" : "956gp2cyMkObE"
+      "en" : "dsG2MIfBZmcjEC4r66Q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "fFQCz6QREi0BiBIFZQI",
-      "month" : "bO2kYRiETG",
-      "day" : "HKIL89mvbA"
+      "year" : "cSARSrkg4E4rBm",
+      "month" : "l4LWPeTKRFmJ3tl7RS5",
+      "day" : "IsszAztACME70mhYRP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e3d1815f-b748-4657-9cd6-af410d6ba32c",
-        "name" : "16LKSXsAamiz",
-        "nameType" : "Personal",
-        "orcId" : "ZtTRmehtu0BM8K1gn",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/ad9d6a5b-1859-4919-95eb-1f0b3f042f4a",
+        "name" : "SJUYVHPkPTXUEJT",
+        "nameType" : "Organizational",
+        "orcId" : "4XQFTonXMTG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TJi3xjkHLOmgjrfS",
-          "value" : "XpiiS6rr4rzJ7sBONX8"
+          "sourceName" : "Dxqp35AefmTqplM",
+          "value" : "lAXTsNWNUIT0MebRqp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AC1F2u5zGT",
-          "value" : "HSp1NFv8uCb5r7AD"
+          "sourceName" : "2pSZiNpVqCPFLCwUY5",
+          "value" : "2NBK6HsRfO6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f786b4e2-0af6-4632-b48a-a4d127d1569a"
+        "id" : "https://www.example.org/62b99e0a-ec0f-472e-af30-58f1138a6a33"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/92678bb4-9f87-40a1-b9db-e407e73484ca",
-        "name" : "1w2WfDU0iiEet",
+        "id" : "https://www.example.org/629095cc-6bb7-4e37-b29d-eeda238bba11",
+        "name" : "WlzAkERDzlzJrw",
         "nameType" : "Organizational",
-        "orcId" : "A3dUd1ubGuaeTIsT0U",
-        "verificationStatus" : "Verified",
+        "orcId" : "jMdAtdIfJCe3n",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "C25tJjRbvF",
-          "value" : "x8h38q002SChk"
+          "sourceName" : "Ahu3GWbMWoM1x49pB",
+          "value" : "0Qo1zrc77cv2tSuvc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JBEfPAyK3qXfE4x",
-          "value" : "nqlLjQg3vN8"
+          "sourceName" : "Zcnv9azAr9Ii",
+          "value" : "WXcVNh2pt9CiTq68cO7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/48f847d4-80b3-458f-bbcc-16da17e07dde"
+        "id" : "https://www.example.org/3500960f-36a0-47bd-8c29-ca85fe20705f"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Conductor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "8ieB1mgpokcU"
+      "en" : "CwYYYifddSC"
     },
-    "npiSubjectHeading" : "CtykyF6qG1VMAW0N4z",
-    "tags" : [ "L6EapTaubnxuq" ],
-    "description" : "QrJruYXFda119Ny3S",
+    "npiSubjectHeading" : "ifEbYTYep7dbdu",
+    "tags" : [ "4G9fFrKChgK" ],
+    "description" : "KmMZXV6SSE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/05c60ef8-f684-47e0-a532-6fbc89bbdd39"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c857b1bc-25ca-4a39-b731-12174417dde9"
         },
-        "seriesNumber" : "WATyEGirOxpbZx",
+        "seriesNumber" : "rUXF6T6lLNVQ5vHMA",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/48070e73-a326-4dfa-95b7-15142701d34f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/68126e87-ac52-42a3-a307-422c6daf7ddb",
           "valid" : true
         },
-        "isbnList" : [ "9791910507888" ],
+        "isbnList" : [ "9781900083263", "9780214421778" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "vn3Wdv2Jz3j8"
+          "code" : "wdo5g3Unb8WZi"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "NLx2mRV7Y6QNY"
+          "value" : "0214421775"
         } ]
       },
-      "doi" : "https://www.example.org/2b7485c9-e392-4aca-b1e3-22b67acdc1c9",
+      "doi" : "https://www.example.org/db5ea60c-3846-433f-bf40-481533251a0d",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "jdvAXnwscx5J69",
-            "end" : "cntzrfWuEPjTH9Ooj"
+            "begin" : "K3OjxtcJBqueo3YF",
+            "end" : "fom45Gp6xOb99"
           },
-          "pages" : "jVdKe0u1IhYu",
-          "illustrated" : true
+          "pages" : "OYkUoeLspYVSp",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "p5ncFG68NgA",
-          "month" : "ywd5nksxbqNTxdTN",
-          "day" : "TaEa5bRdhAf"
+          "year" : "UTlXwJuICT1xT",
+          "month" : "bbv8EZrxMW6gO2Me",
+          "day" : "JprWJPpOsrKIjY"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/cfacb4e9-0281-4c4d-bf50-d273c17f0694",
-    "abstract" : "d2pWkfgIn4O"
+    "metadataSource" : "https://www.example.org/e73255a9-2ac9-4c4c-954b-98acc83c9170",
+    "abstract" : "tY7NAGBo4sNK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c056ab7c-ce04-49d2-93bf-86cf3c52a182",
-    "name" : "Z1DHB5LocnD",
+    "id" : "https://www.example.org/539652d9-e77f-4768-b82f-2c39db4812c1",
+    "name" : "aePFGWZDaR",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-09-03T22:37:52.326Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1975-06-05T14:14:47.247Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "4o2kvcM65vgwp53"
+      "applicationCode" : "8UHeLgw9yf"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/89e9f895-134e-43cd-b8be-4211a1355646",
-    "identifier" : "76ipGlHJb2Umu5G",
+    "source" : "https://www.example.org/54cda6ac-02fc-44c2-b454-eabdab7f9227",
+    "identifier" : "8lkJvkIQUOJTropB",
     "labels" : {
-      "el" : "ZlBofhRIcoTckwsN7UH"
+      "pt" : "L4UdxBPiztjjPi9YZjk"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 325492733
+      "currency" : "USD",
+      "amount" : 1159105216
     },
-    "activeFrom" : "1971-06-24T21:58:58.575Z",
-    "activeTo" : "1979-09-30T20:58:32.237Z"
+    "activeFrom" : "2005-03-16T02:32:35.448Z",
+    "activeTo" : "2022-03-26T12:17:59.589Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1af1c81c-2b41-43d9-86f2-797ff42d9ac6",
-    "id" : "https://www.example.org/e2ea75f1-a3ac-4306-a8c6-163c676bbe54",
-    "identifier" : "FBo6p2ppcD1Rtn",
+    "source" : "https://www.example.org/b9a13f22-6b06-45fd-9418-e0cf1d289194",
+    "id" : "https://www.example.org/6bcc748a-a3ff-4391-a399-13134db3c61c",
+    "identifier" : "UcjhMGKzQBhDfi",
     "labels" : {
-      "de" : "7a6QL7wcY5mFbGf9"
+      "it" : "NzDqUuuuoI"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1047695694
+      "currency" : "NOK",
+      "amount" : 125173256
     },
-    "activeFrom" : "1981-10-03T03:45:23.768Z",
-    "activeTo" : "1982-04-12T06:44:06.397Z"
+    "activeFrom" : "2012-03-20T10:34:09.979Z",
+    "activeTo" : "2019-08-27T20:53:13.035Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f93f581c-199e-4c39-b372-39e6dce6eb50" ],
+  "subjects" : [ "https://www.example.org/0ead02c9-510f-40cd-b7ef-4a5c56abe9fc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "697b2abf-c7a3-47e0-bf32-37a3380f2c78",
-    "name" : "EJaXWppTkBnAuu",
-    "mimeType" : "Fldh4v2znC282QA9",
-    "size" : 1039722152,
-    "license" : "https://www.example.com/xiclrovspkx34",
+    "identifier" : "752c545b-64c4-40e6-ba1c-e1622cd6fa28",
+    "name" : "tdc0lNQXrsOrEHV6",
+    "mimeType" : "CVxm7TKIh8PDTOwWs",
+    "size" : 605242351,
+    "license" : "https://www.example.com/idoycivdnb",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QdumSYQQ6peOXCYhkf0",
-    "publishedDate" : "2010-03-25T07:22:12.832Z",
+    "legalNote" : "ejkOP707cz4eUQPNI2",
+    "publishedDate" : "2019-07-13T03:56:31.559Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "AXkKSTheFlX",
-      "uploadedDate" : "1984-11-18T09:58:36.537Z"
+      "uploadedBy" : "uRF3adB9ID",
+      "uploadedDate" : "2018-01-15T12:04:01.649Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Lkuzzak18d7tViWDO",
-    "name" : "DP2JlqbOOb",
-    "description" : "waL0aWtlWSMtN"
+    "id" : "https://www.example.com/AHGY3RNds3L",
+    "name" : "SErCQ1vBhrw",
+    "description" : "rMKviIofCYKTQWCob"
   } ],
-  "rightsHolder" : "60oavhGlUFgeQ8AuO",
-  "duplicateOf" : "https://www.example.org/31b01971-f00d-4814-a8e6-78f776180688",
+  "rightsHolder" : "0OSlhI3tkrBBFkZ",
+  "duplicateOf" : "https://www.example.org/172aa4f5-30d7-4a86-96d1-7076125f5e43",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Q6ypLmvPpyq"
+    "note" : "WEKfwzAXtAO2qLRZRa7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GPm7IfWyTtUDZM7Py6x",
-    "createdBy" : "eFEbOJUGNMLv",
-    "createdDate" : "1996-06-03T13:17:00.917Z"
+    "note" : "CwFDwUfVw9q0q2Mf",
+    "createdBy" : "8b7v5wgmlf2yR",
+    "createdDate" : "1982-11-12T06:57:04.793Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c669b10e-a71d-466e-922b-a93e54e5225a" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/fb08d7e3-91da-48d7-89db-bf363fe61168" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "2CCXQ1YZLAlOa",
-    "ownerAffiliation" : "https://www.example.org/8f369a7a-0686-445d-91fe-096d405c8d2f"
+    "owner" : "cXtA2xdNht",
+    "ownerAffiliation" : "https://www.example.org/13d0c0b4-fa3d-4503-bbb1-c12af61acabd"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d7cc847a-a518-428e-b0bc-7e78374a9dd7"
+    "id" : "https://www.example.org/0c2dff41-0d22-436e-85ec-d0a30f969f7b"
   },
-  "createdDate" : "1986-07-16T13:54:47.445Z",
-  "modifiedDate" : "2007-08-22T05:57:39.720Z",
-  "publishedDate" : "1971-10-20T20:52:42.430Z",
-  "indexedDate" : "2000-01-29T23:27:46.545Z",
-  "handle" : "https://www.example.org/2b46ef3b-d6aa-4f5b-922e-4a63bcd04dab",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/af898b5a-0e5c-4f55-8055-aebdbbab83a9",
+  "createdDate" : "1996-03-22T07:46:37.605Z",
+  "modifiedDate" : "1981-08-12T05:50:26.679Z",
+  "publishedDate" : "1995-11-11T07:10:51.141Z",
+  "indexedDate" : "1974-07-20T00:37:00.517Z",
+  "handle" : "https://www.example.org/a2b714c6-5710-4e23-9d6b-bdee530632fa",
+  "doi" : "https://doi.org/10.1234/iure",
+  "link" : "https://www.example.org/2cd96d58-1115-4e44-8985-a29f57e6e20a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "gXpMrXQfj8g",
+    "mainTitle" : "bMGe9g6tgjBXBVtkF",
     "alternativeTitles" : {
-      "en" : "dsG2MIfBZmcjEC4r66Q"
+      "it" : "4OSxRLaiC6k8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cSARSrkg4E4rBm",
-      "month" : "l4LWPeTKRFmJ3tl7RS5",
-      "day" : "IsszAztACME70mhYRP"
+      "year" : "2t9M5PzCUK",
+      "month" : "G6xVOvExmgxu0JOUjO",
+      "day" : "CFxxgvKLCmYnkmYu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ad9d6a5b-1859-4919-95eb-1f0b3f042f4a",
-        "name" : "SJUYVHPkPTXUEJT",
+        "id" : "https://www.example.org/46e500ff-240b-4139-b9e9-64df4fbac8fd",
+        "name" : "PeQFPnr3WJ",
         "nameType" : "Organizational",
-        "orcId" : "4XQFTonXMTG",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ciido7YclvWjwzGJ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Dxqp35AefmTqplM",
-          "value" : "lAXTsNWNUIT0MebRqp"
+          "sourceName" : "umbgFly0kVcnLngPvw",
+          "value" : "qP2iXO7JvwDfYp0yPnu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2pSZiNpVqCPFLCwUY5",
-          "value" : "2NBK6HsRfO6"
+          "sourceName" : "iii1sY3EpEN",
+          "value" : "OoBEjUb52x"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/62b99e0a-ec0f-472e-af30-58f1138a6a33"
+        "id" : "https://www.example.org/4cbfcb15-fd1c-4d55-b7e6-492b40829c9e"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,171 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/629095cc-6bb7-4e37-b29d-eeda238bba11",
-        "name" : "WlzAkERDzlzJrw",
+        "id" : "https://www.example.org/af3d0292-9791-4070-b53c-ee76b8633dd0",
+        "name" : "nHnBea92gXe43B",
         "nameType" : "Organizational",
-        "orcId" : "jMdAtdIfJCe3n",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "DGzVeYAGthhuoA",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ahu3GWbMWoM1x49pB",
-          "value" : "0Qo1zrc77cv2tSuvc"
+          "sourceName" : "T5b7wND9KEt4lM",
+          "value" : "tj3xz9xwLm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Zcnv9azAr9Ii",
-          "value" : "WXcVNh2pt9CiTq68cO7"
+          "sourceName" : "T35UtgOJljPPZm7m",
+          "value" : "EU1Ep2kijUmpS54Brs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3500960f-36a0-47bd-8c29-ca85fe20705f"
+        "id" : "https://www.example.org/56b5a9c3-fcf3-47f1-a895-8d30dfcf4cdf"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "CwYYYifddSC"
+      "nb" : "vMGNWLWfkuH1ho"
     },
-    "npiSubjectHeading" : "ifEbYTYep7dbdu",
-    "tags" : [ "4G9fFrKChgK" ],
-    "description" : "KmMZXV6SSE",
+    "npiSubjectHeading" : "2DhqHz6v1Z",
+    "tags" : [ "4sirtJEeGAOlsO" ],
+    "description" : "2Ilx9ZPbFx4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c857b1bc-25ca-4a39-b731-12174417dde9"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bc3836b2-95ed-4395-a924-26f680606626"
         },
-        "seriesNumber" : "rUXF6T6lLNVQ5vHMA",
+        "seriesNumber" : "6VIgljlCAVBEKnKd",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/68126e87-ac52-42a3-a307-422c6daf7ddb",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/59d9f741-5cfa-45d4-8999-59f3e282a69a",
           "valid" : true
         },
-        "isbnList" : [ "9781900083263", "9780214421778" ],
+        "isbnList" : [ "9790923001123", "9780904827699" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "wdo5g3Unb8WZi"
+          "code" : "y6k1w8aeMKp"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0214421775"
+          "value" : "0904827690"
         } ]
       },
-      "doi" : "https://www.example.org/db5ea60c-3846-433f-bf40-481533251a0d",
+      "doi" : "https://www.example.org/a503a43e-4dc6-403d-97c7-18c503d75efc",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "K3OjxtcJBqueo3YF",
-            "end" : "fom45Gp6xOb99"
+            "begin" : "4136q83mGXQxdnQ",
+            "end" : "VHEeZ3n7S8Rg6rA"
           },
-          "pages" : "OYkUoeLspYVSp",
+          "pages" : "ZZ8EnvmN4kX6HfM5",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "UTlXwJuICT1xT",
-          "month" : "bbv8EZrxMW6gO2Me",
-          "day" : "JprWJPpOsrKIjY"
+          "year" : "oC4jlN27FsCZLSh9n",
+          "month" : "ws3AXLMq3i1z03wO",
+          "day" : "4i1IQF0aZrF"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e73255a9-2ac9-4c4c-954b-98acc83c9170",
-    "abstract" : "tY7NAGBo4sNK"
+    "metadataSource" : "https://www.example.org/5aeb7a66-a0c5-4df4-aeb4-a30d70482e73",
+    "abstract" : "l9fyKQ0EDGOsa"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/539652d9-e77f-4768-b82f-2c39db4812c1",
-    "name" : "aePFGWZDaR",
+    "id" : "https://www.example.org/5c68f677-2cd6-4db3-bb3d-832dcdb20fb7",
+    "name" : "IBFFvcltBk",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-06-05T14:14:47.247Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "8UHeLgw9yf"
+      "approvalDate" : "1991-12-08T18:45:43.025Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "hJ7wHbXznY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/54cda6ac-02fc-44c2-b454-eabdab7f9227",
-    "identifier" : "8lkJvkIQUOJTropB",
+    "source" : "https://www.example.org/f4ffc2c1-3b24-4b21-b200-a1edb2f0e996",
+    "identifier" : "z3wshEGCBwrMFrLA",
     "labels" : {
-      "pt" : "L4UdxBPiztjjPi9YZjk"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1159105216
-    },
-    "activeFrom" : "2005-03-16T02:32:35.448Z",
-    "activeTo" : "2022-03-26T12:17:59.589Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b9a13f22-6b06-45fd-9418-e0cf1d289194",
-    "id" : "https://www.example.org/6bcc748a-a3ff-4391-a399-13134db3c61c",
-    "identifier" : "UcjhMGKzQBhDfi",
-    "labels" : {
-      "it" : "NzDqUuuuoI"
+      "bg" : "gGIhk8XThh9XaS"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 125173256
+      "amount" : 1776465035
     },
-    "activeFrom" : "2012-03-20T10:34:09.979Z",
-    "activeTo" : "2019-08-27T20:53:13.035Z"
+    "activeFrom" : "2018-03-31T10:56:50.152Z",
+    "activeTo" : "2018-06-28T23:50:31.836Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d7a2c899-eea8-42a5-be4a-7a91b504be94",
+    "id" : "https://www.example.org/a4c01f68-3d39-472a-813a-de7b7e8170d9",
+    "identifier" : "6dqW8p68vXJ",
+    "labels" : {
+      "pl" : "4HRdsEmuN8To"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 928825191
+    },
+    "activeFrom" : "1990-04-05T22:51:48.490Z",
+    "activeTo" : "1993-08-28T03:03:01.924Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0ead02c9-510f-40cd-b7ef-4a5c56abe9fc" ],
+  "subjects" : [ "https://www.example.org/06754243-513c-4ec9-a7b1-587c1b0a6754" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "752c545b-64c4-40e6-ba1c-e1622cd6fa28",
-    "name" : "tdc0lNQXrsOrEHV6",
-    "mimeType" : "CVxm7TKIh8PDTOwWs",
-    "size" : 605242351,
-    "license" : "https://www.example.com/idoycivdnb",
+    "identifier" : "d6a8bdd0-c33d-4d48-abb0-e3fc5a7ec496",
+    "name" : "lsrLk090Dff8sD6u",
+    "mimeType" : "g4JrBoj92nRgy",
+    "size" : 1262755431,
+    "license" : "https://www.example.com/8r8ukinpbio",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "NsAb8j2aQkyenXD"
     },
-    "legalNote" : "ejkOP707cz4eUQPNI2",
-    "publishedDate" : "2019-07-13T03:56:31.559Z",
+    "legalNote" : "0JaOcKE0QgAe",
+    "publishedDate" : "1998-05-15T13:51:01.464Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uRF3adB9ID",
-      "uploadedDate" : "2018-01-15T12:04:01.649Z"
+      "uploadedBy" : "9fojSZ0zEQFalt",
+      "uploadedDate" : "1989-04-08T16:13:43.678Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/AHGY3RNds3L",
-    "name" : "SErCQ1vBhrw",
-    "description" : "rMKviIofCYKTQWCob"
+    "id" : "https://www.example.com/ocMXgWGL2YwDh",
+    "name" : "rx56jcs3s3vBaNqN",
+    "description" : "SWtpMwd0iK8m142IXH"
   } ],
-  "rightsHolder" : "0OSlhI3tkrBBFkZ",
-  "duplicateOf" : "https://www.example.org/172aa4f5-30d7-4a86-96d1-7076125f5e43",
+  "rightsHolder" : "gTfeRwePOrk",
+  "duplicateOf" : "https://www.example.org/a7c885ed-9fef-4bb1-b57f-fd869d16684b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WEKfwzAXtAO2qLRZRa7"
+    "note" : "XIAxN7V7Ke"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CwFDwUfVw9q0q2Mf",
-    "createdBy" : "8b7v5wgmlf2yR",
-    "createdDate" : "1982-11-12T06:57:04.793Z"
+    "note" : "KjGKxUcn9qAPsSErAvu",
+    "createdBy" : "VrnOGunvE3W",
+    "createdDate" : "2004-11-17T08:19:55.443Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fb08d7e3-91da-48d7-89db-bf363fe61168" ],
+  "curatingInstitutions" : [ "https://www.example.org/50fb4830-bbbe-4159-8eb7-84b95fddb235" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "C2DRyqjBmv",
-    "ownerAffiliation" : "https://www.example.org/e3b92e1e-061f-4d3f-8ae6-2e7a3ae7043d"
+    "owner" : "DK4N26HdaC",
+    "ownerAffiliation" : "https://www.example.org/9c783ee7-2ec6-41cd-87c4-80801aaecc7c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b909fd81-cf69-4505-bed8-b055b9b09e27"
+    "id" : "https://www.example.org/8286a3f7-c3a3-47ff-9b06-d7f045136a9e"
   },
-  "createdDate" : "1990-08-24T17:16:22.729Z",
-  "modifiedDate" : "1990-03-29T13:45:39.855Z",
-  "publishedDate" : "2012-12-23T15:41:21.800Z",
-  "indexedDate" : "1983-02-26T18:31:42.077Z",
-  "handle" : "https://www.example.org/6bca4278-78f3-45a0-a49e-79e226031c3f",
-  "doi" : "https://doi.org/10.1234/eos",
-  "link" : "https://www.example.org/2803f881-b6de-42af-a9f3-940cf63f80d5",
+  "createdDate" : "2012-12-19T18:35:08.566Z",
+  "modifiedDate" : "1993-08-29T09:50:56.921Z",
+  "publishedDate" : "1983-05-25T04:48:50.383Z",
+  "indexedDate" : "2018-07-27T14:21:46.674Z",
+  "handle" : "https://www.example.org/9a8735ae-b408-4602-805c-0a25f152c574",
+  "doi" : "https://doi.org/10.1234/sed",
+  "link" : "https://www.example.org/ce73089b-935b-4502-b399-9e44c85e4f1c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9TZFv2vJ5ImvYN",
+    "mainTitle" : "KgWpewVo2rHJ",
     "alternativeTitles" : {
-      "pl" : "LpbI7jhHq2omVIumt"
+      "nl" : "Zl5RNkpRbCKrJdvYY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vLbntkyA95ITh",
-      "month" : "wd6dWzAWkRnAY",
-      "day" : "zmqeqHV9lOlDe8CxGR"
+      "year" : "qZLLKX26QNSkywNm",
+      "month" : "hQsIRtt0sPH",
+      "day" : "MsTny6SzpQP27wBMWMS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fc581ed2-b7cd-498c-a530-19b1d7a77ba7",
-        "name" : "pT7UjmzcuEVjZhkFbO7",
-        "nameType" : "Personal",
-        "orcId" : "ZchfUQNjMjQrE6",
+        "id" : "https://www.example.org/cf5528b7-3386-4599-9d11-80a2f19da500",
+        "name" : "ID5QoYHqJZJdz",
+        "nameType" : "Organizational",
+        "orcId" : "tt3i5srXwhqUj0cM",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QBqXmRCKdYy54Ks",
-          "value" : "rUbJTGIHk4UEz"
+          "sourceName" : "3HM3mNsvWbYz",
+          "value" : "6pf6TEQxmW97"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z45DYDsfKshDPXv",
-          "value" : "JttXqX0zgz3e4"
+          "sourceName" : "ywu5KmbbWtTJbHYYT5a",
+          "value" : "91C4xPdbD9xZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/63aba484-77b6-4cd0-acd3-5a077413731a"
+        "id" : "https://www.example.org/8783d707-5638-42cd-8e85-b329f7e42f8d"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,177 +62,177 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/57be75c0-7844-4216-8975-be023896a888",
-        "name" : "IEKGuI5zpKze",
+        "id" : "https://www.example.org/574c5aa0-6d8b-40b6-b9a0-a84dbbbed244",
+        "name" : "YjtTdVixNyhbAjR",
         "nameType" : "Personal",
-        "orcId" : "glLCl3bUoq",
+        "orcId" : "FDSI8Xup5EAhO",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "N30jpmCrwd06ulek",
-          "value" : "Bji3UzWfBgGnAu"
+          "sourceName" : "T9cZSURZV7DuYGup",
+          "value" : "nynzwVKp3BJCHts1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FnQ8ZwLN4X3fwBGu75K",
-          "value" : "Q1hpMj60LqaGHA8"
+          "sourceName" : "JaonsCNwP1is",
+          "value" : "mtd9xSR6nqWv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/50e021bc-1ca0-4c1b-bab8-d83ecc6da304"
+        "id" : "https://www.example.org/b993fb40-0d0c-4206-a100-1c72da8b4152"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "Yojgq5kxAENVtmEs"
+      "pt" : "4DdU8NToxvB"
     },
-    "npiSubjectHeading" : "PQvERp0yyfWK",
-    "tags" : [ "twRRQC1tgGs" ],
-    "description" : "Zm5BOrvhGhWxueioeg",
+    "npiSubjectHeading" : "lTYVOVryqZ3",
+    "tags" : [ "6zY9JpW5Lk6j3ko20P3" ],
+    "description" : "AIWwVKrnsNI9c5eG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/35c5d9a8-5940-4b5e-bbf7-98562e740a47"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/70684b8a-7518-4821-a9f2-e284cca9d0c5"
         },
-        "seriesNumber" : "hJq4JZ8eHD2lxVH",
+        "seriesNumber" : "MzXvihVvZb",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/24ac6fe2-310a-497d-aa62-777439a2d07d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1e6e709e-0e33-4f69-a032-e22082ed0670",
           "valid" : true
         },
-        "isbnList" : [ "9780952380191" ],
+        "isbnList" : [ "9781810407487", "9780927344678" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "dkQPKwBFdp7UGvT"
+          "code" : "xZDy8lpfdhIf"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "DnYjpZblDKnRNB"
+          "value" : "092734467X"
         } ]
       },
-      "doi" : "https://www.example.org/561637b1-c337-458c-ae23-318a514555ee",
+      "doi" : "https://www.example.org/fcc6ba5c-37be-47be-9e59-5a98ce0f54fa",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "1J2q7BMwp8s",
-            "end" : "aad1FiCqgg3j"
+            "begin" : "wZGcz01XrH56CDzaJm",
+            "end" : "ythNB4CQVIDKO"
           },
-          "pages" : "qLJnkavJ4XD0bzO7i",
+          "pages" : "d8uGHaEt4LzpAe",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "DGGx88erb3G",
-          "month" : "gKEbo7nKzn",
-          "day" : "sZwNZDv6ibvF2"
+          "year" : "mIyVvC7iMyzww",
+          "month" : "X5Df5YBBpP",
+          "day" : "12VUGThO69y2sn"
         },
         "related" : [ {
-          "type" : "UnconfirmedDocument",
-          "text" : "bcc8XmbhtToGWt0PO7R"
-        }, {
           "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/qjhHdzkA2Gu0JRVb8sQ"
+          "identifier" : "https://www.example.com/sx6by8Rh5TwAk6vF"
+        }, {
+          "type" : "UnconfirmedDocument",
+          "text" : "ipKAGnQqz8eOWN2ipb"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/9973ffa6-86ed-4972-8d41-150ec68e6950",
-    "abstract" : "ZgiTRNOFkw"
+    "metadataSource" : "https://www.example.org/e0d44872-79fb-4628-afc3-18286697b4e2",
+    "abstract" : "HDrdxhTCrYhe7Pp"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ffef3ec2-e94f-4b0b-b8c2-cae60057138d",
-    "name" : "JO3ShQCzc7",
+    "id" : "https://www.example.org/cfbeb54f-d1e4-4719-bd6e-de20db916181",
+    "name" : "B0lhkLHnjsik",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2003-06-30T17:18:44.645Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "TF0fWHuCoujA9cwcxs"
+      "approvalDate" : "1991-12-28T09:55:27.429Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Rct9TY0K9o"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/adf7dc52-8423-4305-84ce-1d66b1edb462",
-    "identifier" : "hqgTHinCp47t4MXe5",
+    "source" : "https://www.example.org/9525b45c-a211-44a8-bc84-18dd048cec7d",
+    "identifier" : "4RcKUOa4SnZQcetsMgP",
     "labels" : {
-      "de" : "KY6PAHnQVz4YLNDyoq"
+      "sv" : "FwhIpq7vi37kr1Ma"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 629234094
+      "currency" : "NOK",
+      "amount" : 1513400458
     },
-    "activeFrom" : "2002-07-08T12:54:03.938Z",
-    "activeTo" : "2018-03-19T08:40:40.827Z"
+    "activeFrom" : "1976-11-30T23:25:13.137Z",
+    "activeTo" : "2012-08-04T04:59:10.877Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/df1c3b2b-0189-445f-962c-01867d0b7780",
-    "id" : "https://www.example.org/284fc363-88b8-4146-bcf8-544208b58d84",
-    "identifier" : "adKkQW7JQuJCGQo",
+    "source" : "https://www.example.org/08f1ceac-3f3f-40fb-aede-6868dac45460",
+    "id" : "https://www.example.org/fd04b32c-b7c2-4fcb-9ca8-4c24b1716486",
+    "identifier" : "vDXyr2LumJXS0rm",
     "labels" : {
-      "de" : "X84a4WyUDn6"
+      "ca" : "NrToJQSDm0X1W"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 647522202
+      "currency" : "USD",
+      "amount" : 408130054
     },
-    "activeFrom" : "1981-09-08T18:43:12.001Z",
-    "activeTo" : "2017-10-12T15:55:12.778Z"
+    "activeFrom" : "1973-06-14T02:07:42.843Z",
+    "activeTo" : "2007-12-21T04:08:30.380Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/52e3b8df-6b7c-469b-8550-6c3682a034a3" ],
+  "subjects" : [ "https://www.example.org/e65d8e59-9f05-497b-8c77-efedfc164a8b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ee9367c0-1152-46bb-8a9f-99214f2e493c",
-    "name" : "qBisS5PT4i95BF8EF",
-    "mimeType" : "Mz7NwYaiqGx2W3D",
-    "size" : 1014981317,
-    "license" : "https://www.example.com/jjxg2r1eghc4mbhdilw",
+    "identifier" : "ea8d5495-4d33-4162-8ad1-351d6f31070d",
+    "name" : "vzp1yk0X8Ju23un6pl",
+    "mimeType" : "WlepCWcXB3wOuL0",
+    "size" : 477812779,
+    "license" : "https://www.example.com/cifhhgrdydxksqx",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "YRiHOgOp4cJnS7AFb",
-    "publishedDate" : "1989-01-20T12:58:23.978Z",
+    "legalNote" : "xwI83phtCnU0Wf",
+    "publishedDate" : "2008-01-01T17:49:49.564Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "jQLtleIYhnWGaRK",
-      "uploadedDate" : "2005-09-01T11:42:40.760Z"
+      "uploadedBy" : "FMl6yCOceuq",
+      "uploadedDate" : "1999-11-09T16:23:32.904Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/T1C2iFdMZipnKWf9n",
-    "name" : "r3B5bhftJl156N",
-    "description" : "POURnuT5IInf5"
+    "id" : "https://www.example.com/r8cVhNskQjQ",
+    "name" : "GFRosi9Wzpy7",
+    "description" : "DWPKqA3vpjLhSy1Rwc"
   } ],
-  "rightsHolder" : "7xisJ7K1NXf63NU",
-  "duplicateOf" : "https://www.example.org/17b52030-286c-4456-84be-d8925c2674d5",
+  "rightsHolder" : "63tQbZpBUsZ",
+  "duplicateOf" : "https://www.example.org/a94a3ad3-63c1-46fd-a692-a90823b92734",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7dDO9T3tTMXFlhsR"
+    "note" : "v1vNGpBdv0F"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QdQjpecLg5O3",
-    "createdBy" : "IaoNZau0oAgWAwbtD",
-    "createdDate" : "2011-09-07T18:35:17.714Z"
+    "note" : "K836ry6jeDIVtQDNAlU",
+    "createdBy" : "5ACZ3f5RPPsuo",
+    "createdDate" : "2016-07-03T05:42:26.596Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/492011bb-e08c-4a1b-9f74-ac548a5a5ebe" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/c9aadd45-e9ff-4707-b2f6-dd242b949c35" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "DK4N26HdaC",
-    "ownerAffiliation" : "https://www.example.org/9c783ee7-2ec6-41cd-87c4-80801aaecc7c"
+    "owner" : "IfTotLVpf52GH5i0T2E",
+    "ownerAffiliation" : "https://www.example.org/f640a46e-22a9-491d-a255-a7d3dd8c7c42"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8286a3f7-c3a3-47ff-9b06-d7f045136a9e"
+    "id" : "https://www.example.org/8f8ebe69-504a-447e-8c57-8839e73579fe"
   },
-  "createdDate" : "2012-12-19T18:35:08.566Z",
-  "modifiedDate" : "1993-08-29T09:50:56.921Z",
-  "publishedDate" : "1983-05-25T04:48:50.383Z",
-  "indexedDate" : "2018-07-27T14:21:46.674Z",
-  "handle" : "https://www.example.org/9a8735ae-b408-4602-805c-0a25f152c574",
-  "doi" : "https://doi.org/10.1234/sed",
-  "link" : "https://www.example.org/ce73089b-935b-4502-b399-9e44c85e4f1c",
+  "createdDate" : "2000-01-16T09:03:17.759Z",
+  "modifiedDate" : "2022-08-25T01:16:41.112Z",
+  "publishedDate" : "1975-02-20T20:57:10.088Z",
+  "indexedDate" : "1984-02-25T13:14:13.763Z",
+  "handle" : "https://www.example.org/232a2483-213a-4eb3-8f03-8f89eae8f346",
+  "doi" : "https://doi.org/10.1234/iusto",
+  "link" : "https://www.example.org/2c3f6b1e-f69f-4687-8749-38d3ab1a8a95",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KgWpewVo2rHJ",
+    "mainTitle" : "h8WriFJJBWO",
     "alternativeTitles" : {
-      "nl" : "Zl5RNkpRbCKrJdvYY"
+      "is" : "19uyozHLeSDXTV6XqrL"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qZLLKX26QNSkywNm",
-      "month" : "hQsIRtt0sPH",
-      "day" : "MsTny6SzpQP27wBMWMS"
+      "year" : "Dxh8cJq439g2uhhiobK",
+      "month" : "v9aRAjiw7AWsgX",
+      "day" : "yGIk0uyD6BuvF5f9Uh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cf5528b7-3386-4599-9d11-80a2f19da500",
-        "name" : "ID5QoYHqJZJdz",
-        "nameType" : "Organizational",
-        "orcId" : "tt3i5srXwhqUj0cM",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/dbddd33d-ce9e-4477-ad8a-c2015eb76a6b",
+        "name" : "FI7CDyrRTObLq3BudYV",
+        "nameType" : "Personal",
+        "orcId" : "aJYDFMCZtB1huj6",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3HM3mNsvWbYz",
-          "value" : "6pf6TEQxmW97"
+          "sourceName" : "tbEe0U129YwmQqFETO",
+          "value" : "Kds2qRokpPV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ywu5KmbbWtTJbHYYT5a",
-          "value" : "91C4xPdbD9xZ"
+          "sourceName" : "8tczke154I",
+          "value" : "OfdAHNxHe21"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8783d707-5638-42cd-8e85-b329f7e42f8d"
+        "id" : "https://www.example.org/b7f23f08-4e54-4779-8bea-0d29a52bca68"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,177 +62,177 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/574c5aa0-6d8b-40b6-b9a0-a84dbbbed244",
-        "name" : "YjtTdVixNyhbAjR",
+        "id" : "https://www.example.org/a64539bb-495a-464c-beb0-b930129078ad",
+        "name" : "Y5DN8Lf75Te4jdl",
         "nameType" : "Personal",
-        "orcId" : "FDSI8Xup5EAhO",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "jb04Ef7qq1bu03x",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T9cZSURZV7DuYGup",
-          "value" : "nynzwVKp3BJCHts1"
+          "sourceName" : "hyEzGgXvU93lRanw",
+          "value" : "HL5nHSkBK9avX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JaonsCNwP1is",
-          "value" : "mtd9xSR6nqWv"
+          "sourceName" : "z7bWnlWVMdq",
+          "value" : "rAt2YY81mtXu0OhK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b993fb40-0d0c-4206-a100-1c72da8b4152"
+        "id" : "https://www.example.org/b0b77243-14e2-4d91-a0f9-5f13585bbba5"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "4DdU8NToxvB"
+      "ca" : "8IpJabu93Mwah"
     },
-    "npiSubjectHeading" : "lTYVOVryqZ3",
-    "tags" : [ "6zY9JpW5Lk6j3ko20P3" ],
-    "description" : "AIWwVKrnsNI9c5eG",
+    "npiSubjectHeading" : "JMxrAZuudNXvd",
+    "tags" : [ "Ms1kyumJZE7" ],
+    "description" : "Kyvj9wLtTdK4QXEb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/70684b8a-7518-4821-a9f2-e284cca9d0c5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8d0d4077-77c5-402e-bef8-53d30329020d"
         },
-        "seriesNumber" : "MzXvihVvZb",
+        "seriesNumber" : "jAORwmY9E9ApME",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1e6e709e-0e33-4f69-a032-e22082ed0670",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aca7eebf-35bd-4c67-8d4b-c34240527e12",
           "valid" : true
         },
-        "isbnList" : [ "9781810407487", "9780927344678" ],
+        "isbnList" : [ "9780348241273", "9780907036418" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "xZDy8lpfdhIf"
+          "code" : "xIn2GaO9iCqm9Gx"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "092734467X"
+          "value" : "0907036414"
         } ]
       },
-      "doi" : "https://www.example.org/fcc6ba5c-37be-47be-9e59-5a98ce0f54fa",
+      "doi" : "https://www.example.org/edcc8c81-6e8c-40c3-b593-81a2917adeb8",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "wZGcz01XrH56CDzaJm",
-            "end" : "ythNB4CQVIDKO"
+            "begin" : "AwZ8WFadSTMgLCW",
+            "end" : "jyQsosJj74mXEJF"
           },
-          "pages" : "d8uGHaEt4LzpAe",
-          "illustrated" : false
+          "pages" : "JuTy6WI5FkmLrsV7nU",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "mIyVvC7iMyzww",
-          "month" : "X5Df5YBBpP",
-          "day" : "12VUGThO69y2sn"
+          "year" : "DfRbiT6RjHekpb",
+          "month" : "TsG0w4F7w0vYTf3ZgfH",
+          "day" : "5bjEC7B0Yw1DNPxS"
         },
         "related" : [ {
-          "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/sx6by8Rh5TwAk6vF"
-        }, {
           "type" : "UnconfirmedDocument",
-          "text" : "ipKAGnQqz8eOWN2ipb"
+          "text" : "9XfRMQZWdnlnTui"
+        }, {
+          "type" : "ConfirmedDocument",
+          "identifier" : "https://www.example.com/CKUEK1Rfewr5ozJt"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/e0d44872-79fb-4628-afc3-18286697b4e2",
-    "abstract" : "HDrdxhTCrYhe7Pp"
+    "metadataSource" : "https://www.example.org/885a2678-d1cc-4f47-9e1e-633487c515da",
+    "abstract" : "tHhdhNIgcsfaOm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cfbeb54f-d1e4-4719-bd6e-de20db916181",
-    "name" : "B0lhkLHnjsik",
+    "id" : "https://www.example.org/8b1ad7b9-c88d-4d20-87e7-62875433845f",
+    "name" : "0WQH4pwbba",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-12-28T09:55:27.429Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Rct9TY0K9o"
+      "approvalDate" : "2013-03-19T05:02:18.890Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "8cUyC5hK0pe1M7Ygl8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9525b45c-a211-44a8-bc84-18dd048cec7d",
-    "identifier" : "4RcKUOa4SnZQcetsMgP",
+    "source" : "https://www.example.org/047ce762-97f1-464f-a7ec-f5c00736f0f4",
+    "identifier" : "tw0Rq8YC405W3Rstt",
     "labels" : {
-      "sv" : "FwhIpq7vi37kr1Ma"
+      "fi" : "wfn6GYHlr9vjk"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1513400458
+      "currency" : "GBP",
+      "amount" : 1906159859
     },
-    "activeFrom" : "1976-11-30T23:25:13.137Z",
-    "activeTo" : "2012-08-04T04:59:10.877Z"
+    "activeFrom" : "1975-03-21T05:44:12.153Z",
+    "activeTo" : "2008-05-07T17:59:06.183Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/08f1ceac-3f3f-40fb-aede-6868dac45460",
-    "id" : "https://www.example.org/fd04b32c-b7c2-4fcb-9ca8-4c24b1716486",
-    "identifier" : "vDXyr2LumJXS0rm",
+    "source" : "https://www.example.org/0b716e92-6784-4eef-85d9-ba56385a8b68",
+    "id" : "https://www.example.org/edd8447a-4f77-4402-942b-2ee008c6d4e3",
+    "identifier" : "iJSfT44ZUpC",
     "labels" : {
-      "ca" : "NrToJQSDm0X1W"
+      "de" : "Z7twhpBIjMyXQSu57S"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 408130054
+      "currency" : "GBP",
+      "amount" : 168152056
     },
-    "activeFrom" : "1973-06-14T02:07:42.843Z",
-    "activeTo" : "2007-12-21T04:08:30.380Z"
+    "activeFrom" : "2004-02-17T05:46:18.597Z",
+    "activeTo" : "2015-02-08T22:21:16.533Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e65d8e59-9f05-497b-8c77-efedfc164a8b" ],
+  "subjects" : [ "https://www.example.org/f6b2db6b-e4b6-4ec3-a534-cf4b77fd0cc6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ea8d5495-4d33-4162-8ad1-351d6f31070d",
-    "name" : "vzp1yk0X8Ju23un6pl",
-    "mimeType" : "WlepCWcXB3wOuL0",
-    "size" : 477812779,
-    "license" : "https://www.example.com/cifhhgrdydxksqx",
+    "identifier" : "8b51bcee-9cc9-4ff9-8eee-ec3debec5598",
+    "name" : "irw43eZvmyK8CrLRDQ",
+    "mimeType" : "5CAn38AhU2HyS71U3",
+    "size" : 2131251474,
+    "license" : "https://www.example.com/xnoscriofcevo",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "xwI83phtCnU0Wf",
-    "publishedDate" : "2008-01-01T17:49:49.564Z",
+    "legalNote" : "0cLntV7oX9NX2MV",
+    "publishedDate" : "1975-09-20T15:05:17.727Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "FMl6yCOceuq",
-      "uploadedDate" : "1999-11-09T16:23:32.904Z"
+      "uploadedBy" : "w3EUKchjwChyie4W",
+      "uploadedDate" : "1985-03-29T07:32:03.264Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/r8cVhNskQjQ",
-    "name" : "GFRosi9Wzpy7",
-    "description" : "DWPKqA3vpjLhSy1Rwc"
+    "id" : "https://www.example.com/mu1D77NAt5S",
+    "name" : "SwBHU7DUwo",
+    "description" : "d6MdX5cG0dIWigsj"
   } ],
-  "rightsHolder" : "63tQbZpBUsZ",
-  "duplicateOf" : "https://www.example.org/a94a3ad3-63c1-46fd-a692-a90823b92734",
+  "rightsHolder" : "CxFHLh1mEEWlxB86CBr",
+  "duplicateOf" : "https://www.example.org/e33cf7a6-fd94-4ba1-9a0d-7bbf80c6254e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "v1vNGpBdv0F"
+    "note" : "9ZECNYb0p9i"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "K836ry6jeDIVtQDNAlU",
-    "createdBy" : "5ACZ3f5RPPsuo",
-    "createdDate" : "2016-07-03T05:42:26.596Z"
+    "note" : "eebWUHR773payYz",
+    "createdBy" : "L8VmEeHsGms",
+    "createdDate" : "2019-05-02T05:42:57.992Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c9aadd45-e9ff-4707-b2f6-dd242b949c35" ],
+  "curatingInstitutions" : [ "https://www.example.org/6b602259-68e3-4c44-8b6e-1bea504812eb" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "OQX9DYC47V3ttmlQguM",
-    "ownerAffiliation" : "https://www.example.org/9bb98d32-be9d-4160-a77d-2511c0ad45e9"
+    "owner" : "rf8KYoXkvkKyla9RLFm",
+    "ownerAffiliation" : "https://www.example.org/2b22dc17-190b-49ee-9d9e-310d43b72b66"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8c27d301-d3c8-4ad2-a2f5-f7fc895c9047"
+    "id" : "https://www.example.org/fc076c47-47d8-4902-9c87-c4e946c54ac7"
   },
-  "createdDate" : "1987-12-21T00:44:44.811Z",
-  "modifiedDate" : "1975-10-23T04:38:39.747Z",
-  "publishedDate" : "1991-06-15T08:55:20.443Z",
-  "indexedDate" : "1977-10-10T16:25:51.505Z",
-  "handle" : "https://www.example.org/ca9c63db-f87f-4d1f-b5ee-232cccdf5c7e",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/24214735-b80b-42fe-9396-d36a047cbf65",
+  "createdDate" : "2006-02-26T06:51:35.510Z",
+  "modifiedDate" : "1992-03-15T09:50:12.842Z",
+  "publishedDate" : "1971-05-02T23:34:45.705Z",
+  "indexedDate" : "2017-05-03T01:00:43.700Z",
+  "handle" : "https://www.example.org/1f749a58-bdda-4b54-808f-2c3b3f1016f3",
+  "doi" : "https://doi.org/10.1234/deleniti",
+  "link" : "https://www.example.org/c0b78bf8-bbf1-4d48-bb93-57ce9942ab60",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4cSdeopJks",
+    "mainTitle" : "MSltz7cnelzjiVNtTra",
     "alternativeTitles" : {
-      "da" : "qTzMS9BnWid47PEAUW"
+      "nn" : "a7Ip0PGSVND"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ZB2GrGCVsAzcUW",
-      "month" : "3Q9S9Susel6YL",
-      "day" : "BppVv1F6RM"
+      "year" : "UUt2L2Zt9VYcY",
+      "month" : "xYQr4AArWnuA",
+      "day" : "jD6CnXhmxJAM5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fac7215b-690f-4695-b872-2bcb53e864c1",
-        "name" : "fi6KhMleMzJ7sfq1BQ8",
+        "id" : "https://www.example.org/05349019-54b9-43be-86ba-ff8b7117bb57",
+        "name" : "ehFSU9dNrCdYC",
         "nameType" : "Personal",
-        "orcId" : "amVRHHRwNxQqLggA",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "IKc2SKh1CVuvUv7l",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "14fl8FfnGw",
-          "value" : "2FwPhHvgjKjL"
+          "sourceName" : "o45aoMjylLgj",
+          "value" : "nfsZGp72z0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V6JM0MY4WhV42PJ",
-          "value" : "6IfOuASpjsZZelEXWq"
+          "sourceName" : "JqRodmOMrXT9KUVR",
+          "value" : "knfW1I8ZrZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/29012ae7-9353-47b0-8475-a7e9bf9ef89e"
+        "id" : "https://www.example.org/d6f6cfed-4adf-4211-852c-831f11335995"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ac3173c8-791d-4628-aeb8-6f0cd6d06744",
-        "name" : "6uOlGff3enRIL",
+        "id" : "https://www.example.org/64db8939-6464-4134-99f0-41c34c2f512e",
+        "name" : "irYdPFrcO5ewje7p2",
         "nameType" : "Organizational",
-        "orcId" : "Yl4AVuM3hLe69EGWkh3",
+        "orcId" : "0CACmOKCiiKQb",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RyVfRk5FDvS",
-          "value" : "j8WPN9jXrNr66P"
+          "sourceName" : "K0CRY3sJSb7",
+          "value" : "t35wIexgyAXL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EWCP0ET88LIRWp3C",
-          "value" : "rfySB3SeqIPeo"
+          "sourceName" : "87atcT3SZjalh2Y",
+          "value" : "RjFyEfiPfX6hYh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e987d9ff-a6f9-40b8-8195-4e68fd2536ff"
+        "id" : "https://www.example.org/0d298ad1-c71b-481b-9c5f-c13deb5eacf1"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "CYtjVXW1zAp5HNetrUw"
+      "it" : "6JYtZAiaxRxeHgi0"
     },
-    "npiSubjectHeading" : "wAHq0O6RH6KCTo0",
-    "tags" : [ "3BoQhfYtN24s4" ],
-    "description" : "lKl1rD9ROI",
+    "npiSubjectHeading" : "XBaDYVq0RJgvBC",
+    "tags" : [ "9xblWS9nB1D" ],
+    "description" : "olvykneVdNq1g",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c91398a0-f90b-4e33-96a8-77005be7c5e0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af755e89-f3fa-475e-8cd8-a8b8306507bc"
         },
-        "seriesNumber" : "m2O1L8xeXoGfWASqFo4",
+        "seriesNumber" : "QEqlfCar6e5rAq9rt",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f8ecaee6-2f14-4dd0-a8aa-e4536bc327d1",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/379006bb-ef3f-4b65-8f6b-25a35fd22fd8",
           "valid" : true
         },
-        "isbnList" : [ "9780819698728" ],
+        "isbnList" : [ "9780208067319", "9781899823109" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "unwWKy99YKv3Sgi"
+          "value" : "1899823107"
         } ]
       },
-      "doi" : "https://www.example.org/7d1219a2-952e-48ae-a86f-6223e7e303d7",
+      "doi" : "https://www.example.org/063e59d2-a4df-405f-9c7c-099a6b16e599",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "W6TRRVhTWy8ud14x",
-            "end" : "z1IwLfa1QZr4w"
+            "begin" : "Zn9FQocURAW",
+            "end" : "YVayaoPejbX4"
           },
-          "pages" : "4oowWJB2MuV",
-          "illustrated" : false
+          "pages" : "V7enUP5V49U3t",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/cf92c800-7f58-442b-9a1b-b4f2650e5951",
-    "abstract" : "VGUFOALSs2F7PQyt"
+    "metadataSource" : "https://www.example.org/e6cecee9-c156-4f7d-9164-d5c340d2e1e7",
+    "abstract" : "EmRMhfw4X6n"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5997ffbf-2acb-4482-a101-a1dc05f354f5",
-    "name" : "Gn6rOuCaBKRpnIJ8i",
+    "id" : "https://www.example.org/8608b449-fd30-49b5-8990-87a7e5ec0011",
+    "name" : "ERNCssxiZUCcqv",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-06-23T13:05:04.855Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "5cbP1XgfeXEw"
+      "approvalDate" : "2015-07-05T15:11:44.340Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "qMby5aQ4DqkEHNp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c70df16f-46e6-485d-b9b6-48ab18cbade2",
-    "identifier" : "Fcuw8bcGaVFzren",
+    "source" : "https://www.example.org/b2a5eb5b-0d4d-43e9-96b3-f1241da33443",
+    "identifier" : "oxUJ2RrqGKx24pgB90",
     "labels" : {
-      "es" : "jVWraiJaywD"
+      "cs" : "NkKLktrZYnXWYwP"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1480011836
+      "amount" : 1163182767
     },
-    "activeFrom" : "2014-04-29T06:32:00.439Z",
-    "activeTo" : "2018-11-14T02:18:17.079Z"
+    "activeFrom" : "2016-10-19T12:19:33.631Z",
+    "activeTo" : "2016-11-14T11:52:58.601Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e5556fcf-2ee9-435e-9f9e-b23dc3ead538",
-    "id" : "https://www.example.org/29c5069f-7e83-4740-aa5b-54e964eb215c",
-    "identifier" : "CtfQ46D46xTV3FC",
+    "source" : "https://www.example.org/5ddc6bdd-3b23-4842-8682-1a3b6c7be13f",
+    "id" : "https://www.example.org/e5d4465f-c9a0-40f7-a757-861f36cd5125",
+    "identifier" : "floSJM9nqzjuVBW0q",
     "labels" : {
-      "en" : "wk63dxv4dfw2U"
+      "es" : "7aqMcGb5XGhdE"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2012877617
+      "currency" : "GBP",
+      "amount" : 800925003
     },
-    "activeFrom" : "2010-11-21T03:56:46.089Z",
-    "activeTo" : "2020-11-07T08:55:48.857Z"
+    "activeFrom" : "1996-12-16T22:12:01.358Z",
+    "activeTo" : "2013-12-11T19:46:53.176Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d6df42ea-076b-4b2f-83f8-5cf2bae51698" ],
+  "subjects" : [ "https://www.example.org/7b8f16af-8bd5-4678-b2b8-99aa776304fe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "584f42b4-db61-41b3-a803-8eb4d60b81e7",
-    "name" : "iRuzx5pkm3XHRZ",
-    "mimeType" : "6UuL3kR7WRQNOWEPU",
-    "size" : 21847398,
-    "license" : "https://www.example.com/ppeei4eiodgxetmzt",
+    "identifier" : "e737e795-9380-4eca-b742-4d8832bbadcd",
+    "name" : "64HD3IYGG8zFVQ",
+    "mimeType" : "nZ06Wk4Jpdn0P7",
+    "size" : 159877101,
+    "license" : "https://www.example.com/pkltvcvcfebvx",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "e3jA1uwAusT2Glv",
-    "publishedDate" : "1979-05-19T03:51:07.457Z",
+    "legalNote" : "ZNxLI0148XO",
+    "publishedDate" : "1995-07-14T13:27:37.418Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "bv6WqG9ziUtrni",
-      "uploadedDate" : "2020-12-02T20:25:27.664Z"
+      "uploadedBy" : "9Z55FB3hxxHlgXhXcvy",
+      "uploadedDate" : "1987-12-31T07:24:09.009Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wGxUCToFyVDwOToa",
-    "name" : "KYJEelEepPjTs0VegP",
-    "description" : "9KL64qbGOKIJ8wx0K"
+    "id" : "https://www.example.com/DFFMsKd7mPUKnBXDLz",
+    "name" : "2CVogBDYpPPV5Z",
+    "description" : "7tKnQPAenY78"
   } ],
-  "rightsHolder" : "j6DoBRJ7PrR3Zu5",
-  "duplicateOf" : "https://www.example.org/eb083d43-bf16-4862-b804-5f3e4da82b1f",
+  "rightsHolder" : "6EHnCglgMFh",
+  "duplicateOf" : "https://www.example.org/791e98cc-abf7-4254-9044-e340b11ff6ab",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "XYijmR0QPNrVQ"
+    "note" : "UD9lpljJjJGV"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "j5TdTv98GE7Yk7t",
-    "createdBy" : "9ZaHGcsKSbfr9EE8m",
-    "createdDate" : "2007-12-12T13:55:19.948Z"
+    "note" : "zB0AsLXaemYh38B",
+    "createdBy" : "ibQN1VJtlMBgIqC7",
+    "createdDate" : "1988-03-20T06:59:23.236Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/607928e8-e05a-4241-abe3-52d96d0e9bea" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/25df6969-7dc4-48a5-b784-96fcd872d5b4" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "rf8KYoXkvkKyla9RLFm",
-    "ownerAffiliation" : "https://www.example.org/2b22dc17-190b-49ee-9d9e-310d43b72b66"
+    "owner" : "6v1UkBPlnGO4GbD1",
+    "ownerAffiliation" : "https://www.example.org/18192613-9053-4b2e-8593-21eb6e47bc08"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fc076c47-47d8-4902-9c87-c4e946c54ac7"
+    "id" : "https://www.example.org/79ea8be5-abcf-45e9-bbfe-8d87d5a3f08e"
   },
-  "createdDate" : "2006-02-26T06:51:35.510Z",
-  "modifiedDate" : "1992-03-15T09:50:12.842Z",
-  "publishedDate" : "1971-05-02T23:34:45.705Z",
-  "indexedDate" : "2017-05-03T01:00:43.700Z",
-  "handle" : "https://www.example.org/1f749a58-bdda-4b54-808f-2c3b3f1016f3",
-  "doi" : "https://doi.org/10.1234/deleniti",
-  "link" : "https://www.example.org/c0b78bf8-bbf1-4d48-bb93-57ce9942ab60",
+  "createdDate" : "2015-04-25T10:54:50.487Z",
+  "modifiedDate" : "1972-06-02T08:56:00.593Z",
+  "publishedDate" : "2023-12-03T18:47:32.261Z",
+  "indexedDate" : "1999-07-23T14:31:48.984Z",
+  "handle" : "https://www.example.org/f8747468-e214-4d34-9486-b1f75800a02a",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/ef37f234-f541-43d2-827e-5bd8982e52f6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MSltz7cnelzjiVNtTra",
+    "mainTitle" : "trBt77kQoSnVOFR1S",
     "alternativeTitles" : {
-      "nn" : "a7Ip0PGSVND"
+      "de" : "Q0fMOOwanM44"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UUt2L2Zt9VYcY",
-      "month" : "xYQr4AArWnuA",
-      "day" : "jD6CnXhmxJAM5"
+      "year" : "mupWoq9r74kSyzkYzE",
+      "month" : "SCGKa0eJSTS",
+      "day" : "CT4xJUYvrQED"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/05349019-54b9-43be-86ba-ff8b7117bb57",
-        "name" : "ehFSU9dNrCdYC",
+        "id" : "https://www.example.org/21318508-4e0d-4c9f-a5f7-20a16d2f4ca2",
+        "name" : "0qcy1afgR4Hn",
         "nameType" : "Personal",
-        "orcId" : "IKc2SKh1CVuvUv7l",
-        "verificationStatus" : "Verified",
+        "orcId" : "AMQF6FRUwtuqfKRhYY",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o45aoMjylLgj",
-          "value" : "nfsZGp72z0"
+          "sourceName" : "lFQmoYK2YUo",
+          "value" : "2mGVABbn34luR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JqRodmOMrXT9KUVR",
-          "value" : "knfW1I8ZrZ"
+          "sourceName" : "lwkzWsserGUO2d",
+          "value" : "1zOCu2TxrO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d6f6cfed-4adf-4211-852c-831f11335995"
+        "id" : "https://www.example.org/6102cd7a-7bc9-4b21-9ead-b2d4b113c128"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/64db8939-6464-4134-99f0-41c34c2f512e",
-        "name" : "irYdPFrcO5ewje7p2",
-        "nameType" : "Organizational",
-        "orcId" : "0CACmOKCiiKQb",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f6a3783f-fb23-4e6f-868a-8112c9d41160",
+        "name" : "0UDfu2MTRA3G1PV7q",
+        "nameType" : "Personal",
+        "orcId" : "FCBn3XrQz76BdOta",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "K0CRY3sJSb7",
-          "value" : "t35wIexgyAXL"
+          "sourceName" : "4E3II9SuETRQ0OWX9E",
+          "value" : "PV1jJcdWuGr5TMmskZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "87atcT3SZjalh2Y",
-          "value" : "RjFyEfiPfX6hYh"
+          "sourceName" : "KlpDCD9RrkqA7U00MtI",
+          "value" : "YtkTiSmMmMQuNz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0d298ad1-c71b-481b-9c5f-c13deb5eacf1"
+        "id" : "https://www.example.org/8d4ac79c-c6e6-41a2-8dc8-b2b402345f77"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "6JYtZAiaxRxeHgi0"
+      "af" : "pqbDgkGO7glkHzVQ"
     },
-    "npiSubjectHeading" : "XBaDYVq0RJgvBC",
-    "tags" : [ "9xblWS9nB1D" ],
-    "description" : "olvykneVdNq1g",
+    "npiSubjectHeading" : "2vwJiXkkCC",
+    "tags" : [ "PMitJC02QPXZ" ],
+    "description" : "YnLliU9URpI7GUBDDQr",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af755e89-f3fa-475e-8cd8-a8b8306507bc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3addb940-1773-47aa-a704-6b2d9e34b110"
         },
-        "seriesNumber" : "QEqlfCar6e5rAq9rt",
+        "seriesNumber" : "Lt8kvgJ4SQqD13NqbNV",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/379006bb-ef3f-4b65-8f6b-25a35fd22fd8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/022e97c9-fd54-45d8-81ed-3a95097de941",
           "valid" : true
         },
-        "isbnList" : [ "9780208067319", "9781899823109" ],
+        "isbnList" : [ "9780043644980", "9781805983514" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1899823107"
+          "value" : "1805983512"
         } ]
       },
-      "doi" : "https://www.example.org/063e59d2-a4df-405f-9c7c-099a6b16e599",
+      "doi" : "https://www.example.org/0d1dae1a-1ded-49c2-af85-4b8aa270f3ef",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Zn9FQocURAW",
-            "end" : "YVayaoPejbX4"
+            "begin" : "0FwA2ojduC",
+            "end" : "HgV0bDySzVIT"
           },
-          "pages" : "V7enUP5V49U3t",
+          "pages" : "GXgXqmV7zF447f26Ife",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e6cecee9-c156-4f7d-9164-d5c340d2e1e7",
-    "abstract" : "EmRMhfw4X6n"
+    "metadataSource" : "https://www.example.org/cd28cc0c-e4ea-4ced-8b07-96bb53679ba2",
+    "abstract" : "8a9N3ykLQSoYsV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8608b449-fd30-49b5-8990-87a7e5ec0011",
-    "name" : "ERNCssxiZUCcqv",
+    "id" : "https://www.example.org/add75ef1-2c4e-4cf3-9150-8bfe9a2e382a",
+    "name" : "IalyPY1ZUlpgPIv2F",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-07-05T15:11:44.340Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2020-05-25T08:19:32.413Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "qMby5aQ4DqkEHNp"
+      "applicationCode" : "4u8CEgLaTqYTNpiK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b2a5eb5b-0d4d-43e9-96b3-f1241da33443",
-    "identifier" : "oxUJ2RrqGKx24pgB90",
+    "source" : "https://www.example.org/4d80447d-1205-48db-af7f-fd4de64e9dde",
+    "identifier" : "W98h6D1i48X9K4nT",
     "labels" : {
-      "cs" : "NkKLktrZYnXWYwP"
+      "zh" : "kWLz3hY0uYc"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1163182767
+      "currency" : "EUR",
+      "amount" : 765930902
     },
-    "activeFrom" : "2016-10-19T12:19:33.631Z",
-    "activeTo" : "2016-11-14T11:52:58.601Z"
+    "activeFrom" : "2004-04-12T12:24:20.260Z",
+    "activeTo" : "2022-08-07T09:01:12.121Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5ddc6bdd-3b23-4842-8682-1a3b6c7be13f",
-    "id" : "https://www.example.org/e5d4465f-c9a0-40f7-a757-861f36cd5125",
-    "identifier" : "floSJM9nqzjuVBW0q",
+    "source" : "https://www.example.org/d7b9ef8b-365a-4b4c-a47f-33792a6a7873",
+    "id" : "https://www.example.org/d6516012-0e6d-4ea3-825f-73ae79077cdb",
+    "identifier" : "1ZjPhgQXEHpMeoo3G",
     "labels" : {
-      "es" : "7aqMcGb5XGhdE"
+      "se" : "PE6cGUKJcxSI"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 800925003
+      "currency" : "USD",
+      "amount" : 1797699456
     },
-    "activeFrom" : "1996-12-16T22:12:01.358Z",
-    "activeTo" : "2013-12-11T19:46:53.176Z"
+    "activeFrom" : "2017-05-26T08:37:49.340Z",
+    "activeTo" : "2023-09-20T21:20:02.690Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7b8f16af-8bd5-4678-b2b8-99aa776304fe" ],
+  "subjects" : [ "https://www.example.org/baaebbbd-e6a2-4525-8cf9-500aa973000c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e737e795-9380-4eca-b742-4d8832bbadcd",
-    "name" : "64HD3IYGG8zFVQ",
-    "mimeType" : "nZ06Wk4Jpdn0P7",
-    "size" : 159877101,
-    "license" : "https://www.example.com/pkltvcvcfebvx",
+    "identifier" : "91dc158c-e44b-40b3-ba30-505b2289a14d",
+    "name" : "F7OpXfkrbH",
+    "mimeType" : "sbmgdfdum0BDmU",
+    "size" : 200439649,
+    "license" : "https://www.example.com/ieapkqqxsraj0ubpd6f",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ZNxLI0148XO",
-    "publishedDate" : "1995-07-14T13:27:37.418Z",
+    "legalNote" : "5vkA1FwxyLMyVS",
+    "publishedDate" : "1994-03-23T16:41:17.336Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "9Z55FB3hxxHlgXhXcvy",
-      "uploadedDate" : "1987-12-31T07:24:09.009Z"
+      "uploadedBy" : "VO8B79guICu3FSxF",
+      "uploadedDate" : "2008-03-17T04:18:35.452Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/DFFMsKd7mPUKnBXDLz",
-    "name" : "2CVogBDYpPPV5Z",
-    "description" : "7tKnQPAenY78"
+    "id" : "https://www.example.com/1LtKAMjBcd1",
+    "name" : "ii0YwCoZJA9Q",
+    "description" : "0nVn1hYr3hP0EMf2JAb"
   } ],
-  "rightsHolder" : "6EHnCglgMFh",
-  "duplicateOf" : "https://www.example.org/791e98cc-abf7-4254-9044-e340b11ff6ab",
+  "rightsHolder" : "LCgq4tiTsvgu6IuUdh",
+  "duplicateOf" : "https://www.example.org/ded099b7-fb51-4b61-ad0b-ed850b9b5c8c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UD9lpljJjJGV"
+    "note" : "g5wJMpR45bDVPj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "zB0AsLXaemYh38B",
-    "createdBy" : "ibQN1VJtlMBgIqC7",
-    "createdDate" : "1988-03-20T06:59:23.236Z"
+    "note" : "w5CA7HZLjaD2Q9t5W",
+    "createdBy" : "mbEjTlOa3wfUKgv7s",
+    "createdDate" : "2010-02-10T21:32:17.737Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/25df6969-7dc4-48a5-b784-96fcd872d5b4" ],
+  "curatingInstitutions" : [ "https://www.example.org/cebcb7d1-34a7-4497-b6af-df90fce71b32" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "bE2LculfSkWg",
-    "ownerAffiliation" : "https://www.example.org/dd3e2d33-9fbb-4af7-b933-af9753cae3f7"
+    "owner" : "SziZbVWixKl",
+    "ownerAffiliation" : "https://www.example.org/4d0b5cc7-3a4b-4d81-a729-454e772f6445"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/67896ab3-926b-4f9b-809a-913ec6242b84"
+    "id" : "https://www.example.org/8ad81326-4dca-4ca0-980b-fcf6ee28ea27"
   },
-  "createdDate" : "1981-05-13T15:41:54.629Z",
-  "modifiedDate" : "1981-03-14T13:26:23.867Z",
-  "publishedDate" : "1998-12-18T12:00:55.027Z",
-  "indexedDate" : "1981-01-22T21:13:42.226Z",
-  "handle" : "https://www.example.org/8a954181-cbfb-4f8e-a223-0be9c0f01ed8",
-  "doi" : "https://doi.org/10.1234/fugit",
-  "link" : "https://www.example.org/d1d2683b-00ab-4d2f-8114-a1573ed535da",
+  "createdDate" : "1993-05-04T11:44:25.502Z",
+  "modifiedDate" : "1995-07-02T09:01:02.576Z",
+  "publishedDate" : "1989-11-05T16:47:30.980Z",
+  "indexedDate" : "2017-09-25T09:53:36.561Z",
+  "handle" : "https://www.example.org/05abeb3f-bced-4906-8c42-da2782c83c9f",
+  "doi" : "https://doi.org/10.1234/eaque",
+  "link" : "https://www.example.org/8ad19cb3-93b9-4360-8691-29e243bcaf8f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7xeFWlOWkc4ZcvHC",
+    "mainTitle" : "KJfh8nLrL4m",
     "alternativeTitles" : {
-      "de" : "l7IJBjI9xa1"
+      "fr" : "65F6pg3kRilew"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "K2nvK09ur1Zh0Oq",
-      "month" : "0FnwKBy46Nw3KYX",
-      "day" : "bG2jN8DJ63tUh8o"
+      "year" : "isLlxbA0llcQ8q",
+      "month" : "SfqxYwdcJQnYME",
+      "day" : "qeKMe2861Z6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5257bf44-1659-4699-8a42-ec3489abf163",
-        "name" : "cfY0HSDL2KleVU",
-        "nameType" : "Personal",
-        "orcId" : "GuiAwnEXoJPrNu9Vhd",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/18598473-283e-4f4f-8e59-f6f51f02326c",
+        "name" : "OPgyXMuwn7",
+        "nameType" : "Organizational",
+        "orcId" : "tCJ9FFGZ6IiL6",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wuMtzFo86tRqL",
-          "value" : "G1SzUal0PU2K0y"
+          "sourceName" : "vMdEID00THktB",
+          "value" : "sX8W7VlDeWDX6L"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "M8LBBugk4SA",
-          "value" : "0d6VupPrizzG5VD"
+          "sourceName" : "ijJdIEjEsBQzNX4At",
+          "value" : "ex4w2klxj1M"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5ff95a20-0d88-42d7-a31c-f6f7f4468b23"
+        "id" : "https://www.example.org/6bec6d8a-48d5-4a18-8dda-d5020a971a6c"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "Photographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b2e4af2e-fc4e-4ccf-af55-1ebafc6d94df",
-        "name" : "2YduD6MknVY0Bdq",
-        "nameType" : "Organizational",
-        "orcId" : "4GchDw5DnaiuPlC",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/5aa5d93d-a979-4f42-8e0e-daef4711619c",
+        "name" : "7vGnBVJN7tQABMYX",
+        "nameType" : "Personal",
+        "orcId" : "3Btvx4qz9pIs85iuvIw",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Dh8YiOmltO1Oo2g",
-          "value" : "g8lgic7GXULYN"
+          "sourceName" : "yMzUFAd26pi5fol",
+          "value" : "EH4z9s2obakX09"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ek0ybt9TFKh45P18uoQ",
-          "value" : "2br9iQKu2veFLB"
+          "sourceName" : "aj5FF89gBugyIe",
+          "value" : "cXm3pO0DN1R0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ca6acb24-73b8-4162-a259-d100cab77fbc"
+        "id" : "https://www.example.org/8edd51c5-4268-49a7-a7a3-2e9346d9af85"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "GUNwAdOi1vxYp"
+      "nl" : "Aq7ydO00yomt77"
     },
-    "npiSubjectHeading" : "UQ4wXbZxGyqD0oMo",
-    "tags" : [ "dmf1z2nJdz" ],
-    "description" : "zrIJ8voULBzOp7",
+    "npiSubjectHeading" : "DSjAlXHu8lymtrqQKf",
+    "tags" : [ "Zra3JAvDmvVmT" ],
+    "description" : "3V7VDzlWPe9fwY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/gb84M55rKrKZSeprVGk"
+        "id" : "https://www.example.com/rJJCfO4CWqMf9vNLOH"
       },
-      "doi" : "https://www.example.org/1d01a314-2279-43b0-a200-23fc21105fa8",
+      "doi" : "https://www.example.org/2d4a8c36-78c3-4b24-927b-6b559e6ed8a8",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "mpl3OSU3k1eL",
-          "end" : "9EMcwo7M4sT1GB"
+          "begin" : "kvKBJDGfbp",
+          "end" : "iVa1qywVusg"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b3d1f93a-b133-4d74-bed3-767401160c27",
-    "abstract" : "jctLY1ff1vdze3pUCU"
+    "metadataSource" : "https://www.example.org/9c2350b0-91d2-491d-9054-0243eb14589a",
+    "abstract" : "sflUGR0a8Nth"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/bd8fd6d2-d237-417b-bc1b-595baba82d92",
-    "name" : "JCBw8XhRgn5",
+    "id" : "https://www.example.org/5f6af3fc-5cc9-4632-93b8-10285bc386a9",
+    "name" : "zz2LFMJ0IRNXI8kmpK0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-09-22T04:59:30.882Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "ecpMBszcZkLvdXfo"
+      "approvalDate" : "1997-05-16T06:29:19.735Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "epjScWsgDHt7FU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/81c718e2-48ea-462b-b091-ca4a5e6d9ffc",
-    "identifier" : "RdBTH8Fqw79",
+    "source" : "https://www.example.org/7600841e-7e92-410f-a671-b530b2cef7c6",
+    "identifier" : "CK1uPY5ptapfO",
     "labels" : {
-      "af" : "64tscrw8P7co"
+      "nl" : "eQR2qKQF8ezVl6PI"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 337814422
+    },
+    "activeFrom" : "2004-10-18T11:17:01.980Z",
+    "activeTo" : "2005-11-25T09:32:23.769Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/7700b72d-4188-4197-85f8-6fe533e7ecab",
+    "id" : "https://www.example.org/7d787f07-c10c-42ec-b30f-1e4d96db6208",
+    "identifier" : "OE4gUMKEHTz7lad",
+    "labels" : {
+      "pl" : "kfTDIYD2OHPW9zKD314"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1372773499
+      "amount" : 2048463788
     },
-    "activeFrom" : "2006-05-04T00:38:17.838Z",
-    "activeTo" : "2013-04-19T07:32:47.139Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b7195f97-904b-4f51-8e8a-24c40df4446a",
-    "id" : "https://www.example.org/1c7df093-3b49-4393-a657-ca2e6c4ea7cb",
-    "identifier" : "JifcQEUrri1nx",
-    "labels" : {
-      "de" : "o7bJT5bHFAhaDcPazW"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 935769471
-    },
-    "activeFrom" : "1996-07-06T02:22:01.708Z",
-    "activeTo" : "2004-01-23T05:09:04.521Z"
+    "activeFrom" : "1985-05-16T23:52:36.483Z",
+    "activeTo" : "1998-05-12T10:47:45.914Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ccf44b52-fdf6-42c2-82ab-7b6844140dba" ],
+  "subjects" : [ "https://www.example.org/473d08d2-76d1-4dac-9ca1-41e3afa04632" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fa4e6f45-9ad9-4998-b0c2-b1dac955c92c",
-    "name" : "prEACtA3Hb",
-    "mimeType" : "LKXY4k6HqcXH",
-    "size" : 459688672,
-    "license" : "https://www.example.com/ilq7gaglq31k",
+    "identifier" : "6e08b4b2-4d90-4082-906b-db3681e3879c",
+    "name" : "ohrHTWmYcRQCt3HNg4",
+    "mimeType" : "9XL8J7go0cKU4krp",
+    "size" : 1573382890,
+    "license" : "https://www.example.com/opwzqsctuqmvq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "asMMbD7uEUR6XnN2M"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "5Z1pNj7Whlwsuyw",
-    "publishedDate" : "2000-12-27T11:28:51.806Z",
+    "legalNote" : "B1ZkYtFKLFa",
+    "publishedDate" : "1973-03-16T15:09:09.373Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "4xVjxIt79Q7e",
-      "uploadedDate" : "1978-08-23T13:45:07.217Z"
+      "uploadedBy" : "bxW67n6LRFWVpscwl",
+      "uploadedDate" : "2004-07-10T08:11:56.639Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/D7zfDxBK1mcBLm",
-    "name" : "VBaWdZhUER",
-    "description" : "20gY6GXNGET"
+    "id" : "https://www.example.com/WX7incFEwku",
+    "name" : "69LLnfyGzrdt",
+    "description" : "EA9ZDYGcX80LBRnP"
   } ],
-  "rightsHolder" : "lZNKCybKnl",
-  "duplicateOf" : "https://www.example.org/fdc39cfa-ed4a-4fbd-b85e-e2307acdc447",
+  "rightsHolder" : "jIyZqogLYC6",
+  "duplicateOf" : "https://www.example.org/6415247a-3959-480b-96fc-eb5432422761",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xrBqLKqpPqWl7ngw2"
+    "note" : "9QmekZ5NLGpXwr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sB2JUW1W0mSnK",
-    "createdBy" : "pd5p3jIoFK0",
-    "createdDate" : "2006-01-08T03:42:23.868Z"
+    "note" : "f3pg4oDLLc",
+    "createdBy" : "LmVnOdNStIAKV",
+    "createdDate" : "1985-05-20T05:01:57.897Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/343ba781-fac5-486d-b32e-4e481f00f8f5" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/dac0a236-f9f3-43db-b61d-518e6ec896f0" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "SziZbVWixKl",
-    "ownerAffiliation" : "https://www.example.org/4d0b5cc7-3a4b-4d81-a729-454e772f6445"
+    "owner" : "NpAdUq4PpbLCSKp",
+    "ownerAffiliation" : "https://www.example.org/a3ec008a-ba52-4630-9588-c96e6cef2ead"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8ad81326-4dca-4ca0-980b-fcf6ee28ea27"
+    "id" : "https://www.example.org/ee2ca003-8f4b-4d56-947a-02a5d41f3a20"
   },
-  "createdDate" : "1993-05-04T11:44:25.502Z",
-  "modifiedDate" : "1995-07-02T09:01:02.576Z",
-  "publishedDate" : "1989-11-05T16:47:30.980Z",
-  "indexedDate" : "2017-09-25T09:53:36.561Z",
-  "handle" : "https://www.example.org/05abeb3f-bced-4906-8c42-da2782c83c9f",
-  "doi" : "https://doi.org/10.1234/eaque",
-  "link" : "https://www.example.org/8ad19cb3-93b9-4360-8691-29e243bcaf8f",
+  "createdDate" : "2001-04-01T19:54:02.696Z",
+  "modifiedDate" : "1996-01-24T13:04:16.292Z",
+  "publishedDate" : "1998-05-26T03:07:14.868Z",
+  "indexedDate" : "1992-11-07T13:15:43.102Z",
+  "handle" : "https://www.example.org/d4ebeaab-ebb9-4f61-ac9b-cb088f586e46",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/ea2d2d31-2dd0-4309-a6eb-9dc3284b4ba9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KJfh8nLrL4m",
+    "mainTitle" : "qWS9Xay2BVlKudsQuH",
     "alternativeTitles" : {
-      "fr" : "65F6pg3kRilew"
+      "ca" : "2Tv40vEmXcIHCsdtJ4G"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "isLlxbA0llcQ8q",
-      "month" : "SfqxYwdcJQnYME",
-      "day" : "qeKMe2861Z6"
+      "year" : "qP1Tm2q6QG0Mzu",
+      "month" : "Lo0iDdAzRWkx",
+      "day" : "iWtGGiSdb9F"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/18598473-283e-4f4f-8e59-f6f51f02326c",
-        "name" : "OPgyXMuwn7",
-        "nameType" : "Organizational",
-        "orcId" : "tCJ9FFGZ6IiL6",
+        "id" : "https://www.example.org/70d95cbf-fbc5-453b-abbe-8baeb969cbdc",
+        "name" : "h1ADbmvsrvQ",
+        "nameType" : "Personal",
+        "orcId" : "BzXrUOGlYVrekdLH",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vMdEID00THktB",
-          "value" : "sX8W7VlDeWDX6L"
+          "sourceName" : "AvS7dVeVpx9V9dPv",
+          "value" : "CFdWiixYztHVNEdQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ijJdIEjEsBQzNX4At",
-          "value" : "ex4w2klxj1M"
+          "sourceName" : "n6S4jWnAsawx9",
+          "value" : "8L6k6HvG9E91nDWjy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6bec6d8a-48d5-4a18-8dda-d5020a971a6c"
+        "id" : "https://www.example.org/9cfe1ef7-2785-4d8b-b391-6d31bdc96dbc"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5aa5d93d-a979-4f42-8e0e-daef4711619c",
-        "name" : "7vGnBVJN7tQABMYX",
-        "nameType" : "Personal",
-        "orcId" : "3Btvx4qz9pIs85iuvIw",
+        "id" : "https://www.example.org/8029431b-a4c1-44b6-993d-5980b345a5d6",
+        "name" : "diZndgPh53",
+        "nameType" : "Organizational",
+        "orcId" : "2Rta1eiQUl",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yMzUFAd26pi5fol",
-          "value" : "EH4z9s2obakX09"
+          "sourceName" : "kK3JbHR34WZH",
+          "value" : "D5H6ARKtA7Pp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aj5FF89gBugyIe",
-          "value" : "cXm3pO0DN1R0"
+          "sourceName" : "9BqIJDX0WAMUAyamDM",
+          "value" : "PshwZOQqbCf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8edd51c5-4268-49a7-a7a3-2e9346d9af85"
+        "id" : "https://www.example.org/16a9e6d0-cedf-4168-9dd3-5ef8a375b8b4"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "Aq7ydO00yomt77"
+      "el" : "40F1MTJjmvPoMxlYHr"
     },
-    "npiSubjectHeading" : "DSjAlXHu8lymtrqQKf",
-    "tags" : [ "Zra3JAvDmvVmT" ],
-    "description" : "3V7VDzlWPe9fwY",
+    "npiSubjectHeading" : "0sbtxoS1DEyXtLDNH",
+    "tags" : [ "YtSfYNyLIAKCB8qg" ],
+    "description" : "2XmTWL9Ew6LZCGWb28",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/rJJCfO4CWqMf9vNLOH"
+        "id" : "https://www.example.com/KOOglO9mNhqKPmGR4c"
       },
-      "doi" : "https://www.example.org/2d4a8c36-78c3-4b24-927b-6b559e6ed8a8",
+      "doi" : "https://www.example.org/f5f4bde4-b916-4f71-a964-bd882d27935e",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "kvKBJDGfbp",
-          "end" : "iVa1qywVusg"
+          "begin" : "WxGR7m8JMc6I",
+          "end" : "YLtjI699QexRw"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9c2350b0-91d2-491d-9054-0243eb14589a",
-    "abstract" : "sflUGR0a8Nth"
+    "metadataSource" : "https://www.example.org/09365f89-5d45-47e3-8e71-da57cc14482d",
+    "abstract" : "5F2NTa6jesn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5f6af3fc-5cc9-4632-93b8-10285bc386a9",
-    "name" : "zz2LFMJ0IRNXI8kmpK0",
+    "id" : "https://www.example.org/2e076500-ed87-403f-a54d-4fb0955d4205",
+    "name" : "yHb4QsyVcSYUTG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-05-16T06:29:19.735Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1995-12-10T14:37:08.713Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "epjScWsgDHt7FU"
+      "applicationCode" : "NdYQWVmP5V6cYca6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7600841e-7e92-410f-a671-b530b2cef7c6",
-    "identifier" : "CK1uPY5ptapfO",
+    "source" : "https://www.example.org/d0f13fdc-7bbe-4581-a16c-912601cc570b",
+    "identifier" : "o4WC0rZFni",
     "labels" : {
-      "nl" : "eQR2qKQF8ezVl6PI"
+      "pt" : "AdK2uZQ3IQi2q92Y5"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 337814422
+      "currency" : "USD",
+      "amount" : 896182438
     },
-    "activeFrom" : "2004-10-18T11:17:01.980Z",
-    "activeTo" : "2005-11-25T09:32:23.769Z"
+    "activeFrom" : "1972-03-05T00:09:32.598Z",
+    "activeTo" : "1984-11-25T16:42:16.184Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7700b72d-4188-4197-85f8-6fe533e7ecab",
-    "id" : "https://www.example.org/7d787f07-c10c-42ec-b30f-1e4d96db6208",
-    "identifier" : "OE4gUMKEHTz7lad",
+    "source" : "https://www.example.org/edcde0ac-3412-4fd7-b6d3-4e020b3925ea",
+    "id" : "https://www.example.org/02f27db6-2144-471e-8204-43acb03df8f4",
+    "identifier" : "V5Tj3fOMEtir0",
     "labels" : {
-      "pl" : "kfTDIYD2OHPW9zKD314"
+      "el" : "KtoRHhRy8ZOZ5V4rq"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 2048463788
+      "currency" : "USD",
+      "amount" : 1821255782
     },
-    "activeFrom" : "1985-05-16T23:52:36.483Z",
-    "activeTo" : "1998-05-12T10:47:45.914Z"
+    "activeFrom" : "2001-03-08T22:01:13.951Z",
+    "activeTo" : "2006-09-13T17:29:26.699Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/473d08d2-76d1-4dac-9ca1-41e3afa04632" ],
+  "subjects" : [ "https://www.example.org/06c61e9a-c8fa-4bd3-bf77-1e8ffe5a9caa" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6e08b4b2-4d90-4082-906b-db3681e3879c",
-    "name" : "ohrHTWmYcRQCt3HNg4",
-    "mimeType" : "9XL8J7go0cKU4krp",
-    "size" : 1573382890,
-    "license" : "https://www.example.com/opwzqsctuqmvq",
+    "identifier" : "62911f53-0a42-44a2-86c0-cf54f2204883",
+    "name" : "GAg78uCVu6AWQqnQi",
+    "mimeType" : "XwgFBe4eXp",
+    "size" : 1704885134,
+    "license" : "https://www.example.com/5n43h51oghk",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "B1ZkYtFKLFa",
-    "publishedDate" : "1973-03-16T15:09:09.373Z",
+    "legalNote" : "PqHTlY8Up5sjB0wT",
+    "publishedDate" : "1980-02-06T12:18:33.272Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "bxW67n6LRFWVpscwl",
-      "uploadedDate" : "2004-07-10T08:11:56.639Z"
+      "uploadedBy" : "maeg1WVR9ghRy",
+      "uploadedDate" : "1981-10-06T22:56:39.746Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/WX7incFEwku",
-    "name" : "69LLnfyGzrdt",
-    "description" : "EA9ZDYGcX80LBRnP"
+    "id" : "https://www.example.com/lTV9DsvUNGUDHVluZ",
+    "name" : "Z3fqPYMIhCpF9pNHbF",
+    "description" : "ri0Kpx4HEsOQMeJ"
   } ],
-  "rightsHolder" : "jIyZqogLYC6",
-  "duplicateOf" : "https://www.example.org/6415247a-3959-480b-96fc-eb5432422761",
+  "rightsHolder" : "hUrGKQuSaO7MLwffB",
+  "duplicateOf" : "https://www.example.org/81271009-f3a7-48e1-90c6-f6a571d9e2a3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9QmekZ5NLGpXwr"
+    "note" : "2G0WegobYFv2"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "f3pg4oDLLc",
-    "createdBy" : "LmVnOdNStIAKV",
-    "createdDate" : "1985-05-20T05:01:57.897Z"
+    "note" : "HAAmvgfbh6el",
+    "createdBy" : "tPvdk78aZJ",
+    "createdDate" : "1989-08-27T02:35:13.283Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dac0a236-f9f3-43db-b61d-518e6ec896f0" ],
+  "curatingInstitutions" : [ "https://www.example.org/ac742c71-7b33-443b-86c8-28b746186299" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "hRSdGS224Kg",
-    "ownerAffiliation" : "https://www.example.org/3e7b3cac-fc61-4558-9a9e-318b63f19058"
+    "owner" : "fCS9xQDKbqjb",
+    "ownerAffiliation" : "https://www.example.org/f925e14c-a1ca-4ac3-8b5c-aaae2f3fba19"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/50df0e8b-e160-4614-8b5b-4ec0174f42b7"
+    "id" : "https://www.example.org/6b8fda8f-65d5-40e2-a16e-3f6afdc3539b"
   },
-  "createdDate" : "1995-07-26T07:18:37.699Z",
-  "modifiedDate" : "1982-07-04T03:34:35.705Z",
-  "publishedDate" : "1991-10-09T00:27:37.402Z",
-  "indexedDate" : "2006-06-10T13:39:40.201Z",
-  "handle" : "https://www.example.org/9884d69c-a6c7-47c2-9e32-21ff12f44de1",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/c267150b-31fe-4feb-bef4-026106a78f34",
+  "createdDate" : "2016-09-27T23:11:05.869Z",
+  "modifiedDate" : "2005-07-27T21:53:07.074Z",
+  "publishedDate" : "1973-01-17T02:50:58.549Z",
+  "indexedDate" : "2008-10-18T17:51:21.320Z",
+  "handle" : "https://www.example.org/670855b4-f1f7-4bf4-bf23-eef68017854f",
+  "doi" : "https://doi.org/10.1234/explicabo",
+  "link" : "https://www.example.org/556e517b-6b85-4344-b7e9-e75b3a731087",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "qJVfTl1UCM",
+    "mainTitle" : "7I38viIAr0N5WrJYX",
     "alternativeTitles" : {
-      "fr" : "Ua79d0YsYW"
+      "af" : "A5raFo02Dmdm47Ik"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HhQwCsdGYF7",
-      "month" : "IK5C37pFmPsVCdSIXU",
-      "day" : "dDoq4tyXAtvK4HRgk"
+      "year" : "7WGqe8xYrxx",
+      "month" : "MrwSpYeRPL",
+      "day" : "QWI0R0Jwp6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ccd7c30-5a1f-4860-896b-bd15dd33157f",
-        "name" : "XSlIfUacM88xMvC",
+        "id" : "https://www.example.org/e0da164e-9bf5-4998-9354-82cc38eff5da",
+        "name" : "WxuXEJNbIckY",
         "nameType" : "Organizational",
-        "orcId" : "BdnNuhStp1hyNYv4z17",
-        "verificationStatus" : "Verified",
+        "orcId" : "3dfb4U2P1z9vcBDi",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SHLxAtORnNjrtET",
-          "value" : "gm9hUOLFlXw0oV03"
+          "sourceName" : "g1IbA8WBTfl4",
+          "value" : "HK3faCd6h8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "grEkUZX4cJ",
-          "value" : "QE6JVRNhTDp"
+          "sourceName" : "5qNfXvyqjrI1H",
+          "value" : "LzPbyfpu6vBGUMa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/de641b6d-9f02-4977-9187-fe721ae3315e"
+        "id" : "https://www.example.org/0dcf7449-db83-4cc4-a7a2-408ed7ba88c2"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/55c12960-c289-45b1-8c49-5dd9b0c609ee",
-        "name" : "DeOZRzf5OzeXtThB6",
-        "nameType" : "Organizational",
-        "orcId" : "dZwqqE7V8G",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/2ecd9cef-52a7-4450-8b27-bace2bb97328",
+        "name" : "UHPwx9cLsTPK1p",
+        "nameType" : "Personal",
+        "orcId" : "CdyrxelyoXbikFn6RSG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GvWldl6J9pPbG9Psy",
-          "value" : "2jmdlxJx11PivyiDf7"
+          "sourceName" : "fBoRBZQRv7dNf63H",
+          "value" : "242npcNc99RUcxSqaL8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o8sXnvZJu3dws",
-          "value" : "TE1bmXEcuHHe0"
+          "sourceName" : "H3bwXH0rTNZvml8tf27",
+          "value" : "iuBVUHgGvVXnPz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2db517c5-e16c-409d-809d-7092ea9e0d04"
+        "id" : "https://www.example.org/ed1ca030-2e63-48f9-b361-3cd7b1a31b77"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "1zH6B9LHNNC4IqrC"
+      "fr" : "HaUBd2Jg54"
     },
-    "npiSubjectHeading" : "BIWWwowOeBXcPA",
-    "tags" : [ "r5XXfAjeI9472mD" ],
-    "description" : "zBZ50PjQhovOCQ8uT",
+    "npiSubjectHeading" : "o7GXYE01DZ",
+    "tags" : [ "T3mz2ipvjlnBn" ],
+    "description" : "bE6jum7WG8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e8a036fa-6afa-47b2-a8fa-61e627018b58"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9a33cd7c-25e8-484d-bb2a-e125ba9fd883"
         },
-        "seriesNumber" : "P3HUPeeMT3tD633X",
+        "seriesNumber" : "8j510rqXLHdljEcQ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ed1b8931-a5ae-4ea8-b5e8-4bdf4aa5d9e3",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/606dc1c6-0cbd-4f28-832e-05895a0368b9",
           "valid" : true
         },
-        "isbnList" : [ "9791468639093", "9780653044767" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9781930669635", "9781287108993" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0653044763"
+          "value" : "1287108997"
         } ]
       },
-      "doi" : "https://www.example.org/6a628cf3-0e3c-46da-87e2-758acfa1586f",
+      "doi" : "https://www.example.org/041d30fc-16c0-439a-a5a8-159030834c45",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "tT0B549ZuvbZbaVz4",
-            "end" : "Z0n2y1UKfU"
+            "begin" : "eco03V91d5vae",
+            "end" : "0FTymNAJPt2P6R"
           },
-          "pages" : "kxhY6hUjsaXEubAbtx",
+          "pages" : "V1sBAG64aamUPc1fZK",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3c2f3a87-7b75-482a-8c96-acf37e5ef390",
-    "abstract" : "6GS6L32YG4gisx"
+    "metadataSource" : "https://www.example.org/2849ef6b-7104-4bb4-9641-270e86766b4b",
+    "abstract" : "IuJngE2VW9fAco"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/75903249-e026-4d33-8e73-702c7af38464",
-    "name" : "g9BLG52sOcpQUoIs8J",
+    "id" : "https://www.example.org/93fe8b90-510f-4200-bc2d-e2ec21c55fae",
+    "name" : "qwXHYNADvS9s",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-08-05T17:20:12.734Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1994-05-07T08:33:05.475Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "rMnQA9mK5hjH1L"
+      "applicationCode" : "GMxfVr6xkAMIKn"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5a3ce6f6-5f82-40be-9268-05b7886d8ff3",
-    "identifier" : "D7o4ERfWRFQqV",
+    "source" : "https://www.example.org/033914b2-3d3f-4078-9249-5d304df2dbd3",
+    "identifier" : "KjRDRaWYcA2c6o",
     "labels" : {
-      "el" : "0EBT4luNjBNreeh"
+      "el" : "s1gqDQU0MrdnpQdjB"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 576848586
+    },
+    "activeFrom" : "1985-07-28T22:37:18.488Z",
+    "activeTo" : "1986-03-08T16:05:21.578Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/e183b73b-ca24-4488-a2f7-a00ab56efea9",
+    "id" : "https://www.example.org/3d3c7694-38d6-4ff3-99bd-ce3af4c3cc00",
+    "identifier" : "EqEsboONfFA",
+    "labels" : {
+      "de" : "HagNLkJEOlXh9F7MpC0"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1266994103
+      "amount" : 2033275273
     },
-    "activeFrom" : "1999-06-21T07:49:44.184Z",
-    "activeTo" : "2023-04-16T13:29:21.741Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4b88933e-a9f5-4e2a-8941-44b06406b7fc",
-    "id" : "https://www.example.org/caac63a2-edd8-45f9-9887-8c28e6f7f1ca",
-    "identifier" : "pyvUPPT4C453",
-    "labels" : {
-      "af" : "EOncoU2JVAYi"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 789508139
-    },
-    "activeFrom" : "1983-10-15T03:20:52.937Z",
-    "activeTo" : "2018-08-02T06:12:09.088Z"
+    "activeFrom" : "1980-11-25T09:54:12.372Z",
+    "activeTo" : "1980-12-25T18:11:04.393Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d4064432-4be1-4b95-afde-852ea5532c0e" ],
+  "subjects" : [ "https://www.example.org/a44a4697-4d05-4995-8779-4b9df928c062" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6c744ae9-3258-4f8b-82e1-5073b691f8b6",
-    "name" : "sla0nmKEpG7Uf",
-    "mimeType" : "XV6cdbSHLCX3KA",
-    "size" : 818167527,
-    "license" : "https://www.example.com/xjkw2vxozljagegfrt",
+    "identifier" : "0075c27d-cb50-4b0a-9f4f-9391a40802fd",
+    "name" : "DXNPCbch0Ulm1j",
+    "mimeType" : "gHnm4FyNVbrS",
+    "size" : 2072474977,
+    "license" : "https://www.example.com/sqw7s4hakm2eznopw",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "RHUiTpf1lqPdegMhrsj",
-    "publishedDate" : "2023-10-26T19:15:49.905Z",
+    "legalNote" : "YGr3cBHd2SlTT",
+    "publishedDate" : "1999-07-14T23:55:03.452Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "7ghnDmkKWs",
-      "uploadedDate" : "1971-03-26T00:38:46.944Z"
+      "uploadedBy" : "FtkpCvHLG5gVSv",
+      "uploadedDate" : "2011-10-18T07:18:24.034Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ddRYRVlLApT7EKs4ZW",
-    "name" : "IvLhFBs0BPw",
-    "description" : "9bcvx5dXzd4Y9xMqBj"
+    "id" : "https://www.example.com/7Y4KS2wA1c7",
+    "name" : "iglTJme6URIoSvC1VR9",
+    "description" : "iyUeLHD6o3A"
   } ],
-  "rightsHolder" : "6Ec1nhmnDQr0AV5N",
-  "duplicateOf" : "https://www.example.org/bc0fa7bf-15b3-43a2-804a-d44df782a1e6",
+  "rightsHolder" : "Kmr7XYig50aG9a",
+  "duplicateOf" : "https://www.example.org/901d9456-0660-4cc9-9729-692206897541",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xx2lJydJkxyejnJE4uH"
+    "note" : "ImTVrFfFdthebX"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xKyYedVCuR",
-    "createdBy" : "3K1kLh6pf0s",
-    "createdDate" : "2005-05-28T15:42:38.392Z"
+    "note" : "yC4H9lgbN1GkvNph",
+    "createdBy" : "89l2eYODX08fQwh",
+    "createdDate" : "1996-03-13T18:30:14.838Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/956d0333-3d71-44e4-a2ef-8ce055c27de6" ],
+  "curatingInstitutions" : [ "https://www.example.org/3aefd3f5-7a5f-48ae-9437-e8e6698c1f68" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "9ge14sJWBxFYuqm",
-    "ownerAffiliation" : "https://www.example.org/12b10ac2-6fbc-497e-9cd3-73e5c9aaa2a4"
+    "owner" : "hRSdGS224Kg",
+    "ownerAffiliation" : "https://www.example.org/3e7b3cac-fc61-4558-9a9e-318b63f19058"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/76138bcf-8a79-490d-b9ef-9d9809c5d77e"
+    "id" : "https://www.example.org/50df0e8b-e160-4614-8b5b-4ec0174f42b7"
   },
-  "createdDate" : "2020-01-12T01:24:39.565Z",
-  "modifiedDate" : "1988-02-14T16:49:34.468Z",
-  "publishedDate" : "1974-05-12T03:37:02.628Z",
-  "indexedDate" : "2007-10-08T13:34:31.278Z",
-  "handle" : "https://www.example.org/07ddef8d-5f2f-4170-b2ea-93c617c756ef",
-  "doi" : "https://doi.org/10.1234/iure",
-  "link" : "https://www.example.org/ad9f823a-8266-4882-b521-2e004d8f4875",
+  "createdDate" : "1995-07-26T07:18:37.699Z",
+  "modifiedDate" : "1982-07-04T03:34:35.705Z",
+  "publishedDate" : "1991-10-09T00:27:37.402Z",
+  "indexedDate" : "2006-06-10T13:39:40.201Z",
+  "handle" : "https://www.example.org/9884d69c-a6c7-47c2-9e32-21ff12f44de1",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/c267150b-31fe-4feb-bef4-026106a78f34",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cb6dZQxHQiPkeR2Ds",
+    "mainTitle" : "qJVfTl1UCM",
     "alternativeTitles" : {
-      "nn" : "Oc0ao4EdIPSjX"
+      "fr" : "Ua79d0YsYW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xAuVrmdIVkefzUc",
-      "month" : "okxJgqXCD3OgFAT93",
-      "day" : "Kd2PK1s3xMd9ds7"
+      "year" : "HhQwCsdGYF7",
+      "month" : "IK5C37pFmPsVCdSIXU",
+      "day" : "dDoq4tyXAtvK4HRgk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ae0cf7e9-2070-4862-bea8-96c88afa150e",
-        "name" : "JBl1cePTtc8",
+        "id" : "https://www.example.org/7ccd7c30-5a1f-4860-896b-bd15dd33157f",
+        "name" : "XSlIfUacM88xMvC",
         "nameType" : "Organizational",
-        "orcId" : "kdVbty61nwqcopKrM",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "BdnNuhStp1hyNYv4z17",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Jj5pnONIz4D",
-          "value" : "4qqzSNupFbYYWWa"
+          "sourceName" : "SHLxAtORnNjrtET",
+          "value" : "gm9hUOLFlXw0oV03"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EUnZfIc9fDgyNlWT",
-          "value" : "ZT7jR1QMWwETLWkTMj"
+          "sourceName" : "grEkUZX4cJ",
+          "value" : "QE6JVRNhTDp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/124a4915-da54-41ff-b288-d24c9f949b71"
+        "id" : "https://www.example.org/de641b6d-9f02-4977-9187-fe721ae3315e"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "Librettist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0552aff3-7cef-4e57-9c5d-3aa66b5e5ac1",
-        "name" : "giljHp2ZLpOjuHK1",
-        "nameType" : "Personal",
-        "orcId" : "P2KtUJiSk9D6P6Q6xNw",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/55c12960-c289-45b1-8c49-5dd9b0c609ee",
+        "name" : "DeOZRzf5OzeXtThB6",
+        "nameType" : "Organizational",
+        "orcId" : "dZwqqE7V8G",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Mhy6pyh3trd2a",
-          "value" : "NXfxgGmvD3bQF"
+          "sourceName" : "GvWldl6J9pPbG9Psy",
+          "value" : "2jmdlxJx11PivyiDf7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iXgXKUHojuv",
-          "value" : "nJT7XUkQstdstTv3"
+          "sourceName" : "o8sXnvZJu3dws",
+          "value" : "TE1bmXEcuHHe0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6995d77e-6fa6-49de-a1bd-360dbfa6a89b"
+        "id" : "https://www.example.org/2db517c5-e16c-409d-809d-7092ea9e0d04"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "6rL2tvmJ7dc"
+      "nb" : "1zH6B9LHNNC4IqrC"
     },
-    "npiSubjectHeading" : "LKCGUkbpc5h",
-    "tags" : [ "OGlWG3r9J2TiJfvH" ],
-    "description" : "jQDlEfMWZFt",
+    "npiSubjectHeading" : "BIWWwowOeBXcPA",
+    "tags" : [ "r5XXfAjeI9472mD" ],
+    "description" : "zBZ50PjQhovOCQ8uT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5b7990eb-21bf-40a4-b18c-bc5efbdc2221"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e8a036fa-6afa-47b2-a8fa-61e627018b58"
         },
-        "seriesNumber" : "5mdR0U92OSWLQxg",
+        "seriesNumber" : "P3HUPeeMT3tD633X",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bd245ce8-2d1d-4afd-8538-089ea6986c03",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ed1b8931-a5ae-4ea8-b5e8-4bdf4aa5d9e3",
           "valid" : true
         },
-        "isbnList" : [ "9790087545990" ],
+        "isbnList" : [ "9791468639093", "9780653044767" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "Ry7DSvJ7KCe1sqP"
+          "value" : "0653044763"
         } ]
       },
-      "doi" : "https://www.example.org/e2453178-f8d8-4bf3-80c0-aca622e4714e",
+      "doi" : "https://www.example.org/6a628cf3-0e3c-46da-87e2-758acfa1586f",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rmMl61pWeHbmzohj",
-            "end" : "RCFT9pzUGKnVWWi1"
+            "begin" : "tT0B549ZuvbZbaVz4",
+            "end" : "Z0n2y1UKfU"
           },
-          "pages" : "LBjyCYsKWLn",
-          "illustrated" : false
+          "pages" : "kxhY6hUjsaXEubAbtx",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6e3d3757-43c9-49f0-a905-1dc1751a52ad",
-    "abstract" : "d4db582db8S1zi"
+    "metadataSource" : "https://www.example.org/3c2f3a87-7b75-482a-8c96-acf37e5ef390",
+    "abstract" : "6GS6L32YG4gisx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1f2d8c1f-d453-4ab3-9874-db28fbfaa2eb",
-    "name" : "dcU2EBGkn8D",
+    "id" : "https://www.example.org/75903249-e026-4d33-8e73-702c7af38464",
+    "name" : "g9BLG52sOcpQUoIs8J",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-03-12T21:18:56.044Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "3VLU9B0lOhk0"
+      "approvalDate" : "1972-08-05T17:20:12.734Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "rMnQA9mK5hjH1L"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/24942ddb-ab90-4582-8210-d8c50d77bce6",
-    "identifier" : "z1Gy7ABWipU25ES",
+    "source" : "https://www.example.org/5a3ce6f6-5f82-40be-9268-05b7886d8ff3",
+    "identifier" : "D7o4ERfWRFQqV",
     "labels" : {
-      "es" : "CxmlIqH5dbpb1xuDBb4"
+      "el" : "0EBT4luNjBNreeh"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 944696228
+      "currency" : "GBP",
+      "amount" : 1266994103
     },
-    "activeFrom" : "2003-09-09T04:32:40.350Z",
-    "activeTo" : "2012-12-24T04:26:45.943Z"
+    "activeFrom" : "1999-06-21T07:49:44.184Z",
+    "activeTo" : "2023-04-16T13:29:21.741Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c4eb06ca-c5c7-468b-b121-e447774d6bf6",
-    "id" : "https://www.example.org/f292ce23-9424-4d37-a463-861a6076713f",
-    "identifier" : "EEr1LCvqYyimtuq3bPK",
+    "source" : "https://www.example.org/4b88933e-a9f5-4e2a-8941-44b06406b7fc",
+    "id" : "https://www.example.org/caac63a2-edd8-45f9-9887-8c28e6f7f1ca",
+    "identifier" : "pyvUPPT4C453",
     "labels" : {
-      "nn" : "2QLQI5hMUNBM1J"
+      "af" : "EOncoU2JVAYi"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1084980740
+      "amount" : 789508139
     },
-    "activeFrom" : "1998-12-08T02:38:51.680Z",
-    "activeTo" : "1999-03-01T06:40:22.085Z"
+    "activeFrom" : "1983-10-15T03:20:52.937Z",
+    "activeTo" : "2018-08-02T06:12:09.088Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ae29a4b9-b846-4d00-ad46-0c03e008ec20" ],
+  "subjects" : [ "https://www.example.org/d4064432-4be1-4b95-afde-852ea5532c0e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f5daa840-d677-4628-a5ea-ca8875192fa6",
-    "name" : "Wbaz20LqQl4s0CfU6",
-    "mimeType" : "UOUN6uQ3o6PvL",
-    "size" : 964201535,
-    "license" : "https://www.example.com/a5fstwqidxad",
+    "identifier" : "6c744ae9-3258-4f8b-82e1-5073b691f8b6",
+    "name" : "sla0nmKEpG7Uf",
+    "mimeType" : "XV6cdbSHLCX3KA",
+    "size" : 818167527,
+    "license" : "https://www.example.com/xjkw2vxozljagegfrt",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "JeMR5VUOT2IXHFr",
-    "publishedDate" : "2022-10-21T00:55:35.671Z",
+    "legalNote" : "RHUiTpf1lqPdegMhrsj",
+    "publishedDate" : "2023-10-26T19:15:49.905Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "xH2VKKTTDDudjs1vJ",
-      "uploadedDate" : "1986-06-22T00:24:43.249Z"
+      "uploadedBy" : "7ghnDmkKWs",
+      "uploadedDate" : "1971-03-26T00:38:46.944Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FCp3uS0EzCUGNw0ou1n",
-    "name" : "SHplnibhkOW4AIKC",
-    "description" : "rF2M5C96wCSOM05qt"
+    "id" : "https://www.example.com/ddRYRVlLApT7EKs4ZW",
+    "name" : "IvLhFBs0BPw",
+    "description" : "9bcvx5dXzd4Y9xMqBj"
   } ],
-  "rightsHolder" : "ZFCw6OfqpJlJyzzY",
-  "duplicateOf" : "https://www.example.org/60e5f45b-2527-476c-bc1d-075814a45150",
+  "rightsHolder" : "6Ec1nhmnDQr0AV5N",
+  "duplicateOf" : "https://www.example.org/bc0fa7bf-15b3-43a2-804a-d44df782a1e6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "mBBXTYxK98AvcDG5G"
+    "note" : "xx2lJydJkxyejnJE4uH"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "6rquk043oGbEsj6db",
-    "createdBy" : "O9csK1CWBtLF",
-    "createdDate" : "1981-09-03T08:42:05.379Z"
+    "note" : "xKyYedVCuR",
+    "createdBy" : "3K1kLh6pf0s",
+    "createdDate" : "2005-05-28T15:42:38.392Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/30dcf045-4753-4ce4-a01c-52fd2003b15a" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/956d0333-3d71-44e4-a2ef-8ce055c27de6" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "J7W5BZzrEPaS",
-    "ownerAffiliation" : "https://www.example.org/bf2747ec-14f7-485f-83d5-0443045a5c02"
+    "owner" : "x5crsnMwGSKigpkK",
+    "ownerAffiliation" : "https://www.example.org/d74cdf11-a7e2-47be-9c60-c11f78655d21"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6ae43ee3-92a1-4ab0-ac1e-b7524ae8296a"
+    "id" : "https://www.example.org/dc4f290c-6332-4dc4-8eac-4cd042890b14"
   },
-  "createdDate" : "2018-08-19T14:01:25.346Z",
-  "modifiedDate" : "1984-11-11T21:29:47.588Z",
-  "publishedDate" : "2009-03-04T13:52:32.789Z",
-  "indexedDate" : "1992-06-24T04:40:36.453Z",
-  "handle" : "https://www.example.org/47420dae-afec-4c30-9875-69bcb9162d2c",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/572fef99-0e5d-4213-8c00-27acccad53a6",
+  "createdDate" : "1977-03-28T02:07:35.943Z",
+  "modifiedDate" : "1978-05-13T00:11:43.064Z",
+  "publishedDate" : "2006-01-04T16:49:44.982Z",
+  "indexedDate" : "1972-01-03T10:26:49.327Z",
+  "handle" : "https://www.example.org/6015ebef-b558-4d12-ab99-5642716da3b9",
+  "doi" : "https://doi.org/10.1234/impedit",
+  "link" : "https://www.example.org/cece80fc-2c04-4415-bc2d-0cb1ad670158",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0cH4a0ViqH45KzO8h",
+    "mainTitle" : "L11L7K0sh7",
     "alternativeTitles" : {
-      "el" : "zeoA5vYOwIYHPEmj1"
+      "hu" : "T2bEzmFV5PxmPTtZil"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "5UrVubza4Em",
-      "month" : "8r7M5PeLwJjBNp",
-      "day" : "m5tHLsFXjG41YvS620"
+      "year" : "kdicMhDWnXeNSwmX",
+      "month" : "hhXe7NMxhHFnyoCQP47",
+      "day" : "YjVkF7M9Eu9OQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fc8131d4-018e-4d93-99d6-c644e434503d",
-        "name" : "yRtaf9Y1n3",
-        "nameType" : "Organizational",
-        "orcId" : "PEh9H5ALZ0OciAj8e",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f9bb5772-b3ef-40c6-b146-dd9e6136cad5",
+        "name" : "0SwvEPW9iN",
+        "nameType" : "Personal",
+        "orcId" : "mptVHOnIFJt0NF2ykp8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "J23TduAmg0PfRcOPRYP",
-          "value" : "48WS3OVrfkEuJOMe"
+          "sourceName" : "uOvTRdNWYT",
+          "value" : "oShympyBRG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zcxvE0y8WpgD",
-          "value" : "6Ktg1ngTr4C"
+          "sourceName" : "1Df0XrsqQjkR5Mc0",
+          "value" : "FBoPHpuVeOic"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/455e7934-3ab0-4c45-9d76-c8ab5e417e08"
+        "id" : "https://www.example.org/4b5318ac-ae23-4b14-9cd0-340015ce929e"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Curator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5a257f26-f8f8-4dfb-a443-149b247e455b",
-        "name" : "27157mVC299rVVEJ",
-        "nameType" : "Personal",
-        "orcId" : "6oYziLEBNkkgbwN",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/742e996f-034a-49eb-b9ae-028c3ebd48d0",
+        "name" : "h2BJZTUPcjTgtdwW",
+        "nameType" : "Organizational",
+        "orcId" : "WqEfkIvQs6E",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o8MfKPCLCLbvO",
-          "value" : "37fqyOsAWxuf9SC"
+          "sourceName" : "wrLs3nZsu7Vg49",
+          "value" : "hilalzyY1X5tRpzf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ou57H9mQ5Og",
-          "value" : "RuNbiIwkJCl"
+          "sourceName" : "AllpFKOvdDoD",
+          "value" : "o1t42tiFVB13pT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/77e4eed0-6103-4a6d-85ff-f67d6f472a53"
+        "id" : "https://www.example.org/5d4e21cf-952a-4b72-9cc1-44d4616d13c2"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "LightDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "o44w3Q37Tbgj56BtnY"
+      "ru" : "lqv8BxuL8OYi"
     },
-    "npiSubjectHeading" : "KnzzhZcCKL94PfqNZ",
-    "tags" : [ "yt3Ctr7tnQfNpL7f" ],
-    "description" : "EYY1xvQby7ibp",
+    "npiSubjectHeading" : "fWRP2OKzsp4",
+    "tags" : [ "TQFr7S6n0EU48V6s" ],
+    "description" : "Vn3oDGtHccERQmBa4I",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/BKKvICNv6pyQEDgSC93"
+        "id" : "https://www.example.com/LD7MKWfB6Zk4O418Jmd"
       },
-      "doi" : "https://www.example.org/79706419-a565-4160-b9f9-27876c187678",
+      "doi" : "https://www.example.org/fa989de0-93fa-4420-b665-0306f875750a",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "dLhLpOSFDRIyFG",
-          "end" : "n4MNA4ppkjniM"
+          "begin" : "Cd1k19u0TokVCOm",
+          "end" : "3Fbuu5OSdLMN0"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a0edd43c-3179-4055-a81f-4e9e01a60329",
-    "abstract" : "e4gsiihCvCd"
+    "metadataSource" : "https://www.example.org/65935646-1b6b-45d8-9e4c-e40f0afe17af",
+    "abstract" : "j1acEsUVLB3uUrU3EV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/00b64b7c-0422-4b2d-9750-a71c5a6ffa69",
-    "name" : "8aO0AdADkbeuC",
+    "id" : "https://www.example.org/9a8fc3ac-4c98-4054-b493-eae9f9617a1b",
+    "name" : "mQCR0ka49NncWcMJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-10-14T18:57:52.852Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "dvrbU8oMwPHxX9YGS"
+      "approvalDate" : "2006-06-16T18:28:22.504Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "etJQpTkAZS50F96xuw"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6177a347-57ee-4c0d-a35d-0e9018af6bf1",
-    "identifier" : "s1NrjTviqc35IqDh",
+    "source" : "https://www.example.org/7106641a-9af7-4c2d-bf25-a8f9f075eb99",
+    "identifier" : "9n5WfVxW0gUf",
     "labels" : {
-      "hu" : "brcVspQOfsFwgolXs"
+      "it" : "YecSVCE163PAKS7btT"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 604585032
+      "currency" : "EUR",
+      "amount" : 799414351
     },
-    "activeFrom" : "1983-10-30T18:48:17.527Z",
-    "activeTo" : "2009-08-22T18:26:30.134Z"
+    "activeFrom" : "2004-03-31T07:15:34.553Z",
+    "activeTo" : "2016-02-05T00:59:37.486Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4e571bc0-fa4f-4947-89ee-ee06983a64e9",
-    "id" : "https://www.example.org/dabb8e56-8ad7-4b51-8cef-3f57abff0eea",
-    "identifier" : "3uCkebMKNnu",
+    "source" : "https://www.example.org/fbde0206-124e-4d34-8556-c64f02c410a1",
+    "id" : "https://www.example.org/1c6858bb-f6f2-46a0-a343-9b95d091c33b",
+    "identifier" : "M8cwMIEOqpWGhOK",
     "labels" : {
-      "fi" : "DYmkUY3g38QW4cl4"
+      "da" : "XKWO2af8KE44zr3ZG1"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 636741407
+      "amount" : 1289091401
     },
-    "activeFrom" : "1972-02-03T13:26:57.796Z",
-    "activeTo" : "1977-06-19T05:40:41.438Z"
+    "activeFrom" : "1975-05-20T16:31:25.106Z",
+    "activeTo" : "1983-09-11T08:26:24.789Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/59b847b1-62dd-49cf-8c7e-b2aefcaf19be" ],
+  "subjects" : [ "https://www.example.org/af66d38b-4c0a-4cbc-a269-7fb44a26303f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d96a429c-b1b5-4468-a24c-7afa5afd0bee",
-    "name" : "4tlDOQOzXjZz",
-    "mimeType" : "TeAUWfL2hev",
-    "size" : 619311365,
-    "license" : "https://www.example.com/pmoutlvhl0snx8rd",
+    "identifier" : "68603044-cbdc-4100-b789-20a69c91ac9a",
+    "name" : "GyQS1wumb4lLE",
+    "mimeType" : "qzo3GPyYMPP5",
+    "size" : 1339685143,
+    "license" : "https://www.example.com/izhiptc64qmvt5v",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "hTZCkQH8vMr6dr"
     },
-    "legalNote" : "7z5CpINLapwdo",
-    "publishedDate" : "1981-08-24T09:52:08.832Z",
+    "legalNote" : "fb5WpqrvnZyX",
+    "publishedDate" : "2005-08-13T07:53:40.771Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "BJbzFp77PgW4",
-      "uploadedDate" : "1978-11-01T15:44:14.115Z"
+      "uploadedBy" : "u5OkBT8X85",
+      "uploadedDate" : "2013-10-02T00:15:57.571Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KoaStKCDcE2LgrAe",
-    "name" : "GQooVzdCB2NXSC5",
-    "description" : "k8wyzpomvSwMUifBeml"
+    "id" : "https://www.example.com/i7oLiotLHy8kY",
+    "name" : "mDKMZT6Q99vtb",
+    "description" : "R1Qpha0OHcvWA7x6K"
   } ],
-  "rightsHolder" : "ZGDR4YahzQ5wcpiLv2m",
-  "duplicateOf" : "https://www.example.org/c10dca3a-1333-4277-9722-62cefc6d7b4a",
+  "rightsHolder" : "D6JaWHuw2HXf",
+  "duplicateOf" : "https://www.example.org/9bfa7e57-8783-4998-a0ad-1a430c992ba4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "GkbNxrMbW6AU0Z"
+    "note" : "NUW6EwOwsJ9cfRk"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Bpgzg2oJOajV5hi",
-    "createdBy" : "JZmOH9WWOVNjjr8E",
-    "createdDate" : "2008-12-23T09:15:39.369Z"
+    "note" : "RX5zf3hfxYh94l",
+    "createdBy" : "kbg5skKOacOeiY3",
+    "createdDate" : "2004-07-03T19:17:48.829Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2de1ae3b-487e-4f71-b6f7-fc5049367633" ],
+  "curatingInstitutions" : [ "https://www.example.org/98e354e5-bdee-4a17-b287-b10709d07f6f" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "IwkEMot7HiQmcdTK7",
-    "ownerAffiliation" : "https://www.example.org/93d4fe22-c1d7-4710-a481-d802904b7307"
+    "owner" : "J7W5BZzrEPaS",
+    "ownerAffiliation" : "https://www.example.org/bf2747ec-14f7-485f-83d5-0443045a5c02"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/91388239-483f-4fde-8af0-4b1282629757"
+    "id" : "https://www.example.org/6ae43ee3-92a1-4ab0-ac1e-b7524ae8296a"
   },
-  "createdDate" : "1997-01-06T05:04:56.813Z",
-  "modifiedDate" : "2011-09-03T17:13:18.420Z",
-  "publishedDate" : "1989-08-16T23:32:18.445Z",
-  "indexedDate" : "1982-12-09T20:05:54.577Z",
-  "handle" : "https://www.example.org/22da19d4-215e-40f8-bf25-faacea30d7f5",
-  "doi" : "https://doi.org/10.1234/voluptates",
-  "link" : "https://www.example.org/daa57c0d-eb83-4b07-861a-473cfab3dfc9",
+  "createdDate" : "2018-08-19T14:01:25.346Z",
+  "modifiedDate" : "1984-11-11T21:29:47.588Z",
+  "publishedDate" : "2009-03-04T13:52:32.789Z",
+  "indexedDate" : "1992-06-24T04:40:36.453Z",
+  "handle" : "https://www.example.org/47420dae-afec-4c30-9875-69bcb9162d2c",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/572fef99-0e5d-4213-8c00-27acccad53a6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "76ghwagtSU8okXB",
+    "mainTitle" : "0cH4a0ViqH45KzO8h",
     "alternativeTitles" : {
-      "it" : "ziYPWUmqa21"
+      "el" : "zeoA5vYOwIYHPEmj1"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bp2l27QAdEiRfFkn",
-      "month" : "yH0iU8ElPmpy",
-      "day" : "vfVh06XZWNgYhlh5EC"
+      "year" : "5UrVubza4Em",
+      "month" : "8r7M5PeLwJjBNp",
+      "day" : "m5tHLsFXjG41YvS620"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dbfe221f-b709-46e8-bccb-ec92397e782c",
-        "name" : "k24Y0qRCQJkm",
+        "id" : "https://www.example.org/fc8131d4-018e-4d93-99d6-c644e434503d",
+        "name" : "yRtaf9Y1n3",
         "nameType" : "Organizational",
-        "orcId" : "6nridoF3gm",
-        "verificationStatus" : "Verified",
+        "orcId" : "PEh9H5ALZ0OciAj8e",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "plgVqO5YPE3gcX",
-          "value" : "Iif4RGVqRw0fmdk9"
+          "sourceName" : "J23TduAmg0PfRcOPRYP",
+          "value" : "48WS3OVrfkEuJOMe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uIehpqVLDVo6B",
-          "value" : "ChVcDtjAO514CLPE"
+          "sourceName" : "zcxvE0y8WpgD",
+          "value" : "6Ktg1ngTr4C"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/521f7c42-eed9-4e27-aa40-d8fcc4bc78ee"
+        "id" : "https://www.example.org/455e7934-3ab0-4c45-9d76-c8ab5e417e08"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d591914a-78f1-424e-bdd2-666e72c1f1af",
-        "name" : "tlbceh0eSm",
+        "id" : "https://www.example.org/5a257f26-f8f8-4dfb-a443-149b247e455b",
+        "name" : "27157mVC299rVVEJ",
         "nameType" : "Personal",
-        "orcId" : "Rq4TLC9YJ5noEMa1E",
-        "verificationStatus" : "Verified",
+        "orcId" : "6oYziLEBNkkgbwN",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l7XVQQsu3F",
-          "value" : "6OcqZngSFgCOS"
+          "sourceName" : "o8MfKPCLCLbvO",
+          "value" : "37fqyOsAWxuf9SC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BxiZSrUtxBXNyu",
-          "value" : "JmHMFw9We5BtXOf7"
+          "sourceName" : "Ou57H9mQ5Og",
+          "value" : "RuNbiIwkJCl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f7d2155f-37ae-44c1-bd87-f51cb95c2bc7"
+        "id" : "https://www.example.org/77e4eed0-6103-4a6d-85ff-f67d6f472a53"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "agDzC4JWpUgTqqsttAC"
+      "it" : "o44w3Q37Tbgj56BtnY"
     },
-    "npiSubjectHeading" : "Yk0x4AmNqPgRbEz6Xx",
-    "tags" : [ "BfnAF1PZgVszjNq" ],
-    "description" : "SKhBE65NPHWIpv6l",
+    "npiSubjectHeading" : "KnzzhZcCKL94PfqNZ",
+    "tags" : [ "yt3Ctr7tnQfNpL7f" ],
+    "description" : "EYY1xvQby7ibp",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/tWyzbTs0eG"
+        "id" : "https://www.example.com/BKKvICNv6pyQEDgSC93"
       },
-      "doi" : "https://www.example.org/d8695fcf-e23e-4f71-838d-c6382ba26725",
+      "doi" : "https://www.example.org/79706419-a565-4160-b9f9-27876c187678",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "JgYMmieT1rJ6y",
-          "end" : "3FaMhRc1a3AbJ9D1yd"
+          "begin" : "dLhLpOSFDRIyFG",
+          "end" : "n4MNA4ppkjniM"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6d22d846-1412-4f97-8075-28a040cc340b",
-    "abstract" : "jyA3g7RB4hAualHz"
+    "metadataSource" : "https://www.example.org/a0edd43c-3179-4055-a81f-4e9e01a60329",
+    "abstract" : "e4gsiihCvCd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/10264d20-61a5-47cc-8b04-35812486d56a",
-    "name" : "hSy0dJ6leOe0ka3D",
+    "id" : "https://www.example.org/00b64b7c-0422-4b2d-9750-a71c5a6ffa69",
+    "name" : "8aO0AdADkbeuC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-11-14T16:22:13.807Z",
+      "approvalDate" : "2023-10-14T18:57:52.852Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "uRCdkc1Z5CY"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "dvrbU8oMwPHxX9YGS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/af056d14-8a60-41aa-9f6b-5eb3de01264b",
-    "identifier" : "6B6iDcvHBqXABK8",
+    "source" : "https://www.example.org/6177a347-57ee-4c0d-a35d-0e9018af6bf1",
+    "identifier" : "s1NrjTviqc35IqDh",
     "labels" : {
-      "ca" : "Fd0e67VyQfSJYVxK2J"
+      "hu" : "brcVspQOfsFwgolXs"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1710068357
+      "currency" : "NOK",
+      "amount" : 604585032
     },
-    "activeFrom" : "1990-04-28T08:16:22.703Z",
-    "activeTo" : "1998-12-29T00:35:35.995Z"
+    "activeFrom" : "1983-10-30T18:48:17.527Z",
+    "activeTo" : "2009-08-22T18:26:30.134Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/93a58874-7017-42cb-9f5b-7c5cdf0fe7e0",
-    "id" : "https://www.example.org/3cdf5dba-a6b0-49e8-8dfc-e43e3e7f7d23",
-    "identifier" : "9EncUnIiTJtFkC9V",
+    "source" : "https://www.example.org/4e571bc0-fa4f-4947-89ee-ee06983a64e9",
+    "id" : "https://www.example.org/dabb8e56-8ad7-4b51-8cef-3f57abff0eea",
+    "identifier" : "3uCkebMKNnu",
     "labels" : {
-      "en" : "NsQkR40fQNqC7iJbH"
+      "fi" : "DYmkUY3g38QW4cl4"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 59114719
+      "currency" : "NOK",
+      "amount" : 636741407
     },
-    "activeFrom" : "1975-08-23T18:09:30.318Z",
-    "activeTo" : "2021-05-07T19:37:12.927Z"
+    "activeFrom" : "1972-02-03T13:26:57.796Z",
+    "activeTo" : "1977-06-19T05:40:41.438Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/957fd902-083b-49c8-a7c4-eb1e62b519cc" ],
+  "subjects" : [ "https://www.example.org/59b847b1-62dd-49cf-8c7e-b2aefcaf19be" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "872dbf5e-efc7-4db5-abda-ddbad4290258",
-    "name" : "3PRjFh0j9w2u5z",
-    "mimeType" : "jpi2Gb0H816Hosy",
-    "size" : 1822276969,
-    "license" : "https://www.example.com/hxzijoqpnldo2",
+    "identifier" : "d96a429c-b1b5-4468-a24c-7afa5afd0bee",
+    "name" : "4tlDOQOzXjZz",
+    "mimeType" : "TeAUWfL2hev",
+    "size" : 619311365,
+    "license" : "https://www.example.com/pmoutlvhl0snx8rd",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "owydD7Yu17fvF",
-    "publishedDate" : "2001-08-24T07:37:23.641Z",
+    "legalNote" : "7z5CpINLapwdo",
+    "publishedDate" : "1981-08-24T09:52:08.832Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "1u54KKEcZRf0",
-      "uploadedDate" : "2013-05-20T17:08:15.870Z"
+      "uploadedBy" : "BJbzFp77PgW4",
+      "uploadedDate" : "1978-11-01T15:44:14.115Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/rw7oCagOO7IB8",
-    "name" : "Z9sZZwRPwXGrmM78G1",
-    "description" : "RQPVpkkdaeWCjtfL1S"
+    "id" : "https://www.example.com/KoaStKCDcE2LgrAe",
+    "name" : "GQooVzdCB2NXSC5",
+    "description" : "k8wyzpomvSwMUifBeml"
   } ],
-  "rightsHolder" : "6ak5IiRU3k1yxDIy",
-  "duplicateOf" : "https://www.example.org/609a26fb-a664-4d59-81fe-2ffe924b0a41",
+  "rightsHolder" : "ZGDR4YahzQ5wcpiLv2m",
+  "duplicateOf" : "https://www.example.org/c10dca3a-1333-4277-9722-62cefc6d7b4a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DoQvkh4hQxkqM3C"
+    "note" : "GkbNxrMbW6AU0Z"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oKNAUrlqJU",
-    "createdBy" : "xojNw8gxvSL",
-    "createdDate" : "2009-08-23T22:12:50.834Z"
+    "note" : "Bpgzg2oJOajV5hi",
+    "createdBy" : "JZmOH9WWOVNjjr8E",
+    "createdDate" : "2008-12-23T09:15:39.369Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0953e181-6f84-4563-9fda-5e219d24d485" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/2de1ae3b-487e-4f71-b6f7-fc5049367633" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "A2C2uDOt1Gj",
-    "ownerAffiliation" : "https://www.example.org/f203758d-456d-429d-87aa-a5391dabe635"
+    "owner" : "iXQsgwtjQ2vKDye6x",
+    "ownerAffiliation" : "https://www.example.org/d7f36a78-2588-41ae-be8c-b94225b8e969"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c8bf132c-0148-476c-b14d-5f1deb2138b7"
+    "id" : "https://www.example.org/caf36da6-140b-4ba6-a744-0b3c4cecdb9c"
   },
-  "createdDate" : "1994-05-05T02:17:40.831Z",
-  "modifiedDate" : "1987-10-23T00:08:38.328Z",
-  "publishedDate" : "1986-08-03T21:16:31.653Z",
-  "indexedDate" : "2002-06-27T05:52:16.717Z",
-  "handle" : "https://www.example.org/a356e3fd-d1bf-4ca6-a223-5aff42226f97",
-  "doi" : "https://doi.org/10.1234/sunt",
-  "link" : "https://www.example.org/2c90899e-2091-4dc9-8957-fd689bdfc93c",
+  "createdDate" : "1979-10-24T21:20:43.494Z",
+  "modifiedDate" : "1997-07-24T19:27:57.959Z",
+  "publishedDate" : "1995-12-06T05:20:01.976Z",
+  "indexedDate" : "1978-04-18T18:17:50.923Z",
+  "handle" : "https://www.example.org/622381a5-1b76-4d2a-b2bf-e4636809f7cb",
+  "doi" : "https://doi.org/10.1234/accusamus",
+  "link" : "https://www.example.org/db3dbf75-d6dd-46b6-9f9e-d4fcd63febe6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DnuK9GBt8m",
+    "mainTitle" : "5RAf1DLnLKtmygGHev9",
     "alternativeTitles" : {
-      "ca" : "YwYgxONb3x"
+      "af" : "32HLn9m8o9rlbDXr"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "YVKYeN3YNY",
-      "month" : "XSsVmnxXleYZx",
-      "day" : "y5OXl4hIVZVEjo"
+      "year" : "sLpYZ2Ms0kk3ZRwSPxM",
+      "month" : "qj05drXr3j48D6",
+      "day" : "ctHfj09JM49uBE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c1f6464b-8dc1-460f-8265-f8252050c59b",
-        "name" : "NlijcMLYQ1y",
-        "nameType" : "Personal",
-        "orcId" : "QiLq99efIcUm1jq0X",
+        "id" : "https://www.example.org/eeee253b-304e-4fea-8b14-d022d0d3bd7f",
+        "name" : "TKK3Abp0q0viH",
+        "nameType" : "Organizational",
+        "orcId" : "7mneGLfQJ5",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OnW5HSTAhe2jr",
-          "value" : "eS0H8bBY02qtbur"
+          "sourceName" : "Iyl66owL4WfwVbSWmj",
+          "value" : "KzSFIr3TIh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5fz2m4lkyo1zkvMF",
-          "value" : "aUZonU52yMAZigbUNZ"
+          "sourceName" : "RaNd5PNz7oYwuj8En",
+          "value" : "n3LhUTsICb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c1e98cbd-4c75-45d6-9eb7-90a8e3ae58ec"
+        "id" : "https://www.example.org/f7efb259-f4e8-4118-b572-ec9f8ce95144"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Organizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,94 +62,95 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6f769c1e-e654-484d-a388-500b67cc5a4b",
-        "name" : "LxxiQ75OESksMKusAy",
-        "nameType" : "Personal",
-        "orcId" : "wWrlCIgZxLHi",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/f073a39f-c166-4834-8f06-2938b0ec7ecc",
+        "name" : "kWbkpFRqyu5",
+        "nameType" : "Organizational",
+        "orcId" : "l6jwqMJiMqlnOATHd",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xG6FBziPoQycpttf7",
-          "value" : "45ing2ZQs0WW0G"
+          "sourceName" : "CVJIM74yAirc7fFqzDc",
+          "value" : "lkm5DQTfurYOvn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "O7rgsSl64G5q",
-          "value" : "KL6yPZ9fbQdLsXp7q"
+          "sourceName" : "sYZOb4yE8nC38f",
+          "value" : "4BGzmdrYD2OOD3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ee2a7f29-28d0-45b5-bc08-0eda6f338569"
+        "id" : "https://www.example.org/fc29c067-c455-4a1b-8519-dd3db41e6144"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "RoleOther",
+        "description" : "gsKKduMfLGC8jry28"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "dN2DTitaE17jWBDyn"
+      "af" : "PBcGycL90Y"
     },
-    "npiSubjectHeading" : "e6IZB0unJsg",
-    "tags" : [ "duWoI8djgBAPRa62ZHH" ],
-    "description" : "F5tFZ319P2A8bjEK",
+    "npiSubjectHeading" : "XqbyEM9mchzUt",
+    "tags" : [ "Zmz9Y3sCWSS7Z9" ],
+    "description" : "ONDI1tK5buEZA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/92b29511-c695-45b0-806f-d826cd265f90",
+      "doi" : "https://www.example.org/60d1c0a8-e20c-4d2d-8d79-82edc2b00dcf",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "DigitalExhibition"
+          "type" : "AmbulatingExhibition"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/yHZIHTg6Tnx5OLIcwL"
+          "id" : "https://www.example.com/IqyihMNHGbBI"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "XCuT8oCNvsgDbIS"
+            "name" : "Mn7pjH4YFNFmlSEQj"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "bsVHgTDdVrAhzKiPS",
-            "country" : "kAB62xi5lvJ"
+            "label" : "A58qBUZx3CW",
+            "country" : "N5dHkbSG8oA046jF1ul"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2017-01-08T23:35:49.584Z",
-            "to" : "2022-11-28T04:17:22.304Z"
+            "from" : "2013-07-10T13:21:40.178Z",
+            "to" : "2014-07-31T05:43:34.514Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "40HlTEwj8MieI81Xo",
-          "issue" : "RUxP7jJIiJ4oTfhLt",
-          "pages" : "hiWfSxb6HZ",
+          "title" : "daWaDA1leszeOeR5",
+          "issue" : "yhtBxFBb0Pm5q",
+          "pages" : "mFUPXrPyZoPK9PHb",
           "date" : {
             "type" : "Instant",
-            "value" : "2009-03-26T10:28:17.787Z"
+            "value" : "1979-06-20T21:05:24.807Z"
           },
-          "otherInformation" : "uPfwYLdPyb7"
+          "otherInformation" : "okN7cwi5zeGOlV3aC9u"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "h7EhTmgDbAPlFaI5C",
-          "description" : "OYhIydtiKxfM2Ul0CR",
+          "typeDescription" : "cqkHiIY9q1s8Ts67n",
+          "description" : "6wD2wMDa6r",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "ibrcD1etlUDG37Edj6y",
-            "country" : "U9cCFj5Xim4"
+            "label" : "KdSMedHBqix1H",
+            "country" : "DAtCS1P2Uu1k"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "UrSs2khNXmom6vJ",
+            "name" : "dS5141yQ3GBeQ",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1991-04-12T17:22:22.442Z"
+            "value" : "1991-03-26T16:04:33.031Z"
           }
         } ],
         "pages" : {
@@ -157,94 +158,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2127da88-b1f1-4c76-9de8-e44dd1e51118",
-    "abstract" : "np3z4V5dO83Ua"
+    "metadataSource" : "https://www.example.org/3f34b17d-fafd-4bf8-ba9d-be7314e71029",
+    "abstract" : "acGaTY1tHNITOgPg"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7fb5fdd2-34b9-4f4a-be43-8440c0ce2f90",
-    "name" : "7d4fe3Hz4Ph",
+    "id" : "https://www.example.org/f9ccea38-6a26-4f07-beda-ee19a567de0b",
+    "name" : "PUjyCXLuUv9SJ45nR",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-11-22T13:37:42.351Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "fDs2hqAGqyKxbLHP9u"
+      "approvalDate" : "1994-12-04T13:22:04.215Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "s5Pol3oOItiJqR9"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cba053df-561f-4bb0-a49c-b459355e90da",
-    "identifier" : "dXOXSfMZUvUJ",
+    "source" : "https://www.example.org/c373a461-e3f4-4b7e-b823-c5422d81456a",
+    "identifier" : "k3d7g6tYEnBehLbbwKC",
     "labels" : {
-      "ru" : "LT04guC9eMHlGYC"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1698927205
-    },
-    "activeFrom" : "1979-04-10T02:32:43.996Z",
-    "activeTo" : "1997-05-26T06:16:31.459Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/21303c52-9ad4-41f6-8390-4354881c093f",
-    "id" : "https://www.example.org/48a366c9-c30f-4620-85a7-ec073b314a51",
-    "identifier" : "nZJShJOqctHgoYOK",
-    "labels" : {
-      "af" : "rzLK3SLefpHep"
+      "ru" : "ZQ57fKYaAtOwfnmDgPQ"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 918478951
+      "amount" : 1401446128
     },
-    "activeFrom" : "2014-04-20T06:07:57.753Z",
-    "activeTo" : "2022-10-13T07:51:08.618Z"
+    "activeFrom" : "1987-11-09T00:43:29.963Z",
+    "activeTo" : "2023-06-06T16:34:36.178Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/6d95289e-c99c-46a3-9a5e-d6a784b98fc3",
+    "id" : "https://www.example.org/600a108f-1bc8-4729-9eaf-32f15abdee04",
+    "identifier" : "I4nDtsgGwYf0RBruY",
+    "labels" : {
+      "se" : "n5htxsVecwEG0FO1YF"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 970668198
+    },
+    "activeFrom" : "1983-12-27T22:56:20.017Z",
+    "activeTo" : "2011-06-14T13:57:22.675Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a55cb3f6-4850-41a0-93d1-1e96ef105240" ],
+  "subjects" : [ "https://www.example.org/392e0534-9909-474c-9e41-0e5aa4e15ce1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a2f48135-88bc-4a77-a460-6a76c9ef82c1",
-    "name" : "byx7tatImtJSdW9",
-    "mimeType" : "U8u3vzgKrE",
-    "size" : 609914278,
-    "license" : "https://www.example.com/lqe08o1n8vv6r71",
+    "identifier" : "fa358990-0c7e-44ff-bc5b-e765403f0eef",
+    "name" : "4DTJwsHWoh",
+    "mimeType" : "VQDwaZHQxzaclDVf",
+    "size" : 1603295617,
+    "license" : "https://www.example.com/79ayua8by9cqygljj",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "kPwjk30zfjbUn"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "1yEqrnIIq8tZyu8e",
-    "publishedDate" : "1980-12-08T05:20:08.413Z",
+    "legalNote" : "7gJfgMgoCtf",
+    "publishedDate" : "2002-12-31T08:00:55.096Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "SFDqSUsV4bi5cSnxeFd",
-      "uploadedDate" : "2013-03-14T08:08:02.778Z"
+      "uploadedBy" : "yaDwTCtK2Gdd9",
+      "uploadedDate" : "2019-03-25T11:29:57.211Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zkyrqgOcxkpgMt6",
-    "name" : "7cmPxNUe34YM",
-    "description" : "L2bFmCMJg2sQxk"
+    "id" : "https://www.example.com/Xh74HVAliNUCpk",
+    "name" : "DNtUjnJYWt",
+    "description" : "7Bjs8dUTzKAUbFBS5"
   } ],
-  "rightsHolder" : "vCsqMvTwCiOaUlewlE",
-  "duplicateOf" : "https://www.example.org/256c711e-2ee8-428b-a669-9b92194d1ab5",
+  "rightsHolder" : "a55WbrY8puO1Y8apEk",
+  "duplicateOf" : "https://www.example.org/6a616a4e-1223-4a2e-b82d-493c798b96cc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "viRYAJHAXSHM"
+    "note" : "1YUWwqLJxZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SA9J6GWiXLGOpDT",
-    "createdBy" : "d1RDy3jvsijKQ6VaAPj",
-    "createdDate" : "1996-01-17T23:46:40.828Z"
+    "note" : "oWOHthRCAG4QG0",
+    "createdBy" : "D7wnfmNj74pEKXEG4rZ",
+    "createdDate" : "2013-12-11T13:13:06.584Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b362cea5-2acb-49b5-b786-edfff2581274" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/7db0b7b0-cc30-4cb5-a621-6db0a8f3a710" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "iXQsgwtjQ2vKDye6x",
-    "ownerAffiliation" : "https://www.example.org/d7f36a78-2588-41ae-be8c-b94225b8e969"
+    "owner" : "ei7hgCUwPIn1PpE",
+    "ownerAffiliation" : "https://www.example.org/50fc19d4-48d0-4fb9-baae-767c619e30af"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/caf36da6-140b-4ba6-a744-0b3c4cecdb9c"
+    "id" : "https://www.example.org/d08e0626-4783-4c73-a868-913b5ad16b95"
   },
-  "createdDate" : "1979-10-24T21:20:43.494Z",
-  "modifiedDate" : "1997-07-24T19:27:57.959Z",
-  "publishedDate" : "1995-12-06T05:20:01.976Z",
-  "indexedDate" : "1978-04-18T18:17:50.923Z",
-  "handle" : "https://www.example.org/622381a5-1b76-4d2a-b2bf-e4636809f7cb",
-  "doi" : "https://doi.org/10.1234/accusamus",
-  "link" : "https://www.example.org/db3dbf75-d6dd-46b6-9f9e-d4fcd63febe6",
+  "createdDate" : "2018-08-21T20:17:27.837Z",
+  "modifiedDate" : "1983-02-27T14:12:22.234Z",
+  "publishedDate" : "2014-08-09T10:01:54.356Z",
+  "indexedDate" : "2005-01-25T13:36:31.948Z",
+  "handle" : "https://www.example.org/899c798c-99ad-4dca-abbd-7a5ec1f13c41",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/7bce949d-edf8-4499-8ebf-a6d63479e8a2",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5RAf1DLnLKtmygGHev9",
+    "mainTitle" : "q0IgZHclkyuev1q",
     "alternativeTitles" : {
-      "af" : "32HLn9m8o9rlbDXr"
+      "hu" : "tgzKD5nxMv"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "sLpYZ2Ms0kk3ZRwSPxM",
-      "month" : "qj05drXr3j48D6",
-      "day" : "ctHfj09JM49uBE"
+      "year" : "0SMg9Mmd2Yg4",
+      "month" : "rif3V31daAJ5",
+      "day" : "oA37q5uAM8ILaCpRDq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eeee253b-304e-4fea-8b14-d022d0d3bd7f",
-        "name" : "TKK3Abp0q0viH",
-        "nameType" : "Organizational",
-        "orcId" : "7mneGLfQJ5",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/872ea041-a14e-438c-983f-629a6658c148",
+        "name" : "t4X4Cnm0D5DorcW",
+        "nameType" : "Personal",
+        "orcId" : "h1H6mvqkKsO3aLQ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Iyl66owL4WfwVbSWmj",
-          "value" : "KzSFIr3TIh"
+          "sourceName" : "IwgcJVFPWV2A3Kfs",
+          "value" : "cBQ6vtOlpGMX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RaNd5PNz7oYwuj8En",
-          "value" : "n3LhUTsICb"
+          "sourceName" : "IZqjMIME0kzX0DyRfZ1",
+          "value" : "zeasgF4FpTP5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f7efb259-f4e8-4118-b572-ec9f8ce95144"
+        "id" : "https://www.example.org/3042409e-2b0c-4108-b35a-4d3afb07bf47"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,95 +62,94 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f073a39f-c166-4834-8f06-2938b0ec7ecc",
-        "name" : "kWbkpFRqyu5",
-        "nameType" : "Organizational",
-        "orcId" : "l6jwqMJiMqlnOATHd",
+        "id" : "https://www.example.org/c3765e69-1363-4b4a-9a12-f92219cbede7",
+        "name" : "JBYKUoyuWOCw69Gfm9",
+        "nameType" : "Personal",
+        "orcId" : "4HuTLhUErC9bgfy1u",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CVJIM74yAirc7fFqzDc",
-          "value" : "lkm5DQTfurYOvn"
+          "sourceName" : "bEj0ZNYcY3ug1Fqe",
+          "value" : "dNDPrycZ6YufzGf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sYZOb4yE8nC38f",
-          "value" : "4BGzmdrYD2OOD3"
+          "sourceName" : "9ImGTUHDvvrs2",
+          "value" : "Xw8OevMx2VMClXH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fc29c067-c455-4a1b-8519-dd3db41e6144"
+        "id" : "https://www.example.org/28793a1f-cd5c-4d8e-bcd7-eccdd84f75a2"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "gsKKduMfLGC8jry28"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "PBcGycL90Y"
+      "en" : "ql7MVAJiwEpUaCm"
     },
-    "npiSubjectHeading" : "XqbyEM9mchzUt",
-    "tags" : [ "Zmz9Y3sCWSS7Z9" ],
-    "description" : "ONDI1tK5buEZA",
+    "npiSubjectHeading" : "5Jz5dox0JWV9q4",
+    "tags" : [ "WM63PNz886NzqYeTEk" ],
+    "description" : "nvXotPDAUag5kVPF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/60d1c0a8-e20c-4d2d-8d79-82edc2b00dcf",
+      "doi" : "https://www.example.org/063c402f-1f0b-48fa-abbc-7350d8323f16",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "AmbulatingExhibition"
+          "type" : "TemporaryExhibition"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/IqyihMNHGbBI"
+          "id" : "https://www.example.com/GQubGttQna2x"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "Mn7pjH4YFNFmlSEQj"
+            "name" : "9INfr5KDtfHuhpejiAE"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "A58qBUZx3CW",
-            "country" : "N5dHkbSG8oA046jF1ul"
+            "label" : "J2BaZBTi8iyKkgX6WPO",
+            "country" : "itSvbPdl3JSk1"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2013-07-10T13:21:40.178Z",
-            "to" : "2014-07-31T05:43:34.514Z"
+            "from" : "1982-03-27T19:09:05.425Z",
+            "to" : "1996-12-04T16:08:20.003Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "daWaDA1leszeOeR5",
-          "issue" : "yhtBxFBb0Pm5q",
-          "pages" : "mFUPXrPyZoPK9PHb",
+          "title" : "YclnvL6P6fn",
+          "issue" : "euVBJQduEd6DayCaiAU",
+          "pages" : "ESRgS4xJxmlw",
           "date" : {
             "type" : "Instant",
-            "value" : "1979-06-20T21:05:24.807Z"
+            "value" : "1992-02-15T13:45:34.699Z"
           },
-          "otherInformation" : "okN7cwi5zeGOlV3aC9u"
+          "otherInformation" : "W20InV6gkL"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "cqkHiIY9q1s8Ts67n",
-          "description" : "6wD2wMDa6r",
+          "typeDescription" : "HD7a4wRbDI",
+          "description" : "eMuGHwtlZoI",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "KdSMedHBqix1H",
-            "country" : "DAtCS1P2Uu1k"
+            "label" : "aHu53R7EocDE1",
+            "country" : "SRhLM9T8rfS3FFXa"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "dS5141yQ3GBeQ",
+            "name" : "OZb026hGqK7Vc8hEDV",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1991-03-26T16:04:33.031Z"
+            "value" : "2020-07-07T11:48:49.476Z"
           }
         } ],
         "pages" : {
@@ -158,93 +157,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3f34b17d-fafd-4bf8-ba9d-be7314e71029",
-    "abstract" : "acGaTY1tHNITOgPg"
+    "metadataSource" : "https://www.example.org/f50acf15-8ef3-43f4-bc44-c4cc7a53a364",
+    "abstract" : "2VkxkK59vPev"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f9ccea38-6a26-4f07-beda-ee19a567de0b",
-    "name" : "PUjyCXLuUv9SJ45nR",
+    "id" : "https://www.example.org/89cc2095-52ae-410a-b8b1-e63072e9e475",
+    "name" : "8GJowTYGdnlADlNx",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-12-04T13:22:04.215Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2008-12-08T20:24:13.334Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "s5Pol3oOItiJqR9"
+      "applicationCode" : "xBQropl6CZLz"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c373a461-e3f4-4b7e-b823-c5422d81456a",
-    "identifier" : "k3d7g6tYEnBehLbbwKC",
+    "source" : "https://www.example.org/6f2a4404-b5bf-4411-a0f4-121b2570c5a1",
+    "identifier" : "U1xQxlM15VCkVNihEd3",
     "labels" : {
-      "ru" : "ZQ57fKYaAtOwfnmDgPQ"
+      "ru" : "AbwkbypIX6CMK"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1401446128
+      "currency" : "USD",
+      "amount" : 35996688
     },
-    "activeFrom" : "1987-11-09T00:43:29.963Z",
-    "activeTo" : "2023-06-06T16:34:36.178Z"
+    "activeFrom" : "2010-09-23T00:06:50.697Z",
+    "activeTo" : "2022-07-06T09:09:03.916Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6d95289e-c99c-46a3-9a5e-d6a784b98fc3",
-    "id" : "https://www.example.org/600a108f-1bc8-4729-9eaf-32f15abdee04",
-    "identifier" : "I4nDtsgGwYf0RBruY",
+    "source" : "https://www.example.org/f8b3e56e-2bba-45ed-bca9-39941f3307eb",
+    "id" : "https://www.example.org/95b98ed4-e975-4ad9-a814-5b469667cba9",
+    "identifier" : "GarwgaZlAOrEJAM",
     "labels" : {
-      "se" : "n5htxsVecwEG0FO1YF"
+      "is" : "Y2uCitBk5Almet79B"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 970668198
+      "currency" : "USD",
+      "amount" : 2022580027
     },
-    "activeFrom" : "1983-12-27T22:56:20.017Z",
-    "activeTo" : "2011-06-14T13:57:22.675Z"
+    "activeFrom" : "2017-11-24T04:48:25.835Z",
+    "activeTo" : "2022-01-22T15:42:59.219Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/392e0534-9909-474c-9e41-0e5aa4e15ce1" ],
+  "subjects" : [ "https://www.example.org/909c4b3f-f9e6-4dba-a896-f6dba8937c51" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fa358990-0c7e-44ff-bc5b-e765403f0eef",
-    "name" : "4DTJwsHWoh",
-    "mimeType" : "VQDwaZHQxzaclDVf",
-    "size" : 1603295617,
-    "license" : "https://www.example.com/79ayua8by9cqygljj",
+    "identifier" : "1730c728-02a9-48d6-a548-874955caab31",
+    "name" : "xzYFxNklN1LXJf",
+    "mimeType" : "2K868LIoaX2gz",
+    "size" : 1611166886,
+    "license" : "https://www.example.com/mb7j2jvnh7d",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "7gJfgMgoCtf",
-    "publishedDate" : "2002-12-31T08:00:55.096Z",
+    "legalNote" : "tPO38bXcLJJR2iKq1Ns",
+    "publishedDate" : "1985-08-09T17:26:12.525Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "yaDwTCtK2Gdd9",
-      "uploadedDate" : "2019-03-25T11:29:57.211Z"
+      "uploadedBy" : "cxTo6niNPhSl5FGzomI",
+      "uploadedDate" : "2017-11-29T15:22:56.276Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Xh74HVAliNUCpk",
-    "name" : "DNtUjnJYWt",
-    "description" : "7Bjs8dUTzKAUbFBS5"
+    "id" : "https://www.example.com/nMS861jSRgCARm",
+    "name" : "L5d90miCJUMxKzh",
+    "description" : "OpNyEXDEhs9qhuU2"
   } ],
-  "rightsHolder" : "a55WbrY8puO1Y8apEk",
-  "duplicateOf" : "https://www.example.org/6a616a4e-1223-4a2e-b82d-493c798b96cc",
+  "rightsHolder" : "HWDfzqM5IxKxh8",
+  "duplicateOf" : "https://www.example.org/6358d3c4-dd7b-4e27-9a0b-4082d7c6ae2e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "1YUWwqLJxZ"
+    "note" : "0zlu7j18Jgx2dYl"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oWOHthRCAG4QG0",
-    "createdBy" : "D7wnfmNj74pEKXEG4rZ",
-    "createdDate" : "2013-12-11T13:13:06.584Z"
+    "note" : "pG6JSj7eb355",
+    "createdBy" : "7QJ0HIgdNFPuprP",
+    "createdDate" : "2014-03-23T06:48:37.150Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7db0b7b0-cc30-4cb5-a621-6db0a8f3a710" ],
+  "curatingInstitutions" : [ "https://www.example.org/87090ee6-7d42-430f-9651-a7f63f892b18" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "uhk7GsQU3IkhVAT",
-    "ownerAffiliation" : "https://www.example.org/9cf40458-ea57-468e-899a-87dea8e222e8"
+    "owner" : "ULPHCMMuweBohT6lzA",
+    "ownerAffiliation" : "https://www.example.org/52babc88-9a37-47e8-adad-9094ef62dcad"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/54faf122-ddf3-44d4-aa75-d07ce150657f"
+    "id" : "https://www.example.org/d38a4cc5-b9fb-4184-8e76-7b499e8f9d9f"
   },
-  "createdDate" : "1988-01-22T14:16:12.945Z",
-  "modifiedDate" : "1977-12-28T19:05:58.550Z",
-  "publishedDate" : "2016-04-02T08:21:46.451Z",
-  "indexedDate" : "2018-04-02T08:37:31.140Z",
-  "handle" : "https://www.example.org/49607dc9-efe4-48d4-b424-1433e5c20993",
-  "doi" : "https://doi.org/10.1234/autem",
-  "link" : "https://www.example.org/768e15d5-301a-4050-a5f6-62c240470941",
+  "createdDate" : "1971-04-18T23:25:49.640Z",
+  "modifiedDate" : "2008-09-06T13:40:17.931Z",
+  "publishedDate" : "1996-04-11T10:01:58.624Z",
+  "indexedDate" : "1984-12-07T09:16:20.586Z",
+  "handle" : "https://www.example.org/c22b3d62-ccb6-4e2e-8158-785156514198",
+  "doi" : "https://doi.org/10.1234/velit",
+  "link" : "https://www.example.org/91ef09f0-80f6-4092-8a2b-48d305aa033c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "qCRjVTr7OAefngZxkgn",
+    "mainTitle" : "greY8SQtsbesDZtsxe5",
     "alternativeTitles" : {
-      "is" : "GkfUKGENhjMs0srr6B"
+      "nl" : "w9UoiCVvHp5ab5yU"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qkdQtBBAKEHjHoF",
-      "month" : "kp4vNEbeqKWMav9U",
-      "day" : "UwtyvV0yYt3N9FUf"
+      "year" : "hkVsBtzNuSBOoM0i",
+      "month" : "y7jJPVWVGOswA",
+      "day" : "JILf36QtU83P"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ccca0e8c-42f3-4495-a678-b1eb713de2a3",
-        "name" : "DH18BBeqwv7tZOU2kp",
+        "id" : "https://www.example.org/9204f27e-b40d-4c0f-ac0e-083d5d162310",
+        "name" : "xftyXb2YaFlimg",
         "nameType" : "Personal",
-        "orcId" : "tVvY0UpXZfNgyWnQRsS",
+        "orcId" : "nEBnmrvOlvAeNcc",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tXWqJ4i4Zfk",
-          "value" : "IrNeiCZkwAhO3Oe"
+          "sourceName" : "RGwEXguiuHf9DjPv",
+          "value" : "WoQymSvaN86Yo3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "s0IxEDvjVGnIT4GSs",
-          "value" : "UkBBGgPimGIoh6pA9P"
+          "sourceName" : "gzVGREKG8MlrqCr4",
+          "value" : "2d0uyyPjClVWbwi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/729d5b57-516f-4d85-9694-aab332b54c4e"
+        "id" : "https://www.example.org/2e858c6d-3734-4a9a-9f1a-e7e8ef9cf2d2"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b59ff12a-eaaf-464c-a6b3-bb9de672cb56",
-        "name" : "OfSD8vHzmI",
-        "nameType" : "Organizational",
-        "orcId" : "WdYY5xbH4Zd8L",
+        "id" : "https://www.example.org/d36f71c6-848f-45b6-8685-1f20cb152d41",
+        "name" : "9epAiywJlfrMLKehC",
+        "nameType" : "Personal",
+        "orcId" : "Zn2ZmYfge4YSWtgDYTS",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9UG8xqlkWzUxMwe",
-          "value" : "z2HRP4wc0SiRFbes"
+          "sourceName" : "QfubCykhVMIYAzAH",
+          "value" : "5sEAxYZES6US4y"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bu5RcioG3KNId1G0N",
-          "value" : "x2Orx2fXO4ouzYHuqx"
+          "sourceName" : "fqMy43as1Y8fAv",
+          "value" : "jr3CWJoitKF1ilgJeL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d916429b-57c8-4ca9-97a4-51116271e308"
+        "id" : "https://www.example.org/62dbe167-259c-4985-8aff-267e0146bdd0"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Librettist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "LFikgIEpLSyp"
+      "en" : "N959UgVXLENn4"
     },
-    "npiSubjectHeading" : "r2a3t2LFPY",
-    "tags" : [ "XNJobcOYaHHK" ],
-    "description" : "d5ucyw4x1UCCMEG",
+    "npiSubjectHeading" : "oCRFQQJ9SSKb6WT",
+    "tags" : [ "PB1bIV0Xk5eVayWg" ],
+    "description" : "wfQUUoCaKRM4h84m",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/RlzLJyf7wmcnHI7"
+        "id" : "https://www.example.com/CNyaIbRrVQqdJKZcyb7"
       },
-      "doi" : "https://www.example.org/c54fdf56-a94f-439e-9cbe-53bd6ae8a46e",
+      "doi" : "https://www.example.org/a15171cb-407d-4fb5-96a9-4285e2e3b531",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "67d6nf58wLLRkGw2RzO",
-          "end" : "bjcHXTYAxNzGlbtO"
+          "begin" : "S9I50RLbhqLFk",
+          "end" : "sNIGNO7YYODSc1"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/660d5d04-5313-49e5-8c72-2d7d45197fe4",
-    "abstract" : "87E7ZCO2E9z2f"
+    "metadataSource" : "https://www.example.org/babe9ff4-d7e7-4ea8-bbe1-5b53e7503841",
+    "abstract" : "z6weN91ofa"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2eb23d3a-0215-40bf-a610-ee8310b50723",
-    "name" : "eAxMexbavfr5U67e",
+    "id" : "https://www.example.org/6b75881d-81cb-48bc-9b1a-8b1c0d36c279",
+    "name" : "T3Uzwmxg1vVTpT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-05-22T16:37:17.671Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "aP2P6O8RZ30"
+      "approvalDate" : "2007-11-14T07:25:20.619Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "SdzKrlfktaNo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d55c267d-6dab-4d59-bb6a-1333dbb8ddb0",
-    "identifier" : "neqPLAiW5mw",
+    "source" : "https://www.example.org/4386edf3-ea15-4225-8e9f-fb6337b93cc6",
+    "identifier" : "dBkG3FbISAUh0kE8b4q",
     "labels" : {
-      "nb" : "hptH8BOupXx5r88"
+      "nn" : "NtCdGnbFSzvRPson"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 571540859
+      "currency" : "NOK",
+      "amount" : 616566769
     },
-    "activeFrom" : "2014-03-24T22:00:08.984Z",
-    "activeTo" : "2019-08-25T00:17:18.272Z"
+    "activeFrom" : "1980-08-21T11:40:23.187Z",
+    "activeTo" : "1989-08-08T05:25:20.342Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a78b3d39-d405-4c59-9101-21e1c52befb1",
-    "id" : "https://www.example.org/d0c8ef52-de34-42de-b41d-a55d68afd0cd",
-    "identifier" : "OG0pJcgfBKib",
+    "source" : "https://www.example.org/9ef95482-3518-4337-9169-6652f80734cb",
+    "id" : "https://www.example.org/c9c65fce-4088-452d-8ffd-791c8add043e",
+    "identifier" : "ZXOEjdwYUI070gS7bV",
     "labels" : {
-      "ru" : "3XxDIKsMqYM"
+      "cs" : "ocyqnqtVCmZClF2Q517"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1337053235
+      "currency" : "GBP",
+      "amount" : 2090820487
     },
-    "activeFrom" : "1994-08-27T15:17:15.471Z",
-    "activeTo" : "2007-02-14T21:41:09.159Z"
+    "activeFrom" : "2015-12-12T17:10:34.182Z",
+    "activeTo" : "2019-02-03T17:11:38.564Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bd44e990-c357-4199-bb15-69c61411003d" ],
+  "subjects" : [ "https://www.example.org/b0758751-e944-404b-acd3-de57116fb434" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "576ce1af-6d2f-4695-b866-09b7089f6971",
-    "name" : "jrS4rZbwRVvh3So",
-    "mimeType" : "YcjF768UpSMbdtrSYmO",
-    "size" : 462894431,
-    "license" : "https://www.example.com/3ujzcrsqom",
+    "identifier" : "e90a8235-9db2-4d70-87d3-a03138f05555",
+    "name" : "pJF6ZFab35",
+    "mimeType" : "qDYQV2hP838DcquRynf",
+    "size" : 935166908,
+    "license" : "https://www.example.com/dwiy6aq0c0steo",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "4TuABuA6ul"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "SVCypXsEg0B",
-    "publishedDate" : "2011-09-21T16:22:54.137Z",
+    "legalNote" : "KSPAmofj6py",
+    "publishedDate" : "2008-03-01T07:39:12.318Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3pflP41ZNUZVhhfriw",
-      "uploadedDate" : "1979-10-18T03:19:54.235Z"
+      "uploadedBy" : "kSKvEQSd4Z",
+      "uploadedDate" : "2001-08-29T05:42:00.429Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/dHhGN6NZf9aNE6",
-    "name" : "1H4cgBANtDjSZ",
-    "description" : "GtnCueGDuoOVlbUgv"
+    "id" : "https://www.example.com/GTTECCxIaGPE41B",
+    "name" : "96GT6JIrJ1HOdpPetod",
+    "description" : "2Va8Ha4KBYXjrhEV"
   } ],
-  "rightsHolder" : "TVP5qHkFXChl2RyQ",
-  "duplicateOf" : "https://www.example.org/4cc92690-d06f-4397-906f-89182650a4bc",
+  "rightsHolder" : "sNaDN6G8FuLs",
+  "duplicateOf" : "https://www.example.org/64fda97b-db31-4147-aec1-956a3f06be10",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "PKB2yFeQROkPjZ"
+    "note" : "AUxZr4AGMHXm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "lkbLK7hDjmXS2",
-    "createdBy" : "CnvWRyvAN4pfDZ",
-    "createdDate" : "1971-05-11T13:21:53.313Z"
+    "note" : "SdpRgSYGIBG",
+    "createdBy" : "CdacG0MfWiSibt",
+    "createdDate" : "1996-06-13T18:29:48.916Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/55cb50bd-49e7-4795-8372-9bc89f4c3000" ],
+  "curatingInstitutions" : [ "https://www.example.org/95d39907-9fc8-4baf-8126-d6d19458ceca" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "lBblokEL7bFP7dGmU7",
-    "ownerAffiliation" : "https://www.example.org/6d7f8ed8-ead0-4923-93c6-cbc60aa1ea76"
+    "owner" : "uhk7GsQU3IkhVAT",
+    "ownerAffiliation" : "https://www.example.org/9cf40458-ea57-468e-899a-87dea8e222e8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c8d16b89-f9ee-40fe-9ba7-adcfc72a116b"
+    "id" : "https://www.example.org/54faf122-ddf3-44d4-aa75-d07ce150657f"
   },
-  "createdDate" : "1984-10-10T14:08:52.712Z",
-  "modifiedDate" : "1998-02-12T16:36:07Z",
-  "publishedDate" : "1973-03-21T03:46:49.040Z",
-  "indexedDate" : "1994-06-07T00:09:05.723Z",
-  "handle" : "https://www.example.org/c94e5c0e-00e6-4cb2-b937-9791a26eb203",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/409589b7-821a-446b-87d3-eda4bcd55850",
+  "createdDate" : "1988-01-22T14:16:12.945Z",
+  "modifiedDate" : "1977-12-28T19:05:58.550Z",
+  "publishedDate" : "2016-04-02T08:21:46.451Z",
+  "indexedDate" : "2018-04-02T08:37:31.140Z",
+  "handle" : "https://www.example.org/49607dc9-efe4-48d4-b424-1433e5c20993",
+  "doi" : "https://doi.org/10.1234/autem",
+  "link" : "https://www.example.org/768e15d5-301a-4050-a5f6-62c240470941",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kCd6MdR2wSfyC",
+    "mainTitle" : "qCRjVTr7OAefngZxkgn",
     "alternativeTitles" : {
-      "nb" : "EVJE9BP562k6uTZ0GY"
+      "is" : "GkfUKGENhjMs0srr6B"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "t4UJIg4KWc",
-      "month" : "qRyY6oiFpaqr",
-      "day" : "gQXJV0PYdnj0VZy3X3"
+      "year" : "qkdQtBBAKEHjHoF",
+      "month" : "kp4vNEbeqKWMav9U",
+      "day" : "UwtyvV0yYt3N9FUf"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/15bbaabc-7f4d-4624-84b1-3bca7fa16c13",
-        "name" : "GBcVKXoLMTDyyWdpqdQ",
-        "nameType" : "Organizational",
-        "orcId" : "D5EXhSvIiuSs32SKSQ",
+        "id" : "https://www.example.org/ccca0e8c-42f3-4495-a678-b1eb713de2a3",
+        "name" : "DH18BBeqwv7tZOU2kp",
+        "nameType" : "Personal",
+        "orcId" : "tVvY0UpXZfNgyWnQRsS",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kI0UlouxBf",
-          "value" : "djcl2ccUQ5YEpH8SR"
+          "sourceName" : "tXWqJ4i4Zfk",
+          "value" : "IrNeiCZkwAhO3Oe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OH35cOtyxHStklLsE",
-          "value" : "LMh1OK6LwNSEitc14"
+          "sourceName" : "s0IxEDvjVGnIT4GSs",
+          "value" : "UkBBGgPimGIoh6pA9P"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/17525d71-1e94-4466-a693-0698ace05667"
+        "id" : "https://www.example.org/729d5b57-516f-4d85-9694-aab332b54c4e"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ce1b701e-38bc-4844-828b-a81ad4a2ce03",
-        "name" : "3lQ1ynBqaB",
+        "id" : "https://www.example.org/b59ff12a-eaaf-464c-a6b3-bb9de672cb56",
+        "name" : "OfSD8vHzmI",
         "nameType" : "Organizational",
-        "orcId" : "cdI7nCW39UtlffLLFP",
+        "orcId" : "WdYY5xbH4Zd8L",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wARACSlIUpDal",
-          "value" : "dFhHx4OHeQ0E6dw"
+          "sourceName" : "9UG8xqlkWzUxMwe",
+          "value" : "z2HRP4wc0SiRFbes"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "20FnbKf2K2NSsLaW",
-          "value" : "bWpPaVFTNfn"
+          "sourceName" : "bu5RcioG3KNId1G0N",
+          "value" : "x2Orx2fXO4ouzYHuqx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e6cd3855-0554-4929-aa95-303568578039"
+        "id" : "https://www.example.org/d916429b-57c8-4ca9-97a4-51116271e308"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "OQXX65VCNogh95qp6b"
+      "fr" : "LFikgIEpLSyp"
     },
-    "npiSubjectHeading" : "UfBkIiy7iKKz79bTacP",
-    "tags" : [ "rwGK8FC87fnt7SVfQzG" ],
-    "description" : "mIuUZZQVQIjTL5",
+    "npiSubjectHeading" : "r2a3t2LFPY",
+    "tags" : [ "XNJobcOYaHHK" ],
+    "description" : "d5ucyw4x1UCCMEG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/v2l3ixsTgMvp"
+        "id" : "https://www.example.com/RlzLJyf7wmcnHI7"
       },
-      "doi" : "https://www.example.org/f9735c9d-e9ed-4f3c-b2e0-d727f33ad168",
+      "doi" : "https://www.example.org/c54fdf56-a94f-439e-9cbe-53bd6ae8a46e",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "3ISKFBZ08w3rhAIRF6",
-          "end" : "jaZixPtT2ZqNztH"
+          "begin" : "67d6nf58wLLRkGw2RzO",
+          "end" : "bjcHXTYAxNzGlbtO"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/20520906-4032-4e66-8edd-ab00fc3b810b",
-    "abstract" : "UdopoaxYA6fb2lTk"
+    "metadataSource" : "https://www.example.org/660d5d04-5313-49e5-8c72-2d7d45197fe4",
+    "abstract" : "87E7ZCO2E9z2f"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0aaf35f5-3620-4e86-82d2-5115cce21060",
-    "name" : "trwG8lqLGqO",
+    "id" : "https://www.example.org/2eb23d3a-0215-40bf-a610-ee8310b50723",
+    "name" : "eAxMexbavfr5U67e",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-07-13T11:16:14.956Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "jXcvxlOg6b1b"
+      "approvalDate" : "2020-05-22T16:37:17.671Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "aP2P6O8RZ30"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/98399f21-0eb7-44d3-aae7-e8d2c3a0426f",
-    "identifier" : "xe57s7nIco80pmf",
+    "source" : "https://www.example.org/d55c267d-6dab-4d59-bb6a-1333dbb8ddb0",
+    "identifier" : "neqPLAiW5mw",
     "labels" : {
-      "de" : "OS0KrzQOymuf3"
+      "nb" : "hptH8BOupXx5r88"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1761230667
+      "currency" : "USD",
+      "amount" : 571540859
     },
-    "activeFrom" : "1988-05-12T18:57:22.628Z",
-    "activeTo" : "2002-04-27T22:48:38.726Z"
+    "activeFrom" : "2014-03-24T22:00:08.984Z",
+    "activeTo" : "2019-08-25T00:17:18.272Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0fc27464-f15b-4e5a-81cf-74e995aa3c81",
-    "id" : "https://www.example.org/01df024f-f8aa-4189-95fc-659969d2a187",
-    "identifier" : "QALl0IfTdKLeBQc",
+    "source" : "https://www.example.org/a78b3d39-d405-4c59-9101-21e1c52befb1",
+    "id" : "https://www.example.org/d0c8ef52-de34-42de-b41d-a55d68afd0cd",
+    "identifier" : "OG0pJcgfBKib",
     "labels" : {
-      "da" : "nMy3bIh11hEN"
+      "ru" : "3XxDIKsMqYM"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2118507564
+      "currency" : "USD",
+      "amount" : 1337053235
     },
-    "activeFrom" : "2005-01-29T14:15:08.907Z",
-    "activeTo" : "2024-02-02T16:41:08.852Z"
+    "activeFrom" : "1994-08-27T15:17:15.471Z",
+    "activeTo" : "2007-02-14T21:41:09.159Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dc5064e1-8ba7-479e-a0bd-97de051427f2" ],
+  "subjects" : [ "https://www.example.org/bd44e990-c357-4199-bb15-69c61411003d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "33130804-2216-4f2c-b209-c9e77845efea",
-    "name" : "b3dL1pwRAIFnNys2nM",
-    "mimeType" : "DwT8qpLLTgXOcjRIYt1",
-    "size" : 1850896692,
-    "license" : "https://www.example.com/xaykoxdofzrw6",
+    "identifier" : "576ce1af-6d2f-4695-b866-09b7089f6971",
+    "name" : "jrS4rZbwRVvh3So",
+    "mimeType" : "YcjF768UpSMbdtrSYmO",
+    "size" : 462894431,
+    "license" : "https://www.example.com/3ujzcrsqom",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "4TuABuA6ul"
     },
-    "legalNote" : "6wEz2siul56AjxxNE",
-    "publishedDate" : "1976-07-13T08:43:18.870Z",
+    "legalNote" : "SVCypXsEg0B",
+    "publishedDate" : "2011-09-21T16:22:54.137Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TYB2g6gdHiQuE",
-      "uploadedDate" : "2002-04-16T18:41:12.950Z"
+      "uploadedBy" : "3pflP41ZNUZVhhfriw",
+      "uploadedDate" : "1979-10-18T03:19:54.235Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7jQNl04lXeM",
-    "name" : "rYW4zpFOS4SFOn6",
-    "description" : "JMMqDm1pWcO0qS"
+    "id" : "https://www.example.com/dHhGN6NZf9aNE6",
+    "name" : "1H4cgBANtDjSZ",
+    "description" : "GtnCueGDuoOVlbUgv"
   } ],
-  "rightsHolder" : "jCQF8BubIuUKhqEuX",
-  "duplicateOf" : "https://www.example.org/89c6ef16-7bc5-4a59-a6c9-904abbab0575",
+  "rightsHolder" : "TVP5qHkFXChl2RyQ",
+  "duplicateOf" : "https://www.example.org/4cc92690-d06f-4397-906f-89182650a4bc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "MxYyV5vF49RDnklFh"
+    "note" : "PKB2yFeQROkPjZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jYqX559Cud9dwxWS",
-    "createdBy" : "vCCCw6y8SI0TKWn0",
-    "createdDate" : "2008-07-09T09:18:42.994Z"
+    "note" : "lkbLK7hDjmXS2",
+    "createdBy" : "CnvWRyvAN4pfDZ",
+    "createdDate" : "1971-05-11T13:21:53.313Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0ae405bd-25dc-4c49-9b05-3e5e01cd0804" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/55cb50bd-49e7-4795-8372-9bc89f4c3000" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "K17JKPilfiUL",
-    "ownerAffiliation" : "https://www.example.org/4bd6cf4c-b760-4f3f-bf73-5866c75ad17e"
+    "owner" : "KgrIJoB3ulOK3NY",
+    "ownerAffiliation" : "https://www.example.org/e995c1aa-0fdb-439a-821b-720f272daf43"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4a441e1c-dedc-4028-bd80-b3bea9e1eb04"
+    "id" : "https://www.example.org/5127b01e-5a46-4f60-9810-90a8aacab3c6"
   },
-  "createdDate" : "2021-05-12T23:25:52.846Z",
-  "modifiedDate" : "1978-11-14T08:41:57.675Z",
-  "publishedDate" : "1988-06-26T18:54:52.081Z",
-  "indexedDate" : "2001-01-06T08:40:33.897Z",
-  "handle" : "https://www.example.org/5de2b835-cdbb-4f4f-aa02-73f4a222534c",
-  "doi" : "https://doi.org/10.1234/velit",
-  "link" : "https://www.example.org/4ccce290-396d-4f30-906d-2523b93f0ea7",
+  "createdDate" : "2023-05-15T22:37:47.484Z",
+  "modifiedDate" : "2004-07-03T18:46:56.587Z",
+  "publishedDate" : "2016-12-15T14:14:39.157Z",
+  "indexedDate" : "2005-07-09T15:22:18.913Z",
+  "handle" : "https://www.example.org/e1b3f5ce-4600-41ca-ab1a-d547d1f259d3",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/e42ae30e-04d9-46da-ab15-f346b212d2db",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tR5iYpUMzMfxm",
+    "mainTitle" : "ucr2YG1OTpyvZ",
     "alternativeTitles" : {
-      "da" : "XrYXyAeQyE6jwlYo"
+      "de" : "5XVQ30oKo1iuRh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "gidRBPNwob",
-      "month" : "rCAYuyQwN5JFDXCCB",
-      "day" : "2syXWTQyu3"
+      "year" : "xW6l1SdhvXwnSb3lu",
+      "month" : "cWD8M3tJa194BTVn8",
+      "day" : "ZTpSguvGypgS6GW3mu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/835308c5-9d48-4c2a-a2eb-539cda89fa60",
-        "name" : "T45qbtHF9ugj9SNYKsG",
-        "nameType" : "Organizational",
-        "orcId" : "5ahgAiFvEOSDC",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/b17b229a-0f36-48ba-9ea1-cb451548f917",
+        "name" : "BB5PytWXgSJJUGKxD",
+        "nameType" : "Personal",
+        "orcId" : "ru5dFd0ZehTCf1vmUE",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "h7K52bXZ3hJ3rC",
-          "value" : "bwgAuOPMykz0Ust2Q"
+          "sourceName" : "BS38n9ezeN83m",
+          "value" : "QwMwPUtMEyYPlyyL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XcPhwwtN28sJcERyg",
-          "value" : "LhR2vpE5I9ihJMMAla"
+          "sourceName" : "8UBJHt0gWb3",
+          "value" : "sdcVoTQupfVX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/97411994-7fab-4f6e-b394-91fcafae173b"
+        "id" : "https://www.example.org/e8583419-0ea2-4b50-acde-73e3c36ebb68"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eddfc818-aa2c-48cb-90ba-4cca6e534609",
-        "name" : "yxTDlXSIGaK",
-        "nameType" : "Personal",
-        "orcId" : "e29IWU4kVD",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/3c8ef855-5d36-4163-bb0d-7f9b40d82799",
+        "name" : "Wms0oPMgNgv8s8jRS3",
+        "nameType" : "Organizational",
+        "orcId" : "pctU4xyorl7",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CkZdx0FakaySNAHpLG8",
-          "value" : "3QGoVEf4xO1"
+          "sourceName" : "hs0GFCD7Y3xw7ObFL9",
+          "value" : "Lph8j60l0ok"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LVOBF7LKxqK0jlm",
-          "value" : "hekdQ4x0q8TiPdZJ"
+          "sourceName" : "QHVYESyvCPln",
+          "value" : "i6UxW12ybXg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ce509bcc-2060-4c3c-8abb-02d49ee9a248"
+        "id" : "https://www.example.org/0c25aee9-5898-46b4-9398-b5311bf6c60e"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "InterviewSubject"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "0Lj9hqgfidw8"
+      "de" : "N9naQBwgQqMo"
     },
-    "npiSubjectHeading" : "QPqRBnJUC7pT",
-    "tags" : [ "nQVBeCG7F4Ij4" ],
-    "description" : "rwmB467pcYiI1SE",
+    "npiSubjectHeading" : "jswHZby2THqWqRP",
+    "tags" : [ "CdwfkZ6Ca61q" ],
+    "description" : "Ktc8d7wEI9CUA7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cf6a6616-3bcd-4502-915c-dfd6c676624f"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/38ba54db-77c1-465d-a0b8-462f080769a8"
       },
-      "doi" : "https://www.example.org/9097013d-dbc4-400d-8448-d3783b93d715",
+      "doi" : "https://www.example.org/d43c721a-4808-48fc-a803-accf6cb920df",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "q50MT4HIZaeveNh",
-        "issue" : "kRbVesXQeE962V",
-        "articleNumber" : "uiXo4PZRKqW4Cf9",
+        "volume" : "aEjxlX57UqVsbmxYm",
+        "issue" : "4tnYVvQBTg8Mm41",
+        "articleNumber" : "sC9yVdEFat96arVO",
         "pages" : {
           "type" : "Range",
-          "begin" : "RqupHYBFHj2lI2ZTra",
-          "end" : "nDC6N2hTJ3eMNvQRX"
+          "begin" : "TXFtWuQMVfI",
+          "end" : "UQF9CF8TE3hRsdCJ"
         },
-        "corrigendumFor" : "https://www.example.com/r3e3toToqON8fhgznPF"
+        "corrigendumFor" : "https://www.example.com/YvnErDpIuZztsSmi"
       }
     },
-    "metadataSource" : "https://www.example.org/36adf442-8eff-4f79-98c1-268e61ff1e2a",
-    "abstract" : "6hLs0Y2uYcq4dK"
+    "metadataSource" : "https://www.example.org/6d890968-533f-4b0e-bbde-ed10e1cc7fea",
+    "abstract" : "WjXfeiQ56MdgHp8r5V"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9064f697-d94d-4c81-93f1-a5f52c9fd2d0",
-    "name" : "stFtlf9zYwNKxaR",
+    "id" : "https://www.example.org/bcd0e045-3bb5-4cb1-a4a6-98f5c31cdaaa",
+    "name" : "ZlmW9rvjeVRV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-02-03T16:33:31.758Z",
+      "approvalDate" : "1974-07-05T11:39:40.431Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "J147hRDl5AwNy"
+      "applicationCode" : "fZmkl6v9Lyil"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/36263375-c0d3-4c1a-95a0-49812d046c97",
-    "identifier" : "wbiRG6rsbU",
+    "source" : "https://www.example.org/ed8ded33-ea53-49b8-a9e6-56473b93cec2",
+    "identifier" : "zs36S5jjdGQ",
     "labels" : {
-      "nl" : "GPN8zHGKfVCKJz8eoc"
+      "nn" : "h3MExMZjykkRpzkb"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 373434146
+      "amount" : 1676117514
     },
-    "activeFrom" : "1990-11-28T18:29:51.288Z",
-    "activeTo" : "2017-08-28T17:36:45.072Z"
+    "activeFrom" : "1979-05-27T14:55:37.897Z",
+    "activeTo" : "2007-11-20T21:28:55.793Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eecb4aab-1c0f-440a-84eb-0b31843fa1b3",
-    "id" : "https://www.example.org/2e01aa0d-7abc-4006-b5ee-deec9ee1cbef",
-    "identifier" : "MPDoyXiWnqe5sb8PB0e",
+    "source" : "https://www.example.org/109fe8cd-fbb1-43b7-9745-1ecdcdc176a9",
+    "id" : "https://www.example.org/7471785b-be18-485d-b06b-28c87988bb23",
+    "identifier" : "OCVORTaDFseoEFONH",
     "labels" : {
-      "zh" : "DaeFMLw4SES9b6K"
+      "sv" : "OsXhhmaNnO7uEcZS"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 877574463
+      "currency" : "USD",
+      "amount" : 1341078649
     },
-    "activeFrom" : "1972-12-26T04:11:39.869Z",
-    "activeTo" : "2012-09-18T14:35:38.767Z"
+    "activeFrom" : "1981-08-21T19:09:13.561Z",
+    "activeTo" : "1994-05-15T22:14:17.124Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2b723512-a412-4097-913d-d5298b21c950" ],
+  "subjects" : [ "https://www.example.org/c2f04288-7175-4dd8-8804-376216d8f6cb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "887d493a-d780-44e6-8c31-9018c91d277e",
-    "name" : "MxsRjTY9URXlJiiciz0",
-    "mimeType" : "haXscIlasVD",
-    "size" : 18681184,
-    "license" : "https://www.example.com/ieiaqwddsmvv",
+    "identifier" : "4ed58038-09ff-4e3c-8ddf-1a25c9a368b2",
+    "name" : "bez5En6noBxoCh",
+    "mimeType" : "zXflGdVsCtuihSKx",
+    "size" : 987120176,
+    "license" : "https://www.example.com/0w5ykmkg0f",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ZvKdBV05NmGNbt9Tc",
-    "publishedDate" : "1996-09-08T06:23:22.637Z",
+    "legalNote" : "iTMonXcjSFik8",
+    "publishedDate" : "2008-05-31T10:26:12.203Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "tzHac7auyzcWkdnwEE",
-      "uploadedDate" : "2009-04-23T17:40:28.830Z"
+      "uploadedBy" : "HzUApwJiHDro8h6",
+      "uploadedDate" : "1994-07-13T05:51:54.619Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/glMyufu3VtRjyt88",
-    "name" : "PCvyjk9RqzGWi",
-    "description" : "X6iHj9n3zGmVCb4XuSE"
+    "id" : "https://www.example.com/LRh2HONYpVdFsx1wwn",
+    "name" : "VCBfVaCFAGRgmM",
+    "description" : "imUt6KYl5Bgv1"
   } ],
-  "rightsHolder" : "czgCRnkto6Acg",
-  "duplicateOf" : "https://www.example.org/0ac9529a-f540-4db5-8fae-ffa789033d79",
+  "rightsHolder" : "oQ3mDFnB4J",
+  "duplicateOf" : "https://www.example.org/b7b2c29f-7409-4633-8a49-18fdb6c877ec",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tG9WFBDfrXdr5a"
+    "note" : "2Npy5VA62LCA"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sTwkX68tE3r",
-    "createdBy" : "uJBfo05llY",
-    "createdDate" : "1991-03-05T08:53:53.175Z"
+    "note" : "USueOZ7Z1gF4",
+    "createdBy" : "2xDaWvFSZ8",
+    "createdDate" : "2020-02-18T03:15:52.766Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fd84d8b4-a853-4380-bbcf-532287b1fddc" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/ddfd554d-5c8d-4ca0-91c7-47a9003547a2" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "KgrIJoB3ulOK3NY",
-    "ownerAffiliation" : "https://www.example.org/e995c1aa-0fdb-439a-821b-720f272daf43"
+    "owner" : "J4k6imbloeWk",
+    "ownerAffiliation" : "https://www.example.org/f7d1f8d4-947c-4147-b2d2-959e118e8d2f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5127b01e-5a46-4f60-9810-90a8aacab3c6"
+    "id" : "https://www.example.org/64b9a674-6404-4262-ac68-6ca20b2f183d"
   },
-  "createdDate" : "2023-05-15T22:37:47.484Z",
-  "modifiedDate" : "2004-07-03T18:46:56.587Z",
-  "publishedDate" : "2016-12-15T14:14:39.157Z",
-  "indexedDate" : "2005-07-09T15:22:18.913Z",
-  "handle" : "https://www.example.org/e1b3f5ce-4600-41ca-ab1a-d547d1f259d3",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/e42ae30e-04d9-46da-ab15-f346b212d2db",
+  "createdDate" : "1995-05-21T14:04:21.859Z",
+  "modifiedDate" : "1982-05-12T18:27:21.060Z",
+  "publishedDate" : "1977-01-14T19:06:52.750Z",
+  "indexedDate" : "2000-12-16T01:43:11.284Z",
+  "handle" : "https://www.example.org/3be4721b-09d0-4ef3-bf1e-75185c3ec082",
+  "doi" : "https://doi.org/10.1234/eligendi",
+  "link" : "https://www.example.org/b9742a3f-1db4-48bd-ba48-12851ec617a0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ucr2YG1OTpyvZ",
+    "mainTitle" : "zitUQB5mSU5ZX",
     "alternativeTitles" : {
-      "de" : "5XVQ30oKo1iuRh"
+      "de" : "LdF4LtpLXnjHEWlkUk0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xW6l1SdhvXwnSb3lu",
-      "month" : "cWD8M3tJa194BTVn8",
-      "day" : "ZTpSguvGypgS6GW3mu"
+      "year" : "EadmTlGxSMoWY",
+      "month" : "YnmEjjdi1CJ",
+      "day" : "lLMIBT6pxB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b17b229a-0f36-48ba-9ea1-cb451548f917",
-        "name" : "BB5PytWXgSJJUGKxD",
+        "id" : "https://www.example.org/a4cc6306-3000-4cb0-bc77-2572312a3758",
+        "name" : "QQUXPmq0Qlv11EjFg",
         "nameType" : "Personal",
-        "orcId" : "ru5dFd0ZehTCf1vmUE",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "WwiG3eR6iy5kVRnX",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BS38n9ezeN83m",
-          "value" : "QwMwPUtMEyYPlyyL"
+          "sourceName" : "b94uGYMoSpR2RLEZGzu",
+          "value" : "2NJh6jKPnownfbe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8UBJHt0gWb3",
-          "value" : "sdcVoTQupfVX"
+          "sourceName" : "QQRFQkXGDkPk7mwJ",
+          "value" : "k7xfGLz6xAgc9Q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e8583419-0ea2-4b50-acde-73e3c36ebb68"
+        "id" : "https://www.example.org/f6d66bd5-9a18-4977-bce6-fc3d5e25f995"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3c8ef855-5d36-4163-bb0d-7f9b40d82799",
-        "name" : "Wms0oPMgNgv8s8jRS3",
-        "nameType" : "Organizational",
-        "orcId" : "pctU4xyorl7",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/041412e8-aef9-4615-bdf5-1c40667bc39a",
+        "name" : "aXrEaXELaQD",
+        "nameType" : "Personal",
+        "orcId" : "iu8FITr5ikfuMOm",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hs0GFCD7Y3xw7ObFL9",
-          "value" : "Lph8j60l0ok"
+          "sourceName" : "bM0OUBS9AtP4OIG",
+          "value" : "J0XKFBVE4UcM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QHVYESyvCPln",
-          "value" : "i6UxW12ybXg"
+          "sourceName" : "HCp3LTB7qR",
+          "value" : "Mv9gphbz2s4CYO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0c25aee9-5898-46b4-9398-b5311bf6c60e"
+        "id" : "https://www.example.org/f6b1eb0f-b702-41d4-9f46-400eee151c7a"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "N9naQBwgQqMo"
+      "af" : "JSviLEfK2zvyhqDOgV"
     },
-    "npiSubjectHeading" : "jswHZby2THqWqRP",
-    "tags" : [ "CdwfkZ6Ca61q" ],
-    "description" : "Ktc8d7wEI9CUA7",
+    "npiSubjectHeading" : "azOWKD04zuaRN2SQi7",
+    "tags" : [ "k63mNvYS6s7F" ],
+    "description" : "QW6Dyn8rvlI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/38ba54db-77c1-465d-a0b8-462f080769a8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2b3766d2-e8e5-43ea-8cc1-a227701be431"
       },
-      "doi" : "https://www.example.org/d43c721a-4808-48fc-a803-accf6cb920df",
+      "doi" : "https://www.example.org/65d0d95b-34a4-48b4-9ddd-4e7ee0ad513b",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "aEjxlX57UqVsbmxYm",
-        "issue" : "4tnYVvQBTg8Mm41",
-        "articleNumber" : "sC9yVdEFat96arVO",
+        "volume" : "094Z0RHioD3jcpohY",
+        "issue" : "u3XqJ4LbVo",
+        "articleNumber" : "SJq6SIL1eNQVkEcK",
         "pages" : {
           "type" : "Range",
-          "begin" : "TXFtWuQMVfI",
-          "end" : "UQF9CF8TE3hRsdCJ"
+          "begin" : "zKYgUUJupOYjk1L6m6",
+          "end" : "dR3gmsA5VyC0mM"
         },
-        "corrigendumFor" : "https://www.example.com/YvnErDpIuZztsSmi"
+        "corrigendumFor" : "https://www.example.com/FjeT1SXj0EhQ"
       }
     },
-    "metadataSource" : "https://www.example.org/6d890968-533f-4b0e-bbde-ed10e1cc7fea",
-    "abstract" : "WjXfeiQ56MdgHp8r5V"
+    "metadataSource" : "https://www.example.org/bdadce81-6184-4e85-9198-98e8608ff0c9",
+    "abstract" : "PmQrlGPbgjk1v0An9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/bcd0e045-3bb5-4cb1-a4a6-98f5c31cdaaa",
-    "name" : "ZlmW9rvjeVRV",
+    "id" : "https://www.example.org/50fd53c5-8e9a-4830-bee6-206b358262c5",
+    "name" : "RKgAfScN7hAABns",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-07-05T11:39:40.431Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "fZmkl6v9Lyil"
+      "approvalDate" : "1982-05-12T22:37:33.428Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "6ol3ymXtmr7vlNn"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ed8ded33-ea53-49b8-a9e6-56473b93cec2",
-    "identifier" : "zs36S5jjdGQ",
+    "source" : "https://www.example.org/91ba5fc9-28e5-4b1a-b814-e8f3362265b3",
+    "identifier" : "L1EJotbvzpk1x",
     "labels" : {
-      "nn" : "h3MExMZjykkRpzkb"
+      "nl" : "s3sNiUNQxFaV"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1676117514
+      "amount" : 1470151384
     },
-    "activeFrom" : "1979-05-27T14:55:37.897Z",
-    "activeTo" : "2007-11-20T21:28:55.793Z"
+    "activeFrom" : "1971-04-30T23:00:56.731Z",
+    "activeTo" : "2004-12-27T03:36:26.235Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/109fe8cd-fbb1-43b7-9745-1ecdcdc176a9",
-    "id" : "https://www.example.org/7471785b-be18-485d-b06b-28c87988bb23",
-    "identifier" : "OCVORTaDFseoEFONH",
+    "source" : "https://www.example.org/e214339b-7a6e-4f16-be2c-523b7876f869",
+    "id" : "https://www.example.org/a4773fb3-8acc-460c-b8f1-a848b15c4c09",
+    "identifier" : "qCHT3D5CBqvP11MV0",
     "labels" : {
-      "sv" : "OsXhhmaNnO7uEcZS"
+      "bg" : "h4oyyFN4KPSANCkhDV"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1341078649
+      "currency" : "GBP",
+      "amount" : 274409900
     },
-    "activeFrom" : "1981-08-21T19:09:13.561Z",
-    "activeTo" : "1994-05-15T22:14:17.124Z"
+    "activeFrom" : "1996-11-21T17:59:34.832Z",
+    "activeTo" : "2001-09-12T11:09:13.482Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c2f04288-7175-4dd8-8804-376216d8f6cb" ],
+  "subjects" : [ "https://www.example.org/22f0598b-4177-4217-a191-81bb8cc33a67" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4ed58038-09ff-4e3c-8ddf-1a25c9a368b2",
-    "name" : "bez5En6noBxoCh",
-    "mimeType" : "zXflGdVsCtuihSKx",
-    "size" : 987120176,
-    "license" : "https://www.example.com/0w5ykmkg0f",
+    "identifier" : "3ff2b4a4-4b29-41a0-8629-e3c45bf374b6",
+    "name" : "TczdgMQqaAjhfMVhqnK",
+    "mimeType" : "RBvzTWJXKVDiU",
+    "size" : 154108535,
+    "license" : "https://www.example.com/jffyc0jab2",
     "administrativeAgreement" : false,
-    "publisherVersion" : "UpdatedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "iTMonXcjSFik8",
-    "publishedDate" : "2008-05-31T10:26:12.203Z",
+    "legalNote" : "h7Zflc2BZF",
+    "publishedDate" : "2018-02-13T06:00:03.664Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "HzUApwJiHDro8h6",
-      "uploadedDate" : "1994-07-13T05:51:54.619Z"
+      "uploadedBy" : "zYRhVkjcAkgmf05WiPv",
+      "uploadedDate" : "1988-12-05T00:35:06.206Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/LRh2HONYpVdFsx1wwn",
-    "name" : "VCBfVaCFAGRgmM",
-    "description" : "imUt6KYl5Bgv1"
+    "id" : "https://www.example.com/a4SGOKr5ggCRS",
+    "name" : "hLJ515uHmnCVDFR",
+    "description" : "r9lxx6A8ZyB2"
   } ],
-  "rightsHolder" : "oQ3mDFnB4J",
-  "duplicateOf" : "https://www.example.org/b7b2c29f-7409-4633-8a49-18fdb6c877ec",
+  "rightsHolder" : "t7hyZMsXVs5hjuv",
+  "duplicateOf" : "https://www.example.org/2c9e627c-ebcf-4ecf-91ad-344df9aa97d7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "2Npy5VA62LCA"
+    "note" : "Jms5OhQktygmSA20keB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "USueOZ7Z1gF4",
-    "createdBy" : "2xDaWvFSZ8",
-    "createdDate" : "2020-02-18T03:15:52.766Z"
+    "note" : "dTg3oseHyyEcaZA",
+    "createdBy" : "JNFHEBdciEe6oSm",
+    "createdDate" : "2009-10-16T05:35:05.134Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ddfd554d-5c8d-4ca0-91c7-47a9003547a2" ],
+  "curatingInstitutions" : [ "https://www.example.org/a2e3be1f-199f-45b1-a30d-9743922f27de" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "2GcgZfEChhjcQAH5PS",
-    "ownerAffiliation" : "https://www.example.org/3f0b5f01-4e0b-4759-9b59-3fcc7349db62"
+    "owner" : "r2DAouwJQBfVa9kzVU4",
+    "ownerAffiliation" : "https://www.example.org/94c91e0e-00b4-4a7a-bda4-2aa5490f4aa9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cd8fe2a4-3bed-462b-8783-dbb3823075aa"
+    "id" : "https://www.example.org/609216e3-099c-42a3-b274-4f687c641b88"
   },
-  "createdDate" : "1979-04-13T01:42:54.431Z",
-  "modifiedDate" : "1987-05-06T06:50:34.895Z",
-  "publishedDate" : "2000-06-06T12:08:32.503Z",
-  "indexedDate" : "2013-06-03T01:29:03.174Z",
-  "handle" : "https://www.example.org/11fb90fa-f90e-4b8b-b0fd-0c83e79472af",
-  "doi" : "https://doi.org/10.1234/iusto",
-  "link" : "https://www.example.org/3acc4515-f4a7-4749-b116-4530ebedaebb",
+  "createdDate" : "2011-12-08T04:15:09.239Z",
+  "modifiedDate" : "1993-09-18T10:25:45.145Z",
+  "publishedDate" : "1996-12-05T20:11:14.429Z",
+  "indexedDate" : "2011-11-16T20:26:37.406Z",
+  "handle" : "https://www.example.org/a4f10f4e-d259-474e-ad3f-2666081e1505",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/a30506c0-b836-48ae-9634-48bc73897839",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "aHLfmsOfypI5Ylfh8",
+    "mainTitle" : "TayVGJdq8p6qDesMKHf",
     "alternativeTitles" : {
-      "sv" : "pwDleCfYbZ3MpULMox"
+      "ca" : "oGt2aysFDCR1I"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7jx5dxWePzT1",
-      "month" : "fuxbaS4Ls1Sibn",
-      "day" : "BeTumjmq4oYsb8dC"
+      "year" : "rZpzOEv1HnHlpIGv1a",
+      "month" : "v1xf4EtmL2jmvC2sw",
+      "day" : "drSxgLyLjg"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c004457e-3cfb-4ec4-be18-ef386bef519b",
-        "name" : "B9QNsKffOmURH8otQ",
-        "nameType" : "Organizational",
-        "orcId" : "ldlRlP27nZ",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/382a6332-001d-4e60-8655-af1e0c298e08",
+        "name" : "5Cgrbt8Pvcg",
+        "nameType" : "Personal",
+        "orcId" : "GnIkWZrLUTyV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qd0YuQAUpvS",
-          "value" : "J7A1NYAVvN3KVGVJ"
+          "sourceName" : "tGxAiQLgGr",
+          "value" : "LoMFpCVjzz8oc7QsHvo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bXUFPvkqm64LOe",
-          "value" : "SwsC38NwgD6"
+          "sourceName" : "4ghcfmBAsNai",
+          "value" : "StWe0aM9IZS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dff1a72a-71b9-4685-87ec-7b7b3982a3cf"
+        "id" : "https://www.example.org/373b3670-4867-4a63-bae4-d8126de3b7ae"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4f86a905-197a-400b-982c-68f95f8e8633",
-        "name" : "GdjaaN0PbIl4AXk2kz",
-        "nameType" : "Organizational",
-        "orcId" : "NHBkdKRTZQalEAo8fJh",
+        "id" : "https://www.example.org/9c3af6f2-23a7-4bdb-b382-8640ac4a1c48",
+        "name" : "7yidhFcucJMqvnH",
+        "nameType" : "Personal",
+        "orcId" : "dE0RvZUpvywI6sYS28",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NvOl6vBoo2uhjCr",
-          "value" : "n75wwcdwogHp90EE9L"
+          "sourceName" : "r2KFnOQUmqz2",
+          "value" : "N6uu4ydDSOMzTDR4E5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "d2e3yn6c0GVVB6",
-          "value" : "em0f0FORdEvvWNfE"
+          "sourceName" : "EhIbQ0j1NlpxZOZ4",
+          "value" : "YqZd5th34EvQP7wF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6ae00fa6-ccd3-43e2-910b-fe73e95c05fe"
+        "id" : "https://www.example.org/9b9be1ce-d9f7-4d54-b4f9-dc70bf855e65"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "luk8UTP6Sat9M"
+      "fi" : "XjPkJjG33DODnPufQ4u"
     },
-    "npiSubjectHeading" : "qZ2IbAO6S7B",
-    "tags" : [ "dOjY0NUnEbd6DYp2" ],
-    "description" : "6ueu1qeCMUBE2JnOlNu",
+    "npiSubjectHeading" : "vOoSkjyXZxdhr",
+    "tags" : [ "ZOJNpiRCRo7" ],
+    "description" : "kC49A6z7HTgLIgew",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/defa6547-cc14-40cc-9f90-87d9d06a020c"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0d4c33e0-6825-435a-98fc-c62d19bea4bd"
       },
-      "doi" : "https://www.example.org/8579b291-e283-42bb-9aa6-af3e7a0269af",
+      "doi" : "https://www.example.org/c93b1e42-d42b-4635-806b-db9def82054e",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "JrmrDv94eirI7MXN",
-        "issue" : "OI78L2MZWbsBQ",
-        "articleNumber" : "Pn3Kj1mi03K5wd9",
+        "volume" : "BP13xDHcEEsPCCvBf",
+        "issue" : "jzEYLmuCB2TVaU",
+        "articleNumber" : "f12PTJVi1TOFD0EuD",
         "pages" : {
           "type" : "Range",
-          "begin" : "UWBzI1A2eX2",
-          "end" : "6Ckcvv6lo0tv"
+          "begin" : "P16AA4jCZtTX2Z",
+          "end" : "WSncOaPDB9"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4387998b-dedc-49e1-ad52-03f372432527",
-    "abstract" : "mkyfEKjWftxXq"
+    "metadataSource" : "https://www.example.org/e969b1da-87c8-4678-965a-c78e5e518cc8",
+    "abstract" : "CtHygKb7hO1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6b18c0f8-43d1-4555-b5ff-793322301f2d",
-    "name" : "vXCAVjIeIze",
+    "id" : "https://www.example.org/33495b05-f2ae-4b2a-acf2-b0123e18a39d",
+    "name" : "pLDn4TRPEhg1emD",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-02-15T06:15:56.435Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Su2Ddiw24k"
+      "approvalDate" : "2011-08-16T07:47:55.620Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "zYCNDUSvGPSDaAMdfM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b2d81e8d-f9fd-41c5-b482-dfcc3ded3f30",
-    "identifier" : "cre1xSGEaZQ3wE5BG",
+    "source" : "https://www.example.org/89868eaf-388e-49a2-86b6-f279e0acb4d6",
+    "identifier" : "6C6eirdIfsLMf8HfUp",
     "labels" : {
-      "cs" : "1zhNf1EtgFSa"
+      "ru" : "5A4aHrGfEf9mcCK2Am"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1713512420
+      "currency" : "USD",
+      "amount" : 1759103069
     },
-    "activeFrom" : "1991-11-06T13:48:59.054Z",
-    "activeTo" : "1999-12-29T00:43:15.599Z"
+    "activeFrom" : "1985-07-02T21:08:15.377Z",
+    "activeTo" : "1990-09-11T01:27:53.574Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3afa52d8-12dd-48dc-82a5-d6b360a26146",
-    "id" : "https://www.example.org/6301ef49-c022-4bd6-84b6-09ec70a7095c",
-    "identifier" : "zYf9p3ADntBoc",
+    "source" : "https://www.example.org/1a911a16-f1c8-4ad0-8efa-e62426b79c74",
+    "id" : "https://www.example.org/7ea8c6e8-d860-4fbd-a394-8984137df9f5",
+    "identifier" : "mFaCl2fYeQVQI",
     "labels" : {
-      "sv" : "cu68uxaR1UbY"
+      "pl" : "De8H9udpJJD3K5P6U6n"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 52572652
+      "amount" : 1161681433
     },
-    "activeFrom" : "1999-07-15T08:02:47.846Z",
-    "activeTo" : "2010-10-27T22:31:42.495Z"
+    "activeFrom" : "2022-02-26T22:04:50.144Z",
+    "activeTo" : "2022-03-29T00:40:25.636Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/55108c8a-fd89-4d10-8efa-a66cb2ada5b0" ],
+  "subjects" : [ "https://www.example.org/dd6572ad-f9ba-4a70-aefb-ca329ea051f6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d640bcc6-7f02-4065-9b07-46e3f040a8bd",
-    "name" : "HjcHFaZcePdw5",
-    "mimeType" : "xipHlYXZo0H4gViT1Z",
-    "size" : 62959204,
-    "license" : "https://www.example.com/1gfalfp5nddn",
+    "identifier" : "9d8c44bd-4b3b-440a-88b0-b347cc946ea3",
+    "name" : "vOyNcxI8bfBton33",
+    "mimeType" : "41xq4nKNFncP",
+    "size" : 1666858579,
+    "license" : "https://www.example.com/bckmohfl0samb51ooi",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "7cYbUsnAn3mqlIxyu",
-    "publishedDate" : "2016-02-01T09:27:52.662Z",
+    "legalNote" : "jv8rGL0vFjJOCVG",
+    "publishedDate" : "2012-10-19T13:14:44.203Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Bhtx2VaGkbUy20iS37",
-      "uploadedDate" : "1989-02-09T08:47:35.256Z"
+      "uploadedBy" : "CNkIdG7w1KDW",
+      "uploadedDate" : "2007-06-22T01:15:47.046Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7iOmDQfqQF4xgmRsl",
-    "name" : "WpP9e0koz1QcLC",
-    "description" : "O46QBPyMqdSY7qg048"
+    "id" : "https://www.example.com/twUyxFfwZ12fSGM0SvI",
+    "name" : "NoR7Z4eFAQe8yHn",
+    "description" : "ayUBCc786XWeEv"
   } ],
-  "rightsHolder" : "N6rjbCxmO95p",
-  "duplicateOf" : "https://www.example.org/8d6d9233-4890-4d57-b867-a0e38c2b3292",
+  "rightsHolder" : "LbJhaYhQeQY4FYD62",
+  "duplicateOf" : "https://www.example.org/7a495bf6-d73b-4f9e-bb23-5a2060e64095",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lcUwIRhbqp"
+    "note" : "UR82SxiNRu"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iVIwpYKPwFdV0F",
-    "createdBy" : "1uvyaoFzlS52Cbt",
-    "createdDate" : "2008-04-25T22:05:28.994Z"
+    "note" : "mkILCdRjEc",
+    "createdBy" : "gPmWgvqS3YgZ",
+    "createdDate" : "1973-07-10T12:10:30.656Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/40367f71-fb21-4d17-974a-d23734211199" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/9c6fbe6a-06f6-41c4-945b-31bd13a8d014" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "r2DAouwJQBfVa9kzVU4",
-    "ownerAffiliation" : "https://www.example.org/94c91e0e-00b4-4a7a-bda4-2aa5490f4aa9"
+    "owner" : "AFxUOeV7pIE5QxkAWE",
+    "ownerAffiliation" : "https://www.example.org/61512462-6b00-49b0-8685-80f9c9a55ac8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/609216e3-099c-42a3-b274-4f687c641b88"
+    "id" : "https://www.example.org/8e4ac013-f1c5-4106-b627-127f421583a2"
   },
-  "createdDate" : "2011-12-08T04:15:09.239Z",
-  "modifiedDate" : "1993-09-18T10:25:45.145Z",
-  "publishedDate" : "1996-12-05T20:11:14.429Z",
-  "indexedDate" : "2011-11-16T20:26:37.406Z",
-  "handle" : "https://www.example.org/a4f10f4e-d259-474e-ad3f-2666081e1505",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/a30506c0-b836-48ae-9634-48bc73897839",
+  "createdDate" : "1997-01-02T07:12:17.539Z",
+  "modifiedDate" : "1995-06-13T00:12:44.963Z",
+  "publishedDate" : "2020-02-04T12:54:06.206Z",
+  "indexedDate" : "2014-01-26T05:29:06.735Z",
+  "handle" : "https://www.example.org/71ea9e7f-bbbc-4046-81cf-dcb225ff705d",
+  "doi" : "https://doi.org/10.1234/repudiandae",
+  "link" : "https://www.example.org/b12815b8-fc2b-4c30-b2b9-728ca6e1eb35",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TayVGJdq8p6qDesMKHf",
+    "mainTitle" : "IZ37LjH1SE",
     "alternativeTitles" : {
-      "ca" : "oGt2aysFDCR1I"
+      "es" : "riBexqib1d1"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "rZpzOEv1HnHlpIGv1a",
-      "month" : "v1xf4EtmL2jmvC2sw",
-      "day" : "drSxgLyLjg"
+      "year" : "su4N6KKBVj",
+      "month" : "MGDML4PTAtifBjF",
+      "day" : "gVFpVNTCp9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/382a6332-001d-4e60-8655-af1e0c298e08",
-        "name" : "5Cgrbt8Pvcg",
+        "id" : "https://www.example.org/1174ccaa-e15c-4543-9bf7-2a9191cc30c2",
+        "name" : "O5O4OJwafNM0aT",
         "nameType" : "Personal",
-        "orcId" : "GnIkWZrLUTyV",
-        "verificationStatus" : "Verified",
+        "orcId" : "EsmLilvVIimQ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tGxAiQLgGr",
-          "value" : "LoMFpCVjzz8oc7QsHvo"
+          "sourceName" : "Qm442WfJnoA6Vhk",
+          "value" : "HsHAtj7xLFNRDr9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4ghcfmBAsNai",
-          "value" : "StWe0aM9IZS"
+          "sourceName" : "J1roTfxZlf8",
+          "value" : "7XYtXlcbhEj6j2GNvEW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/373b3670-4867-4a63-bae4-d8126de3b7ae"
+        "id" : "https://www.example.org/f05b1203-afe5-4151-9752-a275e1bf723e"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9c3af6f2-23a7-4bdb-b382-8640ac4a1c48",
-        "name" : "7yidhFcucJMqvnH",
+        "id" : "https://www.example.org/57303a17-96e2-4b56-a32b-a2bdbc819c6b",
+        "name" : "8Ur9rebjMD2pKYu",
         "nameType" : "Personal",
-        "orcId" : "dE0RvZUpvywI6sYS28",
-        "verificationStatus" : "Verified",
+        "orcId" : "MjZMEAtMchu1xMXd7",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "r2KFnOQUmqz2",
-          "value" : "N6uu4ydDSOMzTDR4E5"
+          "sourceName" : "EpV1SzkHCgv9SLVit",
+          "value" : "IGNg3mMcWWXK9MN2N"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EhIbQ0j1NlpxZOZ4",
-          "value" : "YqZd5th34EvQP7wF"
+          "sourceName" : "5VgvwsPXztDMblY",
+          "value" : "r4WZgQ073W2e"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9b9be1ce-d9f7-4d54-b4f9-dc70bf855e65"
+        "id" : "https://www.example.org/243118e2-cfdf-4dba-8b5e-86d2cdc49b34"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "Writer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "XjPkJjG33DODnPufQ4u"
+      "ru" : "4NI8bJ6ioZkfMlo"
     },
-    "npiSubjectHeading" : "vOoSkjyXZxdhr",
-    "tags" : [ "ZOJNpiRCRo7" ],
-    "description" : "kC49A6z7HTgLIgew",
+    "npiSubjectHeading" : "SWnLINxtmxdtHbzbsG",
+    "tags" : [ "BhWZarpQnE" ],
+    "description" : "IghHYAhj1sMVmXy7N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0d4c33e0-6825-435a-98fc-c62d19bea4bd"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/65514fe4-d0dc-4cf8-971e-cf50bd7f405a"
       },
-      "doi" : "https://www.example.org/c93b1e42-d42b-4635-806b-db9def82054e",
+      "doi" : "https://www.example.org/87b84520-9143-41b6-9e97-373eefc3f830",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "BP13xDHcEEsPCCvBf",
-        "issue" : "jzEYLmuCB2TVaU",
-        "articleNumber" : "f12PTJVi1TOFD0EuD",
+        "volume" : "GG1Udro7lLjZNS9s",
+        "issue" : "x3fZ3KrRgw",
+        "articleNumber" : "NtBApv0kEUwrZzcF2",
         "pages" : {
           "type" : "Range",
-          "begin" : "P16AA4jCZtTX2Z",
-          "end" : "WSncOaPDB9"
+          "begin" : "63mkIVladyCJi",
+          "end" : "o8heMPEXkwt"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e969b1da-87c8-4678-965a-c78e5e518cc8",
-    "abstract" : "CtHygKb7hO1"
+    "metadataSource" : "https://www.example.org/e832cd69-3325-4879-b0bc-2770126b7f3d",
+    "abstract" : "YHu9jLtYp9JDcE2H2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/33495b05-f2ae-4b2a-acf2-b0123e18a39d",
-    "name" : "pLDn4TRPEhg1emD",
+    "id" : "https://www.example.org/119ca5b2-576f-411c-ad29-21a6ee7ebc77",
+    "name" : "omRw5X1pNzIXp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-08-16T07:47:55.620Z",
+      "approvalDate" : "1973-01-02T09:59:29.180Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "zYCNDUSvGPSDaAMdfM"
+      "applicationCode" : "8gl6XYnEneFIB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/89868eaf-388e-49a2-86b6-f279e0acb4d6",
-    "identifier" : "6C6eirdIfsLMf8HfUp",
+    "source" : "https://www.example.org/bd567cd1-03f1-4fbc-b99d-70b4f35dc282",
+    "identifier" : "5z2xRHMtdEukDRWnWk4",
     "labels" : {
-      "ru" : "5A4aHrGfEf9mcCK2Am"
+      "en" : "NqHi3NmyU3vXH7paT"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1759103069
+      "currency" : "GBP",
+      "amount" : 1438049275
     },
-    "activeFrom" : "1985-07-02T21:08:15.377Z",
-    "activeTo" : "1990-09-11T01:27:53.574Z"
+    "activeFrom" : "1986-06-15T04:20:43.401Z",
+    "activeTo" : "2017-07-11T08:13:08.047Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1a911a16-f1c8-4ad0-8efa-e62426b79c74",
-    "id" : "https://www.example.org/7ea8c6e8-d860-4fbd-a394-8984137df9f5",
-    "identifier" : "mFaCl2fYeQVQI",
+    "source" : "https://www.example.org/e67b6971-eb66-412d-9519-3c071f790bb8",
+    "id" : "https://www.example.org/b7f215c8-5231-469e-a476-682baa4bc6c6",
+    "identifier" : "DO5pLJW2M9GE",
     "labels" : {
-      "pl" : "De8H9udpJJD3K5P6U6n"
+      "se" : "eWWaeucSxsu3"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1161681433
+      "currency" : "EUR",
+      "amount" : 885303288
     },
-    "activeFrom" : "2022-02-26T22:04:50.144Z",
-    "activeTo" : "2022-03-29T00:40:25.636Z"
+    "activeFrom" : "2005-12-04T23:57:36.710Z",
+    "activeTo" : "2021-10-15T20:48:57.549Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dd6572ad-f9ba-4a70-aefb-ca329ea051f6" ],
+  "subjects" : [ "https://www.example.org/ac59a692-0021-4bb0-85e6-d5f8f80fb036" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9d8c44bd-4b3b-440a-88b0-b347cc946ea3",
-    "name" : "vOyNcxI8bfBton33",
-    "mimeType" : "41xq4nKNFncP",
-    "size" : 1666858579,
-    "license" : "https://www.example.com/bckmohfl0samb51ooi",
+    "identifier" : "80493ee0-e70f-4a84-b132-fa5a01070994",
+    "name" : "hMzmA9n9nbm",
+    "mimeType" : "y6FrwL4TIg",
+    "size" : 309550811,
+    "license" : "https://www.example.com/yphoua2ubh3vmrbo",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "jv8rGL0vFjJOCVG",
-    "publishedDate" : "2012-10-19T13:14:44.203Z",
+    "legalNote" : "mYkoxzYo7kooFHSC",
+    "publishedDate" : "2012-08-01T06:56:29.631Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "CNkIdG7w1KDW",
-      "uploadedDate" : "2007-06-22T01:15:47.046Z"
+      "uploadedBy" : "Z8hhwyaC0hxdJP",
+      "uploadedDate" : "1993-06-13T03:10:20.724Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/twUyxFfwZ12fSGM0SvI",
-    "name" : "NoR7Z4eFAQe8yHn",
-    "description" : "ayUBCc786XWeEv"
+    "id" : "https://www.example.com/hp4BRTu3BBVEs",
+    "name" : "27E9PUqdFSDh4gnGFJJ",
+    "description" : "i55A0IE3ar85Ml"
   } ],
-  "rightsHolder" : "LbJhaYhQeQY4FYD62",
-  "duplicateOf" : "https://www.example.org/7a495bf6-d73b-4f9e-bb23-5a2060e64095",
+  "rightsHolder" : "VmOZ8uOwHOypN0i",
+  "duplicateOf" : "https://www.example.org/0c50b609-a0bc-4761-941d-1aaf891df1ac",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UR82SxiNRu"
+    "note" : "xfi9ciPC9OjPYj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "mkILCdRjEc",
-    "createdBy" : "gPmWgvqS3YgZ",
-    "createdDate" : "1973-07-10T12:10:30.656Z"
+    "note" : "MoKLC5MS9x",
+    "createdBy" : "RmKhcKXQ7T",
+    "createdDate" : "2011-03-27T02:11:25.739Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9c6fbe6a-06f6-41c4-945b-31bd13a8d014" ],
+  "curatingInstitutions" : [ "https://www.example.org/29dab69d-1ce3-42f5-9bf4-c3e71a551106" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "hjLbJNKMsNbB7iKU",
-    "ownerAffiliation" : "https://www.example.org/35233f0a-6804-4ba3-a1b4-95d511258869"
+    "owner" : "JVDLuPKRzByXIN",
+    "ownerAffiliation" : "https://www.example.org/ba549b38-6dfd-4868-aebb-1ddc23e08ae0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cf6ef51f-82e7-44e2-90b7-219eea3a0e49"
+    "id" : "https://www.example.org/5e5d662b-d32f-4385-bfec-f73e78bba4d3"
   },
-  "createdDate" : "1985-02-08T01:00:47.291Z",
-  "modifiedDate" : "1978-12-17T18:08:23.799Z",
-  "publishedDate" : "1982-07-09T18:50:55.694Z",
-  "indexedDate" : "1996-02-25T03:20:02.077Z",
-  "handle" : "https://www.example.org/f24b9974-2bc9-4e2a-9301-e0dbd5e96a28",
-  "doi" : "https://doi.org/10.1234/cumque",
-  "link" : "https://www.example.org/2b5aa3ef-e6e6-48ac-9c82-a3698d75fc5c",
+  "createdDate" : "1975-06-27T06:49:55.333Z",
+  "modifiedDate" : "1999-11-16T05:39:06.795Z",
+  "publishedDate" : "1987-03-04T00:01:11.098Z",
+  "indexedDate" : "2023-01-14T13:01:39.893Z",
+  "handle" : "https://www.example.org/41948c2b-bab0-4ea5-a461-6d09c36a72a7",
+  "doi" : "https://doi.org/10.1234/mollitia",
+  "link" : "https://www.example.org/136acb71-a344-4fc7-9362-ffde6b4eefd0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NQDHn9MwIvp0GE",
+    "mainTitle" : "NmZwvdWMRtCC8SeIlla",
     "alternativeTitles" : {
-      "da" : "QxBPySNFEtm"
+      "se" : "l9ZIb0VnrjBcRMRs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GRILcXTw6KHKW7i3E",
-      "month" : "6vHZgM9lmj9JNke",
-      "day" : "6OciJFP9zLZ1gye"
+      "year" : "RWBaWXzQ1p",
+      "month" : "JkuADArkf1OZ",
+      "day" : "LIBLNUhqtQw110B9c"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b16e750e-78e7-4686-9344-1c8a1c701dc3",
-        "name" : "e6qmjR9zbqKKFRmHj",
+        "id" : "https://www.example.org/678fe152-593c-4ac4-bf90-d79c4c59fe21",
+        "name" : "gBB9pl0c0nRYA",
         "nameType" : "Organizational",
-        "orcId" : "U0o1Y7V5mV7Jnd",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "WkXsePw4nXOGis",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nBNkoN18qy",
-          "value" : "KTpcIn6MUYyEWwIa6ml"
+          "sourceName" : "tWj4CodO0mS",
+          "value" : "uguQObPyY77N1yy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aPi9px6uzWv",
-          "value" : "LVgysceVBPr6r7P"
+          "sourceName" : "T7iwnDnKweH9mVKY",
+          "value" : "HIXGvRAcY1WZQl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5ee4e2ff-ad33-4914-952d-a2be00c8ba32"
+        "id" : "https://www.example.org/fa2ec84f-d571-454f-864b-202fa3d2f992"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f38be759-01e1-482c-a318-099a96ac1058",
-        "name" : "DwNfSYMfyAtsDCvU",
-        "nameType" : "Organizational",
-        "orcId" : "RX5wVSNjHKysqTldm",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/20479fae-b648-47fc-abe7-7d0c08c0537b",
+        "name" : "uUAx1YtNexcjRLOvvyN",
+        "nameType" : "Personal",
+        "orcId" : "sqC96JtbwFdDWax",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yXe2vNO3Uj6JuWuim3j",
-          "value" : "j1YuIiMPW7J"
+          "sourceName" : "cWwYsSN76YW",
+          "value" : "QpDp7lRBi4dsc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aN1Dj4HgE79H",
-          "value" : "rXutyy1O7tTWW"
+          "sourceName" : "wbL9Oj0fVtTJ1aeYgp1",
+          "value" : "qDyCZ7HEfTJ6z"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5f63af21-4069-4d3a-98bc-d2fe3d5a6982"
+        "id" : "https://www.example.org/e5957ffb-d177-41a6-a141-017b8edf0772"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "QUSK5tIlG8Vm"
+      "pl" : "gSNI7iRPtO"
     },
-    "npiSubjectHeading" : "2uBPJQSXK24r",
-    "tags" : [ "kgg9ilQVtKz" ],
-    "description" : "VJcXlWwSxQrc0",
+    "npiSubjectHeading" : "BhgjCEqUhjzW4P",
+    "tags" : [ "ABvf6vMwcfOhv" ],
+    "description" : "L1VCmOQEEtzRNpVZN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6f20a93b-bcd9-403d-8f0e-a6eee783968e"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/be2d66d1-f616-499e-8fc4-55dd3000b0c2"
       },
-      "doi" : "https://www.example.org/5103d157-6674-43d7-a539-9ea551ac014c",
+      "doi" : "https://www.example.org/316e5c3f-c9d9-4d12-912d-9e8fcd192c89",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "sgZRvkTLMJ",
-        "issue" : "ewNyIu1JfrR",
-        "articleNumber" : "DqnvpFO9xaPhVbM5",
+        "volume" : "SGXEAL0Tq7P7Qoc",
+        "issue" : "mJlw6VqS4hi",
+        "articleNumber" : "wzMsWqP4hGUMK",
         "pages" : {
           "type" : "Range",
-          "begin" : "2t3g3f3f4WH",
-          "end" : "MDVMIYJXwqVrVj2dQge"
+          "begin" : "3M8YciF9ezs5wxiad",
+          "end" : "z3hif3UQ4OeMJo"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/920957fd-07f0-4e2f-83b3-cd44db4d097d",
-    "abstract" : "E3zaQF4WWH7v9v"
+    "metadataSource" : "https://www.example.org/d9a9b608-5566-44ad-b617-79a50ff6bd1f",
+    "abstract" : "SNg013a7otrAtI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4ca27b7d-ac12-4446-a39f-9c8b25e7ec27",
-    "name" : "CTXw0oTSGtdDD",
+    "id" : "https://www.example.org/cf379432-828c-4ca0-9d89-2d9edcd5c2b2",
+    "name" : "RKPl6bEnZw",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-05-23T02:22:05.715Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zm6URqZsvp"
+      "approvalDate" : "1998-07-23T14:21:30.673Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "TocIwv2Kh19vN3n"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4d4f6298-3fef-4dfc-b035-59cd5fab044f",
-    "identifier" : "VZy2r98Pchjp",
+    "source" : "https://www.example.org/f9ee5373-a1af-4b6d-8f9a-aa0490fc385d",
+    "identifier" : "VLXQDwlNqy312y",
     "labels" : {
-      "cs" : "SX05JrkJN5Ibu7WThU7"
+      "es" : "HNwXTAE40OJU"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 2075323507
+      "currency" : "EUR",
+      "amount" : 1875630730
     },
-    "activeFrom" : "1995-05-13T11:02:07.080Z",
-    "activeTo" : "2005-07-06T03:19:58.738Z"
+    "activeFrom" : "1990-12-27T12:34:12.356Z",
+    "activeTo" : "1998-09-07T22:37:09.055Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e3affb1c-ef6d-4d32-9937-c4afb513e62e",
-    "id" : "https://www.example.org/7b1e1476-784d-4241-9ea9-cc434e89248b",
-    "identifier" : "qifzK1nxyjbb577dbK",
+    "source" : "https://www.example.org/88720e64-12ab-44b7-95a1-5687a0ffd575",
+    "id" : "https://www.example.org/be8a2f86-ade0-4c5c-9c63-3bb67451682f",
+    "identifier" : "z0ufOplb0Y6U",
     "labels" : {
-      "is" : "5T5ZPfo0BSieKwwi"
+      "ca" : "DmRusIeXpPQkhXIup"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 564245413
+      "amount" : 433098275
     },
-    "activeFrom" : "2022-03-08T14:20:43.606Z",
-    "activeTo" : "2023-04-08T14:14:04.210Z"
+    "activeFrom" : "1983-10-26T16:27:23.049Z",
+    "activeTo" : "1990-11-20T08:17:33.977Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a7a705fe-dc3f-4f74-91f6-7d913d394a5a" ],
+  "subjects" : [ "https://www.example.org/d97ec7fa-61e0-4d47-9d5a-c8cd0207af98" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5f2dcff3-ea7a-4054-8282-abdb436cb93e",
-    "name" : "DK4k2XG9QAeMCVoqLPX",
-    "mimeType" : "1K2dZOGAEV1j4Bzn2",
-    "size" : 644152715,
-    "license" : "https://www.example.com/hgcju4rsn5ybukm9q8",
+    "identifier" : "563967b3-d28d-4fc6-a3ab-940e867649be",
+    "name" : "4CvxQCTReaRop4sw3X",
+    "mimeType" : "tiONPQiK63M6F2D",
+    "size" : 1934735962,
+    "license" : "https://www.example.com/7ogddo4xr8ben",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "vfNaV2aafequmGfRPI"
+      "overriddenBy" : "25cJP4Zlwv"
     },
-    "legalNote" : "Cn4nJt46Rch",
-    "publishedDate" : "2004-04-20T18:15:53.393Z",
+    "legalNote" : "BtqdKZil9u",
+    "publishedDate" : "1975-01-21T12:15:13.258Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "QHAXbgeGK0",
-      "uploadedDate" : "1978-11-29T22:04:43.814Z"
+      "uploadedBy" : "L4Wi2wiBsOTe42A",
+      "uploadedDate" : "2010-05-12T01:02:04.569Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ZzBfblfq0rhMh",
-    "name" : "nJffWSpa87eH6SbGjK",
-    "description" : "klp8JRX7n39"
+    "id" : "https://www.example.com/DqwxchlyiqxQczJ8eg",
+    "name" : "VUNmv6FpjWrPraWY",
+    "description" : "ULhs4aqZUivsrS7Fb"
   } ],
-  "rightsHolder" : "SHEW0Mx3oSSDjx",
-  "duplicateOf" : "https://www.example.org/a829892d-785d-4107-906d-b58ffafab4fc",
+  "rightsHolder" : "6iy27JecLK7j10d5VB",
+  "duplicateOf" : "https://www.example.org/6e934aa9-592f-4593-b281-746e11620148",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YjKn3W7peJ1Gigso"
+    "note" : "lWUydPMVE4XQyKbxN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Yp7CFcMnFIN6917AC",
-    "createdBy" : "fOMYCDRHuAscff",
-    "createdDate" : "2005-08-14T15:32:42.990Z"
+    "note" : "tGkdDpRqgTnH0kmLXT",
+    "createdBy" : "lUTOVXPPMr",
+    "createdDate" : "1995-05-17T20:51:43.658Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5d0b5827-2473-4dd8-94cf-ff6953017c55" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/c10174ba-417e-40de-b3ff-f2847ef5a249" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "JVDLuPKRzByXIN",
-    "ownerAffiliation" : "https://www.example.org/ba549b38-6dfd-4868-aebb-1ddc23e08ae0"
+    "owner" : "mxzD9VZ3n5LAS8Z",
+    "ownerAffiliation" : "https://www.example.org/64fce92d-7e32-424e-a35b-e90e5204c8c8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5e5d662b-d32f-4385-bfec-f73e78bba4d3"
+    "id" : "https://www.example.org/a0d5a127-26d7-40cb-bdad-35a175f62e74"
   },
-  "createdDate" : "1975-06-27T06:49:55.333Z",
-  "modifiedDate" : "1999-11-16T05:39:06.795Z",
-  "publishedDate" : "1987-03-04T00:01:11.098Z",
-  "indexedDate" : "2023-01-14T13:01:39.893Z",
-  "handle" : "https://www.example.org/41948c2b-bab0-4ea5-a461-6d09c36a72a7",
-  "doi" : "https://doi.org/10.1234/mollitia",
-  "link" : "https://www.example.org/136acb71-a344-4fc7-9362-ffde6b4eefd0",
+  "createdDate" : "2005-12-31T15:15:18.656Z",
+  "modifiedDate" : "1985-05-21T03:46:56.594Z",
+  "publishedDate" : "2014-10-14T21:05:46.441Z",
+  "indexedDate" : "2004-11-22T06:44:29.329Z",
+  "handle" : "https://www.example.org/1e9775ea-b985-4da0-b6e4-d24a6d95623d",
+  "doi" : "https://doi.org/10.1234/minima",
+  "link" : "https://www.example.org/5a8cdee4-e56d-464f-8948-5d3fe3ba00b0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NmZwvdWMRtCC8SeIlla",
+    "mainTitle" : "i2Uqw4e4Xj415Re",
     "alternativeTitles" : {
-      "se" : "l9ZIb0VnrjBcRMRs"
+      "nl" : "dPrA8BboXk0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "RWBaWXzQ1p",
-      "month" : "JkuADArkf1OZ",
-      "day" : "LIBLNUhqtQw110B9c"
+      "year" : "8u5cj8gWtjNQIh",
+      "month" : "yVagezkC51h1t1R",
+      "day" : "G2GUXLh3sE7AqacAv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/678fe152-593c-4ac4-bf90-d79c4c59fe21",
-        "name" : "gBB9pl0c0nRYA",
+        "id" : "https://www.example.org/3af57973-0d7a-4f78-96d6-4adb27a4eb00",
+        "name" : "VDFPih4NmDydNVQj",
         "nameType" : "Organizational",
-        "orcId" : "WkXsePw4nXOGis",
+        "orcId" : "FG2jOzV3FVhErF",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tWj4CodO0mS",
-          "value" : "uguQObPyY77N1yy"
+          "sourceName" : "6ogMYdq6DnTE37vT",
+          "value" : "xzYhFt0TD7hAR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T7iwnDnKweH9mVKY",
-          "value" : "HIXGvRAcY1WZQl"
+          "sourceName" : "ZZS9nwcKs5iViCdXS",
+          "value" : "jImnfX5QszdvxIw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fa2ec84f-d571-454f-864b-202fa3d2f992"
+        "id" : "https://www.example.org/93e27f66-36fb-4402-b6cf-ba6cc3261a13"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/20479fae-b648-47fc-abe7-7d0c08c0537b",
-        "name" : "uUAx1YtNexcjRLOvvyN",
-        "nameType" : "Personal",
-        "orcId" : "sqC96JtbwFdDWax",
+        "id" : "https://www.example.org/4b6ecacd-d34d-4450-8984-b073a95964ba",
+        "name" : "8IKzZySwJvRQbo",
+        "nameType" : "Organizational",
+        "orcId" : "SKy71JTvsia",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cWwYsSN76YW",
-          "value" : "QpDp7lRBi4dsc"
+          "sourceName" : "OLa0AtY0Lst2c",
+          "value" : "dTvfGFVPwHbM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wbL9Oj0fVtTJ1aeYgp1",
-          "value" : "qDyCZ7HEfTJ6z"
+          "sourceName" : "2wog2oSReidoCu5Zly",
+          "value" : "6JvjF3deMmsaTj1IIYb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e5957ffb-d177-41a6-a141-017b8edf0772"
+        "id" : "https://www.example.org/4413ab7e-0a5e-4a57-8170-a4cce83b0d06"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "gSNI7iRPtO"
+      "se" : "IXqDyVoSUo1"
     },
-    "npiSubjectHeading" : "BhgjCEqUhjzW4P",
-    "tags" : [ "ABvf6vMwcfOhv" ],
-    "description" : "L1VCmOQEEtzRNpVZN",
+    "npiSubjectHeading" : "4eQzLFZXgcYcFG",
+    "tags" : [ "9ZCKugj3W7IA" ],
+    "description" : "Gr9NusA59n8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/be2d66d1-f616-499e-8fc4-55dd3000b0c2"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2c4cd76b-cb0f-4f41-84d9-8e4f8cbfa1c2"
       },
-      "doi" : "https://www.example.org/316e5c3f-c9d9-4d12-912d-9e8fcd192c89",
+      "doi" : "https://www.example.org/83c6018e-7898-4237-927a-f0b089ac858f",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "SGXEAL0Tq7P7Qoc",
-        "issue" : "mJlw6VqS4hi",
-        "articleNumber" : "wzMsWqP4hGUMK",
+        "volume" : "sRwYQvdo9cw6",
+        "issue" : "a4JccbcmvjWsIWh",
+        "articleNumber" : "sVMMqZ7QOQptG4",
         "pages" : {
           "type" : "Range",
-          "begin" : "3M8YciF9ezs5wxiad",
-          "end" : "z3hif3UQ4OeMJo"
+          "begin" : "wCD0p0kYrPq",
+          "end" : "2HakJeC4MzKnltB"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d9a9b608-5566-44ad-b617-79a50ff6bd1f",
-    "abstract" : "SNg013a7otrAtI"
+    "metadataSource" : "https://www.example.org/85e46d14-20f4-4051-9dd4-90e37d64d08c",
+    "abstract" : "1RJBXOrL2r0Xup"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cf379432-828c-4ca0-9d89-2d9edcd5c2b2",
-    "name" : "RKPl6bEnZw",
+    "id" : "https://www.example.org/0a740feb-cb1e-477f-a5fa-e69ab1fb6c7a",
+    "name" : "Z5E9f3tFft41cgpDfsl",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-07-23T14:21:30.673Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "TocIwv2Kh19vN3n"
+      "approvalDate" : "2009-01-28T12:43:57.984Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "d2eRLj1MYaLuo0Z"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f9ee5373-a1af-4b6d-8f9a-aa0490fc385d",
-    "identifier" : "VLXQDwlNqy312y",
+    "source" : "https://www.example.org/aa0cc1d2-6d06-43b6-8428-30914e6bdf3b",
+    "identifier" : "Hsi900qUbCC",
     "labels" : {
-      "es" : "HNwXTAE40OJU"
+      "nn" : "hQFpNglfMEDzRo9BUr"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1875630730
+      "amount" : 1681163562
     },
-    "activeFrom" : "1990-12-27T12:34:12.356Z",
-    "activeTo" : "1998-09-07T22:37:09.055Z"
+    "activeFrom" : "1974-03-09T18:10:37.654Z",
+    "activeTo" : "2020-08-15T10:01:49.170Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/88720e64-12ab-44b7-95a1-5687a0ffd575",
-    "id" : "https://www.example.org/be8a2f86-ade0-4c5c-9c63-3bb67451682f",
-    "identifier" : "z0ufOplb0Y6U",
+    "source" : "https://www.example.org/f3ef684b-a5bf-48f2-89af-f724ca51e886",
+    "id" : "https://www.example.org/a1e53982-e026-4214-b2da-560274e7c33b",
+    "identifier" : "tRDEWxJCO8iF",
     "labels" : {
-      "ca" : "DmRusIeXpPQkhXIup"
+      "fr" : "nnLjONNHB467K"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 433098275
+      "currency" : "GBP",
+      "amount" : 1692495032
     },
-    "activeFrom" : "1983-10-26T16:27:23.049Z",
-    "activeTo" : "1990-11-20T08:17:33.977Z"
+    "activeFrom" : "2019-12-28T15:03:55.572Z",
+    "activeTo" : "2024-02-01T06:36:55.857Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d97ec7fa-61e0-4d47-9d5a-c8cd0207af98" ],
+  "subjects" : [ "https://www.example.org/443b156e-3ea7-46db-af32-5e3e58e54364" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "563967b3-d28d-4fc6-a3ab-940e867649be",
-    "name" : "4CvxQCTReaRop4sw3X",
-    "mimeType" : "tiONPQiK63M6F2D",
-    "size" : 1934735962,
-    "license" : "https://www.example.com/7ogddo4xr8ben",
+    "identifier" : "427277bd-881b-40f4-88f8-24c193a84ba2",
+    "name" : "fMgDzyKbB0LwvQ",
+    "mimeType" : "O7zscj5htz6kax35KS",
+    "size" : 709620590,
+    "license" : "https://www.example.com/trszxu0php",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "25cJP4Zlwv"
+      "overriddenBy" : "owMSYkLmo3CGACj"
     },
-    "legalNote" : "BtqdKZil9u",
-    "publishedDate" : "1975-01-21T12:15:13.258Z",
+    "legalNote" : "FQY3WNsf52cSEJR0tLR",
+    "publishedDate" : "1974-05-03T07:04:55.894Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "L4Wi2wiBsOTe42A",
-      "uploadedDate" : "2010-05-12T01:02:04.569Z"
+      "uploadedBy" : "7EY2xZg0tE5U",
+      "uploadedDate" : "1986-01-31T09:36:31.711Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/DqwxchlyiqxQczJ8eg",
-    "name" : "VUNmv6FpjWrPraWY",
-    "description" : "ULhs4aqZUivsrS7Fb"
+    "id" : "https://www.example.com/Vf7Y3JbHscJ3",
+    "name" : "KuDTvGqR6YbOH",
+    "description" : "6BVetBkkQF4Kj8v9b"
   } ],
-  "rightsHolder" : "6iy27JecLK7j10d5VB",
-  "duplicateOf" : "https://www.example.org/6e934aa9-592f-4593-b281-746e11620148",
+  "rightsHolder" : "QyTtwhkxYz5JuQ",
+  "duplicateOf" : "https://www.example.org/69d886e4-3c7a-4ff4-9308-40a2f92e43cb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lWUydPMVE4XQyKbxN"
+    "note" : "Nt2MDR562uFRiVRWlpZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "tGkdDpRqgTnH0kmLXT",
-    "createdBy" : "lUTOVXPPMr",
-    "createdDate" : "1995-05-17T20:51:43.658Z"
+    "note" : "k2btgXsnTuCm6TPx",
+    "createdBy" : "Iqev1jjQGF6zBp",
+    "createdDate" : "1984-08-16T17:45:45.305Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c10174ba-417e-40de-b3ff-f2847ef5a249" ],
+  "curatingInstitutions" : [ "https://www.example.org/6f218d5b-d5e6-4e49-af67-8e89f51a8a59" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "DiR7fJzdtXA",
-    "ownerAffiliation" : "https://www.example.org/6118fd20-5aa8-40fd-99f8-dbe19d97f53e"
+    "owner" : "fcSvph1WrdsKs",
+    "ownerAffiliation" : "https://www.example.org/e88a851e-4325-4fbb-9ec4-030aebc49ba9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c7a0c611-cfc4-4789-93c7-909e1e92eb0e"
+    "id" : "https://www.example.org/60fef2c1-a313-41f2-9f33-7f9545621f81"
   },
-  "createdDate" : "1974-10-30T11:03:34.654Z",
-  "modifiedDate" : "1984-06-29T23:26:42.782Z",
-  "publishedDate" : "2019-10-04T08:38:16.177Z",
-  "indexedDate" : "1999-05-20T16:01:55.249Z",
-  "handle" : "https://www.example.org/4e79c935-2092-4d98-aeb8-5aabe30537f9",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/744db8ea-395f-4e43-9d4a-15ff6761dce4",
+  "createdDate" : "1992-02-11T12:29:33.379Z",
+  "modifiedDate" : "2000-06-26T21:16:59.894Z",
+  "publishedDate" : "1988-12-21T23:07:35.231Z",
+  "indexedDate" : "2007-04-04T00:55:53.977Z",
+  "handle" : "https://www.example.org/5f1b7203-0f14-4250-ae40-1571918263c4",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/f27d6fe0-3db0-421b-8681-509ff9e614f7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "q0Q90KI3B8WB",
+    "mainTitle" : "dAiZBC4Bg0sBH3kll",
     "alternativeTitles" : {
-      "it" : "NwfHvBR0bMK7lgaotV"
+      "pt" : "ij8cBURg73"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vWc3Rl1XIouFbpKt5H",
-      "month" : "mnBhbsSTTZ9LySbQgO",
-      "day" : "Fqdomf572zluaK"
+      "year" : "54yhcjid0HT16S",
+      "month" : "WDIL9ELtkCGO",
+      "day" : "oEzwOS5lFP5zz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/81851223-4f7f-4ca5-b657-c7263b7f9703",
-        "name" : "3i7OG2Ugip23hZy6",
-        "nameType" : "Personal",
-        "orcId" : "UYDKgxLxnBkSm",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/0b4322fa-d0a9-429a-a081-d5400a2b2f36",
+        "name" : "tS3deZlMkTS",
+        "nameType" : "Organizational",
+        "orcId" : "YVNkyutnJv",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CrWl0l2bJpXO",
-          "value" : "JjRT46qy8khAP8fA"
+          "sourceName" : "OjzoS9QnAHSgsNB8",
+          "value" : "WY3qotaVwO1dLcOhgoN"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TAudXioPoaSkitv7m",
-          "value" : "tOfh38rs2O4Pt0ndb"
+          "sourceName" : "A53tGgxqqg9VG1M4",
+          "value" : "BXtIsIrj2Ka"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7b6abf35-01b9-4856-95f3-1a0045fc7804"
+        "id" : "https://www.example.org/d6b199a1-1d48-41b7-b08b-a794ac39a534"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "Scenographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0c63363e-38c7-4938-afa8-65f367c672fc",
-        "name" : "b3B6xmpyJJHqpGe",
+        "id" : "https://www.example.org/53e7c37f-7144-480c-8fdf-e060ca59028f",
+        "name" : "JrGxgQ5BlD",
         "nameType" : "Personal",
-        "orcId" : "t4E31oIxjPBixjTel",
+        "orcId" : "pJuNu3DxVtrV",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e0KJkH9M9bFWIsFXGwK",
-          "value" : "xeHbYkOKxea1GLPK"
+          "sourceName" : "rDcQrsTEry6a",
+          "value" : "Gyq15uUrkZKXygFr8zc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MbpDTsbzT1eGPxN4442",
-          "value" : "kGlHf9HTKuRF"
+          "sourceName" : "fm1NxeDwH3ucjT",
+          "value" : "geaMlgJFJfFJX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2c60b8af-fc3f-45a4-a15e-370446614fed"
+        "id" : "https://www.example.org/05eafde7-9233-47a2-a16f-3596e6372d7d"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "5nxKXwpzBSa"
+      "cs" : "6Np9ocZ6flt7KEdcv"
     },
-    "npiSubjectHeading" : "11ftcukDmh3",
-    "tags" : [ "jvlotBnftpJ4lIkPS6" ],
-    "description" : "TYN8HUkDYarUa5ZH",
+    "npiSubjectHeading" : "fkAEfD65hMiyFG5Pwa",
+    "tags" : [ "fP2TyqdjgOq" ],
+    "description" : "b7vEGlC3wMF4aTP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e6bb59c3-3236-45a8-9fed-dcaf86420253"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8def23ae-13a8-48f7-a3f9-f725e21347e6"
       },
-      "doi" : "https://www.example.org/2353172a-d88f-4dfb-b833-49441e553747",
+      "doi" : "https://www.example.org/f85ccb36-4511-4f33-9971-8e9b87d11f16",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "3v9NXocoX5CzEc1hW",
-        "issue" : "8zkWEP5q5iMRQNtCSs",
-        "articleNumber" : "1ReghPrhQqHaHC",
+        "volume" : "g9NuNqMNNi",
+        "issue" : "6QkIxE02eG6Q95Y",
+        "articleNumber" : "vrq6Y39BpDIjHAE9",
         "pages" : {
           "type" : "Range",
-          "begin" : "enkzqr4gBXZ99j64",
-          "end" : "t1oQYpnFqpph2"
+          "begin" : "idilKrFpSwP",
+          "end" : "FZvhe2jnnzydTnlM"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7766258b-539f-4921-bc24-a55eb1382683",
-    "abstract" : "cmNFiWmmzI4Nko"
+    "metadataSource" : "https://www.example.org/15bef1e4-3b83-425d-952e-add96ec48b91",
+    "abstract" : "UcNM5b3KyDocc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/eb16a401-5aa6-4962-af50-21254d93cc60",
-    "name" : "v2feIaeOgNRMLAeF",
+    "id" : "https://www.example.org/08817b1c-7454-4d10-acd2-21b0aac95bf3",
+    "name" : "f8YSMGN05E",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-12-31T18:55:13.415Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "AYzxK7PACA6xhphrzvA"
+      "approvalDate" : "1993-08-29T07:31:35.089Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "hKTiSOk8zWntGOvAA5"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ca539e34-ca84-40a2-b41c-ac7374638887",
-    "identifier" : "4OiDBNu7M9buul",
+    "source" : "https://www.example.org/1e0651f9-fced-4def-82a2-04565a2a4265",
+    "identifier" : "iIZ6jy56cuf",
     "labels" : {
-      "is" : "GFVGUnYgPVWo0D2WH"
+      "nb" : "ZDFZiBdW9LvBKc62bm3"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 569194045
+      "amount" : 699322291
     },
-    "activeFrom" : "1991-09-06T19:19:51.966Z",
-    "activeTo" : "1995-06-21T17:11:51.205Z"
+    "activeFrom" : "1987-08-28T07:55:36.456Z",
+    "activeTo" : "2011-08-27T00:29:58.308Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b4b4e7b8-d56b-477f-8b7d-99239a147a23",
-    "id" : "https://www.example.org/6d4a789a-a713-407b-b222-0b055647ee3b",
-    "identifier" : "OpJpcdkNecb",
+    "source" : "https://www.example.org/08ea4998-1d67-4172-808d-04815f18a8d4",
+    "id" : "https://www.example.org/a568f419-3cd0-4fd6-a9d4-08ad87ca91b9",
+    "identifier" : "3YKNQKI9zW1L7k",
     "labels" : {
-      "nn" : "4s2usP331nwWFDcVw"
+      "ca" : "j3jdrvLGgDy"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1698479739
+      "amount" : 120418852
     },
-    "activeFrom" : "1973-11-02T09:12:13.105Z",
-    "activeTo" : "2022-10-12T04:50:23.704Z"
+    "activeFrom" : "1974-12-27T12:47:55.728Z",
+    "activeTo" : "2023-03-12T18:03:34.719Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4ac78994-414d-4045-b554-de6907b16da5" ],
+  "subjects" : [ "https://www.example.org/d7f70525-44c7-450e-a264-e4d2f8ebf64d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f5bb53af-8d51-4cbd-9891-16b4ef9fee8f",
-    "name" : "TmTs6MYDL7x68SX04N",
-    "mimeType" : "GFvnlUHiQEoiU6b4K",
-    "size" : 1791984184,
-    "license" : "https://www.example.com/vyjloqrmqgilra",
+    "identifier" : "61d697b4-f1f7-4838-96fe-1810396d9ba8",
+    "name" : "bmZgolQCu1I",
+    "mimeType" : "415tHoSbmTAX",
+    "size" : 1338258273,
+    "license" : "https://www.example.com/chkssquci2uvoucsdqq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "3XsgwbUy7vF5",
-    "publishedDate" : "1993-08-08T07:07:08.315Z",
+    "legalNote" : "DBbgRYxrPKBI6rg",
+    "publishedDate" : "2000-03-16T21:56:00.517Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "COQEMCsPpfh8Ee6jVK",
-      "uploadedDate" : "2019-04-22T22:38:39.302Z"
+      "uploadedBy" : "uXrWzCxcLZS",
+      "uploadedDate" : "2013-01-12T09:56:14.075Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/iZUtXznkweS9yLXse",
-    "name" : "hYJe7bGgmePn",
-    "description" : "3GRsNA9wYI9YZMNwnHP"
+    "id" : "https://www.example.com/3DKgLtXhrDDC3rcNA",
+    "name" : "JuUR483hNetRWOdJ",
+    "description" : "g9uE4cUKkQK8Wp19t"
   } ],
-  "rightsHolder" : "UA55NL2QnfLn",
-  "duplicateOf" : "https://www.example.org/b65790e7-c65d-4ec3-a43a-68f7b282a465",
+  "rightsHolder" : "SKLKJs6u3xI1Vpu",
+  "duplicateOf" : "https://www.example.org/79e23426-92b2-4f75-a6e3-fe4a4388dc04",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "R4afMi9ynlY7p"
+    "note" : "DdhOX4Qji4Zxi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1cqYnXGB56RYWkMDi",
-    "createdBy" : "XRhdpFK8Uvbz309LD",
-    "createdDate" : "1982-12-26T01:31:56.181Z"
+    "note" : "SXEJrBDdBJjvvN8GHtJ",
+    "createdBy" : "MONQY3KqJS",
+    "createdDate" : "1972-09-29T23:25:40.260Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9e682fa4-f07e-40da-8284-e3b6131a79f5" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/97ba8671-bb3a-467b-be5d-b3ad348cb0f2" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "fcSvph1WrdsKs",
-    "ownerAffiliation" : "https://www.example.org/e88a851e-4325-4fbb-9ec4-030aebc49ba9"
+    "owner" : "NgeLkF3G3X",
+    "ownerAffiliation" : "https://www.example.org/f3d20c71-c98b-489c-a3c1-80ed25158527"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/60fef2c1-a313-41f2-9f33-7f9545621f81"
+    "id" : "https://www.example.org/d8d58ed9-bad9-4ad4-990f-75506ab78476"
   },
-  "createdDate" : "1992-02-11T12:29:33.379Z",
-  "modifiedDate" : "2000-06-26T21:16:59.894Z",
-  "publishedDate" : "1988-12-21T23:07:35.231Z",
-  "indexedDate" : "2007-04-04T00:55:53.977Z",
-  "handle" : "https://www.example.org/5f1b7203-0f14-4250-ae40-1571918263c4",
+  "createdDate" : "2014-10-14T16:24:42.676Z",
+  "modifiedDate" : "2000-06-19T12:46:32.477Z",
+  "publishedDate" : "2005-06-20T00:46:54.103Z",
+  "indexedDate" : "2000-05-22T13:16:56.116Z",
+  "handle" : "https://www.example.org/f933e619-39c8-4911-87cb-4899211ee30a",
   "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/f27d6fe0-3db0-421b-8681-509ff9e614f7",
+  "link" : "https://www.example.org/2041781b-bd41-4fae-a980-86043114ac60",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "dAiZBC4Bg0sBH3kll",
+    "mainTitle" : "7bWj02qdL3b",
     "alternativeTitles" : {
-      "pt" : "ij8cBURg73"
+      "pl" : "5Wik6yQ2Akk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "54yhcjid0HT16S",
-      "month" : "WDIL9ELtkCGO",
-      "day" : "oEzwOS5lFP5zz"
+      "year" : "1KDnrnuQ0ES",
+      "month" : "4k04O1gA4CEcQ",
+      "day" : "1iady9jYwThJzDlX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0b4322fa-d0a9-429a-a081-d5400a2b2f36",
-        "name" : "tS3deZlMkTS",
-        "nameType" : "Organizational",
-        "orcId" : "YVNkyutnJv",
+        "id" : "https://www.example.org/99f25bd3-df61-4968-8a17-12f6084481ad",
+        "name" : "IAYVh3eCrjP3",
+        "nameType" : "Personal",
+        "orcId" : "HOCuKx5DnBFHU7k2p8Z",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OjzoS9QnAHSgsNB8",
-          "value" : "WY3qotaVwO1dLcOhgoN"
+          "sourceName" : "sW0Lk5EviB50L0",
+          "value" : "2yxyOFaClt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "A53tGgxqqg9VG1M4",
-          "value" : "BXtIsIrj2Ka"
+          "sourceName" : "pRdmHh3DioNd9V45v7",
+          "value" : "tFCdLATxm3t6g2fX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d6b199a1-1d48-41b7-b08b-a794ac39a534"
+        "id" : "https://www.example.org/a9b1ec4d-c0d9-4653-afd3-a47b16f7e4cc"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/53e7c37f-7144-480c-8fdf-e060ca59028f",
-        "name" : "JrGxgQ5BlD",
+        "id" : "https://www.example.org/4ebb82ad-34d2-42c6-8cb8-5ab9c0d46690",
+        "name" : "2sURndcL7uvm",
         "nameType" : "Personal",
-        "orcId" : "pJuNu3DxVtrV",
-        "verificationStatus" : "Verified",
+        "orcId" : "v9JejpSZGLS",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rDcQrsTEry6a",
-          "value" : "Gyq15uUrkZKXygFr8zc"
+          "sourceName" : "5Gde2QxfYwH0",
+          "value" : "hY8gLD022fgHXuR6vw4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fm1NxeDwH3ucjT",
-          "value" : "geaMlgJFJfFJX"
+          "sourceName" : "jLshMM5mytuMxC",
+          "value" : "c4n1hq1MGoBwB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/05eafde7-9233-47a2-a16f-3596e6372d7d"
+        "id" : "https://www.example.org/cbb530f2-62d0-4557-9d26-398bfee7d34e"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "6Np9ocZ6flt7KEdcv"
+      "el" : "hgxgVCJe5MsFjSh"
     },
-    "npiSubjectHeading" : "fkAEfD65hMiyFG5Pwa",
-    "tags" : [ "fP2TyqdjgOq" ],
-    "description" : "b7vEGlC3wMF4aTP",
+    "npiSubjectHeading" : "bSzhBZtN2rtCsYMxD",
+    "tags" : [ "RKo7NHLkuUUlm4L91Q" ],
+    "description" : "1BBTcyT7CzzkXn",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8def23ae-13a8-48f7-a3f9-f725e21347e6"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a6da7138-3a1b-4478-b93a-47c0d61baab8"
       },
-      "doi" : "https://www.example.org/f85ccb36-4511-4f33-9971-8e9b87d11f16",
+      "doi" : "https://www.example.org/4dd75be0-e429-42c6-a8ff-9ab05e0224db",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "g9NuNqMNNi",
-        "issue" : "6QkIxE02eG6Q95Y",
-        "articleNumber" : "vrq6Y39BpDIjHAE9",
+        "volume" : "mFe4FvQ3QV3G91YVK",
+        "issue" : "YqTtn5pvfeM2SdO",
+        "articleNumber" : "GSEXvDt4x1Y8g7xLcb",
         "pages" : {
           "type" : "Range",
-          "begin" : "idilKrFpSwP",
-          "end" : "FZvhe2jnnzydTnlM"
+          "begin" : "XCYXbxF9W7dnSBu",
+          "end" : "M0SwexIGCXf94"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/15bef1e4-3b83-425d-952e-add96ec48b91",
-    "abstract" : "UcNM5b3KyDocc"
+    "metadataSource" : "https://www.example.org/024e77d6-7b75-4eb6-abb4-d59689f12777",
+    "abstract" : "VDLd8HuWNRUm9fLZ9n"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/08817b1c-7454-4d10-acd2-21b0aac95bf3",
-    "name" : "f8YSMGN05E",
+    "id" : "https://www.example.org/36db0364-2ca2-49d9-a14b-9fa758a13c92",
+    "name" : "MIuUB8EBmUwdVlBocn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-08-29T07:31:35.089Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1992-11-17T20:03:00.692Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "hKTiSOk8zWntGOvAA5"
+      "applicationCode" : "TarAAvUjt3SuMxW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1e0651f9-fced-4def-82a2-04565a2a4265",
-    "identifier" : "iIZ6jy56cuf",
+    "source" : "https://www.example.org/d087fc5e-0bc0-4f3b-88ff-62655ae18eb0",
+    "identifier" : "MUxo3ngtRXG",
     "labels" : {
-      "nb" : "ZDFZiBdW9LvBKc62bm3"
+      "af" : "iF0Hf9vhaIB"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 699322291
+      "currency" : "EUR",
+      "amount" : 1850444071
     },
-    "activeFrom" : "1987-08-28T07:55:36.456Z",
-    "activeTo" : "2011-08-27T00:29:58.308Z"
+    "activeFrom" : "1987-10-29T22:02:39.438Z",
+    "activeTo" : "2015-06-01T21:17:10.196Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/08ea4998-1d67-4172-808d-04815f18a8d4",
-    "id" : "https://www.example.org/a568f419-3cd0-4fd6-a9d4-08ad87ca91b9",
-    "identifier" : "3YKNQKI9zW1L7k",
+    "source" : "https://www.example.org/da0027c2-00b6-4212-92d4-7d6029ec245c",
+    "id" : "https://www.example.org/1e2dd497-3d61-4f04-9385-c8c3225ea6c4",
+    "identifier" : "sKqWAoeB0MhfQ",
     "labels" : {
-      "ca" : "j3jdrvLGgDy"
+      "ru" : "c3nnE8D76PzL"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 120418852
+      "currency" : "NOK",
+      "amount" : 1069805859
     },
-    "activeFrom" : "1974-12-27T12:47:55.728Z",
-    "activeTo" : "2023-03-12T18:03:34.719Z"
+    "activeFrom" : "1975-10-05T10:16:46.031Z",
+    "activeTo" : "1990-04-01T07:50:37.114Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d7f70525-44c7-450e-a264-e4d2f8ebf64d" ],
+  "subjects" : [ "https://www.example.org/daf0e181-2224-41e3-b546-a8abd0ba6dc2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "61d697b4-f1f7-4838-96fe-1810396d9ba8",
-    "name" : "bmZgolQCu1I",
-    "mimeType" : "415tHoSbmTAX",
-    "size" : 1338258273,
-    "license" : "https://www.example.com/chkssquci2uvoucsdqq",
+    "identifier" : "c851c6e3-d5f1-45de-a33a-cfe5dd6dec6e",
+    "name" : "lUhmvTdDmtcUEB9",
+    "mimeType" : "ww2PGmeiGZ7lbupww",
+    "size" : 1758267315,
+    "license" : "https://www.example.com/k5mpy0mfk6",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "YlnoGfafppV"
     },
-    "legalNote" : "DBbgRYxrPKBI6rg",
-    "publishedDate" : "2000-03-16T21:56:00.517Z",
+    "legalNote" : "WPCYSpAebBjW",
+    "publishedDate" : "2019-03-18T17:50:36.747Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uXrWzCxcLZS",
-      "uploadedDate" : "2013-01-12T09:56:14.075Z"
+      "uploadedBy" : "ZKrNhFjtK1UEjtj73ao",
+      "uploadedDate" : "1972-12-16T05:51:44.704Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3DKgLtXhrDDC3rcNA",
-    "name" : "JuUR483hNetRWOdJ",
-    "description" : "g9uE4cUKkQK8Wp19t"
+    "id" : "https://www.example.com/aUEwDUTslgLIDGgw",
+    "name" : "ddZnAMC54csmp2YTj",
+    "description" : "eNCH8PBHcXLxraMg"
   } ],
-  "rightsHolder" : "SKLKJs6u3xI1Vpu",
-  "duplicateOf" : "https://www.example.org/79e23426-92b2-4f75-a6e3-fe4a4388dc04",
+  "rightsHolder" : "RBbXCLbAIc",
+  "duplicateOf" : "https://www.example.org/9b43e379-4979-4ee0-aaf9-2b52125fd76d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DdhOX4Qji4Zxi"
+    "note" : "Chl6HWyukVLrjIes0h"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SXEJrBDdBJjvvN8GHtJ",
-    "createdBy" : "MONQY3KqJS",
-    "createdDate" : "1972-09-29T23:25:40.260Z"
+    "note" : "z9WHYjZYF5o",
+    "createdBy" : "zkiNddOqeGoGdH",
+    "createdDate" : "2015-01-03T06:52:50.836Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/97ba8671-bb3a-467b-be5d-b3ad348cb0f2" ],
+  "curatingInstitutions" : [ "https://www.example.org/418a06d4-4dc5-4972-b10b-f5188d48c958" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "b6TzarZiHMdew",
-    "ownerAffiliation" : "https://www.example.org/a87e68ca-5cee-45eb-8e77-12b05262ba35"
+    "owner" : "ojU4MKNw9PMg0uXoXbn",
+    "ownerAffiliation" : "https://www.example.org/37753f99-5507-4bee-9121-475a2201df9c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/41d9623e-242a-4044-bd17-bed2c6e994ad"
+    "id" : "https://www.example.org/7a07c72c-bbaf-41c0-8c85-b0056c6d0f12"
   },
-  "createdDate" : "1997-02-15T23:03:58.663Z",
-  "modifiedDate" : "1984-05-23T05:51:30.022Z",
-  "publishedDate" : "2001-08-17T10:15:40.379Z",
-  "indexedDate" : "2021-05-04T11:35:55.582Z",
-  "handle" : "https://www.example.org/a2eaa70d-df80-452c-ac43-c5e633552dad",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/979145bc-1a89-4166-b7e3-ac51266dac78",
+  "createdDate" : "1990-05-31T08:23:23.111Z",
+  "modifiedDate" : "2015-03-22T08:17:30.604Z",
+  "publishedDate" : "1981-10-24T13:02:49.132Z",
+  "indexedDate" : "1983-03-10T09:16:41.777Z",
+  "handle" : "https://www.example.org/aa701788-a919-4b02-bab8-d2b0b286f229",
+  "doi" : "https://doi.org/10.1234/nulla",
+  "link" : "https://www.example.org/2c64caa3-3806-40a6-b5d3-3d8aeb5ee1ab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "SYW0XUlVG1ndE",
+    "mainTitle" : "RoOHagFCv8",
     "alternativeTitles" : {
-      "af" : "uAlECwUWMq"
+      "en" : "4NKHoK4n36TQgKBU0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wpvueCi4MTeie3DEZ8s",
-      "month" : "Q6PRALyRsQB",
-      "day" : "c44k30DqxpS"
+      "year" : "szFmk2jTsem2aMObEcd",
+      "month" : "UfU8gDYSIE1MlSF",
+      "day" : "DVY8hQ9beSS78S"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/78afea9c-c51b-431d-8737-e5c0a7d22e0a",
-        "name" : "q56jCyEcSuN7",
-        "nameType" : "Personal",
-        "orcId" : "h7STyNm2mbmLYr",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/1f81adfc-eb0e-4425-969a-1b5d38ed6bdc",
+        "name" : "Y7uhyzNsKHG3ZVs",
+        "nameType" : "Organizational",
+        "orcId" : "OYSNdljqlvqM",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8s54mTxWvE",
-          "value" : "tuYnIceNV2ZgYv119"
+          "sourceName" : "BJqiVbWv28ss45SXs",
+          "value" : "Ye8DyBUvJvlKcf8c"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZgVOl37SeEKHlQwQnF",
-          "value" : "C7qK0paYnZGTYh"
+          "sourceName" : "pKyHE5afAgj9OtNEnBT",
+          "value" : "VT3q55hRyOl2P5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/421e12a4-dcf7-469a-916e-be32db3cb879"
+        "id" : "https://www.example.org/ba46d53e-4fb9-4315-bd5f-63919746a862"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1f186787-20a0-4846-8a05-80d246c47ebc",
-        "name" : "PMQx79DW4gPCq3",
+        "id" : "https://www.example.org/e116689b-af2f-4094-87da-49494af8f477",
+        "name" : "3pJjOaalkN",
         "nameType" : "Organizational",
-        "orcId" : "0Lbv3Uiy1U0x910sjK",
-        "verificationStatus" : "Verified",
+        "orcId" : "IC2JZA5ZJ0Au",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ohdLcrMXzbXkY",
-          "value" : "04P7FsjWif8y59"
+          "sourceName" : "BFOpGKarUs9Pz8nHnlS",
+          "value" : "7XoZKsID0tLYkR3YF6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DApUNGPVdY8Ea1MIl",
-          "value" : "vKVBubBMWEw7IO"
+          "sourceName" : "V6Pot8lP15k8cVYtT0",
+          "value" : "jfWEXq9FMyM5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a5679bef-3190-4d86-bd22-e3a4adb817be"
+        "id" : "https://www.example.org/55e34198-2696-49a0-8993-11619a66f063"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "KdXIalIGi9BA9eefD"
+      "fr" : "HD4bk3ZAgkRs"
     },
-    "npiSubjectHeading" : "oo0hYJNF3BC",
-    "tags" : [ "VhvuqfV5gIxVo" ],
-    "description" : "9tEHcZJAmNnnnkK",
+    "npiSubjectHeading" : "def669Bqvngd",
+    "tags" : [ "oWL3bpgdNKo" ],
+    "description" : "ZEpjoyoQeO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/92f621e1-d3c8-41e2-aa5f-e90494a924b5"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/63c79d20-aa7e-44ed-8529-11e5a6197ad4"
       },
-      "doi" : "https://www.example.org/f47d296c-992f-4643-8845-84170be7309d",
+      "doi" : "https://www.example.org/eb0737b0-ebdb-4479-b562-6afd961d20f7",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "fn0clK4kAE",
-        "issue" : "YahWvmkAYl",
-        "articleNumber" : "PavRkI62fN",
+        "volume" : "DBKHSGBW5ziKMPoJJS",
+        "issue" : "9LafCYZqrJ65ow",
+        "articleNumber" : "jfc7wdHk5T3ICD",
         "pages" : {
           "type" : "Range",
-          "begin" : "GRB26kgrFWt",
-          "end" : "L4Ck3BOzcvhYTkxq94"
+          "begin" : "cf9xlvKA9nUbUpso",
+          "end" : "s7WvAa6jW59"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1dcd913f-7f87-429f-8e9d-7600fdce4d42",
-    "abstract" : "bKXokfcBBFMtzF7ByE"
+    "metadataSource" : "https://www.example.org/a8dab019-e647-4244-8b66-703330f0028f",
+    "abstract" : "fW6Acd5bt4oLCu1YMN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e24bba36-1dc8-4c24-a94c-2489f5b68c68",
-    "name" : "mVuglS5FPysD7",
+    "id" : "https://www.example.org/64a0e111-6542-4204-bbbc-2a8aff55e2e6",
+    "name" : "zOsXSfK9FjA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-01-10T21:16:13.580Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ZGU7uwB5jN6q32"
+      "approvalDate" : "2001-10-05T15:57:54.330Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "2OkxlTdYBL"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8899d01e-95c5-479a-87f6-c67b1afc779d",
-    "identifier" : "ULj5kiORPPr",
+    "source" : "https://www.example.org/f1dd415b-f96d-415f-99a2-e4ee3036400f",
+    "identifier" : "NeO53jU7eAPv2NFSQ",
     "labels" : {
-      "af" : "vUxlIO5rRhY9"
+      "nl" : "K3PuAfLPCxlv8NJZUb"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1935569656
+      "amount" : 812025338
     },
-    "activeFrom" : "2013-09-02T07:46:55.277Z",
-    "activeTo" : "2015-04-20T05:56:55.395Z"
+    "activeFrom" : "1990-01-21T04:14:48.276Z",
+    "activeTo" : "1997-07-08T04:07:01.643Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2b8bf2e5-d1c7-4e52-9d4f-5a60743b9c6e",
-    "id" : "https://www.example.org/cd1593ba-ce1a-46bd-ba25-95c35b55fc9b",
-    "identifier" : "CW3WA9J5mwqX7uw9",
+    "source" : "https://www.example.org/1d141776-2ce9-453c-9b0a-abe97068ebad",
+    "id" : "https://www.example.org/e20eb3cd-7176-4c99-bba6-3d7e8dd924cf",
+    "identifier" : "eJlzJRBP5yebf23d",
     "labels" : {
-      "it" : "6pj25Ptz7pSE6AS9Oh"
+      "af" : "Yp7wT360bsqDB8Raplt"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 339719385
+      "currency" : "GBP",
+      "amount" : 1033691357
     },
-    "activeFrom" : "2005-05-05T05:25:29.726Z",
-    "activeTo" : "2020-06-10T20:37:17.599Z"
+    "activeFrom" : "1996-11-26T10:36:25.555Z",
+    "activeTo" : "2021-03-28T23:14:18.088Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/49f8a080-7974-4eb2-93f3-b47736e5f6e5" ],
+  "subjects" : [ "https://www.example.org/18909400-cf1c-47ca-80a5-5d04a4238c9e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d3202979-7115-4398-a2d6-669e25d3c280",
-    "name" : "hbgiqphmq9Cb",
-    "mimeType" : "AmV7ZtpRIciZsVTkhX",
-    "size" : 13627338,
-    "license" : "https://www.example.com/p65dn9liq3noeplrw",
+    "identifier" : "5daf31fa-e7ad-4807-b58f-27d9cafcf55e",
+    "name" : "EdUQCh1IRf5kUlw7a9o",
+    "mimeType" : "W3VSL0WFNJr",
+    "size" : 736740971,
+    "license" : "https://www.example.com/wegrrbkoqbsmy1a",
     "administrativeAgreement" : false,
     "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Uu2U2Dh3oGoId6VP",
-    "publishedDate" : "2014-07-29T02:30:22.935Z",
+    "legalNote" : "Ylx8dFQtyVT8P0hk4",
+    "publishedDate" : "2015-04-12T14:27:14.034Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "VZIaYRB8pjysjB8d",
-      "uploadedDate" : "1972-02-29T18:28:02.958Z"
+      "uploadedBy" : "86GtreDa31Z00jOhh",
+      "uploadedDate" : "2016-11-25T20:37:09.228Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/xs0cXDIAmkTNN8f",
-    "name" : "8KgKiZeb2q2",
-    "description" : "oGHEekvd3z1g4RR"
+    "id" : "https://www.example.com/uF2Q2qKOZFnmvENRZh",
+    "name" : "q6frDkPJgfjw10",
+    "description" : "yiURx5AMj6"
   } ],
-  "rightsHolder" : "sD6DBRRxS6U7Ha9RVOY",
-  "duplicateOf" : "https://www.example.org/0b12cb25-56c0-43c5-b21b-ad9bcfea81b0",
+  "rightsHolder" : "0Pgy78MOYwdt4Zd",
+  "duplicateOf" : "https://www.example.org/8e3366a2-04b3-4c5f-a37f-1aeeff9dc918",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "uF1HlOz0rtapNmMyNB"
+    "note" : "YexTSxexX3p4TB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "O7Ac82xLgOwf1ZSFR",
-    "createdBy" : "WQj73WbcwFKDSJhxG5l",
-    "createdDate" : "1972-03-29T21:16:25.553Z"
+    "note" : "9yMreBgfQXsLsIuzAM",
+    "createdBy" : "S7BA2G4UAt8YyWgc80N",
+    "createdDate" : "1984-04-04T16:44:30.269Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f5a20f63-e9b5-42b4-91f3-26f275a330c3" ],
+  "curatingInstitutions" : [ "https://www.example.org/461a0dd0-d317-4c04-a614-2c42851c4c14" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "XbpGVkkSmY4Nfil",
-    "ownerAffiliation" : "https://www.example.org/905d1c4c-0ed1-464e-8359-35cbdfc1ecd2"
+    "owner" : "b6TzarZiHMdew",
+    "ownerAffiliation" : "https://www.example.org/a87e68ca-5cee-45eb-8e77-12b05262ba35"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/17f4393b-8c3f-44fd-a0da-c6396defb0de"
+    "id" : "https://www.example.org/41d9623e-242a-4044-bd17-bed2c6e994ad"
   },
-  "createdDate" : "2008-10-06T08:55:46.901Z",
-  "modifiedDate" : "1977-09-17T02:29:52.349Z",
-  "publishedDate" : "1985-11-04T14:18:15.027Z",
-  "indexedDate" : "1981-10-03T00:59:17.707Z",
-  "handle" : "https://www.example.org/8f786a15-f6d9-49da-ade0-5cde8aee5eea",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/ad623bac-0bbf-45fe-be2f-e9dd0a46d722",
+  "createdDate" : "1997-02-15T23:03:58.663Z",
+  "modifiedDate" : "1984-05-23T05:51:30.022Z",
+  "publishedDate" : "2001-08-17T10:15:40.379Z",
+  "indexedDate" : "2021-05-04T11:35:55.582Z",
+  "handle" : "https://www.example.org/a2eaa70d-df80-452c-ac43-c5e633552dad",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/979145bc-1a89-4166-b7e3-ac51266dac78",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "76gvxXzM7Usb2h4GzM",
+    "mainTitle" : "SYW0XUlVG1ndE",
     "alternativeTitles" : {
-      "es" : "RDbn3XIdVJ8NiPdoDCq"
+      "af" : "uAlECwUWMq"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "alWFJFw89unI",
-      "month" : "LrF2LcvfZM0YLJ",
-      "day" : "nvjhtTjRVpSc5Ac6Kdj"
+      "year" : "wpvueCi4MTeie3DEZ8s",
+      "month" : "Q6PRALyRsQB",
+      "day" : "c44k30DqxpS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cf8e9f4e-222c-4bc8-996f-48de81f17d92",
-        "name" : "u2FCxcwVnnerZotD",
-        "nameType" : "Organizational",
-        "orcId" : "jbzhZjmrPJP8",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/78afea9c-c51b-431d-8737-e5c0a7d22e0a",
+        "name" : "q56jCyEcSuN7",
+        "nameType" : "Personal",
+        "orcId" : "h7STyNm2mbmLYr",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TQ8rKKqnC4ixgy9vKB",
-          "value" : "99ttzL0CVEJyjl04"
+          "sourceName" : "8s54mTxWvE",
+          "value" : "tuYnIceNV2ZgYv119"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nGgUa6fdUmKtI",
-          "value" : "WghwsymiaQoi1xxsi"
+          "sourceName" : "ZgVOl37SeEKHlQwQnF",
+          "value" : "C7qK0paYnZGTYh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c3ff394f-3cea-4e4d-b5b7-02bd9df43a42"
+        "id" : "https://www.example.org/421e12a4-dcf7-469a-916e-be32db3cb879"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5b361c27-9a7e-4e58-b9e3-e1a2fa287399",
-        "name" : "EkqeSfckox3SRR8hT",
-        "nameType" : "Personal",
-        "orcId" : "kbuXXx2LktrV",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1f186787-20a0-4846-8a05-80d246c47ebc",
+        "name" : "PMQx79DW4gPCq3",
+        "nameType" : "Organizational",
+        "orcId" : "0Lbv3Uiy1U0x910sjK",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QKnnQ7zHT4H9JRII",
-          "value" : "F8YxbYFOzMZ5o"
+          "sourceName" : "ohdLcrMXzbXkY",
+          "value" : "04P7FsjWif8y59"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tgEQm86W26Q47Y",
-          "value" : "IOd56v0mItNDQv8wK"
+          "sourceName" : "DApUNGPVdY8Ea1MIl",
+          "value" : "vKVBubBMWEw7IO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ba28b383-7f86-49b3-8f0a-a3ed485b3745"
+        "id" : "https://www.example.org/a5679bef-3190-4d86-bd22-e3a4adb817be"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "1kkqRG3is0Dll"
+      "fi" : "KdXIalIGi9BA9eefD"
     },
-    "npiSubjectHeading" : "hoRzju2sQT",
-    "tags" : [ "1BE2Ly32EnQVZrkQzO" ],
-    "description" : "cczIGQaGwPDlqkWD",
+    "npiSubjectHeading" : "oo0hYJNF3BC",
+    "tags" : [ "VhvuqfV5gIxVo" ],
+    "description" : "9tEHcZJAmNnnnkK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/78acabc5-d646-4ecc-bad0-c4d8528ce91e"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/92f621e1-d3c8-41e2-aa5f-e90494a924b5"
       },
-      "doi" : "https://www.example.org/99325585-13fa-4cab-9fcd-ee946e223a0d",
+      "doi" : "https://www.example.org/f47d296c-992f-4643-8845-84170be7309d",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "XQC036F5CB1V",
-        "issue" : "sDZ74mANst",
-        "articleNumber" : "5p7TSUoJ1lzev8N7K",
+        "volume" : "fn0clK4kAE",
+        "issue" : "YahWvmkAYl",
+        "articleNumber" : "PavRkI62fN",
         "pages" : {
           "type" : "Range",
-          "begin" : "uL5gzsq58Q0e1z",
-          "end" : "8I4wNOZBrGal508T"
+          "begin" : "GRB26kgrFWt",
+          "end" : "L4Ck3BOzcvhYTkxq94"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2353a515-9cc7-4e73-b423-43fdd6d366e9",
-    "abstract" : "0Vopd6egwZDNVb"
+    "metadataSource" : "https://www.example.org/1dcd913f-7f87-429f-8e9d-7600fdce4d42",
+    "abstract" : "bKXokfcBBFMtzF7ByE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0c797414-560f-4d62-b179-f1c079911d7b",
-    "name" : "LavXf9nv6j6BhME8o7",
+    "id" : "https://www.example.org/e24bba36-1dc8-4c24-a94c-2489f5b68c68",
+    "name" : "mVuglS5FPysD7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-02-02T22:17:47.881Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "BH8nSHleJpnxDqTBIA"
+      "approvalDate" : "1980-01-10T21:16:13.580Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ZGU7uwB5jN6q32"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/318b48c7-d97e-4dff-a55c-0353505b0f6d",
-    "identifier" : "ZhuQY7VmMAIymv13v5",
+    "source" : "https://www.example.org/8899d01e-95c5-479a-87f6-c67b1afc779d",
+    "identifier" : "ULj5kiORPPr",
     "labels" : {
-      "de" : "Wu0sxWsiR5rkTyWx"
+      "af" : "vUxlIO5rRhY9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1377918213
+      "currency" : "NOK",
+      "amount" : 1935569656
     },
-    "activeFrom" : "2007-02-15T07:40:16.073Z",
-    "activeTo" : "2013-05-08T14:51:44.624Z"
+    "activeFrom" : "2013-09-02T07:46:55.277Z",
+    "activeTo" : "2015-04-20T05:56:55.395Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cbe3e1e8-e7a3-43f8-b96d-a4fba93d6564",
-    "id" : "https://www.example.org/668954cc-2c33-4c18-8a6b-7933e3ba4464",
-    "identifier" : "02mna6vE6PGkj",
+    "source" : "https://www.example.org/2b8bf2e5-d1c7-4e52-9d4f-5a60743b9c6e",
+    "id" : "https://www.example.org/cd1593ba-ce1a-46bd-ba25-95c35b55fc9b",
+    "identifier" : "CW3WA9J5mwqX7uw9",
     "labels" : {
-      "de" : "dPvUSv0WEa"
+      "it" : "6pj25Ptz7pSE6AS9Oh"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 460206619
+      "amount" : 339719385
     },
-    "activeFrom" : "2012-11-07T13:47:28.972Z",
-    "activeTo" : "2021-04-12T18:03:00.911Z"
+    "activeFrom" : "2005-05-05T05:25:29.726Z",
+    "activeTo" : "2020-06-10T20:37:17.599Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1ecb59c8-1b17-49b1-9a2b-da397ef8a9c4" ],
+  "subjects" : [ "https://www.example.org/49f8a080-7974-4eb2-93f3-b47736e5f6e5" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "50060455-7466-455a-a30e-b2cecc2f8bb1",
-    "name" : "jZQdobAqwdnm4s",
-    "mimeType" : "qYKQCr1EWwT",
-    "size" : 352593408,
-    "license" : "https://www.example.com/6u58brrqg5mlzi8z3",
+    "identifier" : "d3202979-7115-4398-a2d6-669e25d3c280",
+    "name" : "hbgiqphmq9Cb",
+    "mimeType" : "AmV7ZtpRIciZsVTkhX",
+    "size" : 13627338,
+    "license" : "https://www.example.com/p65dn9liq3noeplrw",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "rFFwpKZ8uzeb",
-    "publishedDate" : "1972-01-16T06:28:39.901Z",
+    "legalNote" : "Uu2U2Dh3oGoId6VP",
+    "publishedDate" : "2014-07-29T02:30:22.935Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uVHM0d8OyIN",
-      "uploadedDate" : "1979-03-25T07:15:55.408Z"
+      "uploadedBy" : "VZIaYRB8pjysjB8d",
+      "uploadedDate" : "1972-02-29T18:28:02.958Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/OzYwMO9l4wmjr",
-    "name" : "BdxswjDiTtrrfPI",
-    "description" : "meQHlMN8u2hjA"
+    "id" : "https://www.example.com/xs0cXDIAmkTNN8f",
+    "name" : "8KgKiZeb2q2",
+    "description" : "oGHEekvd3z1g4RR"
   } ],
-  "rightsHolder" : "egy8fbURVLH0hZf",
-  "duplicateOf" : "https://www.example.org/6583c0e5-21e6-450a-9244-a64cbad4127e",
+  "rightsHolder" : "sD6DBRRxS6U7Ha9RVOY",
+  "duplicateOf" : "https://www.example.org/0b12cb25-56c0-43c5-b21b-ad9bcfea81b0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "6BjB59FLgVM4"
+    "note" : "uF1HlOz0rtapNmMyNB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "HMmnnB00aG2",
-    "createdBy" : "5KRCOQgXE7tjH",
-    "createdDate" : "2006-02-27T02:33:14.585Z"
+    "note" : "O7Ac82xLgOwf1ZSFR",
+    "createdBy" : "WQj73WbcwFKDSJhxG5l",
+    "createdDate" : "1972-03-29T21:16:25.553Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/548c533b-4667-478d-be99-5bb7b12a13d3" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/f5a20f63-e9b5-42b4-91f3-26f275a330c3" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "aLz52OSKhbIAU",
-    "ownerAffiliation" : "https://www.example.org/741f2513-f7eb-4794-a3dc-187890a97204"
+    "owner" : "OnkDol9t4S5EUDzV",
+    "ownerAffiliation" : "https://www.example.org/f9446932-da46-4d0b-91bb-5e9d1517bdf7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a4144c49-ef57-4fde-9c56-9ca8e42e88a5"
+    "id" : "https://www.example.org/45f4931d-822f-4a00-8749-865dacdb207b"
   },
-  "createdDate" : "2009-09-26T02:34:05.552Z",
-  "modifiedDate" : "1992-01-22T08:15:12.797Z",
-  "publishedDate" : "2005-09-12T12:36:28.871Z",
-  "indexedDate" : "2024-05-19T14:42:39.841Z",
-  "handle" : "https://www.example.org/b128b451-f503-412f-bc39-70e93b98cbec",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/d6ac2636-c88c-43a5-9a35-6ca83fad270b",
+  "createdDate" : "1979-02-18T02:19:03.157Z",
+  "modifiedDate" : "2022-10-30T08:18:20.016Z",
+  "publishedDate" : "2004-01-19T01:03:03.600Z",
+  "indexedDate" : "2008-08-26T04:23:43.133Z",
+  "handle" : "https://www.example.org/a275474a-4927-4a20-9b70-1645e9d9725c",
+  "doi" : "https://doi.org/10.1234/earum",
+  "link" : "https://www.example.org/4531e7e1-f5b7-44a8-862a-35b636d33ee0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zMhAh3KGCJUnrGW",
+    "mainTitle" : "BQ0znInGD10M2",
     "alternativeTitles" : {
-      "nb" : "zyGc9kafrteysHyK6k"
+      "fr" : "FL2bcmXnXzY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "kf0lT1WTFqg",
-      "month" : "KKhrpZ3XiBRSC5",
-      "day" : "i8ESd7CsTpl488O"
+      "year" : "5SWXcLYMvuyiAV",
+      "month" : "LzZRODIhJia5IWc",
+      "day" : "02JcNhhqliSSmPtoin6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/77a9bbec-69bb-4b3e-a4d5-0ded33c7c743",
-        "name" : "IC3hx9xx3vdUlHwl",
+        "id" : "https://www.example.org/17f912f3-ae09-4746-861f-64f6dc9d5baf",
+        "name" : "XVMfWsRCDfX510aO",
         "nameType" : "Personal",
-        "orcId" : "RzztAHlrlz6",
-        "verificationStatus" : "Verified",
+        "orcId" : "9hmCReuerWVcrCel8F",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OG3js8QtcgeJprBJ",
-          "value" : "AhMbL5MbKYZky7v"
+          "sourceName" : "xRs3VFzEYOTFQcO",
+          "value" : "yzi2ajjU5JpHu6UzYe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PfbBFN6RCk3cTuOTw6",
-          "value" : "QhsWxGkJMWC"
+          "sourceName" : "y6i4PhEaisWX3Ars",
+          "value" : "ox5WgGzakwSagafxd"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/233b9d32-bb91-48c0-9991-0827d8f10e9a"
+        "id" : "https://www.example.org/3929ea7a-594a-4ae7-9696-ee6e1a790c3f"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "Organizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/226710b9-32ed-4ed0-8e9a-e7ed40ab0cf0",
-        "name" : "9YWL2W7NP0AFr",
+        "id" : "https://www.example.org/a892b9ea-8293-4c98-8ef7-6ba2eb78ac1e",
+        "name" : "DDpABU2b9si",
         "nameType" : "Organizational",
-        "orcId" : "zAvXJZz8BDxdhT",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "2T64DqUv7v2aDm",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e550BKk2yt9TdSQ1",
-          "value" : "kiDQyGMpHajxY1YmXy"
+          "sourceName" : "4Gjg0d3OEm7uu25f1Z",
+          "value" : "buHXH7gjRux75N"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4NbxyzNB6TKRbHLjql",
-          "value" : "7THl92ynwbraUIfyy"
+          "sourceName" : "9WJJKERgqHUC2m",
+          "value" : "hNKmYiDz8nl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/aaf10e79-a53c-42a9-b7e9-f802c61dd92d"
+        "id" : "https://www.example.org/1890205d-9e31-4ad6-9035-98cfd139bb73"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "ipwdPmlcK1"
+      "ru" : "YmDLgm3WhHnoD3A"
     },
-    "npiSubjectHeading" : "8KojNmcCoZ8Gi",
-    "tags" : [ "RPEoKfCDCxyHRdYwo" ],
-    "description" : "uTX311EE34M",
+    "npiSubjectHeading" : "5h3hnBn1Ay",
+    "tags" : [ "cYR8IIEpzx1BBr0" ],
+    "description" : "nr6AUTOGFFmi0Vm34",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "zXUCo4qzBWU",
+        "label" : "iSbuiyUg7WAMT",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "nPUuBMle3tI15amS",
-          "country" : "9MuEvX3SOfiUV"
+          "label" : "G69IeyhITJQl",
+          "country" : "bRDpfHolGMBlk2UA"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "1991-07-29T20:48:20.332Z",
-          "to" : "1997-08-17T03:29:18.822Z"
+          "type" : "Instant",
+          "value" : "2010-02-21T23:31:51.468Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/AslqFJ4HvYDZWoqMK"
+          "id" : "https://www.example.com/IzLvpJ53Cb"
         },
-        "product" : "https://www.example.com/Zf3ZKzsHnwn"
+        "product" : "https://www.example.com/f0Udp0yet1"
       },
-      "doi" : "https://www.example.org/5cd34fbf-f37f-472b-832f-4b8c928674cb",
+      "doi" : "https://www.example.org/5fc28735-9c47-4b25-922d-a3039a6f3f26",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -122,94 +121,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7bbe859a-8261-47ae-9f3a-e3fa36bb888a",
-    "abstract" : "Le9HVZn3scnTmogi"
+    "metadataSource" : "https://www.example.org/d4afc416-d33c-44c2-b0ed-7aae0d5d2c67",
+    "abstract" : "Kep0RBvvilmnL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0d05fa95-7772-48a2-838b-df449989044b",
-    "name" : "EO3CPXtCEtVhgNeWY",
+    "id" : "https://www.example.org/4f5b1d10-b68c-4ef9-9970-afb2d5616610",
+    "name" : "12o9IO35V6PW962ZnIx",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-10-29T20:18:33.226Z",
+      "approvalDate" : "1976-07-10T16:10:53.293Z",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "caRqmqsWNjsh2vSK1"
+      "applicationCode" : "Qxh6DZOaaMDVdu2S"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1cd6666c-b4b5-4c89-adac-c54a2038fb03",
-    "identifier" : "S4gsUGHqfszhLhwfVds",
+    "source" : "https://www.example.org/9f1d80aa-5491-4999-a42b-16169d859abb",
+    "identifier" : "ha17fED8jDuI3l",
     "labels" : {
-      "ru" : "joRWJa9MnM5"
+      "it" : "tSz7YF1JUozquXXc"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 492127947
+    },
+    "activeFrom" : "2001-06-08T23:29:30.482Z",
+    "activeTo" : "2003-01-11T03:27:21.744Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d428230f-726a-4f36-80b5-9be90d97ce95",
+    "id" : "https://www.example.org/108966dc-2b5b-41a0-adc7-ee972fb0a68e",
+    "identifier" : "7TktoL4SKhkgR",
+    "labels" : {
+      "en" : "LW2raCE3YNstMz3cCrc"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1988540018
+      "amount" : 1808692647
     },
-    "activeFrom" : "2009-03-09T12:51:34.946Z",
-    "activeTo" : "2018-01-10T07:17:25.278Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2d7ab1f4-5969-416a-bbd9-81829d32a40d",
-    "id" : "https://www.example.org/c261757b-c908-4bcd-aac3-ed832d1422a7",
-    "identifier" : "1rqXTy5rXdU5",
-    "labels" : {
-      "pl" : "xni00Aqozr"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 934625842
-    },
-    "activeFrom" : "1973-06-09T16:07:18.123Z",
-    "activeTo" : "1977-05-14T06:33:06.870Z"
+    "activeFrom" : "1999-05-25T17:49:52.627Z",
+    "activeTo" : "2017-10-15T22:41:54.352Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fb7a1ea2-749a-43f1-a74f-5ed01c73a271" ],
+  "subjects" : [ "https://www.example.org/ef8d3ab9-858d-41e1-80e2-e8b2ee581e19" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "466ca00d-5158-499d-9f32-084062b1bd45",
-    "name" : "0hbwKHw9kgx",
-    "mimeType" : "PBrSrwuemUe097002",
-    "size" : 2071816020,
-    "license" : "https://www.example.com/oiq3hcxsuplhfky6v2",
+    "identifier" : "6da01da0-9013-451c-9f1b-ad6015f4223a",
+    "name" : "RP16UOQQslM0Dt",
+    "mimeType" : "mbzWrMpulhnGAVH",
+    "size" : 1870948655,
+    "license" : "https://www.example.com/dlwecvbu9nf",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "kseXIzVsRp3wEFtLC"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "m8MMoFAFcwetwf",
-    "publishedDate" : "1985-03-03T11:57:44.036Z",
+    "legalNote" : "p9yLBpeVMnbN",
+    "publishedDate" : "1983-03-30T20:03:33Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Udhat2dFCq",
-      "uploadedDate" : "2002-03-07T14:27:26.538Z"
+      "uploadedBy" : "jSKPZK56UP",
+      "uploadedDate" : "1998-12-25T18:09:53.190Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ykDDJw4WuN8J",
-    "name" : "ivXWcQYepji",
-    "description" : "wwgsrS8t1lo8Bve4"
+    "id" : "https://www.example.com/b2h5c0fq93zOYx",
+    "name" : "udfdcedYICMa",
+    "description" : "2LtS25zBeDyew55QwU"
   } ],
-  "rightsHolder" : "6vPTmNVT8G",
-  "duplicateOf" : "https://www.example.org/3daed97a-9a35-4622-872e-8ead1b8df7c1",
+  "rightsHolder" : "3et90Qt8cQaT5e713HK",
+  "duplicateOf" : "https://www.example.org/a2bb9c64-7c8b-4ed5-b575-55c579633767",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "p27kxGDpq8cRurQF"
+    "note" : "sIwgpdGFUAg"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "mJMVBneikSuP",
-    "createdBy" : "BIKscCxp4edJZg",
-    "createdDate" : "2017-06-13T05:11:29.670Z"
+    "note" : "xS8kcCk5DGxr",
+    "createdBy" : "Gwx5skjIjs1xwGNLbS8",
+    "createdDate" : "2014-06-11T05:34:20.448Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f3b14287-8886-4199-a549-5c5259b603a3" ],
+  "curatingInstitutions" : [ "https://www.example.org/5275570f-1edc-45bf-b2a4-9d016c78b220" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "ZbGIfBatGKu1",
-    "ownerAffiliation" : "https://www.example.org/75513209-4233-4d1f-b7be-6a4b2f9cd072"
+    "owner" : "aLz52OSKhbIAU",
+    "ownerAffiliation" : "https://www.example.org/741f2513-f7eb-4794-a3dc-187890a97204"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2b191569-7e12-4164-8b92-8e4beb88a73f"
+    "id" : "https://www.example.org/a4144c49-ef57-4fde-9c56-9ca8e42e88a5"
   },
-  "createdDate" : "1978-06-16T06:25:17.891Z",
-  "modifiedDate" : "1992-10-16T10:36:23.977Z",
-  "publishedDate" : "1973-11-21T12:39:15.862Z",
-  "indexedDate" : "1985-01-06T01:20:44.439Z",
-  "handle" : "https://www.example.org/7c447a66-00ed-41fe-be74-636f9f358d97",
-  "doi" : "https://doi.org/10.1234/hic",
-  "link" : "https://www.example.org/9b871a08-f47b-42c0-87bf-be6b8eb792ee",
+  "createdDate" : "2009-09-26T02:34:05.552Z",
+  "modifiedDate" : "1992-01-22T08:15:12.797Z",
+  "publishedDate" : "2005-09-12T12:36:28.871Z",
+  "indexedDate" : "2024-05-19T14:42:39.841Z",
+  "handle" : "https://www.example.org/b128b451-f503-412f-bc39-70e93b98cbec",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/d6ac2636-c88c-43a5-9a35-6ca83fad270b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "K5uworl6JSHllgb",
+    "mainTitle" : "zMhAh3KGCJUnrGW",
     "alternativeTitles" : {
-      "pl" : "N7DEGT9l2OdEovy4"
+      "nb" : "zyGc9kafrteysHyK6k"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "V8ZOuLNegrs",
-      "month" : "jNpB5fZeHQPV",
-      "day" : "DNa4HlliQr"
+      "year" : "kf0lT1WTFqg",
+      "month" : "KKhrpZ3XiBRSC5",
+      "day" : "i8ESd7CsTpl488O"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a6eeac2f-bce7-46bc-8fed-a55125001faa",
-        "name" : "IRQyvdCiukGKuxhVYfB",
-        "nameType" : "Organizational",
-        "orcId" : "KMOuvtMgisVJRs",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/77a9bbec-69bb-4b3e-a4d5-0ded33c7c743",
+        "name" : "IC3hx9xx3vdUlHwl",
+        "nameType" : "Personal",
+        "orcId" : "RzztAHlrlz6",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bTb5fLIBQ5sIe",
-          "value" : "sPRW7ViMkwzRfzWgkhg"
+          "sourceName" : "OG3js8QtcgeJprBJ",
+          "value" : "AhMbL5MbKYZky7v"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "f7GtqO6itv",
-          "value" : "XOMPz1chyUh2YkCKmn"
+          "sourceName" : "PfbBFN6RCk3cTuOTw6",
+          "value" : "QhsWxGkJMWC"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8cb67452-0173-4984-9030-0319dcaa5273"
+        "id" : "https://www.example.org/233b9d32-bb91-48c0-9991-0827d8f10e9a"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6eb13099-de8e-4c69-8897-8f6a4eee098e",
-        "name" : "c2lzlkrXCcdi3BBQE8",
-        "nameType" : "Personal",
-        "orcId" : "A6eHI3l9Cz6IGmPp9y",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/226710b9-32ed-4ed0-8e9a-e7ed40ab0cf0",
+        "name" : "9YWL2W7NP0AFr",
+        "nameType" : "Organizational",
+        "orcId" : "zAvXJZz8BDxdhT",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5KNWaRB9pJx5nZ",
-          "value" : "p60pec92AA"
+          "sourceName" : "e550BKk2yt9TdSQ1",
+          "value" : "kiDQyGMpHajxY1YmXy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZkCBWLxKVW8PSzw",
-          "value" : "ihzDvMhS2Z24Og"
+          "sourceName" : "4NbxyzNB6TKRbHLjql",
+          "value" : "7THl92ynwbraUIfyy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d686d9f0-70bf-4f13-8865-1c3574100390"
+        "id" : "https://www.example.org/aaf10e79-a53c-42a9-b7e9-f802c61dd92d"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "Librettist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "v1UzJfknznm4G6rr8oq"
+      "is" : "ipwdPmlcK1"
     },
-    "npiSubjectHeading" : "tS0hSnm74jX6Ddc14x",
-    "tags" : [ "Lw5hYOVIwy" ],
-    "description" : "5EBU18txnciOYRZ1TV",
+    "npiSubjectHeading" : "8KojNmcCoZ8Gi",
+    "tags" : [ "RPEoKfCDCxyHRdYwo" ],
+    "description" : "uTX311EE34M",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "JErx3HysUS6Fk3VZUo",
+        "label" : "zXUCo4qzBWU",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "ol42MCXn7YZtT",
-          "country" : "V4rV7ePj7UUe"
+          "label" : "nPUuBMle3tI15amS",
+          "country" : "9MuEvX3SOfiUV"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "1974-10-28T13:39:10.868Z"
+          "type" : "Period",
+          "from" : "1991-07-29T20:48:20.332Z",
+          "to" : "1997-08-17T03:29:18.822Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/49OmESIzvDV4wIxVprp"
+          "id" : "https://www.example.com/AslqFJ4HvYDZWoqMK"
         },
-        "product" : "https://www.example.com/E0CI2ljCwyY"
+        "product" : "https://www.example.com/Zf3ZKzsHnwn"
       },
-      "doi" : "https://www.example.org/ed073b74-a675-45bb-aa7b-4485dcc8d019",
+      "doi" : "https://www.example.org/5cd34fbf-f37f-472b-832f-4b8c928674cb",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -121,94 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/954c486b-d29a-4e34-8837-9ae51bd40612",
-    "abstract" : "ejCIHP2kZSh3xzK"
+    "metadataSource" : "https://www.example.org/7bbe859a-8261-47ae-9f3a-e3fa36bb888a",
+    "abstract" : "Le9HVZn3scnTmogi"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a33f58af-a10f-4bbc-b7c6-64a703c2a465",
-    "name" : "clJURbHUHvFwjD2",
+    "id" : "https://www.example.org/0d05fa95-7772-48a2-838b-df449989044b",
+    "name" : "EO3CPXtCEtVhgNeWY",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-06-04T16:43:05.209Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "c2ysaM5vDHwF"
+      "approvalDate" : "1992-10-29T20:18:33.226Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "caRqmqsWNjsh2vSK1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4de6c922-b5f8-4795-bf69-42cfb2dc3961",
-    "identifier" : "YJUZ2lVcm0",
+    "source" : "https://www.example.org/1cd6666c-b4b5-4c89-adac-c54a2038fb03",
+    "identifier" : "S4gsUGHqfszhLhwfVds",
     "labels" : {
-      "pl" : "rgbgTN8f8ZzLpf"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 516871518
-    },
-    "activeFrom" : "1993-08-09T13:24:40.360Z",
-    "activeTo" : "2008-05-29T20:08:30.978Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d9e6b17b-6f0b-4647-8a20-5dd4f5d11fd0",
-    "id" : "https://www.example.org/a3522b84-084f-4e28-8fdf-516b7e541d49",
-    "identifier" : "zlTJEEndApqJLhrFs",
-    "labels" : {
-      "pl" : "wCVtHfRUkv4d"
+      "ru" : "joRWJa9MnM5"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1471491825
+      "amount" : 1988540018
     },
-    "activeFrom" : "1973-06-10T13:35:55.646Z",
-    "activeTo" : "2001-04-18T05:13:51.681Z"
+    "activeFrom" : "2009-03-09T12:51:34.946Z",
+    "activeTo" : "2018-01-10T07:17:25.278Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/2d7ab1f4-5969-416a-bbd9-81829d32a40d",
+    "id" : "https://www.example.org/c261757b-c908-4bcd-aac3-ed832d1422a7",
+    "identifier" : "1rqXTy5rXdU5",
+    "labels" : {
+      "pl" : "xni00Aqozr"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 934625842
+    },
+    "activeFrom" : "1973-06-09T16:07:18.123Z",
+    "activeTo" : "1977-05-14T06:33:06.870Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e727bfe6-43b3-4350-8206-f641802aec67" ],
+  "subjects" : [ "https://www.example.org/fb7a1ea2-749a-43f1-a74f-5ed01c73a271" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "01d4db27-ed23-4b51-b787-ee8fefd12b33",
-    "name" : "3DMHuEEqGkctv",
-    "mimeType" : "jA6qSzsgbHUEDcd",
-    "size" : 203302048,
-    "license" : "https://www.example.com/v6ldnj1in0obp047ius",
+    "identifier" : "466ca00d-5158-499d-9f32-084062b1bd45",
+    "name" : "0hbwKHw9kgx",
+    "mimeType" : "PBrSrwuemUe097002",
+    "size" : 2071816020,
+    "license" : "https://www.example.com/oiq3hcxsuplhfky6v2",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "tgw73oi9AcZXMd"
+      "overriddenBy" : "kseXIzVsRp3wEFtLC"
     },
-    "legalNote" : "NdzE5mDiYfO",
-    "publishedDate" : "2011-06-30T09:17:40.478Z",
+    "legalNote" : "m8MMoFAFcwetwf",
+    "publishedDate" : "1985-03-03T11:57:44.036Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Z4cVMxvgzPiCS9t5BG",
-      "uploadedDate" : "2020-08-24T08:00:43.371Z"
+      "uploadedBy" : "Udhat2dFCq",
+      "uploadedDate" : "2002-03-07T14:27:26.538Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JUcRdjfYjwI6d3bmNeI",
-    "name" : "WtelLmKq0brQo",
-    "description" : "b9KD2DQhQb4eApGM6YX"
+    "id" : "https://www.example.com/ykDDJw4WuN8J",
+    "name" : "ivXWcQYepji",
+    "description" : "wwgsrS8t1lo8Bve4"
   } ],
-  "rightsHolder" : "BXqyFGL3yd73",
-  "duplicateOf" : "https://www.example.org/0584d028-a64e-4c68-b06b-c606c4949602",
+  "rightsHolder" : "6vPTmNVT8G",
+  "duplicateOf" : "https://www.example.org/3daed97a-9a35-4622-872e-8ead1b8df7c1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "iU6KQOdJiK"
+    "note" : "p27kxGDpq8cRurQF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "BsQVLlPONJq",
-    "createdBy" : "y1ApO9d4Y9n",
-    "createdDate" : "1972-05-12T01:22:07.797Z"
+    "note" : "mJMVBneikSuP",
+    "createdBy" : "BIKscCxp4edJZg",
+    "createdDate" : "2017-06-13T05:11:29.670Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a3667963-62c2-42f0-aaeb-48380580dd85" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/f3b14287-8886-4199-a549-5c5259b603a3" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "L86tyYiZxDSbcPX",
-    "ownerAffiliation" : "https://www.example.org/6b5b660c-2554-403d-b560-3deaf52f6233"
+    "owner" : "prfhkm6cvyQCIric",
+    "ownerAffiliation" : "https://www.example.org/e1aa2007-ec10-4d7e-8b57-b38ad807c0df"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/deacdfab-0b79-48a3-9bdb-13ae56462aa4"
+    "id" : "https://www.example.org/131ab3ef-61f4-49ca-86f7-8a758d8848e5"
   },
-  "createdDate" : "1988-02-04T16:29:35.383Z",
-  "modifiedDate" : "1996-05-03T12:18:30.913Z",
-  "publishedDate" : "1992-07-26T13:25:45.571Z",
-  "indexedDate" : "2018-07-20T13:58:35.269Z",
-  "handle" : "https://www.example.org/aa0bf974-3fba-4a94-ba10-1e57338c2621",
-  "doi" : "https://doi.org/10.1234/minima",
-  "link" : "https://www.example.org/17f11442-f5c9-4b0e-8abb-759f99d09207",
+  "createdDate" : "1979-04-29T12:38:24.979Z",
+  "modifiedDate" : "2016-07-19T07:38:27.892Z",
+  "publishedDate" : "1977-03-27T11:03:15.175Z",
+  "indexedDate" : "1974-06-27T10:52:47.651Z",
+  "handle" : "https://www.example.org/140d7899-6415-4c1c-8d99-f9b6e7f31519",
+  "doi" : "https://doi.org/10.1234/blanditiis",
+  "link" : "https://www.example.org/130a180d-e6c4-4d44-af6f-4b6430e9ac8d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uOshwG5w9O3Ba7sXQ",
+    "mainTitle" : "r601cKdF4mQIYo",
     "alternativeTitles" : {
-      "es" : "nlZijV9iAjYR"
+      "de" : "wAxOLP3A8KRhbi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BRWCmp3lfcrbr",
-      "month" : "i282FgNYAUB4kObCgE",
-      "day" : "UVjwQT1p326k3"
+      "year" : "Mpr6OJw8OhXMIJxFRVV",
+      "month" : "2Ga1VxCJOD91",
+      "day" : "1b2J9NO5V65dVmq15w"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d4da40a8-7b1c-48bf-8f6a-455d0df496ca",
-        "name" : "K7LfBQznJnyjNVGMtUX",
-        "nameType" : "Organizational",
-        "orcId" : "qYknMCTF1H",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a9c40866-fb0a-4fa7-86f4-178014220a90",
+        "name" : "bmvv6gUJZt",
+        "nameType" : "Personal",
+        "orcId" : "ZYqAojJ5jeLPsT50Ik",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cmeGeCs7YvLHJk",
-          "value" : "pt2fyofyVXHjP"
+          "sourceName" : "No1cOMiGiT6",
+          "value" : "q2Cvp1ibZ9cvHl09g"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "82Bxijjbatx",
-          "value" : "wstagjpYU71"
+          "sourceName" : "D61evKBaONO1nVRAt",
+          "value" : "3M7rGmIvtb9NM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b50bf3df-3280-4273-b52d-bff146ccd80f"
+        "id" : "https://www.example.org/07e603ac-ca8d-49be-a8af-849353b9cca3"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,216 +62,215 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6b3912b1-2d2c-46aa-823f-3b1941ee3b41",
-        "name" : "bfh1STVszK3VBB0k",
-        "nameType" : "Organizational",
-        "orcId" : "Mze7uKs3mrAnTqpt6G",
+        "id" : "https://www.example.org/9ee1b5bb-d09e-473a-a821-9f8c2ea4d8a3",
+        "name" : "Z6tkaTWZCnroLJdJDY",
+        "nameType" : "Personal",
+        "orcId" : "hR2iBF5SXhsjtVBrx",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "r6j1dZyqp2BJIZA",
-          "value" : "3TAGVqdaQZP"
+          "sourceName" : "6voqRUZQ1th9p0Wj8",
+          "value" : "oc9NXlHnRxcnVB4mmi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1Ujk4aXozSg",
-          "value" : "VZeudxE3Pef9l5RTB0"
+          "sourceName" : "i9WQ3b1e9i2qlu",
+          "value" : "6iHVlArBNGBlMe4V"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5d0ca10a-8dd1-4a33-893d-c40b289cc674"
+        "id" : "https://www.example.org/971038bd-4207-42d5-aab6-8ac7c1c91af9"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "MyJhsUZvjx4"
+      "el" : "WlFSvKqan4JrQy2bQLS"
     },
-    "npiSubjectHeading" : "6rZXSWRGBSGW",
-    "tags" : [ "i3jDWtBZ6A4" ],
-    "description" : "7uagaNl3VP0i6Z",
+    "npiSubjectHeading" : "gAHCsC9wZDlS5a1GiRy",
+    "tags" : [ "xg1rYmGgOpSeENsyo" ],
+    "description" : "5aiaRjdJTbq4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/74769f7c-ec77-4530-8f1a-bf45c8c6e9c1",
+      "doi" : "https://www.example.org/e1e75f96-e51b-4e23-8a23-8d7d7fc762d3",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
           "type" : "LiteraryArtsOther",
-          "description" : "SogkCZVhFhNkLii9vg"
+          "description" : "tnRgcaSdk2"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "p83q6WbyOcW",
+            "name" : "uFxf6Z5mvXwy7g57PTp",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "hTByqPMUMwrZ",
-            "month" : "CMlVsBVEEGRD",
-            "day" : "ZLLSViX5epg"
+            "year" : "QYARG2UDIfsDmJtDqk3",
+            "month" : "r60ZAipnqKJ3DZ",
+            "day" : "g5cOMeDRdIbMcXK"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "embcVPtesJFz9l1FBy",
-              "end" : "qsjqhTuY3z2g2X8TsM"
+              "begin" : "SnTIb80IwlKz",
+              "end" : "Yb4QFgi26JC"
             },
-            "pages" : "9XYRA6t2jB",
-            "illustrated" : true
+            "pages" : "vDvWqZA297LhfnCN",
+            "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
-            "type" : "LiteraryArtsAudioVisualOther",
-            "description" : "n0MvTm4MbhcRDP"
+            "type" : "Audiobook"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "fsYIFHCBvy1hj9udP",
+            "name" : "i31yn4REguQ75V3T",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "fjzQuXt1nB",
-            "month" : "vjYiRWiBrpXfwgIDkO",
-            "day" : "7nDE5B8OZiKstuS5"
+            "year" : "0DBNhnU7MY4",
+            "month" : "Dj10WCi73H6AR",
+            "day" : "DQ5YVzJwNJs3Wonekw"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 1142105751
+          "extent" : 1450711053
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "Play"
+            "type" : "Reading"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "MY7ctsFlhucJ",
-            "country" : "wjZOf0gJEbUGf"
+            "label" : "mbs4rlw2HT",
+            "country" : "qlYHbIFthpVjcSEfcO"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "UsKsfCa7mQ0ea",
-            "month" : "XGQBbwPOIXSKS",
-            "day" : "wJTomf9aUQKcak"
+            "year" : "btYdfIaqOa5mb",
+            "month" : "zjlBDJNWuLRQvmT",
+            "day" : "lclaMboDsr0fK7oI"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/NLoT57f9OLrSutBGMz",
+          "id" : "https://www.example.com/kdBAvcJQD9MGLH",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "G9jvSBgSwzZpSL",
+            "name" : "kqwLJWQbK6Q",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "VGBru3BoYItp0dK",
-            "month" : "MEdETsyJLDTq6TxN",
-            "day" : "X48vEbxpkh0gS2C"
+            "year" : "twvuTF3tSzyoTZS2P",
+            "month" : "5pQPDwG3hSbuDapLH",
+            "day" : "NkVE8heEabdcr0pD3"
           }
         } ],
-        "description" : "WYogUAKaANmb",
+        "description" : "fWfXaPjK5ZpQI5uY",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e826a017-cbec-40db-a47a-7a4ba7397f4b",
-    "abstract" : "rW6yNTMpx3f"
+    "metadataSource" : "https://www.example.org/7a085f55-23df-4d07-962a-25f17610a9e8",
+    "abstract" : "OSXaRXvLvheR4dh74"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4aa3757d-077f-4939-85cc-47d72f7b08ee",
-    "name" : "lDlhLMBKu7hDNDNLVmd",
+    "id" : "https://www.example.org/01096898-a3df-425f-ab7f-5c91469ac9e1",
+    "name" : "Fmk1bA6UoRQWNSG83d",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-10-01T12:03:05.213Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "nx4DodxwosIcJZ8mDy"
+      "approvalDate" : "2017-11-07T13:10:54.027Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "epz7sx2yP70nRW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/29412d45-93dd-406d-9c62-6ac27d452e87",
-    "identifier" : "HKeX19aO42po",
+    "source" : "https://www.example.org/0a8d0b55-258b-48e3-aaf8-2a5d0146b275",
+    "identifier" : "eZ4lotj5Ix0fwPBu",
     "labels" : {
-      "sv" : "mEWC0N6SLAWP2oS"
+      "ca" : "Yp404fHBf4jGhUcF3"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2049832607
+      "amount" : 218949776
     },
-    "activeFrom" : "1992-01-29T00:21:42.954Z",
-    "activeTo" : "2000-04-25T02:14:15.493Z"
+    "activeFrom" : "2005-10-02T21:59:02.045Z",
+    "activeTo" : "2007-09-11T09:16:04.186Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d5245dae-3f1c-429d-ae5d-247a72869f29",
-    "id" : "https://www.example.org/54adea18-4abb-45e1-aaff-da4cf245d490",
-    "identifier" : "9QIyrUPybfNIpiO",
+    "source" : "https://www.example.org/3f946184-b00f-4cdc-bcfa-56af4022836a",
+    "id" : "https://www.example.org/801cbc11-a26d-491d-a779-71336fa0ef4a",
+    "identifier" : "qC06S1zqrQXPoM",
     "labels" : {
-      "da" : "Brwjf4KrdL8e6OOYQNE"
+      "hu" : "I92ccBlAd6YLVcd"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1151321610
+      "currency" : "EUR",
+      "amount" : 1986500096
     },
-    "activeFrom" : "1979-02-27T17:50:58.806Z",
-    "activeTo" : "1988-01-03T10:04:53.769Z"
+    "activeFrom" : "2010-10-21T05:22:04.935Z",
+    "activeTo" : "2017-06-07T19:02:55.855Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4d65c0e8-a481-433b-b404-e94d46a05c3e" ],
+  "subjects" : [ "https://www.example.org/7347dced-4bf4-4429-9f35-824c238bd97f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "95c5824d-b462-4eec-9604-e48888b1be07",
-    "name" : "Zj3T2sXEN7vq9t",
-    "mimeType" : "Fzbc8msjxs3b40n",
-    "size" : 496664721,
-    "license" : "https://www.example.com/gdvbu0k336ubjqr7ons",
+    "identifier" : "fff8a0c4-d990-4194-aac9-76bd53df06ff",
+    "name" : "mZkWo0r8mNucCh",
+    "mimeType" : "YP7xwxiWKr",
+    "size" : 1331940446,
+    "license" : "https://www.example.com/enzkzf3y3b8gcaqzp",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "DpnlfhM0YjcH",
-    "publishedDate" : "2003-01-26T20:47:07.111Z",
+    "legalNote" : "ZgHw2s6a5UR9",
+    "publishedDate" : "1982-12-04T19:28:35.929Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "EnbWrZRpHH0gTrgV",
-      "uploadedDate" : "1977-09-14T08:34:04.246Z"
+      "uploadedBy" : "zJup1wQzr8o",
+      "uploadedDate" : "2021-08-10T20:18:31.026Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/a6qJjdjslqX07Y3",
-    "name" : "xit7AXKRKnTAKhq",
-    "description" : "jo6f9IEVXUZV6GA"
+    "id" : "https://www.example.com/hFMb5aXr0Bm",
+    "name" : "XSxYfnA8IRgYlj0NBrG",
+    "description" : "jF64lhubvD"
   } ],
-  "rightsHolder" : "smHf6S3SvOp36LAM",
-  "duplicateOf" : "https://www.example.org/27f583d5-ef7f-41cb-8218-55b551c96331",
+  "rightsHolder" : "gJvDwsZAcPAl",
+  "duplicateOf" : "https://www.example.org/7a8ef864-301b-422c-b5b3-8ae87abb08fe",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Y4otqXr0YgdRN6FWwB"
+    "note" : "rwavwK6Mvbht3qvbh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "MRCOKn5GN4J",
-    "createdBy" : "ZlUfmMKyBkYu6DalR",
-    "createdDate" : "2005-10-17T07:59:44.538Z"
+    "note" : "eNjrQudJKbmFr1",
+    "createdBy" : "wsZZ7XRBcrzkMVW",
+    "createdDate" : "2016-11-08T06:54:39.869Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1b30c32d-2ce7-411b-aa5a-d6552ea32250" ],
+  "curatingInstitutions" : [ "https://www.example.org/c5e0efb2-e0da-4cd6-9222-3dc2c98a4ec6" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "AXi41IdRoHiNaAN8M6",
-    "ownerAffiliation" : "https://www.example.org/1ef84f0e-2545-425d-99e1-9dadee630538"
+    "owner" : "L86tyYiZxDSbcPX",
+    "ownerAffiliation" : "https://www.example.org/6b5b660c-2554-403d-b560-3deaf52f6233"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7951d603-d75b-41ac-8b18-f2fa7b6ed090"
+    "id" : "https://www.example.org/deacdfab-0b79-48a3-9bdb-13ae56462aa4"
   },
-  "createdDate" : "2015-05-07T07:27:13.408Z",
-  "modifiedDate" : "1974-08-19T02:18:15.825Z",
-  "publishedDate" : "2016-12-27T02:53:11.244Z",
-  "indexedDate" : "1984-04-07T15:26:39.230Z",
-  "handle" : "https://www.example.org/5d69d89f-8941-4513-b9ca-5155d8d2ed26",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/15e2879b-116a-4f60-be52-c98be7f888e6",
+  "createdDate" : "1988-02-04T16:29:35.383Z",
+  "modifiedDate" : "1996-05-03T12:18:30.913Z",
+  "publishedDate" : "1992-07-26T13:25:45.571Z",
+  "indexedDate" : "2018-07-20T13:58:35.269Z",
+  "handle" : "https://www.example.org/aa0bf974-3fba-4a94-ba10-1e57338c2621",
+  "doi" : "https://doi.org/10.1234/minima",
+  "link" : "https://www.example.org/17f11442-f5c9-4b0e-8abb-759f99d09207",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3mXy3Aj8fxiHjkxxd9",
+    "mainTitle" : "uOshwG5w9O3Ba7sXQ",
     "alternativeTitles" : {
-      "de" : "7PZAUEW9Cta6bkbCE9Z"
+      "es" : "nlZijV9iAjYR"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3my8wowoj7QxecyuB",
-      "month" : "RT0CnIb6ZS",
-      "day" : "0EjESgykfaBXnk6SuY"
+      "year" : "BRWCmp3lfcrbr",
+      "month" : "i282FgNYAUB4kObCgE",
+      "day" : "UVjwQT1p326k3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cab62452-44e6-4c1c-b53f-585589a8d4f4",
-        "name" : "SamdjYNmOZBihfnf0",
+        "id" : "https://www.example.org/d4da40a8-7b1c-48bf-8f6a-455d0df496ca",
+        "name" : "K7LfBQznJnyjNVGMtUX",
         "nameType" : "Organizational",
-        "orcId" : "Jz6S0Qf3romEvHDLA97",
+        "orcId" : "qYknMCTF1H",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "N7BKOHlHgkRqalE",
-          "value" : "nh0jsiqRXRVfg"
+          "sourceName" : "cmeGeCs7YvLHJk",
+          "value" : "pt2fyofyVXHjP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DVhVnF3GVANv37",
-          "value" : "SPRQLOYi9RE"
+          "sourceName" : "82Bxijjbatx",
+          "value" : "wstagjpYU71"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/09c06ac4-8cc6-4cb8-b183-efeeda823f5d"
+        "id" : "https://www.example.org/b50bf3df-3280-4273-b52d-bff146ccd80f"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,216 +62,216 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cff93742-3f05-4af4-98ce-d5e290d56abd",
-        "name" : "hMFWX92FKtaw2Tct8",
-        "nameType" : "Personal",
-        "orcId" : "guVKm8ZN4Y7cRIC0",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/6b3912b1-2d2c-46aa-823f-3b1941ee3b41",
+        "name" : "bfh1STVszK3VBB0k",
+        "nameType" : "Organizational",
+        "orcId" : "Mze7uKs3mrAnTqpt6G",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o5PikHC9SzE2h",
-          "value" : "kBeeMZV0LiF5Lklog"
+          "sourceName" : "r6j1dZyqp2BJIZA",
+          "value" : "3TAGVqdaQZP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Le4TdMDXeVfuMetL",
-          "value" : "XAMZu9OcEodpQKUKm"
+          "sourceName" : "1Ujk4aXozSg",
+          "value" : "VZeudxE3Pef9l5RTB0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8d4e0688-85de-494b-957f-d2f04644702e"
+        "id" : "https://www.example.org/5d0ca10a-8dd1-4a33-893d-c40b289cc674"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "vtAMwwjDqP"
+      "is" : "MyJhsUZvjx4"
     },
-    "npiSubjectHeading" : "lba7bJ444et6IOQU",
-    "tags" : [ "J3BbfEydZh" ],
-    "description" : "kz5BTVaFQaCUY",
+    "npiSubjectHeading" : "6rZXSWRGBSGW",
+    "tags" : [ "i3jDWtBZ6A4" ],
+    "description" : "7uagaNl3VP0i6Z",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/6964b5f9-fa67-4ce9-96a0-8bf46dc237d6",
+      "doi" : "https://www.example.org/74769f7c-ec77-4530-8f1a-bf45c8c6e9c1",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Retelling"
+          "type" : "LiteraryArtsOther",
+          "description" : "SogkCZVhFhNkLii9vg"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "fPAN2ZyScdGq",
+            "name" : "p83q6WbyOcW",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "De3DcBMce2",
-            "month" : "ikSYiSqCQT2nqJ",
-            "day" : "IGzgIyoRNIJZSamwX"
+            "year" : "hTByqPMUMwrZ",
+            "month" : "CMlVsBVEEGRD",
+            "day" : "ZLLSViX5epg"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "AN1vEXLTDg2za",
-              "end" : "GAAtv3L0x0"
+              "begin" : "embcVPtesJFz9l1FBy",
+              "end" : "qsjqhTuY3z2g2X8TsM"
             },
-            "pages" : "hj0msMKI8d7mq",
-            "illustrated" : false
+            "pages" : "9XYRA6t2jB",
+            "illustrated" : true
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
             "type" : "LiteraryArtsAudioVisualOther",
-            "description" : "HmVSyhwWZ3zN7"
+            "description" : "n0MvTm4MbhcRDP"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "s5jAdbZP1Z",
+            "name" : "fsYIFHCBvy1hj9udP",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "VgmCzMUO12A",
-            "month" : "WCJ95sy9kYfD",
-            "day" : "1okUljeCmEc"
+            "year" : "fjzQuXt1nB",
+            "month" : "vjYiRWiBrpXfwgIDkO",
+            "day" : "7nDE5B8OZiKstuS5"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 1990549559
+          "extent" : 1142105751
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "LiteraryArtsPerformanceOther",
-            "description" : "pRdc5opY2HXfIXx"
+            "type" : "Play"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Q87d9rdJfILl5kA",
-            "country" : "Sf6fBFBVVemA"
+            "label" : "MY7ctsFlhucJ",
+            "country" : "wjZOf0gJEbUGf"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "zNcXADPqzXe7iCneH",
-            "month" : "E5yIE6LjYYY",
-            "day" : "f2KGU5SWJpZYCXs"
+            "year" : "UsKsfCa7mQ0ea",
+            "month" : "XGQBbwPOIXSKS",
+            "day" : "wJTomf9aUQKcak"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/00MutiNrAUVwQ",
+          "id" : "https://www.example.com/NLoT57f9OLrSutBGMz",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "bSkpYdKEjmfee6Nuk5e",
+            "name" : "G9jvSBgSwzZpSL",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "qdd8BeEO4udVh5PPj7",
-            "month" : "lAuGxx6AytWzff1VsVk",
-            "day" : "oTNin2iv9Lihp1f"
+            "year" : "VGBru3BoYItp0dK",
+            "month" : "MEdETsyJLDTq6TxN",
+            "day" : "X48vEbxpkh0gS2C"
           }
         } ],
-        "description" : "4jnl0LoM9fsbIvWXb9",
+        "description" : "WYogUAKaANmb",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/63a59e99-a5fe-4af2-965c-f4cb809a6439",
-    "abstract" : "GcOresO9dSZ08ycJp"
+    "metadataSource" : "https://www.example.org/e826a017-cbec-40db-a47a-7a4ba7397f4b",
+    "abstract" : "rW6yNTMpx3f"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/67615b82-1887-4d28-84fa-3e2deba5a102",
-    "name" : "odWdyC5dFAtN",
+    "id" : "https://www.example.org/4aa3757d-077f-4939-85cc-47d72f7b08ee",
+    "name" : "lDlhLMBKu7hDNDNLVmd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-09-07T13:42:08.877Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "HpHBNDvTlDlC"
+      "approvalDate" : "1982-10-01T12:03:05.213Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "nx4DodxwosIcJZ8mDy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ef85699b-8bdd-47d9-b441-3114dae8f4e4",
-    "identifier" : "pk47wl2WdQvkVsCv7Y7",
+    "source" : "https://www.example.org/29412d45-93dd-406d-9c62-6ac27d452e87",
+    "identifier" : "HKeX19aO42po",
     "labels" : {
-      "is" : "hGBP7mZIoC4Z"
+      "sv" : "mEWC0N6SLAWP2oS"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2053528633
+      "currency" : "EUR",
+      "amount" : 2049832607
     },
-    "activeFrom" : "1972-03-21T17:34:29.154Z",
-    "activeTo" : "2000-08-02T02:42:17.538Z"
+    "activeFrom" : "1992-01-29T00:21:42.954Z",
+    "activeTo" : "2000-04-25T02:14:15.493Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e00f1049-9b04-45c7-a106-f027b3b57110",
-    "id" : "https://www.example.org/1009e2a5-ea9a-41a1-b686-c1045c98559b",
-    "identifier" : "oNpI0Mr7EQ",
+    "source" : "https://www.example.org/d5245dae-3f1c-429d-ae5d-247a72869f29",
+    "id" : "https://www.example.org/54adea18-4abb-45e1-aaff-da4cf245d490",
+    "identifier" : "9QIyrUPybfNIpiO",
     "labels" : {
-      "se" : "fVBj72F1435DgDku"
+      "da" : "Brwjf4KrdL8e6OOYQNE"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 329910321
+      "currency" : "USD",
+      "amount" : 1151321610
     },
-    "activeFrom" : "1993-10-31T06:40:41.386Z",
-    "activeTo" : "2023-07-06T15:25:25.762Z"
+    "activeFrom" : "1979-02-27T17:50:58.806Z",
+    "activeTo" : "1988-01-03T10:04:53.769Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8c174be1-9444-4003-b78f-a6f1a30de826" ],
+  "subjects" : [ "https://www.example.org/4d65c0e8-a481-433b-b404-e94d46a05c3e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b52835c7-c424-45de-9519-e0599bb67d59",
-    "name" : "LU7AAypt7Gij6frPZ",
-    "mimeType" : "qLfBhAgvcGpnmJaJd",
-    "size" : 955150246,
-    "license" : "https://www.example.com/vud5ipdazmi30l",
+    "identifier" : "95c5824d-b462-4eec-9604-e48888b1be07",
+    "name" : "Zj3T2sXEN7vq9t",
+    "mimeType" : "Fzbc8msjxs3b40n",
+    "size" : 496664721,
+    "license" : "https://www.example.com/gdvbu0k336ubjqr7ons",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "oDmB4xvlqdXLoJ",
-    "publishedDate" : "2015-07-10T09:19:38.094Z",
+    "legalNote" : "DpnlfhM0YjcH",
+    "publishedDate" : "2003-01-26T20:47:07.111Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "BToeCzFN4xsFcbM",
-      "uploadedDate" : "1983-10-06T02:55:13.724Z"
+      "uploadedBy" : "EnbWrZRpHH0gTrgV",
+      "uploadedDate" : "1977-09-14T08:34:04.246Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/iTL0TgRRmNwchAR",
-    "name" : "1TYMdyOQH2",
-    "description" : "EuG8K9V7GRgavOu"
+    "id" : "https://www.example.com/a6qJjdjslqX07Y3",
+    "name" : "xit7AXKRKnTAKhq",
+    "description" : "jo6f9IEVXUZV6GA"
   } ],
-  "rightsHolder" : "YmcXmZrCWFdWAW",
-  "duplicateOf" : "https://www.example.org/5c6900b8-1543-4739-b854-f71f1320cc8e",
+  "rightsHolder" : "smHf6S3SvOp36LAM",
+  "duplicateOf" : "https://www.example.org/27f583d5-ef7f-41cb-8218-55b551c96331",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "GyQdGznYgK31IH7U"
+    "note" : "Y4otqXr0YgdRN6FWwB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VrJOWOBwQMc8",
-    "createdBy" : "ESvhsrFRgOtBPriQn",
-    "createdDate" : "1994-07-14T01:35:00.303Z"
+    "note" : "MRCOKn5GN4J",
+    "createdBy" : "ZlUfmMKyBkYu6DalR",
+    "createdDate" : "2005-10-17T07:59:44.538Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/163178ea-4a02-40ae-8079-2decc95fb270" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/1b30c32d-2ce7-411b-aa5a-d6552ea32250" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "3EpY8itecwd0mtGM6FH",
-    "ownerAffiliation" : "https://www.example.org/0d7e2d72-a1f7-42cb-8a46-94e1982162d3"
+    "owner" : "1m0VVKWCptHCHF",
+    "ownerAffiliation" : "https://www.example.org/b9e59fc1-b1ca-4f88-b94c-9cdb4823a502"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8d8cb43c-1995-48c1-a361-c057a788730c"
+    "id" : "https://www.example.org/60bd3612-5d27-4207-8d53-bef6154921b3"
   },
-  "createdDate" : "1991-12-07T04:50:40.934Z",
-  "modifiedDate" : "2003-03-10T18:35:21.751Z",
-  "publishedDate" : "1998-10-06T05:40:16.582Z",
-  "indexedDate" : "1987-08-05T09:55:04.182Z",
-  "handle" : "https://www.example.org/ee216cb1-1078-4f21-8965-b2e8abe5496a",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/e29922ad-420b-4a04-847d-0354503f7804",
+  "createdDate" : "1990-04-18T08:43:15.126Z",
+  "modifiedDate" : "1994-11-29T12:23:21.358Z",
+  "publishedDate" : "1979-04-09T09:42:04.203Z",
+  "indexedDate" : "2010-06-17T20:29:12.948Z",
+  "handle" : "https://www.example.org/ae61c990-2964-4cf7-9183-fe85c5e24a45",
+  "doi" : "https://doi.org/10.1234/possimus",
+  "link" : "https://www.example.org/dca76e0f-4d82-4675-a351-4f29cf0df43a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6bv5qxJYFR",
+    "mainTitle" : "slwW8aaKVuHS9vwhW2",
     "alternativeTitles" : {
-      "sv" : "J7MYIYIj8NXIX8GBJ"
+      "af" : "zDBssRTXeIkX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AZQXaglbkIWh",
-      "month" : "mE2UXOvMU21ui9DVV",
-      "day" : "qKn24o0w4JvgGB"
+      "year" : "vIpAaydjXs1seKaao",
+      "month" : "qNFEMclOK3vYNDza",
+      "day" : "Pj6NQsN0nRHF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4247038f-b009-4d38-b9c3-28adc908ed3f",
-        "name" : "o9ek4CGu13dBMV",
+        "id" : "https://www.example.org/229005c6-eb74-4762-8492-58fea9c7f34f",
+        "name" : "HXcCOBUxsa7iK",
         "nameType" : "Organizational",
-        "orcId" : "GJ6kJL7K9JWEuU1zOG",
-        "verificationStatus" : "Verified",
+        "orcId" : "2632td9ZxbgByNV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qleO416THJCN8aOraRM",
-          "value" : "SOGq6YmB4jH0wYShX"
+          "sourceName" : "n1zTYX3JRuSXru",
+          "value" : "OvezItgQCPIgosc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VHNpusgc4aObvjHr",
-          "value" : "IEo4rd0ghmwk6tNc"
+          "sourceName" : "CDhba9C2kEp",
+          "value" : "r3mORmnylNiuUYw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c9a222e7-8f35-4955-92ba-0fea19a5aab4"
+        "id" : "https://www.example.org/06ae4c45-aa20-4a95-ad83-9e3814c3ac27"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,150 +62,150 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/308935e0-b589-46dc-a066-16f30d0bfc34",
-        "name" : "qqHgDqgdnQLe",
+        "id" : "https://www.example.org/e06ba0f4-fbb9-428c-b621-5d5e25a58885",
+        "name" : "CjfpbF6G25z",
         "nameType" : "Organizational",
-        "orcId" : "XbMyafrb1P2rSEmKZ5",
-        "verificationStatus" : "Verified",
+        "orcId" : "i6PoyFnHeMW20Af",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EkX2bUqcWXvfyt",
-          "value" : "e3FBFy5tutReD"
+          "sourceName" : "z7Shfg8Tez6",
+          "value" : "Sc8w8Av1qYZDRL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VU3Cd1q4M9x",
-          "value" : "ZcC2V5C9uv"
+          "sourceName" : "vBLehlhrkd",
+          "value" : "Doqak4QhXJi2c8pUoK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c51ecce1-592a-4a0b-b115-05a60359d102"
+        "id" : "https://www.example.org/869b34e9-20b9-48b3-832c-c50a85ed1b52"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "Yg3LdzVL6kP"
+      "nl" : "IWdHuAZVYcXYEm3wzCF"
     },
-    "npiSubjectHeading" : "gPSRotDHsGHrHv",
-    "tags" : [ "vCcqhFbzPPacThJ0" ],
-    "description" : "lwWeZGMn51Fa",
+    "npiSubjectHeading" : "mg1GY63A3Ki5",
+    "tags" : [ "4YAXX1jRj2yDHquAF" ],
+    "description" : "vupfF8l4RiDaLPM6i",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f8b78990-f98c-4332-b099-9d9ed7dca0ad",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eb141a0c-d1a2-42a2-bd78-c31b6ab98aec",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/f98b3297-e35d-4aba-b671-932304b0b57b",
+      "doi" : "https://www.example.org/7afd466b-7184-4d3d-8234-6836219e0c9f",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "OzTawFXzGbuNId3Ajn0",
+        "description" : "bOlaLcmEO1qRcq3dW",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "63hYigJdh9J",
-            "end" : "h9pAvjhkhu2uvix"
+            "begin" : "zN2xRrZvdRikvENVB6r",
+            "end" : "xJzBlMOYvXYTTjrpLV"
           },
-          "pages" : "9g41KVyuKoOOFP",
-          "illustrated" : false
+          "pages" : "SxWZVFbK380pa",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4b1da098-c8e1-4d99-9aab-762349f87f76",
-    "abstract" : "eFLA2WrueMbXsPgbH"
+    "metadataSource" : "https://www.example.org/bdcb9a52-800a-40d4-ac65-297fce79fd18",
+    "abstract" : "9E0mF56BUdWHKQVgR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fa642184-8d17-40dd-977f-67c77db256e2",
-    "name" : "PHn8QuuN89gtWkChH",
+    "id" : "https://www.example.org/2d78ee07-abe0-4805-acab-5c3b7a816cc9",
+    "name" : "yxrtz0m6pTt",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-12-04T04:50:02.847Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "7FXsosLTr9Hf"
+      "approvalDate" : "2018-10-06T04:27:26.489Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "AZoWxRo7fPUY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0f4f3ed7-04ea-46f4-9dab-3992ad7c61b4",
-    "identifier" : "StiWFmUu0ePCQH9Is",
+    "source" : "https://www.example.org/87bba51d-fc62-4303-9d94-eb3219d3ecc8",
+    "identifier" : "UyRVlosU8ZuDu9aiEP",
     "labels" : {
-      "da" : "AfecPpDo7h4"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1455378642
-    },
-    "activeFrom" : "1982-09-26T02:39:42.027Z",
-    "activeTo" : "2007-01-28T00:41:11.787Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dc8fd6d9-d453-432f-a7ee-c29bb504d315",
-    "id" : "https://www.example.org/b4f6065b-23b1-42be-8c52-62baf22e264b",
-    "identifier" : "RjUvVwirzRNVFgP",
-    "labels" : {
-      "af" : "hY9xoJ76HGW8h0LT067"
+      "nn" : "1W6P6N7vtYEg"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1017453730
+      "amount" : 1516321943
     },
-    "activeFrom" : "1992-08-17T06:49:44.251Z",
-    "activeTo" : "1992-11-17T23:03:36.501Z"
+    "activeFrom" : "2003-01-25T20:00:36.718Z",
+    "activeTo" : "2018-10-29T12:03:51.472Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/dfc9bced-de9b-4045-8732-c2e6c7f636a7",
+    "id" : "https://www.example.org/b31b8d45-632b-4239-96f9-97184d658ebb",
+    "identifier" : "mZY2bfEmwos",
+    "labels" : {
+      "hu" : "hb0fNqHnpHJjrcua4"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1707694057
+    },
+    "activeFrom" : "1988-04-30T23:04:22.107Z",
+    "activeTo" : "2017-02-23T21:54:23.156Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9fc19b77-aafd-4668-9c11-118f063cd1f9" ],
+  "subjects" : [ "https://www.example.org/584e4fbb-df81-42ca-8784-1ccf00356467" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "104886ad-18de-48fb-8e32-386f7b692b45",
-    "name" : "q4rl5fQbetNVs",
-    "mimeType" : "JCc4MvI6kh3yoFagc8",
-    "size" : 1669496801,
-    "license" : "https://www.example.com/kmlffgmift8ybcqryf9",
+    "identifier" : "3706f55f-77b1-4039-a113-e02618305261",
+    "name" : "eAVD4kVH7zuiaXWHv",
+    "mimeType" : "dbN12A60jIOFUVb",
+    "size" : 1349568713,
+    "license" : "https://www.example.com/jbycnsoqrgm8xkrj",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "OSVhJBy8b85KJVTWABa",
-    "publishedDate" : "1986-04-22T08:06:31.218Z",
+    "legalNote" : "4UWmXcBgT6y7",
+    "publishedDate" : "2018-01-24T23:41:06.778Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "E6ceUhEHCtm7",
-      "uploadedDate" : "2023-04-22T23:40:43.491Z"
+      "uploadedBy" : "8tuEGtccMDzJSR",
+      "uploadedDate" : "1997-09-13T14:16:14.070Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/uyHyR5l91d7",
-    "name" : "DyeghzkJWV6WINy",
-    "description" : "GPoGXBkW2R7TNF9Z9c"
+    "id" : "https://www.example.com/TOGxEBSmcKrE1Z7",
+    "name" : "faBKzm2tq6gz0o5H",
+    "description" : "RWUyQvsEWYkxK20o"
   } ],
-  "rightsHolder" : "zYzrKUySEs2BkaTWWa",
-  "duplicateOf" : "https://www.example.org/b711d58b-667c-4579-bc4a-9dfbf2f353ae",
+  "rightsHolder" : "H5ANkF7P2hF787qgs9a",
+  "duplicateOf" : "https://www.example.org/8eff3a29-f7d6-4a46-afdd-4faeb0622ee8",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QnaBQz9o6mKca"
+    "note" : "3V5NWMbb3MS2G"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VSiED00az3CASRI",
-    "createdBy" : "y2GMc2PXaT",
-    "createdDate" : "2005-01-29T04:33:09.535Z"
+    "note" : "1biN1WZlMWRYjO1",
+    "createdBy" : "14ym3i0Mrv0cWW",
+    "createdDate" : "2003-03-22T18:14:41.267Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/94a6f0a5-4698-431a-8a13-68af4e86d4b3" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/bb14fcc7-7441-4db1-8684-bc076cebfd19" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "1m0VVKWCptHCHF",
-    "ownerAffiliation" : "https://www.example.org/b9e59fc1-b1ca-4f88-b94c-9cdb4823a502"
+    "owner" : "kTnza0eXDMNfO",
+    "ownerAffiliation" : "https://www.example.org/0d9dfa2a-8f49-44f9-a48a-fb930e723873"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/60bd3612-5d27-4207-8d53-bef6154921b3"
+    "id" : "https://www.example.org/4c40ef42-91f7-4d7a-b2de-6960aeddebad"
   },
-  "createdDate" : "1990-04-18T08:43:15.126Z",
-  "modifiedDate" : "1994-11-29T12:23:21.358Z",
-  "publishedDate" : "1979-04-09T09:42:04.203Z",
-  "indexedDate" : "2010-06-17T20:29:12.948Z",
-  "handle" : "https://www.example.org/ae61c990-2964-4cf7-9183-fe85c5e24a45",
-  "doi" : "https://doi.org/10.1234/possimus",
-  "link" : "https://www.example.org/dca76e0f-4d82-4675-a351-4f29cf0df43a",
+  "createdDate" : "1983-09-09T04:12:26.762Z",
+  "modifiedDate" : "2020-05-26T22:34:58.938Z",
+  "publishedDate" : "1987-08-14T19:31:24.950Z",
+  "indexedDate" : "1975-01-01T01:29:55.251Z",
+  "handle" : "https://www.example.org/778cd2bd-cdfc-4d1b-a724-7a74ebc6ca68",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/c00ce012-4a9f-452f-b59f-e36638dc34d6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "slwW8aaKVuHS9vwhW2",
+    "mainTitle" : "hQ7GlV9J0veYBoMcauH",
     "alternativeTitles" : {
-      "af" : "zDBssRTXeIkX"
+      "af" : "3aQpU9bLHB6LZxOd3Yu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vIpAaydjXs1seKaao",
-      "month" : "qNFEMclOK3vYNDza",
-      "day" : "Pj6NQsN0nRHF"
+      "year" : "Szw9uOJCmJt42yAI4LI",
+      "month" : "5ABrRbCjaoq2b3",
+      "day" : "3S8QhkHhbT9f"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/229005c6-eb74-4762-8492-58fea9c7f34f",
-        "name" : "HXcCOBUxsa7iK",
-        "nameType" : "Organizational",
-        "orcId" : "2632td9ZxbgByNV",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ee5376e6-731f-4264-8f3e-92dfdf827789",
+        "name" : "mb7zaW1UCmPRCgKOv",
+        "nameType" : "Personal",
+        "orcId" : "blpb8wdLKKwIZYN",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "n1zTYX3JRuSXru",
-          "value" : "OvezItgQCPIgosc"
+          "sourceName" : "0jMm6PQXpo87t",
+          "value" : "isvVo7jcRoRM658O395"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CDhba9C2kEp",
-          "value" : "r3mORmnylNiuUYw"
+          "sourceName" : "1Shuo3Mnl09buvVIh",
+          "value" : "AmbxL8fVjHD4N"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/06ae4c45-aa20-4a95-ad83-9e3814c3ac27"
+        "id" : "https://www.example.org/de59aae8-2223-4642-9b3e-6ccea7c371d7"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,150 +62,150 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e06ba0f4-fbb9-428c-b621-5d5e25a58885",
-        "name" : "CjfpbF6G25z",
-        "nameType" : "Organizational",
-        "orcId" : "i6PoyFnHeMW20Af",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ad33bb9e-23b6-44b8-9a1d-1b5c59e26508",
+        "name" : "EH6ssbwDpkDEP3KtvO2",
+        "nameType" : "Personal",
+        "orcId" : "V8xMOoGs6Wz",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z7Shfg8Tez6",
-          "value" : "Sc8w8Av1qYZDRL"
+          "sourceName" : "xxjaQSAy72iVLEZN",
+          "value" : "Oyug9yRFxxBzDeoK27"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vBLehlhrkd",
-          "value" : "Doqak4QhXJi2c8pUoK"
+          "sourceName" : "k8MR8r6dROoPhXi",
+          "value" : "IqbW1KflU3gw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/869b34e9-20b9-48b3-832c-c50a85ed1b52"
+        "id" : "https://www.example.org/c6518ba3-5411-4331-9123-f71dda07e8be"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "IWdHuAZVYcXYEm3wzCF"
+      "sv" : "81UsXXlEpj"
     },
-    "npiSubjectHeading" : "mg1GY63A3Ki5",
-    "tags" : [ "4YAXX1jRj2yDHquAF" ],
-    "description" : "vupfF8l4RiDaLPM6i",
+    "npiSubjectHeading" : "M92R5z8lsT",
+    "tags" : [ "XS847op4jlsiE0UCBa" ],
+    "description" : "xBtoVHF0OiO09Ah3VC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eb141a0c-d1a2-42a2-bd78-c31b6ab98aec",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3182e86d-ab05-49f4-9646-a22837344290",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/7afd466b-7184-4d3d-8234-6836219e0c9f",
+      "doi" : "https://www.example.org/7928d77c-8236-431a-bbef-20ba6b90d8c5",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "bOlaLcmEO1qRcq3dW",
+        "description" : "6WbrlxyJj1GJHOz7jli",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zN2xRrZvdRikvENVB6r",
-            "end" : "xJzBlMOYvXYTTjrpLV"
+            "begin" : "Rpo0XNhnnxh",
+            "end" : "hjtWuM1SlcE"
           },
-          "pages" : "SxWZVFbK380pa",
+          "pages" : "pFtxpriHV2NeRiBY5U",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/bdcb9a52-800a-40d4-ac65-297fce79fd18",
-    "abstract" : "9E0mF56BUdWHKQVgR"
+    "metadataSource" : "https://www.example.org/cde827f6-d9bf-461a-aac3-3036f59a13bb",
+    "abstract" : "94nWEL1OGcPeBo2oaE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2d78ee07-abe0-4805-acab-5c3b7a816cc9",
-    "name" : "yxrtz0m6pTt",
+    "id" : "https://www.example.org/a205179a-136d-42f4-8574-9f4c8ec85723",
+    "name" : "yz8B4LlxFMgvU1NVfR",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-10-06T04:27:26.489Z",
+      "approvalDate" : "2018-11-26T03:43:10.111Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "AZoWxRo7fPUY"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "PJsUFieq5t6Zzt7Mp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/87bba51d-fc62-4303-9d94-eb3219d3ecc8",
-    "identifier" : "UyRVlosU8ZuDu9aiEP",
+    "source" : "https://www.example.org/486ed325-ce11-4a8e-b8ad-4d327582ea21",
+    "identifier" : "nRFXWV3sHl2U8",
     "labels" : {
-      "nn" : "1W6P6N7vtYEg"
+      "nn" : "IbtdoWlj89cdmJvCmA"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1516321943
+      "currency" : "EUR",
+      "amount" : 844586771
     },
-    "activeFrom" : "2003-01-25T20:00:36.718Z",
-    "activeTo" : "2018-10-29T12:03:51.472Z"
+    "activeFrom" : "1987-05-13T04:46:51.610Z",
+    "activeTo" : "2008-03-01T23:23:59.508Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dfc9bced-de9b-4045-8732-c2e6c7f636a7",
-    "id" : "https://www.example.org/b31b8d45-632b-4239-96f9-97184d658ebb",
-    "identifier" : "mZY2bfEmwos",
+    "source" : "https://www.example.org/7ad9b046-a663-4c43-aaf8-33bdadabd37f",
+    "id" : "https://www.example.org/3cf86334-e1af-494c-a7a9-43c94c1b4bc6",
+    "identifier" : "qP1txFCwLArLC6",
     "labels" : {
-      "hu" : "hb0fNqHnpHJjrcua4"
+      "sv" : "RZ1JFrUJYci"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1707694057
+      "currency" : "EUR",
+      "amount" : 1752305035
     },
-    "activeFrom" : "1988-04-30T23:04:22.107Z",
-    "activeTo" : "2017-02-23T21:54:23.156Z"
+    "activeFrom" : "1999-06-06T17:37:12.729Z",
+    "activeTo" : "2011-08-01T21:43:32.233Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/584e4fbb-df81-42ca-8784-1ccf00356467" ],
+  "subjects" : [ "https://www.example.org/363641f6-1f61-4480-a05b-22a46916a9d2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3706f55f-77b1-4039-a113-e02618305261",
-    "name" : "eAVD4kVH7zuiaXWHv",
-    "mimeType" : "dbN12A60jIOFUVb",
-    "size" : 1349568713,
-    "license" : "https://www.example.com/jbycnsoqrgm8xkrj",
+    "identifier" : "2c2a738b-c282-4060-8e4c-513683a9c596",
+    "name" : "rLBIEEEGICzAqaq7FiD",
+    "mimeType" : "iitVpN9jI8kGD0henL",
+    "size" : 1003107894,
+    "license" : "https://www.example.com/yqufmty4mlixu9yie",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "4UWmXcBgT6y7",
-    "publishedDate" : "2018-01-24T23:41:06.778Z",
+    "legalNote" : "ZPVGc2PmfNk",
+    "publishedDate" : "1975-12-18T09:31:29.789Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "8tuEGtccMDzJSR",
-      "uploadedDate" : "1997-09-13T14:16:14.070Z"
+      "uploadedBy" : "FbP9m3Wq95ii7VjDc",
+      "uploadedDate" : "1988-10-31T20:15:37.056Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TOGxEBSmcKrE1Z7",
-    "name" : "faBKzm2tq6gz0o5H",
-    "description" : "RWUyQvsEWYkxK20o"
+    "id" : "https://www.example.com/WxPWhU9loj8WZMT1oNZ",
+    "name" : "Z201RGQ04XYwMNzZp",
+    "description" : "fFZmAfDfwbJsD"
   } ],
-  "rightsHolder" : "H5ANkF7P2hF787qgs9a",
-  "duplicateOf" : "https://www.example.org/8eff3a29-f7d6-4a46-afdd-4faeb0622ee8",
+  "rightsHolder" : "gQhb1E3gtQeqs1",
+  "duplicateOf" : "https://www.example.org/3d34380f-a28a-4560-8253-17bef46f9c34",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "3V5NWMbb3MS2G"
+    "note" : "AZeEzjGppQc5e7eEF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1biN1WZlMWRYjO1",
-    "createdBy" : "14ym3i0Mrv0cWW",
-    "createdDate" : "2003-03-22T18:14:41.267Z"
+    "note" : "C8AxsnAR81O8N7Mc",
+    "createdBy" : "j439T38uGqaanEg",
+    "createdDate" : "2003-12-24T18:38:19.342Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/bb14fcc7-7441-4db1-8684-bc076cebfd19" ],
+  "curatingInstitutions" : [ "https://www.example.org/ee4a02d9-0e2f-4705-93f5-76a58812a9c8" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "xDpsRhpyutEk2UoV",
-    "ownerAffiliation" : "https://www.example.org/73b42212-e5fe-4c65-a33b-d0e13c483aab"
+    "owner" : "DFJRCtq9mkKK3eeX3",
+    "ownerAffiliation" : "https://www.example.org/3d268d54-8da6-47b1-acc4-600751d1ba02"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/04a8a987-c09c-4380-b943-4d833e741d50"
+    "id" : "https://www.example.org/70cc9b5e-5072-43c5-8534-9bfa9a26de96"
   },
-  "createdDate" : "1994-09-26T10:11:21.253Z",
-  "modifiedDate" : "1984-05-14T15:36:59.133Z",
-  "publishedDate" : "1990-08-20T08:07:16.254Z",
-  "indexedDate" : "1994-05-23T09:07:31.178Z",
-  "handle" : "https://www.example.org/d502d447-f609-47e7-83a1-9fe6d9e132a9",
-  "doi" : "https://doi.org/10.1234/blanditiis",
-  "link" : "https://www.example.org/4a6cd4be-6cfb-4534-b3d2-b6aab0363074",
+  "createdDate" : "2003-05-28T17:21:28.548Z",
+  "modifiedDate" : "1994-03-06T09:13:49.759Z",
+  "publishedDate" : "1983-01-06T21:12:04.850Z",
+  "indexedDate" : "1989-05-18T03:54:35.207Z",
+  "handle" : "https://www.example.org/8e2bd914-7b5c-416f-b2f8-a85674810168",
+  "doi" : "https://doi.org/10.1234/assumenda",
+  "link" : "https://www.example.org/7085e926-ca06-4c6a-92c9-3272b290475d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "J59GIe3tNYPtWf",
+    "mainTitle" : "lmF9HKNEHCCE00Kwp",
     "alternativeTitles" : {
-      "pl" : "ocKgkDduys6aGZ"
+      "pl" : "wTCB9jnhU2DpMEru52"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GhME8wuth7u",
-      "month" : "iT9zvh5kjiK",
-      "day" : "HGCm9Ymovpt"
+      "year" : "hpMeglFPUhu",
+      "month" : "3WRfelEOIdRdN",
+      "day" : "1tyeF50CyYEC5QA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1af82633-5947-4df5-9d59-7dbf2a03bc72",
-        "name" : "ULVc0Fn507pF",
+        "id" : "https://www.example.org/295d8319-aaa1-4627-97f3-1bc4f4260df4",
+        "name" : "n6XaZNdUZfHwR",
         "nameType" : "Organizational",
-        "orcId" : "namNcyAW9gHR",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "wbAKbAG8YkjFfboKmOS",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iBpDWUHE6PakVK3Q",
-          "value" : "qMftz3RdUxGdl"
+          "sourceName" : "W7RCniNhzQDLrDvFm",
+          "value" : "MdSxHMWTNcqwjKykmpo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CMON7p1xdYypMBl9",
-          "value" : "42u0pj2ywEuwTFmRSi6"
+          "sourceName" : "YAKxSifQbQLiK",
+          "value" : "ClmyNAYcpGk5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1ed22b64-4e48-47be-99fd-577e70156306"
+        "id" : "https://www.example.org/5ec42973-8d6a-4fec-846e-0b153a66c2b4"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Dramaturge"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,54 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6f486b16-a1a3-4326-8cc6-54cb70c6a69a",
-        "name" : "swwzH7uDCyaR7iYl",
+        "id" : "https://www.example.org/06de818e-3fd6-4412-9f1a-4bbd394946a8",
+        "name" : "CkiQrEA5qUTgq",
         "nameType" : "Personal",
-        "orcId" : "eaumVAHVa17sN",
+        "orcId" : "PcDer9CY3XEYNzB",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "n5GrbpLH68hXySAZT2",
-          "value" : "RKF2MF1fzMxa"
+          "sourceName" : "TAcd50vjb4R2nKg",
+          "value" : "XHZtfqtEOzDud"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NGSumnuVWveA6Qj",
-          "value" : "N7LyOeXgxp1YoGO"
+          "sourceName" : "ZmZ2sjt1ZkJgJFJZKX",
+          "value" : "Y8wBWvT42brS9NDCRz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1e8acb07-3c44-4e7a-bd17-3a54f815ade8"
+        "id" : "https://www.example.org/5d8f3e0f-9ac8-4754-a36b-c97530d27bf8"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "wDipeWLe2bar0Jrk"
+      "bg" : "gup5urPRaWzsz"
     },
-    "npiSubjectHeading" : "pUyZ1xs1sF",
-    "tags" : [ "sBsCunQhIJien7Go" ],
-    "description" : "8x571xUviq",
+    "npiSubjectHeading" : "sf8Wm4W5nDWE55",
+    "tags" : [ "htFrnyPJKfk" ],
+    "description" : "8cwfJRtt0l1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "MediaTypeOther",
-          "description" : "svDhO8C8AU4o"
+          "type" : "Internet"
         },
         "format" : "Text",
-        "disseminationChannel" : "wGk8iyai4reCWLv8WF",
+        "disseminationChannel" : "Vixpkhq7ZwMvKa6s",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "7LJIfOtIQ24XS7F4L4P",
-          "seriesPart" : "yzyleThrUIlE"
+          "seriesName" : "cRsyPq1hDat822OyJ",
+          "seriesPart" : "CgHe16gXvz5lrLI"
         }
       },
-      "doi" : "https://www.example.org/9f05b468-02b8-441e-8060-4262bd05e52f",
+      "doi" : "https://www.example.org/f0cc12ae-43b7-4f18-b9a2-7aa3220631b8",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -117,93 +116,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b588e63d-271e-47de-8495-450cc67a5969",
-    "abstract" : "znNubBAYoggc12rxA"
+    "metadataSource" : "https://www.example.org/2335c369-393f-47d7-85cd-a34fca0d4d99",
+    "abstract" : "CSIwxoKAAZF164jzF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fce45f1e-13d5-4acb-98e8-0273e9bdb0f9",
-    "name" : "nAQBBAPBdxRewHB",
+    "id" : "https://www.example.org/48f3c660-c5bb-4856-8e45-11b25cb1a7ee",
+    "name" : "Y5gaIeH6AwPsQzmHe",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-07-20T14:20:28.880Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "4m7DISllg44B"
+      "approvalDate" : "1977-08-23T01:26:02.090Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "VvyGsCUyByfnIbczUD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f7a687ed-e5bf-4f7c-84a1-0a50f2629539",
-    "identifier" : "vUu0HBKXrRKeiicWJEE",
+    "source" : "https://www.example.org/b599fc3b-715f-4a32-a42a-4f8b7f3ac662",
+    "identifier" : "84cfUUj8DZ",
     "labels" : {
-      "fi" : "JnOaSQ4XSDD"
+      "hu" : "hfkDHVVgByTDHhAZ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 743023019
+      "currency" : "GBP",
+      "amount" : 919912347
     },
-    "activeFrom" : "2006-12-02T10:00:26.896Z",
-    "activeTo" : "2019-05-14T10:08:06.753Z"
+    "activeFrom" : "1987-07-10T08:54:46.531Z",
+    "activeTo" : "2005-11-08T07:04:24.993Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/622ac822-cd40-4be8-935d-eefb164ef957",
-    "id" : "https://www.example.org/ab9443ba-467b-4176-ad53-976a68294293",
-    "identifier" : "rclbvGHPDSOUq",
+    "source" : "https://www.example.org/0fbb8dd5-a20a-416c-a529-7dd2fa7bb5b5",
+    "id" : "https://www.example.org/41d88b57-ff6f-4825-89e3-40acf0b92b67",
+    "identifier" : "jj2kb6FqMz",
     "labels" : {
-      "bg" : "VbO8SPVzih"
+      "ru" : "LKcNrjI1OR7jqiq"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 696733441
+      "currency" : "EUR",
+      "amount" : 931939433
     },
-    "activeFrom" : "2010-09-14T18:20:16.576Z",
-    "activeTo" : "2016-12-01T02:33:06.896Z"
+    "activeFrom" : "1973-05-23T05:15:27.792Z",
+    "activeTo" : "1993-06-01T12:12:56.280Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/69a9afd0-5ff6-4333-b1b6-4b031b3a6952" ],
+  "subjects" : [ "https://www.example.org/68bd7698-b49e-4b07-b137-50fe6af44a38" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a27e3bbf-3c8c-4338-9d59-2bdc48ca4eb9",
-    "name" : "HQdgCuwmg5AxTOS5",
-    "mimeType" : "YJD9K4J9BMHzx",
-    "size" : 733852556,
-    "license" : "https://www.example.com/yhai9soo6ponoemc",
+    "identifier" : "ea84d3c8-b96d-433f-96d0-c30e66c5e44b",
+    "name" : "HesZaIWc7H",
+    "mimeType" : "eKRu9s4bhmXi7wXu",
+    "size" : 669295906,
+    "license" : "https://www.example.com/lcuys19gb6h3yidu",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "ObGb7wGxZ2dpOLNplOe"
     },
-    "legalNote" : "O22qV0ogu1Mykfi",
-    "publishedDate" : "1991-07-13T01:40:25.820Z",
+    "legalNote" : "o1ndySxI5k",
+    "publishedDate" : "2019-01-31T06:13:00.407Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "gFFK4Cko0ig",
-      "uploadedDate" : "2012-11-16T11:01:31.927Z"
+      "uploadedBy" : "p6XC6VLFQvLuy",
+      "uploadedDate" : "1975-01-20T04:30:29.425Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/hzzxfD56G6dcE",
-    "name" : "LgqwgDhlMPlxUj9zDC",
-    "description" : "jsUU1txHdc"
+    "id" : "https://www.example.com/RFeA1uyfWIcB",
+    "name" : "XzeXAmRXJO",
+    "description" : "1hvXcd4m0UhneXRkf"
   } ],
-  "rightsHolder" : "tXLKS6i7qv6o",
-  "duplicateOf" : "https://www.example.org/3834bdc4-1a53-499d-8eaf-d84b126a2e45",
+  "rightsHolder" : "DcOYqOdn7qDTA",
+  "duplicateOf" : "https://www.example.org/01eaf5d4-fa2e-4470-8f18-bed610389514",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pY4mwNFmB6Se"
+    "note" : "XQEbcAvHTFHBKwUvN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dqpYEubaPOBO",
-    "createdBy" : "dS09CTgo1jd7mQh",
-    "createdDate" : "1982-04-15T12:47:33.369Z"
+    "note" : "TxZhv0LMflEQeU",
+    "createdBy" : "bpz4L9zGsCkGBJ",
+    "createdDate" : "1987-05-08T17:51:34.615Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a96c0424-c912-4e05-b513-9a0c9f4d8e00" ],
+  "curatingInstitutions" : [ "https://www.example.org/87bce8b5-eb19-4071-8790-9e3b9f3cd924" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "kfq2bxNEMFBZ",
-    "ownerAffiliation" : "https://www.example.org/2a012801-021d-485f-a160-175e4af0c7cb"
+    "owner" : "xDpsRhpyutEk2UoV",
+    "ownerAffiliation" : "https://www.example.org/73b42212-e5fe-4c65-a33b-d0e13c483aab"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/45186b25-2c7a-4cdc-a2aa-be13fd790bd4"
+    "id" : "https://www.example.org/04a8a987-c09c-4380-b943-4d833e741d50"
   },
-  "createdDate" : "1979-06-25T22:11:43.052Z",
-  "modifiedDate" : "2011-08-22T05:05:01.108Z",
-  "publishedDate" : "2007-12-04T13:24:11.241Z",
-  "indexedDate" : "2013-11-25T08:14:38.184Z",
-  "handle" : "https://www.example.org/f430b621-a1db-4efc-ac99-72602f0e41da",
-  "doi" : "https://doi.org/10.1234/porro",
-  "link" : "https://www.example.org/701b6f29-c620-4ddb-afa1-35a65fe8ae7c",
+  "createdDate" : "1994-09-26T10:11:21.253Z",
+  "modifiedDate" : "1984-05-14T15:36:59.133Z",
+  "publishedDate" : "1990-08-20T08:07:16.254Z",
+  "indexedDate" : "1994-05-23T09:07:31.178Z",
+  "handle" : "https://www.example.org/d502d447-f609-47e7-83a1-9fe6d9e132a9",
+  "doi" : "https://doi.org/10.1234/blanditiis",
+  "link" : "https://www.example.org/4a6cd4be-6cfb-4534-b3d2-b6aab0363074",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "UwcXnzhwedY0a",
+    "mainTitle" : "J59GIe3tNYPtWf",
     "alternativeTitles" : {
-      "af" : "adjZQIcNPlEOS1LYD"
+      "pl" : "ocKgkDduys6aGZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3jfklcyeFRk",
-      "month" : "IJwNVkPHaRq5J",
-      "day" : "96blmpXn8Z"
+      "year" : "GhME8wuth7u",
+      "month" : "iT9zvh5kjiK",
+      "day" : "HGCm9Ymovpt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/952c9e71-3054-4c01-ae61-b4ba3181f7d6",
-        "name" : "kgi2bed1taJoB",
+        "id" : "https://www.example.org/1af82633-5947-4df5-9d59-7dbf2a03bc72",
+        "name" : "ULVc0Fn507pF",
         "nameType" : "Organizational",
-        "orcId" : "DS9IlqPbxBfXHdK7",
+        "orcId" : "namNcyAW9gHR",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1FoGn7WzYym",
-          "value" : "nDhZkKgyA2Q1KR"
+          "sourceName" : "iBpDWUHE6PakVK3Q",
+          "value" : "qMftz3RdUxGdl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1zDyqHbLpaldNhTsO",
-          "value" : "myotMwV6dpZTfXi"
+          "sourceName" : "CMON7p1xdYypMBl9",
+          "value" : "42u0pj2ywEuwTFmRSi6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/32f9c2bc-571f-47bc-bb6b-3cf66d41e6d3"
+        "id" : "https://www.example.org/1ed22b64-4e48-47be-99fd-577e70156306"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "Registrar"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,54 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6c6bb488-e2ce-408f-9024-14e216227496",
-        "name" : "HAFtrHvPmnjp",
+        "id" : "https://www.example.org/6f486b16-a1a3-4326-8cc6-54cb70c6a69a",
+        "name" : "swwzH7uDCyaR7iYl",
         "nameType" : "Personal",
-        "orcId" : "IHbxmzx30oKRkDjdy5e",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "eaumVAHVa17sN",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7e7vtILbBux5hmzhD",
-          "value" : "hDSnn3fSKpaCtKL9m5n"
+          "sourceName" : "n5GrbpLH68hXySAZT2",
+          "value" : "RKF2MF1fzMxa"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xgvlVLjB8wu07SxeMhw",
-          "value" : "m9JDkJN026z"
+          "sourceName" : "NGSumnuVWveA6Qj",
+          "value" : "N7LyOeXgxp1YoGO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0b914c97-1889-4573-948b-b854b6ef938b"
+        "id" : "https://www.example.org/1e8acb07-3c44-4e7a-bd17-3a54f815ade8"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "IJybhLSYx7J0"
+      "de" : "wDipeWLe2bar0Jrk"
     },
-    "npiSubjectHeading" : "z1av1rQNXP4HSFjo",
-    "tags" : [ "5dJIvOfFC7a6tIfFhS" ],
-    "description" : "KnBBikx0E5A",
+    "npiSubjectHeading" : "pUyZ1xs1sF",
+    "tags" : [ "sBsCunQhIJien7Go" ],
+    "description" : "8x571xUviq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "MediaTypeOther",
+          "description" : "svDhO8C8AU4o"
         },
-        "format" : "Video",
-        "disseminationChannel" : "vPU3yANe8IYT",
+        "format" : "Text",
+        "disseminationChannel" : "wGk8iyai4reCWLv8WF",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "mqPQg32KTO5OuSd8fh7",
-          "seriesPart" : "j2bQkwtvCPUFgUe6f"
+          "seriesName" : "7LJIfOtIQ24XS7F4L4P",
+          "seriesPart" : "yzyleThrUIlE"
         }
       },
-      "doi" : "https://www.example.org/b24a3b4a-cc27-4eb4-ab63-6f6d7a4f4f8e",
+      "doi" : "https://www.example.org/9f05b468-02b8-441e-8060-4262bd05e52f",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -116,93 +117,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1308593d-13af-413c-a291-4b077836160b",
-    "abstract" : "jOgIQv0KuyyGMbJLt"
+    "metadataSource" : "https://www.example.org/b588e63d-271e-47de-8495-450cc67a5969",
+    "abstract" : "znNubBAYoggc12rxA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/279d820b-bbe8-4a19-b83a-6fa68feb60fa",
-    "name" : "XsFEjxlisUOkkm5",
+    "id" : "https://www.example.org/fce45f1e-13d5-4acb-98e8-0273e9bdb0f9",
+    "name" : "nAQBBAPBdxRewHB",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-07-06T21:29:17.221Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "TrO9abnDcudDkNpX3ZI"
+      "approvalDate" : "1996-07-20T14:20:28.880Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "4m7DISllg44B"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d662bcc3-ce64-47a7-b258-79524412db32",
-    "identifier" : "u0xNVX1t0LI",
+    "source" : "https://www.example.org/f7a687ed-e5bf-4f7c-84a1-0a50f2629539",
+    "identifier" : "vUu0HBKXrRKeiicWJEE",
     "labels" : {
-      "en" : "Ktawy9ymB9j"
+      "fi" : "JnOaSQ4XSDD"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 627751573
+      "currency" : "NOK",
+      "amount" : 743023019
     },
-    "activeFrom" : "1983-03-23T15:55:06.116Z",
-    "activeTo" : "1985-05-13T13:16:39.875Z"
+    "activeFrom" : "2006-12-02T10:00:26.896Z",
+    "activeTo" : "2019-05-14T10:08:06.753Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8df4da95-4320-42e7-a45e-53c22289dd55",
-    "id" : "https://www.example.org/1125e3cd-0e67-499a-80b8-f975fe2e7e78",
-    "identifier" : "eAQg3mHW9pT3eorVJco",
+    "source" : "https://www.example.org/622ac822-cd40-4be8-935d-eefb164ef957",
+    "id" : "https://www.example.org/ab9443ba-467b-4176-ad53-976a68294293",
+    "identifier" : "rclbvGHPDSOUq",
     "labels" : {
-      "pt" : "9byk4CErwZNj3"
+      "bg" : "VbO8SPVzih"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1727881530
+      "currency" : "NOK",
+      "amount" : 696733441
     },
-    "activeFrom" : "2017-04-26T00:27:02.865Z",
-    "activeTo" : "2018-05-28T04:14:49.063Z"
+    "activeFrom" : "2010-09-14T18:20:16.576Z",
+    "activeTo" : "2016-12-01T02:33:06.896Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/66ec58eb-e0f1-42b8-809d-2c775af19ea2" ],
+  "subjects" : [ "https://www.example.org/69a9afd0-5ff6-4333-b1b6-4b031b3a6952" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0893d89a-947e-46c9-bc34-a5b16813125a",
-    "name" : "kP5HZNkVrTPH",
-    "mimeType" : "sj9PQ2kHwBZO8K",
-    "size" : 447692288,
-    "license" : "https://www.example.com/8045fy4ekbhq",
+    "identifier" : "a27e3bbf-3c8c-4338-9d59-2bdc48ca4eb9",
+    "name" : "HQdgCuwmg5AxTOS5",
+    "mimeType" : "YJD9K4J9BMHzx",
+    "size" : 733852556,
+    "license" : "https://www.example.com/yhai9soo6ponoemc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "RFEl7smAETi4FOhy",
-    "publishedDate" : "2005-07-04T23:21:50.379Z",
+    "legalNote" : "O22qV0ogu1Mykfi",
+    "publishedDate" : "1991-07-13T01:40:25.820Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "hylFkT1fwwTVKWat",
-      "uploadedDate" : "2013-01-17T15:26:38.558Z"
+      "uploadedBy" : "gFFK4Cko0ig",
+      "uploadedDate" : "2012-11-16T11:01:31.927Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/lX15QMyW4QzXNx",
-    "name" : "phQN29UUqi0fVXV",
-    "description" : "WwMSLcsVXBK2kzMuO"
+    "id" : "https://www.example.com/hzzxfD56G6dcE",
+    "name" : "LgqwgDhlMPlxUj9zDC",
+    "description" : "jsUU1txHdc"
   } ],
-  "rightsHolder" : "ry7ituI04kSO3zj",
-  "duplicateOf" : "https://www.example.org/ff19882e-86b8-4893-8795-029e66d07fd1",
+  "rightsHolder" : "tXLKS6i7qv6o",
+  "duplicateOf" : "https://www.example.org/3834bdc4-1a53-499d-8eaf-d84b126a2e45",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "8lVU37l4SluPDIHDMZ"
+    "note" : "pY4mwNFmB6Se"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kUChoeLWGdcR7ICyS",
-    "createdBy" : "YzvbVlIcEPbOTRv",
-    "createdDate" : "1987-09-02T16:08:32.761Z"
+    "note" : "dqpYEubaPOBO",
+    "createdBy" : "dS09CTgo1jd7mQh",
+    "createdDate" : "1982-04-15T12:47:33.369Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d3de34bc-263a-4b5d-954f-a768e46367b2" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/a96c0424-c912-4e05-b513-9a0c9f4d8e00" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "ph6whbmKlvw1D3uKxn4",
-    "ownerAffiliation" : "https://www.example.org/cdd9adf4-8c29-4283-96b6-b49a4183519b"
+    "owner" : "Y3IJLY4lULU",
+    "ownerAffiliation" : "https://www.example.org/a233bc32-2b0e-45e6-b74b-0b942a26b59b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/22080ce0-de6d-47c2-be37-290709b3e37d"
+    "id" : "https://www.example.org/bb766529-e067-446b-b49f-d941316f2d7f"
   },
-  "createdDate" : "1998-10-09T17:22:15.479Z",
-  "modifiedDate" : "2005-10-17T01:50:12.711Z",
-  "publishedDate" : "1978-02-01T22:18:43.322Z",
-  "indexedDate" : "2023-07-22T07:12:19.554Z",
-  "handle" : "https://www.example.org/22762493-34b6-491f-b198-6873962dbb66",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/3ee0398d-4b03-4299-a2d9-95de7e586b10",
+  "createdDate" : "2009-10-03T22:22:12.511Z",
+  "modifiedDate" : "1984-03-30T09:23:01.126Z",
+  "publishedDate" : "2005-03-04T09:36:13.365Z",
+  "indexedDate" : "2023-06-12T07:59:37.423Z",
+  "handle" : "https://www.example.org/6501f048-7904-4a68-8ff4-92faeeebf873",
+  "doi" : "https://doi.org/10.1234/quod",
+  "link" : "https://www.example.org/e8d73ad5-5d19-4e29-a650-334815967f34",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FkEuabP95dn",
+    "mainTitle" : "HAIRKuosbuWa4ST",
     "alternativeTitles" : {
-      "hu" : "HfqFBHYICT8c"
+      "pl" : "8sZkRFfJpIpf6n3"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7XpluUICDpRE",
-      "month" : "ey67M0bGkw4lAnjw",
-      "day" : "aTD2HYrEApA62iBe"
+      "year" : "0vOJHZJCw3w2uajsJ4D",
+      "month" : "s7jjxojq8bJtESy",
+      "day" : "eWim4EvMYI2fc6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2115b340-ace5-49d5-b635-a9791a949171",
-        "name" : "myjf61ZouqtGRO8Gt",
-        "nameType" : "Personal",
-        "orcId" : "10IjVE2Yo0QXu",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e97368c4-8ee5-4f03-a03b-1fc442b6be71",
+        "name" : "xorWqOEdf1CkB6",
+        "nameType" : "Organizational",
+        "orcId" : "4dmxdth2C9Lls",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iX7cukdFnglq1x",
-          "value" : "4HezlVHkGvs"
+          "sourceName" : "UOj0Gh5iTKdE0lZeb1P",
+          "value" : "MpuLvr2OTFhFMZfXNa"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ouDWl0s51Y1mas",
-          "value" : "4BhWFviEz5aN"
+          "sourceName" : "hO6P1lF2DhC0qLQv",
+          "value" : "4Iw8d7DrppVwbSQFMH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9cc7e7a3-5d0f-4e19-8304-d53c5a3a8a49"
+        "id" : "https://www.example.org/51e1bde6-a97a-437e-9e4b-918edd9c1f00"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a98c5ac0-8be7-4327-a319-deea1a7bb1c2",
-        "name" : "HKc52AsZpxje1",
-        "nameType" : "Personal",
-        "orcId" : "KTkWExe1u52",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/e19f28e9-91c7-446a-af91-36a3dc99fb31",
+        "name" : "MLAjG61aAg03",
+        "nameType" : "Organizational",
+        "orcId" : "MiQ0vxFU4Uu5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5lHbwv6LvvE",
-          "value" : "95tqdQi2p1VA8"
+          "sourceName" : "7LVXtamzW1v",
+          "value" : "aQn8KW6vKDm0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MJZ4L3R6aABqufQeh",
-          "value" : "6Y36Llhv2rg"
+          "sourceName" : "SabNiMMq18ShnXeTDl",
+          "value" : "fVJ0F4xTOs1XnrGTPQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4df2f74f-2660-452e-9ae6-65de462ba9e7"
+        "id" : "https://www.example.org/0c2907ea-c127-4c7d-8624-9e83ff42f173"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "Writer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "FYxPfgN0OsqoU"
+      "pt" : "ov2SKk14UP"
     },
-    "npiSubjectHeading" : "iwrldbIkkrhE",
-    "tags" : [ "UUnP7Js20u7aEBC3" ],
-    "description" : "hK1Vp4p4JOwK4Z",
+    "npiSubjectHeading" : "FHMMmDAT9sdh",
+    "tags" : [ "WTR9FY3vAH3Oygc1R1" ],
+    "description" : "i72LXGyuBUOTUju",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2498ee78-8bb3-4519-b395-b6c40df5b66d"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8fada1d1-1977-40b2-bd47-458703cf2f33"
       },
-      "doi" : "https://www.example.org/741e03b8-7671-4dae-a7db-910caceefbdd",
+      "doi" : "https://www.example.org/d4dced56-f6c3-4f74-bec2-4c0a11f7e3a5",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "P6Ntyl8xqafa",
-        "issue" : "LyZVGDfLq5hdTXeg34Y",
-        "articleNumber" : "xRwyHdWHXaF",
+        "volume" : "WNBo9t0u2w8",
+        "issue" : "NGyEKuo3JVJ3U",
+        "articleNumber" : "kaQRrqCh9Gn0LYWq",
         "pages" : {
           "type" : "Range",
-          "begin" : "LzHXF5WJBkgly8ckb",
-          "end" : "HNOBiq6lICs"
+          "begin" : "dLDkqRiMpG4NFY",
+          "end" : "vl6MUkaJirZgY0IVlAY"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e626d190-f294-4391-96cf-e8988d4f5df3",
-    "abstract" : "mmFrlYp7eho9w8Jj"
+    "metadataSource" : "https://www.example.org/bdc6bce6-27ec-4211-bff1-00719e8f9c08",
+    "abstract" : "jqWAhBYLujg9OSmbM5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5f87d996-5971-47e5-b747-540990549f94",
-    "name" : "SclDlm91fJ",
+    "id" : "https://www.example.org/56b5aa77-d525-421c-b29f-2a48e79996ad",
+    "name" : "q1cIopSVnJRND",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-11-24T13:43:42.494Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "3xTW3oP4MvIm02"
+      "approvalDate" : "1976-02-20T15:29:24.257Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "fNJrF2OqzkQGin"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0319e16f-168b-427e-98f3-da6e995854ef",
-    "identifier" : "3PTKEZ0AwMP7dol",
+    "source" : "https://www.example.org/8307747e-4a38-4166-8e69-c07ff2040561",
+    "identifier" : "vpJeIkZabT",
     "labels" : {
-      "ca" : "DwNiJv8r7l"
+      "ru" : "7KxGgjLRq8VcAyRuw1"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1397042610
+      "currency" : "GBP",
+      "amount" : 2104738365
     },
-    "activeFrom" : "1994-09-08T03:32:36.609Z",
-    "activeTo" : "1995-09-12T22:35:34.797Z"
+    "activeFrom" : "1985-03-06T16:57:07.239Z",
+    "activeTo" : "2018-10-07T14:24:59.318Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3e4781b6-1343-4f1b-af7f-010d95fc6ae2",
-    "id" : "https://www.example.org/e265dac4-f83a-44ea-bc3b-bfb725667046",
-    "identifier" : "NO3KgqSNDdxIjL",
+    "source" : "https://www.example.org/d834cc1e-3360-42c7-bf8d-d58495f5344e",
+    "id" : "https://www.example.org/21974782-a82a-4f67-b0e1-45e60c75a714",
+    "identifier" : "dsxq84hvNqxOzE",
     "labels" : {
-      "sv" : "ICXshx47ZFx9PAdimI1"
+      "it" : "T54YoSK4oS7Yai"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 168035774
+      "amount" : 1821641315
     },
-    "activeFrom" : "2023-03-11T01:38:56.855Z",
-    "activeTo" : "2023-12-12T20:27:16.499Z"
+    "activeFrom" : "1975-06-17T05:45:33.475Z",
+    "activeTo" : "1978-04-11T17:56:59.238Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/dc121c51-9a82-4fb5-94ed-21a6e2d43dd2" ],
+  "subjects" : [ "https://www.example.org/203da02d-59c7-44b7-a71c-5b9bdc9b4452" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1aee78bb-a613-4a93-a999-dca9813a153b",
-    "name" : "rfg2qdpNvILR",
-    "mimeType" : "NHRoRkg1MsxTK5lanG",
-    "size" : 280050645,
-    "license" : "https://www.example.com/p4qxawbupp",
+    "identifier" : "0917a2d6-b919-47e2-96e3-74a3f4d12ec3",
+    "name" : "ZEKRZVCoXq",
+    "mimeType" : "KdJGtV6BuuUrpVPKxe",
+    "size" : 1564388175,
+    "license" : "https://www.example.com/vkv2l2vik5jsjopvzw",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "QcHpvsPSRG"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "pIngoOkLWVsbPqFLZ",
-    "publishedDate" : "1974-09-27T10:36:33.214Z",
+    "legalNote" : "19hCIkhm6nyk",
+    "publishedDate" : "1972-03-18T06:48:49.752Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "vWKi8KFQyZs57Ut58M",
-      "uploadedDate" : "2013-12-07T20:28:58.881Z"
+      "uploadedBy" : "XZeBPLPSigXZiR",
+      "uploadedDate" : "2010-04-28T11:52:37.020Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HJbf1aG8uByuDqia",
-    "name" : "Ntd3qwu5ybcR",
-    "description" : "fD8Nc3a6zV"
+    "id" : "https://www.example.com/B39wyDTDAGti",
+    "name" : "csgslD2dpwMDrPhOX",
+    "description" : "clOMame2whH"
   } ],
-  "rightsHolder" : "A4HkDnKHcLqb5h4g",
-  "duplicateOf" : "https://www.example.org/99d1b671-0fbf-459f-b2fa-1b46c6673367",
+  "rightsHolder" : "rZqPybFJg1noYMS4FW",
+  "duplicateOf" : "https://www.example.org/a0dc3472-46f8-45b7-9cea-4c40b75571a4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dBOuofd6rHWE"
+    "note" : "YLJ1p1JrNwFhdpd"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "qYf8itroVi9QOA6O19",
-    "createdBy" : "imuGgv4L8pRGW5xBR",
-    "createdDate" : "2017-09-02T14:29:28.183Z"
+    "note" : "8zmzHuAi4byyuza",
+    "createdBy" : "WLN7NPfo520",
+    "createdDate" : "1987-06-13T17:17:19.451Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9a012d0c-6b96-47e1-bfc0-1aeb5a3cddf9" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/66a98cb4-636f-481b-b843-63fe6281a7c6" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Y3IJLY4lULU",
-    "ownerAffiliation" : "https://www.example.org/a233bc32-2b0e-45e6-b74b-0b942a26b59b"
+    "owner" : "DSFJixTKPb1",
+    "ownerAffiliation" : "https://www.example.org/30475ba6-c371-4028-a879-ab7909f49a33"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/bb766529-e067-446b-b49f-d941316f2d7f"
+    "id" : "https://www.example.org/1cf2e5e7-947b-4713-8185-dedef244b513"
   },
-  "createdDate" : "2009-10-03T22:22:12.511Z",
-  "modifiedDate" : "1984-03-30T09:23:01.126Z",
-  "publishedDate" : "2005-03-04T09:36:13.365Z",
-  "indexedDate" : "2023-06-12T07:59:37.423Z",
-  "handle" : "https://www.example.org/6501f048-7904-4a68-8ff4-92faeeebf873",
-  "doi" : "https://doi.org/10.1234/quod",
-  "link" : "https://www.example.org/e8d73ad5-5d19-4e29-a650-334815967f34",
+  "createdDate" : "1988-09-14T13:20:53.155Z",
+  "modifiedDate" : "2010-05-20T03:21:16.688Z",
+  "publishedDate" : "1989-08-28T16:16:19.049Z",
+  "indexedDate" : "1999-09-06T14:11:55.725Z",
+  "handle" : "https://www.example.org/2e2d2cc4-de84-4eae-a840-b3f2cb3b2bdc",
+  "doi" : "https://doi.org/10.1234/fuga",
+  "link" : "https://www.example.org/605a11ac-22a9-4ffd-b82b-ad686ebcc11d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HAIRKuosbuWa4ST",
+    "mainTitle" : "GPDqBKqNRt",
     "alternativeTitles" : {
-      "pl" : "8sZkRFfJpIpf6n3"
+      "sv" : "zxDdvZqOmuz7"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0vOJHZJCw3w2uajsJ4D",
-      "month" : "s7jjxojq8bJtESy",
-      "day" : "eWim4EvMYI2fc6"
+      "year" : "DoV61izzdZNxyZG7mP",
+      "month" : "zwATeGxMX3ADOU",
+      "day" : "TLsvEGCgRRPjEoi8euZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e97368c4-8ee5-4f03-a03b-1fc442b6be71",
-        "name" : "xorWqOEdf1CkB6",
+        "id" : "https://www.example.org/28b4bd45-6c49-4d7b-aa25-5bc2bd482cb2",
+        "name" : "hDJbs3lUG4",
         "nameType" : "Organizational",
-        "orcId" : "4dmxdth2C9Lls",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ZGPwksHs0iwdZdKepyu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UOj0Gh5iTKdE0lZeb1P",
-          "value" : "MpuLvr2OTFhFMZfXNa"
+          "sourceName" : "xuNksVQNyX",
+          "value" : "HcIObjDE3JsDiYLj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hO6P1lF2DhC0qLQv",
-          "value" : "4Iw8d7DrppVwbSQFMH"
+          "sourceName" : "40gUOTHCCfH40m7YkW",
+          "value" : "AjMBvTKnxLyyl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/51e1bde6-a97a-437e-9e4b-918edd9c1f00"
+        "id" : "https://www.example.org/1ba8636b-a35a-4f4d-8815-5572f9e14fac"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e19f28e9-91c7-446a-af91-36a3dc99fb31",
-        "name" : "MLAjG61aAg03",
-        "nameType" : "Organizational",
-        "orcId" : "MiQ0vxFU4Uu5",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/d16efae7-cd4a-426f-8b5d-1d08336c0b14",
+        "name" : "VgiSHDIT1Op6D",
+        "nameType" : "Personal",
+        "orcId" : "GObZ8fBA7lQKt4rXMLj",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7LVXtamzW1v",
-          "value" : "aQn8KW6vKDm0"
+          "sourceName" : "K1EynwOxrVRaEaf",
+          "value" : "lXP1AuRAAzY3AME"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SabNiMMq18ShnXeTDl",
-          "value" : "fVJ0F4xTOs1XnrGTPQ"
+          "sourceName" : "inj9cqN238A7T",
+          "value" : "4NuaTFeLzSL3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0c2907ea-c127-4c7d-8624-9e83ff42f173"
+        "id" : "https://www.example.org/774c9258-0dbc-46e2-b3ca-aa37110b6efc"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "ov2SKk14UP"
+      "it" : "dTMCmWgj8D2aP3"
     },
-    "npiSubjectHeading" : "FHMMmDAT9sdh",
-    "tags" : [ "WTR9FY3vAH3Oygc1R1" ],
-    "description" : "i72LXGyuBUOTUju",
+    "npiSubjectHeading" : "Tm2Jkkvt2KdB",
+    "tags" : [ "elywEQjQILyrmtg7U" ],
+    "description" : "YfsSOPzkQw5riCgI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8fada1d1-1977-40b2-bd47-458703cf2f33"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/709fef40-9883-48ad-8cf8-b60243a0fbf0"
       },
-      "doi" : "https://www.example.org/d4dced56-f6c3-4f74-bec2-4c0a11f7e3a5",
+      "doi" : "https://www.example.org/cae0fc6e-2ca8-4bed-b85e-47fcba300ed3",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "WNBo9t0u2w8",
-        "issue" : "NGyEKuo3JVJ3U",
-        "articleNumber" : "kaQRrqCh9Gn0LYWq",
+        "volume" : "6orGVqF30GNI3",
+        "issue" : "h0C4JmLo7Wg8Mao",
+        "articleNumber" : "dcmyJBL4wnD6cYKIM",
         "pages" : {
           "type" : "Range",
-          "begin" : "dLDkqRiMpG4NFY",
-          "end" : "vl6MUkaJirZgY0IVlAY"
+          "begin" : "NCjNuEYTD4E9qsFGseO",
+          "end" : "4XIGr6iX1o7sz"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/bdc6bce6-27ec-4211-bff1-00719e8f9c08",
-    "abstract" : "jqWAhBYLujg9OSmbM5"
+    "metadataSource" : "https://www.example.org/eaf43101-800e-48b7-81e6-c6139fd54de7",
+    "abstract" : "bG6CdHn3TXer0Ml"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/56b5aa77-d525-421c-b29f-2a48e79996ad",
-    "name" : "q1cIopSVnJRND",
+    "id" : "https://www.example.org/dd53336b-430d-4e1e-bcdf-ade8e50d563c",
+    "name" : "l50HO3KJTSRNH1l",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-02-20T15:29:24.257Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "fNJrF2OqzkQGin"
+      "approvalDate" : "2022-10-03T13:05:35.226Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "UaCiuOsCu0NN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8307747e-4a38-4166-8e69-c07ff2040561",
-    "identifier" : "vpJeIkZabT",
+    "source" : "https://www.example.org/eeca3733-d37c-4b12-a6ac-9093cc190f69",
+    "identifier" : "DdoVlDSpSXek",
     "labels" : {
-      "ru" : "7KxGgjLRq8VcAyRuw1"
+      "bg" : "ICsHQseRXZmfBAn3GSW"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2104738365
+      "amount" : 844779287
     },
-    "activeFrom" : "1985-03-06T16:57:07.239Z",
-    "activeTo" : "2018-10-07T14:24:59.318Z"
+    "activeFrom" : "2021-05-26T00:18:08.718Z",
+    "activeTo" : "2023-12-02T23:03:01.760Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d834cc1e-3360-42c7-bf8d-d58495f5344e",
-    "id" : "https://www.example.org/21974782-a82a-4f67-b0e1-45e60c75a714",
-    "identifier" : "dsxq84hvNqxOzE",
+    "source" : "https://www.example.org/de75bd93-7741-4c63-8c8f-0ee0396b4581",
+    "id" : "https://www.example.org/ec939a13-8119-4eba-a535-a7b160eaa257",
+    "identifier" : "mb8MXzwAqJr",
     "labels" : {
-      "it" : "T54YoSK4oS7Yai"
+      "sv" : "5ttCixtaABrwwQZJ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1821641315
+      "currency" : "USD",
+      "amount" : 17983211
     },
-    "activeFrom" : "1975-06-17T05:45:33.475Z",
-    "activeTo" : "1978-04-11T17:56:59.238Z"
+    "activeFrom" : "1983-05-03T01:02:23.613Z",
+    "activeTo" : "1991-08-26T06:55:20.938Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/203da02d-59c7-44b7-a71c-5b9bdc9b4452" ],
+  "subjects" : [ "https://www.example.org/fb36c982-b4d1-4fe1-aa6c-972568b97a98" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0917a2d6-b919-47e2-96e3-74a3f4d12ec3",
-    "name" : "ZEKRZVCoXq",
-    "mimeType" : "KdJGtV6BuuUrpVPKxe",
-    "size" : 1564388175,
-    "license" : "https://www.example.com/vkv2l2vik5jsjopvzw",
+    "identifier" : "2f9cf1d3-ef53-4763-9b53-d926fa4c27b4",
+    "name" : "ghLwtSkS6uf91",
+    "mimeType" : "Y4UWN8cY8GMpvI01",
+    "size" : 86637230,
+    "license" : "https://www.example.com/phxhdk7xthwfhi2kvta",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "19hCIkhm6nyk",
-    "publishedDate" : "1972-03-18T06:48:49.752Z",
+    "legalNote" : "zm2OXDCvlmzjc9X",
+    "publishedDate" : "2022-03-08T12:28:42.120Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "XZeBPLPSigXZiR",
-      "uploadedDate" : "2010-04-28T11:52:37.020Z"
+      "uploadedBy" : "alPcY8JTClB5",
+      "uploadedDate" : "2012-12-09T20:25:11.595Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/B39wyDTDAGti",
-    "name" : "csgslD2dpwMDrPhOX",
-    "description" : "clOMame2whH"
+    "id" : "https://www.example.com/zjIvsi6vvI8HM",
+    "name" : "DR19AZBpReRGZ",
+    "description" : "5EpUTk4HbJGJ63"
   } ],
-  "rightsHolder" : "rZqPybFJg1noYMS4FW",
-  "duplicateOf" : "https://www.example.org/a0dc3472-46f8-45b7-9cea-4c40b75571a4",
+  "rightsHolder" : "RXENS2SfHBPxXz",
+  "duplicateOf" : "https://www.example.org/04550488-f5a0-44b0-9082-8b7e88943eff",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YLJ1p1JrNwFhdpd"
+    "note" : "xnjeIppv4c"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8zmzHuAi4byyuza",
-    "createdBy" : "WLN7NPfo520",
-    "createdDate" : "1987-06-13T17:17:19.451Z"
+    "note" : "dTwAHDsVpK",
+    "createdBy" : "QeY77o2Daqe",
+    "createdDate" : "2008-04-05T01:06:51.479Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/66a98cb4-636f-481b-b843-63fe6281a7c6" ],
+  "curatingInstitutions" : [ "https://www.example.org/8d6f8fe2-13ce-410a-b47b-ac5b604d7b61" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "L7hMHtD3SE0dTth1",
-    "ownerAffiliation" : "https://www.example.org/21369c69-c2a0-4606-ae03-21b39c9b0237"
+    "owner" : "k0E0D2TYjxFT",
+    "ownerAffiliation" : "https://www.example.org/8be4b981-d0b2-486c-a7fe-9426e83b39ed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8f6bfc31-f2bf-42e4-9758-0cf447bab30b"
+    "id" : "https://www.example.org/49416da6-a1f2-4f85-8a72-5cf8121ed708"
   },
-  "createdDate" : "2009-07-06T05:08:45.471Z",
-  "modifiedDate" : "1983-07-09T01:08:57.536Z",
-  "publishedDate" : "1971-07-24T03:41:38.280Z",
-  "indexedDate" : "2004-05-05T02:52:50.687Z",
-  "handle" : "https://www.example.org/fc1d8e8e-9e75-4544-94e8-bcf52441af87",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/511e3ab0-1114-4bbd-b1a7-04c61cd04386",
+  "createdDate" : "1983-12-16T21:26:38.527Z",
+  "modifiedDate" : "1998-10-07T02:44:11.650Z",
+  "publishedDate" : "1981-05-07T11:58:54.667Z",
+  "indexedDate" : "2020-08-13T08:49:09.186Z",
+  "handle" : "https://www.example.org/2b8efb04-92b4-489c-a8b5-8390553da82e",
+  "doi" : "https://doi.org/10.1234/eius",
+  "link" : "https://www.example.org/2ce41a95-14c7-4702-915b-e760adf16d21",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0ffGEx6RGEU",
+    "mainTitle" : "cqDNAO7GrfNtbyFn",
     "alternativeTitles" : {
-      "se" : "KaFkmaAAzA6HHN3l"
+      "pl" : "p6c2PaTGiBEVFcS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "QyhfH8v0d8zXR4Jt",
-      "month" : "pSqE8kICq2W2DpDRw",
-      "day" : "3yS09yIOp4aWMJ"
+      "year" : "8r50ZygA0K83X",
+      "month" : "h3zJY1dBrW1qiu2",
+      "day" : "DI0CYJKfZsbIAFon"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fe1bca33-b4d0-4a71-86cb-027923e34e42",
-        "name" : "769qVjK2zXbQk07ouB",
+        "id" : "https://www.example.org/c8995d2e-6ba6-4a40-aa86-83f210de4d8e",
+        "name" : "6kMEzHB120rxRMoOt4",
         "nameType" : "Organizational",
-        "orcId" : "gm2CPhovEqrBeQBNZF",
+        "orcId" : "fJIFmAt3VlcZALJ",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ccOEgnV5x7",
-          "value" : "1WO2BzErIiDl"
+          "sourceName" : "hpHUujaAhQqt",
+          "value" : "EDnr6DpSGpszJPi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uGaYADoGCkUT",
-          "value" : "BIo9A5ZCv46zwtBZ6Xr"
+          "sourceName" : "R8Rr6o3cctU7k0TRfn",
+          "value" : "pYDKvhiTew1xf3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1af26d23-a177-48b1-82a2-f637630b87ed"
+        "id" : "https://www.example.org/05c62950-6603-4a49-ae46-92d02df9b2a4"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a8d70067-5aad-40d9-9cf5-822a5bc669d8",
-        "name" : "pM3IstLZuPpgHnf",
-        "nameType" : "Organizational",
-        "orcId" : "HyK1ePnqcNclUoSqz",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d123a6b2-0e00-4b3f-acbd-5795368b0353",
+        "name" : "0xEzCBaT4Swe",
+        "nameType" : "Personal",
+        "orcId" : "69d5IZcCtXLx",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OCKmhf0gxb6rNoBC",
-          "value" : "fsBCvqcIzVVJlM48"
+          "sourceName" : "4lHazbfnLPSyNSqPc",
+          "value" : "SibgDE2dhxxO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zUu62WrFcwI",
-          "value" : "BcvEOC4UpwGIp"
+          "sourceName" : "KGoFLTK7TFKEY",
+          "value" : "PnqDQEbyTY2i2yPOe5t"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ba5cec01-0df5-43db-a1ac-0483e39e904e"
+        "id" : "https://www.example.org/b0da0810-cf32-49fa-9253-09766098a6b4"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "xtgRQP9s3W8okIqgSX"
+      "pl" : "GwVlkTAxW6iBjQ"
     },
-    "npiSubjectHeading" : "muXxglUNYbw7KZ6",
-    "tags" : [ "0GELj5flWygTVd" ],
-    "description" : "6Mv6Lb5NFA",
+    "npiSubjectHeading" : "NhocA9W1ZnS6CDS1",
+    "tags" : [ "lkqVLjBTG5" ],
+    "description" : "UVy0rBw3KD7525lX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -100,15 +100,15 @@
         "medium" : {
           "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "N2J6JTc4oa3RggFVM",
+        "format" : "Video",
+        "disseminationChannel" : "s1R0RqogD17w",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "Cii2yYyNjoNU6x",
-          "seriesPart" : "9owA31eZYZzyYS1d1U"
+          "seriesName" : "BMK1j4DyFkt",
+          "seriesPart" : "btfqfPn1j3keFNxC"
         }
       },
-      "doi" : "https://www.example.org/8f65c812-e578-41f1-b797-2c351725c900",
+      "doi" : "https://www.example.org/88fba4c7-b2b9-4147-9da5-ed14df4d5961",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/83b2d9cf-4f6e-4100-ad1c-d9bf74345d57",
-    "abstract" : "6QakgsQDt2Ol"
+    "metadataSource" : "https://www.example.org/5e093609-eb8e-4a75-8564-a9181f8b86aa",
+    "abstract" : "jAW1c3EbPnpeq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8eb9a9b2-820e-4030-8aa7-84e78387a63a",
-    "name" : "JIsuO08n4lXnR9L6EDg",
+    "id" : "https://www.example.org/ff7d96a1-2bc9-437e-b8d8-3ccafa39490b",
+    "name" : "GKYiVWcV9bnyhjIMnn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-09-18T02:24:50.907Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "QrTYB7RiPaFp"
+      "approvalDate" : "2019-08-16T16:33:46.012Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "vOBFcPawkkg7746aMW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ae53e465-08de-4c97-8a3f-a427798c50d4",
-    "identifier" : "2vMIa7OoQcWx8gtaf03",
+    "source" : "https://www.example.org/05fb8d28-6667-4f5c-9984-8954ebb2c672",
+    "identifier" : "LMMPtt2bXcD8AJc",
     "labels" : {
-      "zh" : "wnZZgP09ze5MN"
+      "af" : "uP3af3GvYrsGy2Ff7K"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 52394070
+      "currency" : "NOK",
+      "amount" : 1811172231
     },
-    "activeFrom" : "2003-03-08T22:09:59.007Z",
-    "activeTo" : "2006-10-11T07:02:18.552Z"
+    "activeFrom" : "1997-09-23T10:58:42.602Z",
+    "activeTo" : "2007-07-21T20:26:06.094Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a7db8cec-3c7a-4b04-9a01-099f4534357e",
-    "id" : "https://www.example.org/73711954-b6b5-47b1-88cf-7a5581e29f80",
-    "identifier" : "e1urglnIsl0",
+    "source" : "https://www.example.org/9e2a19fe-36bf-4417-819a-52b50a1e2f18",
+    "id" : "https://www.example.org/d8775e95-42cf-45ab-bf77-de3330b88751",
+    "identifier" : "5uefrLyTMu0XHzaMMBn",
     "labels" : {
-      "nn" : "vFhipscm5mhx"
+      "el" : "jnVnRcAMzcDG"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1691091730
+      "currency" : "NOK",
+      "amount" : 1461631467
     },
-    "activeFrom" : "2011-05-11T23:21:28.936Z",
-    "activeTo" : "2017-07-31T12:13:53.728Z"
+    "activeFrom" : "1990-04-20T07:43:20.383Z",
+    "activeTo" : "2005-02-17T18:46:36.952Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4681918c-4ef1-47dd-8302-6d3fc0433645" ],
+  "subjects" : [ "https://www.example.org/65436121-ee92-4718-91d9-f24f6ce38993" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b37d565b-ecfb-4757-8a6c-8a49fe244947",
-    "name" : "fyZyuyUaxf",
-    "mimeType" : "EDtIb4UWRAwHqyUuqCV",
-    "size" : 1976908352,
-    "license" : "https://www.example.com/zwkzyxlkasnq",
+    "identifier" : "fb36b188-b6e9-4354-bc32-f3fd00d9ee9b",
+    "name" : "MdYQJ5B8yRuxj1",
+    "mimeType" : "NL6a7ZDzirWFT7ulom",
+    "size" : 1272936184,
+    "license" : "https://www.example.com/gmnv5l0kxpfu9",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "39smvd0faQpoq",
-    "publishedDate" : "1983-07-06T08:04:57.762Z",
+    "legalNote" : "FCAvmWundkno",
+    "publishedDate" : "2004-05-20T05:30:58.810Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "AtqVlbJDG7RIIG",
-      "uploadedDate" : "1987-10-23T13:03:38.248Z"
+      "uploadedBy" : "gbDAud6oC5tlrQZe",
+      "uploadedDate" : "1988-05-06T22:20:24.906Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/eZrWn0grjr6mv6Oq",
-    "name" : "ZtuZGu8M1PpXYMiWD",
-    "description" : "2CoUMK7ysYS1XIF1o"
+    "id" : "https://www.example.com/nCMiBJzE3kebSLl",
+    "name" : "eSSgSK7hPb0PEETQMK",
+    "description" : "OoG37mMnGgIHjs"
   } ],
-  "rightsHolder" : "eZ4Ukyjm0MnBzEtY",
-  "duplicateOf" : "https://www.example.org/4f0dbe8f-628f-40b0-b2b5-1c5ce2420833",
+  "rightsHolder" : "iEfe4t2SpVG",
+  "duplicateOf" : "https://www.example.org/07198407-3844-43dd-add3-24b93d3565aa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Rhi82Eo09fvLei"
+    "note" : "U58Skb7nwNw7z"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "A3GfiL36vK5",
-    "createdBy" : "6Tq9aW6Ujx8EjD",
-    "createdDate" : "2009-07-12T00:22:29.549Z"
+    "note" : "bJ460etJwBgkpu8",
+    "createdBy" : "NCvaGJynVadjqjr",
+    "createdDate" : "1992-02-15T06:28:57.277Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a7d6289b-8be3-447e-9bea-85a5d4a6ff54" ],
+  "curatingInstitutions" : [ "https://www.example.org/898aadbc-be75-490f-b6a8-198e2f40165f" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "RjkA3hT1cHq49cbr",
-    "ownerAffiliation" : "https://www.example.org/e6a072a3-c3f1-47fd-b160-a21ccbf26363"
+    "owner" : "L7hMHtD3SE0dTth1",
+    "ownerAffiliation" : "https://www.example.org/21369c69-c2a0-4606-ae03-21b39c9b0237"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1c3ce452-bb60-419a-a084-1bc9ab95448d"
+    "id" : "https://www.example.org/8f6bfc31-f2bf-42e4-9758-0cf447bab30b"
   },
-  "createdDate" : "1998-07-18T06:31:52.724Z",
-  "modifiedDate" : "1986-02-06T23:52:44.690Z",
-  "publishedDate" : "1999-11-15T16:25:58.353Z",
-  "indexedDate" : "2020-03-04T04:05:41.893Z",
-  "handle" : "https://www.example.org/ebea116f-27bd-4791-95e5-f0d3209cc911",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/6bcf5b9d-d391-40ee-bcae-f95c3ec98114",
+  "createdDate" : "2009-07-06T05:08:45.471Z",
+  "modifiedDate" : "1983-07-09T01:08:57.536Z",
+  "publishedDate" : "1971-07-24T03:41:38.280Z",
+  "indexedDate" : "2004-05-05T02:52:50.687Z",
+  "handle" : "https://www.example.org/fc1d8e8e-9e75-4544-94e8-bcf52441af87",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/511e3ab0-1114-4bbd-b1a7-04c61cd04386",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Z6ko8C9KR2u",
+    "mainTitle" : "0ffGEx6RGEU",
     "alternativeTitles" : {
-      "af" : "ztGNFPKOmRJmSYYJeeW"
+      "se" : "KaFkmaAAzA6HHN3l"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ZC6PgVAiy4sZvTmSJ",
-      "month" : "HDxV4qR1wN",
-      "day" : "3wBYRTx07nPOJEQi"
+      "year" : "QyhfH8v0d8zXR4Jt",
+      "month" : "pSqE8kICq2W2DpDRw",
+      "day" : "3yS09yIOp4aWMJ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cbd328c3-9c64-441f-b63e-11221e8f953a",
-        "name" : "4hSe2O8nJivVN6",
-        "nameType" : "Personal",
-        "orcId" : "IKe8iq6bQbVOSJAu",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/fe1bca33-b4d0-4a71-86cb-027923e34e42",
+        "name" : "769qVjK2zXbQk07ouB",
+        "nameType" : "Organizational",
+        "orcId" : "gm2CPhovEqrBeQBNZF",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MS8RE2LahK5Sju",
-          "value" : "WM76cBko09OKecm06mt"
+          "sourceName" : "ccOEgnV5x7",
+          "value" : "1WO2BzErIiDl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v3pULS80350b",
-          "value" : "8wSdXlGlHQVe6"
+          "sourceName" : "uGaYADoGCkUT",
+          "value" : "BIo9A5ZCv46zwtBZ6Xr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/43d4018d-e2ad-4fff-8577-737a7e3180d4"
+        "id" : "https://www.example.org/1af26d23-a177-48b1-82a2-f637630b87ed"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "InterviewSubject"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,54 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/31f057a9-9203-4d8a-aa2e-b504e90d0959",
-        "name" : "hDfvUb3BBohgpwPvFY",
+        "id" : "https://www.example.org/a8d70067-5aad-40d9-9cf5-822a5bc669d8",
+        "name" : "pM3IstLZuPpgHnf",
         "nameType" : "Organizational",
-        "orcId" : "Nfxy83RCie3BUG",
+        "orcId" : "HyK1ePnqcNclUoSqz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HiuwyuO0BIZoEr",
-          "value" : "RmF6pRr9YEgmlyToGB"
+          "sourceName" : "OCKmhf0gxb6rNoBC",
+          "value" : "fsBCvqcIzVVJlM48"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6FXpVg0waVH5yCDqw",
-          "value" : "XU7B20cPt66NAou9fn"
+          "sourceName" : "zUu62WrFcwI",
+          "value" : "BcvEOC4UpwGIp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/679479cd-7f32-4b16-8fc9-18d1447fc5ab"
+        "id" : "https://www.example.org/ba5cec01-0df5-43db-a1ac-0483e39e904e"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "SoundDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "43HfbVYmL6fPjGs416"
+      "en" : "xtgRQP9s3W8okIqgSX"
     },
-    "npiSubjectHeading" : "9XMdvk0pW4Jaj",
-    "tags" : [ "CN420WqsS8hOdph" ],
-    "description" : "iwuEdyRhYBtI",
+    "npiSubjectHeading" : "muXxglUNYbw7KZ6",
+    "tags" : [ "0GELj5flWygTVd" ],
+    "description" : "6Mv6Lb5NFA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "MediaTypeOther",
-          "description" : "ySKfTxho6Bip9M"
+          "type" : "Radio"
         },
         "format" : "Sound",
-        "disseminationChannel" : "RSTt98lex8Z",
+        "disseminationChannel" : "N2J6JTc4oa3RggFVM",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "t9x9VUFppLoax88ZEuR",
-          "seriesPart" : "hjhdaEVAhqmvBeyfuxt"
+          "seriesName" : "Cii2yYyNjoNU6x",
+          "seriesPart" : "9owA31eZYZzyYS1d1U"
         }
       },
-      "doi" : "https://www.example.org/49f07fd6-5e4f-4845-9ecc-555226bae590",
+      "doi" : "https://www.example.org/8f65c812-e578-41f1-b797-2c351725c900",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -117,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/722863bf-dc02-4c07-b4ad-4264dbe7849a",
-    "abstract" : "oCyncpz4Nvhk"
+    "metadataSource" : "https://www.example.org/83b2d9cf-4f6e-4100-ad1c-d9bf74345d57",
+    "abstract" : "6QakgsQDt2Ol"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5a15fd9b-145b-49a7-86b1-07b63228e433",
-    "name" : "wZlLwUKMEDsAh",
+    "id" : "https://www.example.org/8eb9a9b2-820e-4030-8aa7-84e78387a63a",
+    "name" : "JIsuO08n4lXnR9L6EDg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-02-19T16:49:14.803Z",
+      "approvalDate" : "2020-09-18T02:24:50.907Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "yYOeM8bJE41Ps7Ddzs"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "QrTYB7RiPaFp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b5f6ef24-57cf-468b-9eac-5675fd4bc2ec",
-    "identifier" : "ujneCMWVJnqjv6jdS",
+    "source" : "https://www.example.org/ae53e465-08de-4c97-8a3f-a427798c50d4",
+    "identifier" : "2vMIa7OoQcWx8gtaf03",
     "labels" : {
-      "el" : "47bJavIuOV1q52"
+      "zh" : "wnZZgP09ze5MN"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1905164416
+      "currency" : "EUR",
+      "amount" : 52394070
     },
-    "activeFrom" : "1985-08-20T18:28:40.452Z",
-    "activeTo" : "2010-02-03T11:57:35.602Z"
+    "activeFrom" : "2003-03-08T22:09:59.007Z",
+    "activeTo" : "2006-10-11T07:02:18.552Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d9e371ef-d396-49d6-ae33-8a1759e6694d",
-    "id" : "https://www.example.org/e0efe7ea-3e16-4f45-97aa-da61fa27d9ad",
-    "identifier" : "sEZxaMziEOmS5",
+    "source" : "https://www.example.org/a7db8cec-3c7a-4b04-9a01-099f4534357e",
+    "id" : "https://www.example.org/73711954-b6b5-47b1-88cf-7a5581e29f80",
+    "identifier" : "e1urglnIsl0",
     "labels" : {
-      "ca" : "qa05qZyozCuIaq2d0d"
+      "nn" : "vFhipscm5mhx"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1884893841
+      "currency" : "EUR",
+      "amount" : 1691091730
     },
-    "activeFrom" : "1998-11-27T05:59:34.346Z",
-    "activeTo" : "2021-11-08T13:58:38.522Z"
+    "activeFrom" : "2011-05-11T23:21:28.936Z",
+    "activeTo" : "2017-07-31T12:13:53.728Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b22186dd-5c8f-4afb-b40b-e3560a3b5526" ],
+  "subjects" : [ "https://www.example.org/4681918c-4ef1-47dd-8302-6d3fc0433645" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d382cf8d-bd73-44e9-8d8b-70a92ad2d73f",
-    "name" : "qTRpHoZc2z63bXhft01",
-    "mimeType" : "kgHo90DfoZ9nM",
-    "size" : 392661636,
-    "license" : "https://www.example.com/6yf4j8rtdm",
+    "identifier" : "b37d565b-ecfb-4757-8a6c-8a49fe244947",
+    "name" : "fyZyuyUaxf",
+    "mimeType" : "EDtIb4UWRAwHqyUuqCV",
+    "size" : 1976908352,
+    "license" : "https://www.example.com/zwkzyxlkasnq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "pIHCE8aq4dKAKl",
-    "publishedDate" : "2020-10-18T08:29:53.109Z",
+    "legalNote" : "39smvd0faQpoq",
+    "publishedDate" : "1983-07-06T08:04:57.762Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "E67eH3lZQI7",
-      "uploadedDate" : "2019-08-02T04:01:41.757Z"
+      "uploadedBy" : "AtqVlbJDG7RIIG",
+      "uploadedDate" : "1987-10-23T13:03:38.248Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SPaSPI4GZGk",
-    "name" : "36TRvzmnsoaPCsgU2u",
-    "description" : "YSoUS5w8XHpWplhYe"
+    "id" : "https://www.example.com/eZrWn0grjr6mv6Oq",
+    "name" : "ZtuZGu8M1PpXYMiWD",
+    "description" : "2CoUMK7ysYS1XIF1o"
   } ],
-  "rightsHolder" : "XGap1TJNK5KMb",
-  "duplicateOf" : "https://www.example.org/e31b0046-59d5-4f49-940d-fb8e8f87bcb4",
+  "rightsHolder" : "eZ4Ukyjm0MnBzEtY",
+  "duplicateOf" : "https://www.example.org/4f0dbe8f-628f-40b0-b2b5-1c5ce2420833",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bNtWga9B25"
+    "note" : "Rhi82Eo09fvLei"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xZkGcjBKuycK",
-    "createdBy" : "p02VMq8vwtaWQyG",
-    "createdDate" : "2016-01-27T07:00:50.666Z"
+    "note" : "A3GfiL36vK5",
+    "createdBy" : "6Tq9aW6Ujx8EjD",
+    "createdDate" : "2009-07-12T00:22:29.549Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/147ae4d2-b22a-40b1-85f0-8b45e3027d04" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/a7d6289b-8be3-447e-9bea-85a5d4a6ff54" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "ZoDIzDpvbzP7gzs",
-    "ownerAffiliation" : "https://www.example.org/8467e160-2769-4bec-a2dd-e87cfd2bd44a"
+    "owner" : "43RMPhziCAqSYgmwVKr",
+    "ownerAffiliation" : "https://www.example.org/48f3b75c-2138-45c7-b746-8cf8aafc45aa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9f2bf45b-ba1f-4a62-a2ed-a8d74b2d8050"
+    "id" : "https://www.example.org/491a3396-1f8d-4bb6-9cb3-553c7bae4eb3"
   },
-  "createdDate" : "2019-05-20T07:15:42.245Z",
-  "modifiedDate" : "2002-12-01T04:33:02.786Z",
-  "publishedDate" : "1996-03-06T01:14:13.787Z",
-  "indexedDate" : "2015-12-01T05:43:45.558Z",
-  "handle" : "https://www.example.org/8aa7984f-8755-4278-98a1-bcfd5a6e0aa2",
-  "doi" : "https://doi.org/10.1234/reprehenderit",
-  "link" : "https://www.example.org/2326ad38-6924-4694-8e76-9cf4f825c339",
+  "createdDate" : "2012-01-25T23:54:57.756Z",
+  "modifiedDate" : "1979-05-20T13:31:34.298Z",
+  "publishedDate" : "1975-02-03T22:31:43.752Z",
+  "indexedDate" : "2018-08-01T17:45:25.642Z",
+  "handle" : "https://www.example.org/506f943a-171c-42a2-af88-db0fb5cf7558",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/47ac1977-bd66-4c04-b177-57e2420b6673",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kKtudoZaPD",
+    "mainTitle" : "WYrXiLHFwhjkXI",
     "alternativeTitles" : {
-      "da" : "XMbsy54NSSvX37fbklB"
+      "nl" : "gxSghpllu7TuMaz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "W0NWSrjMgo3p",
-      "month" : "IycMIh6ZFDtIj",
-      "day" : "wX5esZyJeaLQ"
+      "year" : "O7MQ5tqg7c9zG8oy",
+      "month" : "qW3pTiti1F0Bfo3u",
+      "day" : "LulCCHUN1ttP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9001466c-c802-4dc4-940c-881ef96e5d6f",
-        "name" : "KKOcoVdzLU7SJ2NW",
-        "nameType" : "Organizational",
-        "orcId" : "C3v0DP4DIayhixM",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/5fa26900-7ac4-43d8-8150-8b7b74992cf1",
+        "name" : "M85sH3CHwIf5EBY",
+        "nameType" : "Personal",
+        "orcId" : "RaP7WTj7pILkL7N7",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FV2FHI2kQoM0Cb4M",
-          "value" : "4wPoPsuizw4aopuO2z"
+          "sourceName" : "wqo8KY6I0V",
+          "value" : "hD5Dan0J5PJYC5PXS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AxXfBNahZSWo",
-          "value" : "SDIysXfTlvog7I"
+          "sourceName" : "V6qnBlouwR4xRT",
+          "value" : "1FSG2bFGvlf3GxbNU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/26cb6832-1463-4249-b2a0-cfd81e626a93"
+        "id" : "https://www.example.org/60cfbfc1-d445-4ca1-b0f2-20890ad123e9"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "InterviewSubject"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/035a9ca3-f08e-42cd-9fbc-405b5f3f7d2a",
-        "name" : "6y0fEZN47mgTFylDhB",
+        "id" : "https://www.example.org/89d51ee0-cb44-435f-9df9-1eddc5b21da2",
+        "name" : "oUfuXSjnD3Bfe",
         "nameType" : "Personal",
-        "orcId" : "4CcTu1avBZkK",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "OFXxjIJ0WBU6ZMiKN",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bZd0waUJluULdBn",
-          "value" : "wlbJZWpRZjBXDP0"
+          "sourceName" : "1vjXpgCyVnXCJ",
+          "value" : "PG7ouFd1XVmfavpM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kOPoJ82aKkH8lXHO9i",
-          "value" : "GgSijCLTsVkJ"
+          "sourceName" : "cYiVOCTs7FKhAcm",
+          "value" : "3UKLWxz2uz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/90e402a1-c2d3-408a-b799-baaf0d0eb626"
+        "id" : "https://www.example.org/678ef0d7-49bc-4f01-8365-b09bc008ba5a"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "3OsG8z2FQIWw1hOPs"
+      "nn" : "D4r7om0eG5iq"
     },
-    "npiSubjectHeading" : "E8DtDEiibBmQuq",
-    "tags" : [ "Lw6lj9x9GTeuU1j" ],
-    "description" : "so1Qnl3UIrV4",
+    "npiSubjectHeading" : "evkAS461GnvzpqA",
+    "tags" : [ "liFFnFYYzUvVYZC6" ],
+    "description" : "C4KC96Yj1FO6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Radio"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "bGDUV3YuEJsTYyN",
+        "format" : "Video",
+        "disseminationChannel" : "0c7AbpgXO38xgn4v",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "YjgjFBrYfS",
-          "seriesPart" : "ZrQftUO1vFPp"
+          "seriesName" : "0PRy7sAcmsDVyZdh7U0",
+          "seriesPart" : "7EkVIdACduwLvyqjN"
         }
       },
-      "doi" : "https://www.example.org/87bc9f62-3e36-4ae1-a24b-531ff0111727",
+      "doi" : "https://www.example.org/42907949-3d50-401f-9f34-d6b630f9bec4",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f1db814c-27ab-4133-a195-ffbb71609fb4",
-    "abstract" : "h8oefZMDy0CR"
+    "metadataSource" : "https://www.example.org/bb0681c2-1daa-4d67-b0d1-e274c2372c22",
+    "abstract" : "8Mb5x7E2kWKsqks7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9aaf439b-9da8-4542-b943-96251902ece3",
-    "name" : "dZECC9LLhFuz",
+    "id" : "https://www.example.org/858fec2d-a374-4d91-a5f5-d7ae49fa3d5d",
+    "name" : "z3AbXRY47b10Ltl4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-06-16T05:24:08.158Z",
+      "approvalDate" : "2001-12-13T00:48:21.260Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "aIpgxMGWs3sox2yAo"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "qwgNxNoNyKkLkh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/26d67453-cea6-44b8-9075-ef3ecbd5822d",
-    "identifier" : "Ft5cLpHzQuPWWWGLxuH",
+    "source" : "https://www.example.org/de339072-c42a-4efa-b36f-129f57d04492",
+    "identifier" : "UCrrwLriLPTyUTY8CxM",
     "labels" : {
-      "se" : "d00xlACs3PYuZrEpqBL"
+      "da" : "cJoyub5sgTXq1sgq"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 970284777
+      "currency" : "EUR",
+      "amount" : 991208295
     },
-    "activeFrom" : "1995-04-29T06:50:10.055Z",
-    "activeTo" : "2016-06-20T14:58:57.133Z"
+    "activeFrom" : "2010-01-31T20:16:35.904Z",
+    "activeTo" : "2016-06-09T19:25:16.761Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/74f43146-c1de-49b5-97d9-c4334f987a67",
-    "id" : "https://www.example.org/2c5ba33b-f256-49c5-a85c-2f9f6974ac7b",
-    "identifier" : "Z1Xbw7CyTPd",
+    "source" : "https://www.example.org/729a8ae6-9226-43bf-a450-b9b74836c7f6",
+    "id" : "https://www.example.org/5638509b-be27-4064-995b-0adaeff1f6a4",
+    "identifier" : "Z8uT6X34EHc4hwIC",
     "labels" : {
-      "nn" : "chcVLkHsCl"
+      "pl" : "39fyta1fMwx25UG"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1683921473
+      "currency" : "USD",
+      "amount" : 1665614219
     },
-    "activeFrom" : "1975-03-07T01:35:59.826Z",
-    "activeTo" : "2008-06-09T09:29:44.530Z"
+    "activeFrom" : "1984-10-05T06:51:39.901Z",
+    "activeTo" : "2012-04-19T01:44:54.755Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/82493a51-3d4a-4c0d-8b59-49472893bdbd" ],
+  "subjects" : [ "https://www.example.org/201171a6-c0c8-4841-b036-31bf3aaf1817" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f3262a35-606d-402f-877f-ed8d783b8efa",
-    "name" : "Sg491FnK3aoU0aUc",
-    "mimeType" : "bw7Kk4bvzHwa7i22",
-    "size" : 1197536503,
-    "license" : "https://www.example.com/a1scdrznwu",
+    "identifier" : "c4b4c725-4424-4e77-b41c-c8ba9275db78",
+    "name" : "OOqzXtlvEZHtOTE",
+    "mimeType" : "ThdzmVajvCVFrqg77Ab",
+    "size" : 564169630,
+    "license" : "https://www.example.com/wyx97qce4mbt87yavj",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "XoOUo83bOLV4WfNPoem",
-    "publishedDate" : "2007-01-29T00:40:13.257Z",
+    "legalNote" : "tYGbKwBpTIWZ",
+    "publishedDate" : "2012-11-29T19:06:33.989Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "XCNX1KiQ3X2S",
-      "uploadedDate" : "2000-09-30T03:59:33.508Z"
+      "uploadedBy" : "5PSzwnfuVndXMwk2vP",
+      "uploadedDate" : "2012-10-04T16:57:57.356Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/QHpK8W6l7NHY5e",
-    "name" : "dy8V3vX7CEbb",
-    "description" : "z0xER8IvagHsbWsH"
+    "id" : "https://www.example.com/roqwrq0vuLnV7",
+    "name" : "v5UJcoRNI5EQa",
+    "description" : "aVN4Rw76Fd7K"
   } ],
-  "rightsHolder" : "KKeeheQzmrkYllG",
-  "duplicateOf" : "https://www.example.org/8f4e3ee6-f897-45e5-9a48-32aa4242b86c",
+  "rightsHolder" : "SJGq6bDbGi3bWxlC",
+  "duplicateOf" : "https://www.example.org/9a816505-53c2-4897-809e-52809829341b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "nP1xEkRt5J3"
+    "note" : "6ryz9mqhfSki460M"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dQJOSppyPW8oSf7L",
-    "createdBy" : "PJalyOk9ot6Il497",
-    "createdDate" : "1989-11-11T09:44:25.335Z"
+    "note" : "5dbDRu3tz9zcA2Xj",
+    "createdBy" : "QmZqJo5bHR0t97",
+    "createdDate" : "1997-05-25T00:02:17.416Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/87c5d53f-0419-4428-b009-576a4746cc78" ],
+  "curatingInstitutions" : [ "https://www.example.org/c13bcadb-28b5-4f43-9b41-6a1001b258c4" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "5KlFUAgZm5w6if8ndZ",
-    "ownerAffiliation" : "https://www.example.org/a2a5e950-2442-4ccb-91e1-f4b551bd97c0"
+    "owner" : "ZoDIzDpvbzP7gzs",
+    "ownerAffiliation" : "https://www.example.org/8467e160-2769-4bec-a2dd-e87cfd2bd44a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/aa97ccce-3721-4ad9-8422-7b58f4512bab"
+    "id" : "https://www.example.org/9f2bf45b-ba1f-4a62-a2ed-a8d74b2d8050"
   },
-  "createdDate" : "2011-04-23T11:27:03.277Z",
-  "modifiedDate" : "1992-10-14T09:31:52.488Z",
-  "publishedDate" : "1982-04-21T04:11:47.932Z",
-  "indexedDate" : "1971-11-08T02:43:18.880Z",
-  "handle" : "https://www.example.org/8b06bc48-e232-420d-9a7c-11a713726692",
-  "doi" : "https://doi.org/10.1234/beatae",
-  "link" : "https://www.example.org/ebd9428c-2664-497f-9fec-94ebc3177208",
+  "createdDate" : "2019-05-20T07:15:42.245Z",
+  "modifiedDate" : "2002-12-01T04:33:02.786Z",
+  "publishedDate" : "1996-03-06T01:14:13.787Z",
+  "indexedDate" : "2015-12-01T05:43:45.558Z",
+  "handle" : "https://www.example.org/8aa7984f-8755-4278-98a1-bcfd5a6e0aa2",
+  "doi" : "https://doi.org/10.1234/reprehenderit",
+  "link" : "https://www.example.org/2326ad38-6924-4694-8e76-9cf4f825c339",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "anNETCC2RRE8j6GG",
+    "mainTitle" : "kKtudoZaPD",
     "alternativeTitles" : {
-      "es" : "tilGE9dTztGB8jtgh"
+      "da" : "XMbsy54NSSvX37fbklB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "lWgMXxenVn2lRh",
-      "month" : "VSl2Cp9zr7",
-      "day" : "m9vfKcCJXTVR"
+      "year" : "W0NWSrjMgo3p",
+      "month" : "IycMIh6ZFDtIj",
+      "day" : "wX5esZyJeaLQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3dd9bc03-bb7f-4929-83f9-79cf89e708da",
-        "name" : "NbYzgmRYgHqMtFXEI3w",
-        "nameType" : "Personal",
-        "orcId" : "TqbmJdDwiCu4BJykNL",
+        "id" : "https://www.example.org/9001466c-c802-4dc4-940c-881ef96e5d6f",
+        "name" : "KKOcoVdzLU7SJ2NW",
+        "nameType" : "Organizational",
+        "orcId" : "C3v0DP4DIayhixM",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "e06iC2WbwhqurTujJ",
-          "value" : "BZ51IwJsZY1"
+          "sourceName" : "FV2FHI2kQoM0Cb4M",
+          "value" : "4wPoPsuizw4aopuO2z"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mAdPZhsOSU5",
-          "value" : "A2PsyTWBxJvBp1JS"
+          "sourceName" : "AxXfBNahZSWo",
+          "value" : "SDIysXfTlvog7I"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c9f22031-1f3d-41a7-a80e-699c23dcf495"
+        "id" : "https://www.example.org/26cb6832-1463-4249-b2a0-cfd81e626a93"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,54 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dc3d7dae-ba08-4bc8-bc09-72315a075845",
-        "name" : "mQrPE4ClNX5u0d",
-        "nameType" : "Organizational",
-        "orcId" : "sPMj6xcHRHkrZuRdTyA",
+        "id" : "https://www.example.org/035a9ca3-f08e-42cd-9fbc-405b5f3f7d2a",
+        "name" : "6y0fEZN47mgTFylDhB",
+        "nameType" : "Personal",
+        "orcId" : "4CcTu1avBZkK",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iq26nJASo5uBPW",
-          "value" : "afyViaOL5fXYzmZcf"
+          "sourceName" : "bZd0waUJluULdBn",
+          "value" : "wlbJZWpRZjBXDP0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7tiZyUBcxbi06",
-          "value" : "nWfssJKzQzgn7EMqzC"
+          "sourceName" : "kOPoJ82aKkH8lXHO9i",
+          "value" : "GgSijCLTsVkJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f6249853-df3a-4499-8c8d-4b712f43d1c7"
+        "id" : "https://www.example.org/90e402a1-c2d3-408a-b799-baaf0d0eb626"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "xnutp7ipgPVPh44"
+      "af" : "3OsG8z2FQIWw1hOPs"
     },
-    "npiSubjectHeading" : "riUn6YXxGXOBR30ba",
-    "tags" : [ "V11xwxjWMxt9IkUxG" ],
-    "description" : "3P3NWWWy88uiKvc0mq",
+    "npiSubjectHeading" : "E8DtDEiibBmQuq",
+    "tags" : [ "Lw6lj9x9GTeuU1j" ],
+    "description" : "so1Qnl3UIrV4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "MediaTypeOther",
-          "description" : "5VPTjTHRgiVO9"
+          "type" : "Journal"
         },
-        "format" : "Video",
-        "disseminationChannel" : "52KwoxOZPd9e7Q",
+        "format" : "Sound",
+        "disseminationChannel" : "bGDUV3YuEJsTYyN",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "I1sIM8N94j6ofXqF",
-          "seriesPart" : "ejG8OFoCzOyL"
+          "seriesName" : "YjgjFBrYfS",
+          "seriesPart" : "ZrQftUO1vFPp"
         }
       },
-      "doi" : "https://www.example.org/b415d160-848d-4075-a3c3-f10b7ddf48b7",
+      "doi" : "https://www.example.org/87bc9f62-3e36-4ae1-a24b-531ff0111727",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -117,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/bce12df8-2942-4fbc-9985-8a18fb01d5e9",
-    "abstract" : "Gz0ixHI7jKTDSwu"
+    "metadataSource" : "https://www.example.org/f1db814c-27ab-4133-a195-ffbb71609fb4",
+    "abstract" : "h8oefZMDy0CR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b226f2a0-31e1-48ff-939f-789da317671c",
-    "name" : "9LiZWx73aK",
+    "id" : "https://www.example.org/9aaf439b-9da8-4542-b943-96251902ece3",
+    "name" : "dZECC9LLhFuz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-09-03T02:33:43.846Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2002-06-16T05:24:08.158Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "O1ElEv9DTKS2IHwsyP"
+      "applicationCode" : "aIpgxMGWs3sox2yAo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/47b35532-cfe1-4d2f-8d11-c72ce8c79484",
-    "identifier" : "GejoeeuORmIi2XIl",
+    "source" : "https://www.example.org/26d67453-cea6-44b8-9075-ef3ecbd5822d",
+    "identifier" : "Ft5cLpHzQuPWWWGLxuH",
     "labels" : {
-      "hu" : "0AL0spudP2LwdIc"
+      "se" : "d00xlACs3PYuZrEpqBL"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1947401421
+      "amount" : 970284777
     },
-    "activeFrom" : "2012-07-21T23:13:41.923Z",
-    "activeTo" : "2014-11-06T17:13:31.585Z"
+    "activeFrom" : "1995-04-29T06:50:10.055Z",
+    "activeTo" : "2016-06-20T14:58:57.133Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6cef46de-545d-42a2-8145-455fdafa67a6",
-    "id" : "https://www.example.org/6142d34e-e12a-4376-8ba0-8f87017d6cd2",
-    "identifier" : "oeKBCaYz2jBoCX",
+    "source" : "https://www.example.org/74f43146-c1de-49b5-97d9-c4334f987a67",
+    "id" : "https://www.example.org/2c5ba33b-f256-49c5-a85c-2f9f6974ac7b",
+    "identifier" : "Z1Xbw7CyTPd",
     "labels" : {
-      "af" : "zAUdocjU0Thl"
+      "nn" : "chcVLkHsCl"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 27568588
+      "amount" : 1683921473
     },
-    "activeFrom" : "1981-06-18T20:02:08.805Z",
-    "activeTo" : "1998-10-05T23:04:12.597Z"
+    "activeFrom" : "1975-03-07T01:35:59.826Z",
+    "activeTo" : "2008-06-09T09:29:44.530Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/980dad4d-1278-4f42-9fd4-40c2c5726c3b" ],
+  "subjects" : [ "https://www.example.org/82493a51-3d4a-4c0d-8b59-49472893bdbd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5c603e5d-f268-4c05-a7ed-7af1c3d26ccc",
-    "name" : "RqRVSWQNJlSeKMascKs",
-    "mimeType" : "WYKDcgNHpt3Gw1zMr",
-    "size" : 503254932,
-    "license" : "https://www.example.com/cbgidwphl8lvtp",
+    "identifier" : "f3262a35-606d-402f-877f-ed8d783b8efa",
+    "name" : "Sg491FnK3aoU0aUc",
+    "mimeType" : "bw7Kk4bvzHwa7i22",
+    "size" : 1197536503,
+    "license" : "https://www.example.com/a1scdrznwu",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "rocmpuJ7Myoi0ew3",
-    "publishedDate" : "2019-09-13T02:09:41.252Z",
+    "legalNote" : "XoOUo83bOLV4WfNPoem",
+    "publishedDate" : "2007-01-29T00:40:13.257Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TrispzJachpDdmysFOR",
-      "uploadedDate" : "1997-10-29T07:18:21.006Z"
+      "uploadedBy" : "XCNX1KiQ3X2S",
+      "uploadedDate" : "2000-09-30T03:59:33.508Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nSZ7aXKpwAJ5ksqCzrQ",
-    "name" : "yAnXUShLkWajPnAl",
-    "description" : "3EDzgGyAMWCA8vNi"
+    "id" : "https://www.example.com/QHpK8W6l7NHY5e",
+    "name" : "dy8V3vX7CEbb",
+    "description" : "z0xER8IvagHsbWsH"
   } ],
-  "rightsHolder" : "yVgwaSu0jxiSnodhwQ8",
-  "duplicateOf" : "https://www.example.org/a168de92-4bd6-4645-9b6c-b25b51f46256",
+  "rightsHolder" : "KKeeheQzmrkYllG",
+  "duplicateOf" : "https://www.example.org/8f4e3ee6-f897-45e5-9a48-32aa4242b86c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "YffEweTC2Rv0"
+    "note" : "nP1xEkRt5J3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1Ku4eH0fOhXVnfXc0vs",
-    "createdBy" : "2REtqx1u2HQpE",
-    "createdDate" : "2014-05-01T06:26:05.888Z"
+    "note" : "dQJOSppyPW8oSf7L",
+    "createdBy" : "PJalyOk9ot6Il497",
+    "createdDate" : "1989-11-11T09:44:25.335Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/638e364e-941b-4dc2-ae32-6dbe639840bf" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/87c5d53f-0419-4428-b009-576a4746cc78" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "n2JUui92lV3bwYBb",
-    "ownerAffiliation" : "https://www.example.org/3b343667-858f-4c1c-bf30-ee82edb57cba"
+    "owner" : "taxUpW17sySf",
+    "ownerAffiliation" : "https://www.example.org/25172504-5d7f-4665-ba57-4bbcc13b5839"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2c13bf16-aa2a-4d03-8fe1-69b927ee9807"
+    "id" : "https://www.example.org/cdd867bf-72ae-435e-a922-8a0df7df7947"
   },
-  "createdDate" : "1978-11-13T14:59:35.784Z",
-  "modifiedDate" : "2023-05-03T06:13:05.738Z",
-  "publishedDate" : "1999-05-15T09:45:17.001Z",
-  "indexedDate" : "2006-05-14T22:31:57.766Z",
-  "handle" : "https://www.example.org/496256f4-8a8c-4fdf-83ab-c372d89930d3",
-  "doi" : "https://doi.org/10.1234/eos",
-  "link" : "https://www.example.org/e666d9bf-f317-4bdf-93ab-f499aa135a1b",
+  "createdDate" : "1999-05-11T08:16:29.788Z",
+  "modifiedDate" : "2024-04-02T07:53:30.841Z",
+  "publishedDate" : "2022-04-06T05:25:25.343Z",
+  "indexedDate" : "1980-06-29T23:49:25.026Z",
+  "handle" : "https://www.example.org/3df6c589-8d38-47d7-baed-beb6426ccb24",
+  "doi" : "https://doi.org/10.1234/exercitationem",
+  "link" : "https://www.example.org/2393ddaa-adc8-4d44-b3ab-d8fb0598d446",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VwLuqouaK1z0Yr",
+    "mainTitle" : "kT5O3YPKkxZw72rsbK",
     "alternativeTitles" : {
-      "ca" : "llmnGBdC3kGpFiW5bf"
+      "fr" : "L3pKmYSWELA3JtS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TgHtuzR7vtx2GjImgB",
-      "month" : "Fx7Q2Xh6kCo5j8FzI",
-      "day" : "GNqpbxuIbZxlATKsyo"
+      "year" : "0sszsPlbXfsBZ6",
+      "month" : "vuIyeqzYl0",
+      "day" : "CBKGEjqyBWOUy8qQtv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f1123e0d-3c4a-402e-b46c-77d9f580cf29",
-        "name" : "jN0GKqW9czHsuhd5S",
+        "id" : "https://www.example.org/a4d90f2d-a1a0-4e4f-9594-5491f1858815",
+        "name" : "HIfHMdStwrBE",
         "nameType" : "Organizational",
-        "orcId" : "5oRXwYWRFzD7YnIy9h",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "eDpJiQ6i7l5Aqa4J",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "N1XRZHiZlZv",
-          "value" : "BOTUU5YWo0RD24D"
+          "sourceName" : "AvWAgFYkHyf8",
+          "value" : "gcI6ZTTPj1CFaP1IVtF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aO0tSLp5nu8NV5V9E",
-          "value" : "CjeTJ4Pn5oj6xPWa"
+          "sourceName" : "UONTs5rDDVY22N0ch3n",
+          "value" : "PAm91MGWZeftmWac"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fd29952b-4b12-4a80-bd90-1b37328bafef"
+        "id" : "https://www.example.org/5835cf17-e6c8-4651-b2dc-8bad1aa77dcb"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6b37d5b7-d247-42ea-bfbb-b9437b4720e6",
-        "name" : "gR9VcXcz8YqOlSSm7",
+        "id" : "https://www.example.org/a4e58f93-18f9-4a33-9f62-eadb5f9aeff4",
+        "name" : "alWR2m4M02",
         "nameType" : "Personal",
-        "orcId" : "5On3exO4QPdKIP",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "utvGZiH7zVn",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vS3mRDYMDJCAxjwJ",
-          "value" : "E099iWBWFs"
+          "sourceName" : "zDdMVE8EqJK83vzgGm",
+          "value" : "sDab7BZPDlR3TOXDc1r"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5EUrYOM7rZOc",
-          "value" : "fylvZ0VtwzgLL"
+          "sourceName" : "3mOGrFyJNSg4s",
+          "value" : "kuZGwTfJp1x388"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c906573d-bf78-49cb-b131-2b9b9a67589a"
+        "id" : "https://www.example.org/17c90c4b-a84f-4f8e-9c20-f73e8925c0f9"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "BDVVO4aQ5T3iYhvHM"
+      "bg" : "zRJKGwZ4QaSyTr"
     },
-    "npiSubjectHeading" : "Z4sVHloWgIEsOps",
-    "tags" : [ "tqOFVlOTLR" ],
-    "description" : "k2HooBFh8Xhc",
+    "npiSubjectHeading" : "a4EfMmQyWqz6A4nogR",
+    "tags" : [ "ZCe9cFqv1j7w" ],
+    "description" : "897VL1r8kDhqFrv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "TV"
         },
         "format" : "Text",
-        "disseminationChannel" : "3RUMVWfxIB5DRFL4",
+        "disseminationChannel" : "eC0XHs8SGDeC",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "70zxfLEpkTJ",
-          "seriesPart" : "8hKPiV1Bp8eB8g4NniJ"
+          "seriesName" : "im3LXynC8wJ",
+          "seriesPart" : "gBuZjc1qN4q"
         }
       },
-      "doi" : "https://www.example.org/c1feed0d-eed2-4bb7-9c5f-56fb73f364a8",
+      "doi" : "https://www.example.org/7922f88b-21ac-4ff6-aefc-268ef1acd1ab",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -116,93 +116,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c6dc6a60-c81f-4ae6-ac37-ac75399df2fa",
-    "abstract" : "jfRe73Zx4M0"
+    "metadataSource" : "https://www.example.org/1933cc3d-d808-4139-8795-a8c92dabe8a0",
+    "abstract" : "Nz4YxDjpr815J"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/697ce054-da5c-4f42-aad9-900af8cf0b26",
-    "name" : "F6oNEECaCu",
+    "id" : "https://www.example.org/fb76bdc2-4850-42c3-8223-bf3bf1c4dd47",
+    "name" : "bP4A2tiEHKG9q5X75",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-12-14T05:24:36.766Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "r2IJbBIx4S2R6a"
+      "approvalDate" : "1988-04-16T23:43:35.304Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "iBe4u7WLSt31VqJC"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/06800654-e5c0-4dbb-8267-5dbc04776309",
-    "identifier" : "ycWtFuEvwP9W6RP",
+    "source" : "https://www.example.org/44646c3b-b766-4f4b-aa96-012a97910ea3",
+    "identifier" : "V5Ao9cImH8yOqz7Rb",
     "labels" : {
-      "es" : "mAKYcKLwKMaYp"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1027372445
-    },
-    "activeFrom" : "1980-04-07T04:45:48.314Z",
-    "activeTo" : "2004-10-31T09:35:51.565Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/56522851-34fd-40a8-a817-d0a27dce009e",
-    "id" : "https://www.example.org/682d7739-ba43-4e40-9732-869a2acaa26c",
-    "identifier" : "bBXWiJvPbtC",
-    "labels" : {
-      "it" : "PbR5W27AT4Nsh"
+      "ru" : "HT4V1BFrYcyw1GH4cF"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1792756745
+      "amount" : 756659894
     },
-    "activeFrom" : "2017-03-22T08:00:42.106Z",
-    "activeTo" : "2020-01-05T07:35:43.082Z"
+    "activeFrom" : "1971-12-15T07:01:41.575Z",
+    "activeTo" : "1980-06-22T13:38:20.104Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/023c05ce-af77-4ce3-b880-90b42c8a08e1",
+    "id" : "https://www.example.org/686d928f-a6fa-49aa-a15e-87c994acf0d8",
+    "identifier" : "ytU4cdsPlfo",
+    "labels" : {
+      "zh" : "N840ecQK94yN"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1726249379
+    },
+    "activeFrom" : "1999-10-26T17:46:57.403Z",
+    "activeTo" : "2006-12-21T07:53:23.091Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b1c122f1-1f49-4486-8658-f3169376d17d" ],
+  "subjects" : [ "https://www.example.org/856bf08f-03b8-4db8-9e9a-17cc6b87e380" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f240faba-414d-45d6-9d1c-1bf54d0d09a4",
-    "name" : "26lvKa4zd4bKfsvN",
-    "mimeType" : "uwr7FYPDzCddErZHOA",
-    "size" : 46572853,
-    "license" : "https://www.example.com/5wpq3le0xdyf2",
+    "identifier" : "0ed93b07-3031-4f1c-b720-58afec9dc98a",
+    "name" : "mFislcVts9Xrl",
+    "mimeType" : "mOpyyTiw3mgg0fv9fH",
+    "size" : 1704478591,
+    "license" : "https://www.example.com/kvj1jjxk3hdpx7be",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "RRnHUtZwPQmTJyL"
     },
-    "legalNote" : "PjDgFThGyv66ZUVy",
-    "publishedDate" : "1999-03-10T21:59:44.802Z",
+    "legalNote" : "72yyc6noVbuV",
+    "publishedDate" : "1984-07-08T18:40:02.941Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "9W6BTh2gQii",
-      "uploadedDate" : "1981-08-18T19:19:32.151Z"
+      "uploadedBy" : "963UIm97NlxlB",
+      "uploadedDate" : "2016-10-26T07:42:34.981Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/34aas9IGuMaBn",
-    "name" : "A4NeMyzTtlk5oY",
-    "description" : "5hf3dm4RMaoJLutRb7"
+    "id" : "https://www.example.com/3id8WBA4IrtxbOwr",
+    "name" : "DmBelfNHMPb",
+    "description" : "KRqVowwIHz8O5a"
   } ],
-  "rightsHolder" : "kdTwDVKpfXHXQvaB",
-  "duplicateOf" : "https://www.example.org/f1f12df5-4d49-4e9e-8da9-f2104cdb6d2e",
+  "rightsHolder" : "DXMohJrx4NuQB75ssgf",
+  "duplicateOf" : "https://www.example.org/be4d0624-0fee-45be-b26d-98c0b1ebe569",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "yPgnQ3ISDrDg85wY"
+    "note" : "P2vzJvB3hEnMCj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "JZrLdn3S8HQPYGUAi",
-    "createdBy" : "JKXZvz2cmV0gWL",
-    "createdDate" : "1990-05-06T00:50:15.432Z"
+    "note" : "DTgy95BPf72",
+    "createdBy" : "peMrheJy4d9e",
+    "createdDate" : "2022-07-19T22:19:58.708Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2e0f2ba7-09a2-46e5-9a11-5737898bd8ea" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/6f4929ed-58d7-4259-97c9-c0c07246f138" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "taxUpW17sySf",
-    "ownerAffiliation" : "https://www.example.org/25172504-5d7f-4665-ba57-4bbcc13b5839"
+    "owner" : "nQqcNHQmV4b",
+    "ownerAffiliation" : "https://www.example.org/a24ba8ad-ba8b-4d3e-af53-da13a9f1bc37"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cdd867bf-72ae-435e-a922-8a0df7df7947"
+    "id" : "https://www.example.org/b9f5d146-d456-4125-892b-af117e591a4f"
   },
-  "createdDate" : "1999-05-11T08:16:29.788Z",
-  "modifiedDate" : "2024-04-02T07:53:30.841Z",
-  "publishedDate" : "2022-04-06T05:25:25.343Z",
-  "indexedDate" : "1980-06-29T23:49:25.026Z",
-  "handle" : "https://www.example.org/3df6c589-8d38-47d7-baed-beb6426ccb24",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/2393ddaa-adc8-4d44-b3ab-d8fb0598d446",
+  "createdDate" : "2010-05-08T16:45:53.612Z",
+  "modifiedDate" : "1991-03-23T12:33:19.102Z",
+  "publishedDate" : "1990-02-06T02:12:06.038Z",
+  "indexedDate" : "1972-02-29T23:37:28.522Z",
+  "handle" : "https://www.example.org/10e1a61d-f53b-4718-acd9-3b4b232d2901",
+  "doi" : "https://doi.org/10.1234/soluta",
+  "link" : "https://www.example.org/236244aa-1c33-4494-8bb9-469f647f61cc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kT5O3YPKkxZw72rsbK",
+    "mainTitle" : "kljh3bw3OSEf7yymt",
     "alternativeTitles" : {
-      "fr" : "L3pKmYSWELA3JtS"
+      "pt" : "KvqIhxBylGrDP"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0sszsPlbXfsBZ6",
-      "month" : "vuIyeqzYl0",
-      "day" : "CBKGEjqyBWOUy8qQtv"
+      "year" : "M7cTbbSOu9OxM",
+      "month" : "tmLgIU1tINeynlNQo",
+      "day" : "2is6p0s10DuMvtBI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a4d90f2d-a1a0-4e4f-9594-5491f1858815",
-        "name" : "HIfHMdStwrBE",
-        "nameType" : "Organizational",
-        "orcId" : "eDpJiQ6i7l5Aqa4J",
+        "id" : "https://www.example.org/fc61ee54-b48c-4583-9fe1-2894cc3860aa",
+        "name" : "tsGQU7rlrvpttuS2hcN",
+        "nameType" : "Personal",
+        "orcId" : "kbywDUCTT6J0f",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AvWAgFYkHyf8",
-          "value" : "gcI6ZTTPj1CFaP1IVtF"
+          "sourceName" : "4rK9gm4Su24",
+          "value" : "a2P00b5mQ1ZERBaUr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UONTs5rDDVY22N0ch3n",
-          "value" : "PAm91MGWZeftmWac"
+          "sourceName" : "tcKywGBW5ZCNL",
+          "value" : "8qTnzOCGBAUL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5835cf17-e6c8-4651-b2dc-8bad1aa77dcb"
+        "id" : "https://www.example.org/ef1ca02e-909d-4343-be49-82ebed287478"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a4e58f93-18f9-4a33-9f62-eadb5f9aeff4",
-        "name" : "alWR2m4M02",
+        "id" : "https://www.example.org/6ec3de94-771a-49da-9259-a1bff20bb327",
+        "name" : "lWx5hDWxNf5488",
         "nameType" : "Personal",
-        "orcId" : "utvGZiH7zVn",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "XKOokHRwo5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zDdMVE8EqJK83vzgGm",
-          "value" : "sDab7BZPDlR3TOXDc1r"
+          "sourceName" : "C3lFr4aWaX61GRx",
+          "value" : "oh2PZGmmEcSVs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3mOGrFyJNSg4s",
-          "value" : "kuZGwTfJp1x388"
+          "sourceName" : "zHq0eQPLFCkJPlRmOVs",
+          "value" : "h9KQvDvs4GRmBA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/17c90c4b-a84f-4f8e-9c20-f73e8925c0f9"
+        "id" : "https://www.example.org/a64b6a80-7972-4045-bfa5-c73fdd30ff03"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "Producer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "zRJKGwZ4QaSyTr"
+      "fi" : "7vFychFiNkvdB"
     },
-    "npiSubjectHeading" : "a4EfMmQyWqz6A4nogR",
-    "tags" : [ "ZCe9cFqv1j7w" ],
-    "description" : "897VL1r8kDhqFrv",
+    "npiSubjectHeading" : "qyeK4mfpGhN1mZbC",
+    "tags" : [ "2pSd84sbhNwaRTKow" ],
+    "description" : "lWGAIgyEFNgi0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -100,15 +100,15 @@
         "medium" : {
           "type" : "TV"
         },
-        "format" : "Text",
-        "disseminationChannel" : "eC0XHs8SGDeC",
+        "format" : "Sound",
+        "disseminationChannel" : "XeGZeUXMIL5QBzALjoa",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "im3LXynC8wJ",
-          "seriesPart" : "gBuZjc1qN4q"
+          "seriesName" : "2cSJf3xuSzVraV",
+          "seriesPart" : "lP0kFO0JChZOjdSiM4z"
         }
       },
-      "doi" : "https://www.example.org/7922f88b-21ac-4ff6-aefc-268ef1acd1ab",
+      "doi" : "https://www.example.org/c46a108c-12c2-48be-8640-3195017cd8c6",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -116,94 +116,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1933cc3d-d808-4139-8795-a8c92dabe8a0",
-    "abstract" : "Nz4YxDjpr815J"
+    "metadataSource" : "https://www.example.org/2d0c08cd-0e34-4c64-be67-db41d83589f4",
+    "abstract" : "RMFbifIV9WiekPB"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fb76bdc2-4850-42c3-8223-bf3bf1c4dd47",
-    "name" : "bP4A2tiEHKG9q5X75",
+    "id" : "https://www.example.org/4793e518-1cc9-4ddc-a117-ab95caf1c6d4",
+    "name" : "bH7NqgRHElW4bb6WT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1988-04-16T23:43:35.304Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "iBe4u7WLSt31VqJC"
+      "approvalDate" : "2009-06-17T03:49:45.620Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "2GmBmullOZD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/44646c3b-b766-4f4b-aa96-012a97910ea3",
-    "identifier" : "V5Ao9cImH8yOqz7Rb",
+    "source" : "https://www.example.org/ef66b763-af58-4057-9d29-aba7e5544cc7",
+    "identifier" : "7TRuVZpo5zg2",
     "labels" : {
-      "ru" : "HT4V1BFrYcyw1GH4cF"
+      "fr" : "Phk9RdRg1QMPqwkK"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 756659894
+      "amount" : 1466462333
     },
-    "activeFrom" : "1971-12-15T07:01:41.575Z",
-    "activeTo" : "1980-06-22T13:38:20.104Z"
+    "activeFrom" : "2014-04-13T16:28:09.101Z",
+    "activeTo" : "2015-03-12T19:04:58.088Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/023c05ce-af77-4ce3-b880-90b42c8a08e1",
-    "id" : "https://www.example.org/686d928f-a6fa-49aa-a15e-87c994acf0d8",
-    "identifier" : "ytU4cdsPlfo",
+    "source" : "https://www.example.org/a125a927-f9f0-4c34-9342-de57217b1431",
+    "id" : "https://www.example.org/4bb37605-456d-41ee-b0d1-811c9d801946",
+    "identifier" : "dV9G9CJIfdFTdF",
     "labels" : {
-      "zh" : "N840ecQK94yN"
+      "el" : "rDvG7Saez8m"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1726249379
+      "amount" : 511491485
     },
-    "activeFrom" : "1999-10-26T17:46:57.403Z",
-    "activeTo" : "2006-12-21T07:53:23.091Z"
+    "activeFrom" : "1989-07-05T04:48:37.871Z",
+    "activeTo" : "2006-04-06T14:55:49.948Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/856bf08f-03b8-4db8-9e9a-17cc6b87e380" ],
+  "subjects" : [ "https://www.example.org/8eeb0f26-8b50-46c4-80e2-f1dd90e59a67" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0ed93b07-3031-4f1c-b720-58afec9dc98a",
-    "name" : "mFislcVts9Xrl",
-    "mimeType" : "mOpyyTiw3mgg0fv9fH",
-    "size" : 1704478591,
-    "license" : "https://www.example.com/kvj1jjxk3hdpx7be",
+    "identifier" : "cc39015a-76b5-4fe1-92c9-276835a031a7",
+    "name" : "YbRWrx33iVr",
+    "mimeType" : "RyJCxyahIEgpexTrqPe",
+    "size" : 962986641,
+    "license" : "https://www.example.com/m3ydnkfix5pqzaf",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "RRnHUtZwPQmTJyL"
+      "overriddenBy" : "0x1Cq7olv7PW"
     },
-    "legalNote" : "72yyc6noVbuV",
-    "publishedDate" : "1984-07-08T18:40:02.941Z",
+    "legalNote" : "PyT0AiBjupwlynKQq",
+    "publishedDate" : "2010-07-01T16:39:46.922Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "963UIm97NlxlB",
-      "uploadedDate" : "2016-10-26T07:42:34.981Z"
+      "uploadedBy" : "FqXNCnNloSPK",
+      "uploadedDate" : "1983-05-28T09:34:46.872Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3id8WBA4IrtxbOwr",
-    "name" : "DmBelfNHMPb",
-    "description" : "KRqVowwIHz8O5a"
+    "id" : "https://www.example.com/n3c6vuV7K4ePGRqg",
+    "name" : "HtBjdMufNRSl6y0FQ1V",
+    "description" : "iFSoFZFEphDjYPV"
   } ],
-  "rightsHolder" : "DXMohJrx4NuQB75ssgf",
-  "duplicateOf" : "https://www.example.org/be4d0624-0fee-45be-b26d-98c0b1ebe569",
+  "rightsHolder" : "uWCoIgzr7Netknyz0Q",
+  "duplicateOf" : "https://www.example.org/e3960539-6d22-4eaa-a511-0292b2ab9204",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "P2vzJvB3hEnMCj"
+    "note" : "yx9XAiXRWAa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DTgy95BPf72",
-    "createdBy" : "peMrheJy4d9e",
-    "createdDate" : "2022-07-19T22:19:58.708Z"
+    "note" : "zlEGhkCboi2yRiEAh",
+    "createdBy" : "BRlkHl3U1BmYt",
+    "createdDate" : "1991-07-17T06:35:48.405Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6f4929ed-58d7-4259-97c9-c0c07246f138" ],
+  "curatingInstitutions" : [ "https://www.example.org/7c39ce65-f290-431c-a742-6f6b992fe31a" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "m1Jt7GMWN7waTAWK0fc",
-    "ownerAffiliation" : "https://www.example.org/b6c2324b-52e8-4cf8-a8f8-38c1d9ba1919"
+    "owner" : "kxSvBrQVm8k4x",
+    "ownerAffiliation" : "https://www.example.org/f375287a-e64c-4ae0-bed9-b7a568e3b56d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7d8fb35e-b933-4d7e-b0e1-278b0a8c42b9"
+    "id" : "https://www.example.org/23d2068f-6ead-45b2-a895-2a9f0e46438a"
   },
-  "createdDate" : "1986-05-13T17:57:30.355Z",
-  "modifiedDate" : "2013-03-03T01:30:27.727Z",
-  "publishedDate" : "1976-04-29T15:26:30.915Z",
-  "indexedDate" : "1972-10-27T13:49:18.036Z",
-  "handle" : "https://www.example.org/55da63cd-369b-49f4-9e1c-ee566193cd4a",
-  "doi" : "https://doi.org/10.1234/repellat",
-  "link" : "https://www.example.org/c54f2402-97fc-4ab7-9b2d-ecca99bd7422",
+  "createdDate" : "1979-09-23T15:58:55.363Z",
+  "modifiedDate" : "2020-07-29T15:50:33.783Z",
+  "publishedDate" : "1990-01-23T22:27:00.312Z",
+  "indexedDate" : "1976-07-20T03:56:56.113Z",
+  "handle" : "https://www.example.org/0882935f-e480-40d4-8f17-ebe22b556ee9",
+  "doi" : "https://doi.org/10.1234/excepturi",
+  "link" : "https://www.example.org/018828b3-7927-4931-9686-7c24518fabcb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3Z0UmUp7Ts",
+    "mainTitle" : "9ubM9iH2oLkw6b",
     "alternativeTitles" : {
-      "de" : "hF2LSjXUhYWTNeUIrxs"
+      "ca" : "7eFFj0GlK7SptMQJu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "B85gmtX5EzdF8JP",
-      "month" : "zJkX9tyExPikkhI9D7",
-      "day" : "b0REjzyMRM1w"
+      "year" : "2OQTDBVf9EKRSA",
+      "month" : "ez88CNKYoBSUBeGjIcg",
+      "day" : "fl8Fdpx7WpCrzBSiBWe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/63999fe7-058b-49d7-b174-f38c1a5f03d2",
-        "name" : "XNqmAd6OatmJX",
-        "nameType" : "Organizational",
-        "orcId" : "Mu50FvouOfVjyxaN",
+        "id" : "https://www.example.org/e49663e3-19fb-4d03-b7b5-d2923d120a9a",
+        "name" : "IQj0tbXUNu3hYWktI",
+        "nameType" : "Personal",
+        "orcId" : "g1eViqzpfCv8PGg",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mzpaHrAlR7HXP7ze",
-          "value" : "7kmqfGTDezCDo11h"
+          "sourceName" : "lMouRUo5Fd",
+          "value" : "rhB8itCsKLqTi4iG5w"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w0sOicG3iqmrn",
-          "value" : "nNCHteEWTp"
+          "sourceName" : "rRZxbZ27Zwlr7C2JQb",
+          "value" : "vKXbg9lRdWdpJ8MDa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f1de67c-c550-45ef-ba91-e8bd2eef1937"
+        "id" : "https://www.example.org/3aab703a-c944-4e63-82be-63c30e234bb4"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,145 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fd540f4b-cb13-4c54-b157-dd04f50a5ec6",
-        "name" : "puyE1AZi4E4D4zGz",
-        "nameType" : "Organizational",
-        "orcId" : "mzV5wT8N3Fgc",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/961f9c7c-ba1f-4fd7-aa81-e0e43a873020",
+        "name" : "imXOGdn7zftOWujf",
+        "nameType" : "Personal",
+        "orcId" : "oA1GfAZD599",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xGdO5jF3uxoh",
-          "value" : "wnpXcWfHX45K9C"
+          "sourceName" : "4Dc4Pn2MxfLmUpIr00",
+          "value" : "F0PgL7X1Sju"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MKBOt1AsiHwQ8VwV",
-          "value" : "2Surt16XylEmu3OnqKP"
+          "sourceName" : "55lNNwcBENg6Lspdzub",
+          "value" : "w0hH10tVFFv1kSHK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/432be539-c5bb-4f9a-9c06-fcd096d0c6e7"
+        "id" : "https://www.example.org/274a4be0-3ec8-4012-9211-22375402489c"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "NH34r4wb1AYvv0Dd"
+      "hu" : "qdwzkDN018g"
     },
-    "npiSubjectHeading" : "YE5yDmfyXwak",
-    "tags" : [ "rIwvoDoxIK8FIgJ" ],
-    "description" : "4SxBD6grmvF",
+    "npiSubjectHeading" : "Yrayyh40jW",
+    "tags" : [ "9KZoAYm3tplCuZ8G" ],
+    "description" : "YGPbCruR2A2uqhOJPhS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "UnconfirmedMediaContributionPeriodical",
-        "title" : "fFpieEtzTfBn",
-        "printIssn" : "1489-4963",
-        "onlineIssn" : "1412-002X"
+        "title" : "RKYEamvLBT5bjC",
+        "printIssn" : "6633-4403",
+        "onlineIssn" : "4927-9130"
       },
-      "doi" : "https://www.example.org/3d19f45c-54a4-4f1f-9e71-53c559272484",
+      "doi" : "https://www.example.org/d2786bb3-ab7c-40cd-81e6-0f93fae39db3",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "WMBoFRCZsXb6s5r1ofQ",
-        "issue" : "8LlU0TZu3a8gaP",
-        "articleNumber" : "yxCZWPf1SCo3P",
+        "volume" : "XcFirRfIrpSCXHke",
+        "issue" : "IDwFLoGBtNWj",
+        "articleNumber" : "LzGjFLLO5niwySj",
         "pages" : {
           "type" : "Range",
-          "begin" : "pU3a6fa1b6OxCc5W7hL",
-          "end" : "dQoGrKRIRIXMgoWc"
+          "begin" : "yIq61kJvwh8OPpZ",
+          "end" : "fHQUh9YkTmqYw08"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2350529c-6ce9-4e2e-8e26-62833d3d40fd",
-    "abstract" : "jMLtU7bSxK"
+    "metadataSource" : "https://www.example.org/676d8579-d84c-45f9-ba19-281737fdd9cd",
+    "abstract" : "YNR9Fe2kqY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0f87e2ac-18d7-4f19-8cd2-8288b6c0becb",
-    "name" : "kIwhDVYof8o",
+    "id" : "https://www.example.org/9fe2868c-3571-43c1-aa18-6240de017f3f",
+    "name" : "occsNCsZ0NL4Unjk",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-08-09T14:08:36.849Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "s91hVBfg6jh"
+      "approvalDate" : "2019-07-18T18:40:51.701Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "ekOjjVP4WaEtb6Fcopi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e28a824a-d008-4b33-b67e-377ef93a42d4",
-    "identifier" : "KfwypbRN6Z7D34M",
+    "source" : "https://www.example.org/c0c9c764-915e-4607-823b-d775712d0416",
+    "identifier" : "z6RDBTddH9WB",
     "labels" : {
-      "hu" : "w0KAdycvBvyo"
+      "ca" : "3TEzInFnW6Z"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 976237505
+      "amount" : 215275252
     },
-    "activeFrom" : "2014-02-28T05:10:46.521Z",
-    "activeTo" : "2016-04-26T14:07:16.612Z"
+    "activeFrom" : "2003-10-16T05:41:12.986Z",
+    "activeTo" : "2006-02-11T03:26:58.652Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/72791062-ff54-40be-8677-5e80bbcf4e1f",
-    "id" : "https://www.example.org/063c57a6-b5f2-431b-8310-bd136063fadc",
-    "identifier" : "9pN0CZcH6SDSG",
+    "source" : "https://www.example.org/5530515f-bc1c-4251-9dd5-d74ca032cd15",
+    "id" : "https://www.example.org/ca624d0d-cd98-4b4c-832a-5a67e38571bf",
+    "identifier" : "8sJojHuuK71",
     "labels" : {
-      "fi" : "SfXFAnATnTqK"
+      "fr" : "zCXbJ2HVPsqpG"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 236074495
+      "currency" : "GBP",
+      "amount" : 2060774269
     },
-    "activeFrom" : "1999-01-31T15:40:20.063Z",
-    "activeTo" : "2004-08-13T18:12:34.452Z"
+    "activeFrom" : "1995-05-11T20:29:57.581Z",
+    "activeTo" : "2009-05-09T16:21:52.257Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f4315847-9b1d-4495-9588-c6bfbbbefe02" ],
+  "subjects" : [ "https://www.example.org/6bb815a5-a94c-4497-b06f-757988efd913" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "98ea03a5-aca1-4b14-89ce-ca51121ca04b",
-    "name" : "DoBL5mPC8oC4758ZM2",
-    "mimeType" : "BuHKfXMxkVMtjQ3",
-    "size" : 2134801894,
-    "license" : "https://www.example.com/08lsynkt1uo02dm",
+    "identifier" : "c8ba91c9-7a37-41b4-963d-c5ce705961e3",
+    "name" : "doD9kPdEoxJM",
+    "mimeType" : "2WpbbT5j2HNfFuBCY",
+    "size" : 1604022745,
+    "license" : "https://www.example.com/ut5bzqngsnn5lh9",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "H3K3pMSEQA",
-    "publishedDate" : "1989-02-14T09:39:05.329Z",
+    "legalNote" : "JfQEQbPUds0yi",
+    "publishedDate" : "2007-06-09T16:29:14.658Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uBLAn7u0CdW279V2",
-      "uploadedDate" : "1986-05-13T18:11:29.851Z"
+      "uploadedBy" : "3CCbUMTrIAooA2Hm3y",
+      "uploadedDate" : "1978-02-07T23:44:03.690Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XzTj0OvZMr",
-    "name" : "KQdZPnqUz6rkExu7Uwh",
-    "description" : "Jc70SdFNFAvVOLK"
+    "id" : "https://www.example.com/TU8k0oEog0SKJoyZml",
+    "name" : "u3xeOER99iM7mmv0x",
+    "description" : "LKxC2i8x0SYSx"
   } ],
-  "rightsHolder" : "LLUrTXG7iDPl7MDzNo",
-  "duplicateOf" : "https://www.example.org/6601ff69-186b-4d5c-a742-24682bafb421",
+  "rightsHolder" : "NDhfCHVTKpdbPFTOK",
+  "duplicateOf" : "https://www.example.org/10c43361-4717-4a41-878c-aa06d1d4cd2a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Fe6ALKLVPRIzYJWrp"
+    "note" : "HFKdSAy9LbdpdU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hm2Sb8ZBLA",
-    "createdBy" : "7MJT30wgbvwWxaQqXp",
-    "createdDate" : "1975-08-31T15:44:45.224Z"
+    "note" : "SgTexIZy0wnoWLrh",
+    "createdBy" : "CGBs7QL9mAy9jvhM3",
+    "createdDate" : "1971-02-22T15:58:45.538Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0b8213d0-e150-430d-af88-4e45e7037bee" ],
+  "curatingInstitutions" : [ "https://www.example.org/06377a56-3197-4fb2-9fbf-e198295b7c6a" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "0aqsU4xM41AGL",
-    "ownerAffiliation" : "https://www.example.org/e08cda00-d2d9-453e-abb3-79b6936dc321"
+    "owner" : "m1Jt7GMWN7waTAWK0fc",
+    "ownerAffiliation" : "https://www.example.org/b6c2324b-52e8-4cf8-a8f8-38c1d9ba1919"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f3a6fb82-f39d-44d2-86af-c37a3e042348"
+    "id" : "https://www.example.org/7d8fb35e-b933-4d7e-b0e1-278b0a8c42b9"
   },
-  "createdDate" : "1977-12-27T04:37:01.227Z",
-  "modifiedDate" : "2003-12-01T07:55:49.167Z",
-  "publishedDate" : "2003-01-10T15:49:26.130Z",
-  "indexedDate" : "2007-04-21T16:56:40.050Z",
-  "handle" : "https://www.example.org/e40ba799-fc91-4154-9e4c-afba0ce015e3",
-  "doi" : "https://doi.org/10.1234/reiciendis",
-  "link" : "https://www.example.org/390a1023-6619-4df1-a1f0-89920c4dbe0b",
+  "createdDate" : "1986-05-13T17:57:30.355Z",
+  "modifiedDate" : "2013-03-03T01:30:27.727Z",
+  "publishedDate" : "1976-04-29T15:26:30.915Z",
+  "indexedDate" : "1972-10-27T13:49:18.036Z",
+  "handle" : "https://www.example.org/55da63cd-369b-49f4-9e1c-ee566193cd4a",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/c54f2402-97fc-4ab7-9b2d-ecca99bd7422",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cWCwAq8x6nfDkZOsz",
+    "mainTitle" : "3Z0UmUp7Ts",
     "alternativeTitles" : {
-      "nb" : "Vx7fqPM0Tq3yRgBA"
+      "de" : "hF2LSjXUhYWTNeUIrxs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "fl0GlARI2t",
-      "month" : "phJAx9cFmn7k",
-      "day" : "6MjIfzYV0C"
+      "year" : "B85gmtX5EzdF8JP",
+      "month" : "zJkX9tyExPikkhI9D7",
+      "day" : "b0REjzyMRM1w"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/48274a45-e963-4677-8640-8446d3eec099",
-        "name" : "jNRM4LdI5Cz",
-        "nameType" : "Personal",
-        "orcId" : "sC3iOlC55iPHtYxYxCC",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/63999fe7-058b-49d7-b174-f38c1a5f03d2",
+        "name" : "XNqmAd6OatmJX",
+        "nameType" : "Organizational",
+        "orcId" : "Mu50FvouOfVjyxaN",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LM63ntxmEFA",
-          "value" : "6WRYTqNID9D8Q9"
+          "sourceName" : "mzpaHrAlR7HXP7ze",
+          "value" : "7kmqfGTDezCDo11h"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yuwQ5e53zUOEHTZOn",
-          "value" : "sVo51Yd25dY"
+          "sourceName" : "w0sOicG3iqmrn",
+          "value" : "nNCHteEWTp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7f13fe0b-57a3-43bf-96d6-765aa19fc181"
+        "id" : "https://www.example.org/9f1de67c-c550-45ef-ba91-e8bd2eef1937"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/72a8189e-02d5-44f7-8671-02776424a317",
-        "name" : "E1Po9SlGo1xMjXrsRg",
+        "id" : "https://www.example.org/fd540f4b-cb13-4c54-b157-dd04f50a5ec6",
+        "name" : "puyE1AZi4E4D4zGz",
         "nameType" : "Organizational",
-        "orcId" : "sZJIt9MIRitEpwZWPpV",
-        "verificationStatus" : "Verified",
+        "orcId" : "mzV5wT8N3Fgc",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JMKvcg43ugjDkxaN",
-          "value" : "sKJEbxAcm59bGonId"
+          "sourceName" : "xGdO5jF3uxoh",
+          "value" : "wnpXcWfHX45K9C"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aPegLnC219eLnYNFK6k",
-          "value" : "c1elwkzDQV9lw6DgO"
+          "sourceName" : "MKBOt1AsiHwQ8VwV",
+          "value" : "2Surt16XylEmu3OnqKP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/980b68e5-e4db-4c93-a7cf-54d0a7265e12"
+        "id" : "https://www.example.org/432be539-c5bb-4f9a-9c06-fcd096d0c6e7"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "bdawSeD4HB0SDKKagfh"
+      "af" : "NH34r4wb1AYvv0Dd"
     },
-    "npiSubjectHeading" : "QdtThWAoBk2zA",
-    "tags" : [ "OA8xhAtS1L2bJM" ],
-    "description" : "HI8NxdbNewimiG4",
+    "npiSubjectHeading" : "YE5yDmfyXwak",
+    "tags" : [ "rIwvoDoxIK8FIgJ" ],
+    "description" : "4SxBD6grmvF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/719892fa-93e2-44a3-a4e8-6d4c4e0fa4e7"
+        "type" : "UnconfirmedMediaContributionPeriodical",
+        "title" : "fFpieEtzTfBn",
+        "printIssn" : "1489-4963",
+        "onlineIssn" : "1412-002X"
       },
-      "doi" : "https://www.example.org/66b22822-0783-4be4-8feb-a5e117c4a365",
+      "doi" : "https://www.example.org/3d19f45c-54a4-4f1f-9e71-53c559272484",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "bYJEfy22UsoyiLw",
-        "issue" : "QMrDvej9ngI5a4dPyE",
-        "articleNumber" : "k1dpwHFPYOsOzPDM",
+        "volume" : "WMBoFRCZsXb6s5r1ofQ",
+        "issue" : "8LlU0TZu3a8gaP",
+        "articleNumber" : "yxCZWPf1SCo3P",
         "pages" : {
           "type" : "Range",
-          "begin" : "vicG7EY5ts6eVljF",
-          "end" : "ZiVuoKZc1r6F1"
+          "begin" : "pU3a6fa1b6OxCc5W7hL",
+          "end" : "dQoGrKRIRIXMgoWc"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/df91df94-bfd8-4f92-b09e-45a724e08ffc",
-    "abstract" : "TOEoEiQ1zp6"
+    "metadataSource" : "https://www.example.org/2350529c-6ce9-4e2e-8e26-62833d3d40fd",
+    "abstract" : "jMLtU7bSxK"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1f49d837-c592-4c2d-96ef-efffbd6b1865",
-    "name" : "CotRAJwblc",
+    "id" : "https://www.example.org/0f87e2ac-18d7-4f19-8cd2-8288b6c0becb",
+    "name" : "kIwhDVYof8o",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-12-26T15:01:43.740Z",
+      "approvalDate" : "1987-08-09T14:08:36.849Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "LHtx8vqCQ8UHJt"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "s91hVBfg6jh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d0d0f96c-14a1-431f-8245-0a704a99b8e7",
-    "identifier" : "gmem62iDHgehIne2Tz8",
+    "source" : "https://www.example.org/e28a824a-d008-4b33-b67e-377ef93a42d4",
+    "identifier" : "KfwypbRN6Z7D34M",
     "labels" : {
-      "sv" : "SSaOM8IEKI"
+      "hu" : "w0KAdycvBvyo"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 725808445
+      "currency" : "EUR",
+      "amount" : 976237505
     },
-    "activeFrom" : "2002-01-13T00:37:33.417Z",
-    "activeTo" : "2002-05-27T11:02:33.837Z"
+    "activeFrom" : "2014-02-28T05:10:46.521Z",
+    "activeTo" : "2016-04-26T14:07:16.612Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e515bff6-ac3c-4452-817e-4b43851498cf",
-    "id" : "https://www.example.org/863bfe1e-745b-4109-bbf5-383a4279a0e3",
-    "identifier" : "rS0ETIEibf",
+    "source" : "https://www.example.org/72791062-ff54-40be-8677-5e80bbcf4e1f",
+    "id" : "https://www.example.org/063c57a6-b5f2-431b-8310-bd136063fadc",
+    "identifier" : "9pN0CZcH6SDSG",
     "labels" : {
-      "it" : "fo3qCm3DGQEs"
+      "fi" : "SfXFAnATnTqK"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1404021304
+      "amount" : 236074495
     },
-    "activeFrom" : "2023-07-15T01:30:02.898Z",
-    "activeTo" : "2024-04-27T21:31:34.783Z"
+    "activeFrom" : "1999-01-31T15:40:20.063Z",
+    "activeTo" : "2004-08-13T18:12:34.452Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6fdeb866-60a0-41cd-898c-00c5e482e426" ],
+  "subjects" : [ "https://www.example.org/f4315847-9b1d-4495-9588-c6bfbbbefe02" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "63d2fb21-91a2-47c9-8e3e-f151d9ccbd37",
-    "name" : "s9tDihJWUWFs8ykzkkt",
-    "mimeType" : "gbNvcNTXe84x",
-    "size" : 793406948,
-    "license" : "https://www.example.com/yambp7a3mrh",
+    "identifier" : "98ea03a5-aca1-4b14-89ce-ca51121ca04b",
+    "name" : "DoBL5mPC8oC4758ZM2",
+    "mimeType" : "BuHKfXMxkVMtjQ3",
+    "size" : 2134801894,
+    "license" : "https://www.example.com/08lsynkt1uo02dm",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "78kmSHy6u2fcoXnH",
-    "publishedDate" : "2012-01-24T22:30:08.675Z",
+    "legalNote" : "H3K3pMSEQA",
+    "publishedDate" : "1989-02-14T09:39:05.329Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "3UMHG00FvvPWoGLqsx",
-      "uploadedDate" : "2019-04-01T02:53:16.741Z"
+      "uploadedBy" : "uBLAn7u0CdW279V2",
+      "uploadedDate" : "1986-05-13T18:11:29.851Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Gx5To0zoURsZ1t91jy",
-    "name" : "xHDxTxqJhAJ",
-    "description" : "WQFGwIm3wK5zylDaVg"
+    "id" : "https://www.example.com/XzTj0OvZMr",
+    "name" : "KQdZPnqUz6rkExu7Uwh",
+    "description" : "Jc70SdFNFAvVOLK"
   } ],
-  "rightsHolder" : "zgu9huKf0BHvSjR",
-  "duplicateOf" : "https://www.example.org/1dad64eb-1659-4786-809c-55061bf0006b",
+  "rightsHolder" : "LLUrTXG7iDPl7MDzNo",
+  "duplicateOf" : "https://www.example.org/6601ff69-186b-4d5c-a742-24682bafb421",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ztOWmWg1hQj"
+    "note" : "Fe6ALKLVPRIzYJWrp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "V3TFPicnJVWzUlIl",
-    "createdBy" : "tTbZqC6aG4qvnDpt",
-    "createdDate" : "1990-03-14T19:20:54.495Z"
+    "note" : "hm2Sb8ZBLA",
+    "createdBy" : "7MJT30wgbvwWxaQqXp",
+    "createdDate" : "1975-08-31T15:44:45.224Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2bf48433-fb53-44e0-a8e2-b5794ccf542f" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/0b8213d0-e150-430d-af88-4e45e7037bee" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "7AlSF3GhKA",
-    "ownerAffiliation" : "https://www.example.org/cef8f837-80cb-48ad-b4df-deebdeffee07"
+    "owner" : "1uv4Uvs93F05ie",
+    "ownerAffiliation" : "https://www.example.org/88e41d9d-087f-4ec5-b481-60a878b8a9ee"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/886e7a40-f51e-4522-aeb3-c2fd56c1da43"
+    "id" : "https://www.example.org/17d3ae64-be58-440a-8566-36f2e4c530e6"
   },
-  "createdDate" : "2002-04-02T06:29:01.571Z",
-  "modifiedDate" : "2018-05-19T04:48:41.183Z",
-  "publishedDate" : "1991-03-19T08:38:49.625Z",
-  "indexedDate" : "2008-03-25T12:31:16.059Z",
-  "handle" : "https://www.example.org/8cc076d3-738f-4b9d-8a2c-912b6c2759f5",
-  "doi" : "https://doi.org/10.1234/maxime",
-  "link" : "https://www.example.org/42094fcc-de77-4a35-9f64-9e70de174fb4",
+  "createdDate" : "1998-10-20T04:21:29.333Z",
+  "modifiedDate" : "1994-11-25T11:48:05.701Z",
+  "publishedDate" : "1974-07-18T12:29:34.489Z",
+  "indexedDate" : "2005-07-14T23:05:03.899Z",
+  "handle" : "https://www.example.org/2b93607d-0918-4786-8fbd-b4e9b56a79a0",
+  "doi" : "https://doi.org/10.1234/sit",
+  "link" : "https://www.example.org/134c0624-9b09-4d62-b1bf-c7306b2a111c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "omN9R8ocEiLfe",
+    "mainTitle" : "YC8aTAnoXAOlumhv",
     "alternativeTitles" : {
-      "nn" : "MqsetPIW3s"
+      "fi" : "fJKfREZWF73T9x6q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AJz2ZFK35NYb6X",
-      "month" : "SPqEbH9eiZdu8",
-      "day" : "rceb0O0012SPOstunXE"
+      "year" : "eJzNwD7M5M",
+      "month" : "AfVE04HKlOZ",
+      "day" : "nyUFoH8alO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e58c31ed-ae62-48e6-bc31-5b43abdf3bd9",
-        "name" : "o2WQ25hpd0SAA",
+        "id" : "https://www.example.org/bfbaaf65-2293-45dc-894b-70dee3e47271",
+        "name" : "gqQPdEqF4nS6Fr",
         "nameType" : "Organizational",
-        "orcId" : "dC8ZJCnatkY",
+        "orcId" : "rolgVdK5dGxlR",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MM5TYDinryi",
-          "value" : "zDa6r5yTFxR"
+          "sourceName" : "s1p29UHAbUUDlpo",
+          "value" : "vy6S2FsIw5GGVHNsij"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qypIF6JUsgk0bQM",
-          "value" : "D6lFgDlnzhY21"
+          "sourceName" : "IvYAhBh8ssj",
+          "value" : "KxW65BTYy4Om7XGT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/70d4ca8c-6502-427c-960c-56df28f884ef"
+        "id" : "https://www.example.org/6e90b5f5-8cdd-411b-8512-46fbc1240a8d"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,185 +62,185 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/408097be-ee25-48e7-91d3-b073d853d41a",
-        "name" : "Gbqeinv1iL9",
+        "id" : "https://www.example.org/90efa17a-0618-4e21-b017-1064ecf10d50",
+        "name" : "NVQCjR4gJCAW",
         "nameType" : "Organizational",
-        "orcId" : "rs7iyRnvqco",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Utw9gD5JPtTTe3kUi",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w8zs8jR3h6SPfEeA",
-          "value" : "0zNLjys4iBt"
+          "sourceName" : "gZZ1WSwtXJuSZEz4ZQf",
+          "value" : "4dr75tzicRl1ueVXX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eZsBs2ixxn8ZytayL",
-          "value" : "nRs5P4mEjgQ3I"
+          "sourceName" : "lg1e6dh2vTFob2jX",
+          "value" : "nCYzL46EKi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/05cec448-1c10-46d6-a205-8c8610112a88"
+        "id" : "https://www.example.org/d0ad51b9-4c13-4714-afa0-c0c24ac6196f"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "swaCc0tiPrJMUit"
+      "ru" : "xMt0BdTbY15gGsM"
     },
-    "npiSubjectHeading" : "6KncwHU7cioX",
-    "tags" : [ "QhW6Mx757a6j9RQce" ],
-    "description" : "gGYHTsTBaqq61f7",
+    "npiSubjectHeading" : "DIjZMDoZNs",
+    "tags" : [ "Vcu0GGx4dtsNy" ],
+    "description" : "ShlbvEEmKb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/ef88d2ee-cdc7-41d3-ae1d-c712212fa1ff",
+      "doi" : "https://www.example.org/ea26204e-590a-4e20-96f5-76cf14e2fa6f",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "AugmentedVirtualRealityFilm"
+          "type" : "InteractiveFilm"
         },
-        "description" : "znAEZftQq94",
+        "description" : "1emfcRDIrSALyVSqD3",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "vtv0RtzKsYaQuTA48J",
+            "name" : "KcR4DfUwO45XGLLJnpe",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2004-01-26T16:14:18.549Z"
+            "value" : "1981-02-03T00:30:26.027Z"
           },
-          "sequence" : 1260147912
+          "sequence" : 908137172
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "oo49DjCyKjlkvx2",
-            "country" : "az70LYzgSR1"
+            "label" : "OELUq5jVT3",
+            "country" : "bPRI1Obquj"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1999-12-03T09:53:54.276Z"
+            "value" : "1979-04-07T01:11:55.728Z"
           },
-          "sequence" : 415558018
+          "sequence" : 623760497
         }, {
           "type" : "OtherRelease",
-          "description" : "Qoc5HxgX5ntBgO",
+          "description" : "2o1ZXGpA7QFN3h",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "VfsK6jnFWDpdxYbx2",
-            "country" : "HDYXHbKQxUG2w"
+            "label" : "LIX5Dgectu7hTC9Kh",
+            "country" : "qZJnnxbwjTGpuoF"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "MMNfHVzI6YpFNA0dQl",
+            "name" : "Di2gUEiwSLe1dNl",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1979-04-17T10:06:06.008Z"
+            "value" : "1988-11-07T11:47:52.562Z"
           },
-          "sequence" : 1840052843
+          "sequence" : 249888062
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4ea42e19-6af4-40d0-8622-18d8335d5ba9",
-    "abstract" : "3enFFlEAWrdE2EB"
+    "metadataSource" : "https://www.example.org/a91a9483-6cf4-4c84-86b3-a43ba92daa5e",
+    "abstract" : "8jb5dt7AnmRiwdzV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1158c702-a1aa-444b-9c7b-f17f70970825",
-    "name" : "a1rGOfU7818JrL",
+    "id" : "https://www.example.org/3b340f65-9bf2-4e19-b550-a2dd315885bf",
+    "name" : "LvZp0TEW7HDJIp0snT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2023-12-27T06:17:38.392Z",
+      "approvalDate" : "2014-02-08T21:21:07.519Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "aaEePlPlRbYO7zUg5dq"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "ibeSCRtUbUtCnnCD06o"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8f39a178-54f4-475c-962a-4fb6223ef58d",
-    "identifier" : "7evm71tmHvOIObG",
+    "source" : "https://www.example.org/4f3d0716-5627-43fa-854c-8f23831b74b7",
+    "identifier" : "zqWqWFkEtmFgG",
     "labels" : {
-      "fi" : "yJXjV2zuAIFLf"
+      "nn" : "ygCZytygDPH"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 948688636
+      "amount" : 953200093
     },
-    "activeFrom" : "1974-06-14T10:10:47.966Z",
-    "activeTo" : "2024-04-04T20:38:41.486Z"
+    "activeFrom" : "2009-08-09T10:59:24.879Z",
+    "activeTo" : "2019-05-20T20:36:19.575Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/444d939a-a6ee-483b-8a6b-af69abb824d2",
-    "id" : "https://www.example.org/cd3bfca2-e87d-4ba7-8333-20a0082a1064",
-    "identifier" : "3fy9KhqexCmYWzCum7",
+    "source" : "https://www.example.org/6f39d458-a425-4c7d-8e2c-a76f29a6b117",
+    "id" : "https://www.example.org/72c95b7e-a563-4665-a539-1265f23fbb9f",
+    "identifier" : "cnGy20BFd1FCiYlB",
     "labels" : {
-      "cs" : "eriIMoZmpEH9R2P"
+      "se" : "gsMXeSWtycxvYHTG"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1728249256
+      "amount" : 982830345
     },
-    "activeFrom" : "2009-07-18T21:31:15.907Z",
-    "activeTo" : "2020-06-29T10:58:28.074Z"
+    "activeFrom" : "2000-10-05T14:28:09.069Z",
+    "activeTo" : "2014-03-27T03:58:16.323Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b3bb279d-2e98-4a08-8f4d-7aa3d590bff7" ],
+  "subjects" : [ "https://www.example.org/ed1ddb2e-9ffc-40cc-9171-20014999e604" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6192b29e-cafe-4c23-991e-a5b822a4b545",
-    "name" : "4HvHjegJ9e7SSW8Ipj",
-    "mimeType" : "sACtEdzYXeFd",
-    "size" : 1642944054,
-    "license" : "https://www.example.com/pygvugwkmfqfi77gkq",
+    "identifier" : "d61f6a90-b6b9-41bf-abcd-fe8bd6ea05cc",
+    "name" : "x24pKbDPcVxocqj1",
+    "mimeType" : "pSviT0hH9t0cZJw0r",
+    "size" : 586364168,
+    "license" : "https://www.example.com/iapg5ifj9iiznzqiwr8",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "wP9e2Ywsb8Pn9we"
+      "overriddenBy" : "1qqEPizuT6cU"
     },
-    "legalNote" : "WYZ5b0LsJvWCdl",
-    "publishedDate" : "1975-01-07T18:03:55.967Z",
+    "legalNote" : "rwzzcWiWOq",
+    "publishedDate" : "2002-07-24T19:44:32.282Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "6eHsH9sWyHa",
-      "uploadedDate" : "2011-01-26T17:23:04.878Z"
+      "uploadedBy" : "ZXQC3Y3UVVV",
+      "uploadedDate" : "1976-09-27T05:48:26.906Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5TH3FXxbcri",
-    "name" : "aJWYCCVewDTNRriJIB",
-    "description" : "1DcwZ8kZXpWNl"
+    "id" : "https://www.example.com/itVabheipBmgCdft8Uw",
+    "name" : "Ihtwu88AF317",
+    "description" : "0VIFK7uiGpvM7"
   } ],
-  "rightsHolder" : "mpA7MlLRQf",
-  "duplicateOf" : "https://www.example.org/9c2d5c4b-5d92-44b2-8329-06e8a812deb5",
+  "rightsHolder" : "bNCpaSQ8lUC",
+  "duplicateOf" : "https://www.example.org/b81672d9-9866-48ab-a4b2-b7487849815f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "45v6LqnAn9CAm"
+    "note" : "K9CQm8DJ4010"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "NEIDMUuz5KnjQ8n",
-    "createdBy" : "0VSBHiUZNK71sOZrR0",
-    "createdDate" : "1987-01-29T02:43:54.696Z"
+    "note" : "klsW8OirJNes7tUGmC",
+    "createdBy" : "EF0IGBOVGm2i",
+    "createdDate" : "2017-07-01T07:29:50.184Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9b73c9e9-d530-4946-ac91-5aed1e4befc7" ],
+  "curatingInstitutions" : [ "https://www.example.org/eae14074-ffe1-4da2-be77-7ffbf356e763" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "hbymq0ushW",
-    "ownerAffiliation" : "https://www.example.org/34f72218-7c8a-4cb2-a38a-a9434230c435"
+    "owner" : "7AlSF3GhKA",
+    "ownerAffiliation" : "https://www.example.org/cef8f837-80cb-48ad-b4df-deebdeffee07"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/17fcedd9-3ae0-461e-835a-28ba60a38f80"
+    "id" : "https://www.example.org/886e7a40-f51e-4522-aeb3-c2fd56c1da43"
   },
-  "createdDate" : "2020-10-28T21:49:16.603Z",
-  "modifiedDate" : "1983-03-01T23:07:52.504Z",
-  "publishedDate" : "2014-07-28T17:14:37.829Z",
-  "indexedDate" : "2005-08-28T09:15:15.481Z",
-  "handle" : "https://www.example.org/78d4b908-9b0e-4971-835f-c0a2e4d77832",
-  "doi" : "https://doi.org/10.1234/ullam",
-  "link" : "https://www.example.org/b78296a4-87bb-4cc9-a777-6c64292878ba",
+  "createdDate" : "2002-04-02T06:29:01.571Z",
+  "modifiedDate" : "2018-05-19T04:48:41.183Z",
+  "publishedDate" : "1991-03-19T08:38:49.625Z",
+  "indexedDate" : "2008-03-25T12:31:16.059Z",
+  "handle" : "https://www.example.org/8cc076d3-738f-4b9d-8a2c-912b6c2759f5",
+  "doi" : "https://doi.org/10.1234/maxime",
+  "link" : "https://www.example.org/42094fcc-de77-4a35-9f64-9e70de174fb4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "KsJZUzDJYcP",
+    "mainTitle" : "omN9R8ocEiLfe",
     "alternativeTitles" : {
-      "ru" : "mJzSJ3N6RCg6KNVtgCf"
+      "nn" : "MqsetPIW3s"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tqfZkkbuKZOXNZ",
-      "month" : "H6INDDfIbQMaPgXGy",
-      "day" : "BhCZ9qDQdcCimxLIL2Y"
+      "year" : "AJz2ZFK35NYb6X",
+      "month" : "SPqEbH9eiZdu8",
+      "day" : "rceb0O0012SPOstunXE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bd30432a-5f98-4a85-bd99-c6277b583e44",
-        "name" : "n5jJSp9WAxlKUECaegr",
+        "id" : "https://www.example.org/e58c31ed-ae62-48e6-bc31-5b43abdf3bd9",
+        "name" : "o2WQ25hpd0SAA",
         "nameType" : "Organizational",
-        "orcId" : "DaEef9q2oM",
+        "orcId" : "dC8ZJCnatkY",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VCwI7ew5XGR",
-          "value" : "ncHhWAWsehdUoyOrU5y"
+          "sourceName" : "MM5TYDinryi",
+          "value" : "zDa6r5yTFxR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8oa72MJaFNLMfP",
-          "value" : "rRitB3YA6M0wN"
+          "sourceName" : "qypIF6JUsgk0bQM",
+          "value" : "D6lFgDlnzhY21"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/18f36a56-3aba-4476-9a62-56e643bcb9d0"
+        "id" : "https://www.example.org/70d4ca8c-6502-427c-960c-56df28f884ef"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,184 +62,185 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c71ce585-848f-488b-8197-99a5102583db",
-        "name" : "kdkFK04nO4y3u9fh22",
+        "id" : "https://www.example.org/408097be-ee25-48e7-91d3-b073d853d41a",
+        "name" : "Gbqeinv1iL9",
         "nameType" : "Organizational",
-        "orcId" : "V2AzKiC8RsDTiOt3Nlu",
+        "orcId" : "rs7iyRnvqco",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YAaes3HrO5Qew",
-          "value" : "EGgKvJmkBjrPCt26RM"
+          "sourceName" : "w8zs8jR3h6SPfEeA",
+          "value" : "0zNLjys4iBt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AfmfwwvXhkrSrmUBfoU",
-          "value" : "wpRIwvvSSYiBGgkNt0"
+          "sourceName" : "eZsBs2ixxn8ZytayL",
+          "value" : "nRs5P4mEjgQ3I"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e42cc33c-d9fb-49a1-97e3-fefea8897f73"
+        "id" : "https://www.example.org/05cec448-1c10-46d6-a205-8c8610112a88"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "ContactPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "VR67gBhSQAXvZJFCr"
+      "en" : "swaCc0tiPrJMUit"
     },
-    "npiSubjectHeading" : "cFgBDaMkaYQmxYBz",
-    "tags" : [ "khXupSZOl90PcJ" ],
-    "description" : "0K00bRPuqoCQe",
+    "npiSubjectHeading" : "6KncwHU7cioX",
+    "tags" : [ "QhW6Mx757a6j9RQce" ],
+    "description" : "gGYHTsTBaqq61f7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/e59dbc90-c705-444e-b9da-612259c52084",
+      "doi" : "https://www.example.org/ef88d2ee-cdc7-41d3-ae1d-c712212fa1ff",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "Film"
+          "type" : "AugmentedVirtualRealityFilm"
         },
-        "description" : "AnHXIc1sLwYG5MQ",
+        "description" : "znAEZftQq94",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "ySqJhsrCrrok",
+            "name" : "vtv0RtzKsYaQuTA48J",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2008-10-31T21:47:59.156Z"
+            "value" : "2004-01-26T16:14:18.549Z"
           },
-          "sequence" : 617475771
+          "sequence" : 1260147912
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "mmyExlzxWqJRO",
-            "country" : "SNhHvxbCjFQdadAD"
+            "label" : "oo49DjCyKjlkvx2",
+            "country" : "az70LYzgSR1"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1994-09-28T21:12:45.051Z"
+            "value" : "1999-12-03T09:53:54.276Z"
           },
-          "sequence" : 1824617008
+          "sequence" : 415558018
         }, {
           "type" : "OtherRelease",
-          "description" : "c4lrACy50J6sAGC",
+          "description" : "Qoc5HxgX5ntBgO",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "zSFVQ6hUFD",
-            "country" : "diBcsuXz8McHWZGQt"
+            "label" : "VfsK6jnFWDpdxYbx2",
+            "country" : "HDYXHbKQxUG2w"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "9UZqaLX81v1bpTCOZts",
+            "name" : "MMNfHVzI6YpFNA0dQl",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2023-08-11T17:31:21.878Z"
+            "value" : "1979-04-17T10:06:06.008Z"
           },
-          "sequence" : 1965635375
+          "sequence" : 1840052843
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a83f1701-9f03-40cb-965c-ebabcb32c0ad",
-    "abstract" : "HioD3ayrqkF"
+    "metadataSource" : "https://www.example.org/4ea42e19-6af4-40d0-8622-18d8335d5ba9",
+    "abstract" : "3enFFlEAWrdE2EB"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c5b65167-a4ef-4cdf-8d88-65cf0a2dfc6e",
-    "name" : "b46ZmLjvYTTf8acN",
+    "id" : "https://www.example.org/1158c702-a1aa-444b-9c7b-f17f70970825",
+    "name" : "a1rGOfU7818JrL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-02-20T09:00:14.464Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "v1i6nv73u0dysQ50R"
+      "approvalDate" : "2023-12-27T06:17:38.392Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "aaEePlPlRbYO7zUg5dq"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6cd048ac-967d-4768-b784-e421e30510b8",
-    "identifier" : "k9qDKR58XmvP1oJDjF2",
+    "source" : "https://www.example.org/8f39a178-54f4-475c-962a-4fb6223ef58d",
+    "identifier" : "7evm71tmHvOIObG",
     "labels" : {
-      "fr" : "vpOkjOfl2I"
+      "fi" : "yJXjV2zuAIFLf"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1880812546
+      "currency" : "NOK",
+      "amount" : 948688636
     },
-    "activeFrom" : "2022-02-11T10:08:14.195Z",
-    "activeTo" : "2023-11-15T14:40:47.933Z"
+    "activeFrom" : "1974-06-14T10:10:47.966Z",
+    "activeTo" : "2024-04-04T20:38:41.486Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e79c04f3-dbea-4784-8359-82eeed9f1423",
-    "id" : "https://www.example.org/9aaa3e1a-cd4d-4265-8298-d832c9f15ae4",
-    "identifier" : "XHg9jVrqPlK",
+    "source" : "https://www.example.org/444d939a-a6ee-483b-8a6b-af69abb824d2",
+    "id" : "https://www.example.org/cd3bfca2-e87d-4ba7-8333-20a0082a1064",
+    "identifier" : "3fy9KhqexCmYWzCum7",
     "labels" : {
-      "nb" : "3RnuJEkyhZixxsj1"
+      "cs" : "eriIMoZmpEH9R2P"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1902887952
+      "currency" : "EUR",
+      "amount" : 1728249256
     },
-    "activeFrom" : "1976-06-24T02:33:31.017Z",
-    "activeTo" : "1980-01-16T09:05:33.582Z"
+    "activeFrom" : "2009-07-18T21:31:15.907Z",
+    "activeTo" : "2020-06-29T10:58:28.074Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7f005426-7b5e-46c1-8caa-81a7ee4ce2c8" ],
+  "subjects" : [ "https://www.example.org/b3bb279d-2e98-4a08-8f4d-7aa3d590bff7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6a68bbef-596a-4d62-a836-4775ee95679b",
-    "name" : "j1Z5ijlQjrT",
-    "mimeType" : "b9dfNji3wCnSIf",
-    "size" : 1894857116,
-    "license" : "https://www.example.com/rrcfrelw4u1z6l",
+    "identifier" : "6192b29e-cafe-4c23-991e-a5b822a4b545",
+    "name" : "4HvHjegJ9e7SSW8Ipj",
+    "mimeType" : "sACtEdzYXeFd",
+    "size" : 1642944054,
+    "license" : "https://www.example.com/pygvugwkmfqfi77gkq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "wP9e2Ywsb8Pn9we"
     },
-    "legalNote" : "3U6qlKbF7wHz2ldnB",
-    "publishedDate" : "2019-12-02T12:08:50.385Z",
+    "legalNote" : "WYZ5b0LsJvWCdl",
+    "publishedDate" : "1975-01-07T18:03:55.967Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "HyqxT4iHlbla",
-      "uploadedDate" : "1996-11-11T22:25:26.475Z"
+      "uploadedBy" : "6eHsH9sWyHa",
+      "uploadedDate" : "2011-01-26T17:23:04.878Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JUN2qVlbPD3clN",
-    "name" : "vEyVVUEHRzoIAejPt2",
-    "description" : "lObG4NRxCvltEFCQv"
+    "id" : "https://www.example.com/5TH3FXxbcri",
+    "name" : "aJWYCCVewDTNRriJIB",
+    "description" : "1DcwZ8kZXpWNl"
   } ],
-  "rightsHolder" : "eUKrBFBxkOkZtr17l",
-  "duplicateOf" : "https://www.example.org/3a76b4af-cd8f-48f6-86a7-0eafe3f25659",
+  "rightsHolder" : "mpA7MlLRQf",
+  "duplicateOf" : "https://www.example.org/9c2d5c4b-5d92-44b2-8329-06e8a812deb5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "SuPEo9ACo9zBA"
+    "note" : "45v6LqnAn9CAm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SVlCx0YAv1kI7la5bU",
-    "createdBy" : "Ub70BZcAjtXQeWdvFH",
-    "createdDate" : "2019-08-05T14:11:25.655Z"
+    "note" : "NEIDMUuz5KnjQ8n",
+    "createdBy" : "0VSBHiUZNK71sOZrR0",
+    "createdDate" : "1987-01-29T02:43:54.696Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3dd42999-ff84-44c1-89fc-a6c247e12f5c" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/9b73c9e9-d530-4946-ac91-5aed1e4befc7" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "IT1wdMQCIIl",
-    "ownerAffiliation" : "https://www.example.org/1cb9097f-7bec-494c-b8f3-35179d9df824"
+    "owner" : "mWovgLYzujfD",
+    "ownerAffiliation" : "https://www.example.org/288ba03b-6362-4078-9416-1b7503208aa7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/285f38a5-55d3-4790-ac8f-ddae6dfe9a9c"
+    "id" : "https://www.example.org/7cd9f221-029a-45d9-a5f9-5f497e420b3c"
   },
-  "createdDate" : "2008-08-27T04:31:43.365Z",
-  "modifiedDate" : "2011-06-27T12:52:45.484Z",
-  "publishedDate" : "1975-02-07T18:16:05.534Z",
-  "indexedDate" : "2002-01-19T08:02:02.260Z",
-  "handle" : "https://www.example.org/8e2e6eb5-459e-4d73-b385-cc3363d165bc",
-  "doi" : "https://doi.org/10.1234/libero",
-  "link" : "https://www.example.org/4e267f37-3e30-4be1-96cc-4d12d733d013",
+  "createdDate" : "2019-01-12T12:14:01.474Z",
+  "modifiedDate" : "1976-06-04T20:17:16.764Z",
+  "publishedDate" : "2007-10-23T21:36:34.196Z",
+  "indexedDate" : "1996-06-28T05:44:26.637Z",
+  "handle" : "https://www.example.org/014a647e-713a-4ad1-a878-4044f540b24e",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/559bb4de-8312-4c4d-a5b5-f8236f86a9e6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HQcObRp3IRJ",
+    "mainTitle" : "DJ582Ut7EXi3CZ8",
     "alternativeTitles" : {
-      "is" : "JV4npMG1m67KOEI"
+      "ca" : "5Q9H5KG8y87GJcJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "9Q6l7WQVEM",
-      "month" : "S8axxShFHJvGWi",
-      "day" : "STL099TQyxfdrfT6"
+      "year" : "pfCMa9CQiqA",
+      "month" : "y7mxeIKQJuJ",
+      "day" : "W8tohIAdVpF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a58d1013-a2a6-4fd6-b376-5dfa34917565",
-        "name" : "QqrOhnfBlGzm3VMnno",
-        "nameType" : "Personal",
-        "orcId" : "bpQJdTWQmskMmt882",
+        "id" : "https://www.example.org/0a91f8b4-aa70-40d0-b45b-1c0a192e75d8",
+        "name" : "a0AnZyPtLC2zbNiwt",
+        "nameType" : "Organizational",
+        "orcId" : "ZgfzPOHeqi3Kbf",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RizQRCY8vaZ",
-          "value" : "U7rDIJauDdTU3Da"
+          "sourceName" : "0ps24QHw5VtISp3vH",
+          "value" : "UAnAQBMiQM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JL854RXzA5DO0Hi7raL",
-          "value" : "HyBHsT3ke7NNg"
+          "sourceName" : "8P70rYUIUk",
+          "value" : "cKd7cvP2iPvcXoKa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3963dae5-6537-4753-8ae6-b8b2fe00f2f6"
+        "id" : "https://www.example.org/15a0370f-ed19-4144-a298-53da769c5b73"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Architect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,61 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ccb4a3c9-3b78-419c-82b1-658bea8637f9",
-        "name" : "74giboqoKOulB1Wnl",
+        "id" : "https://www.example.org/5d913233-3084-4940-9d82-190d309c70d8",
+        "name" : "VQz9GgKHx1",
         "nameType" : "Organizational",
-        "orcId" : "MG630fqGgDTOjmlJR",
+        "orcId" : "WBUX4O1z8W4JoAXW",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "npcU8oQPdAnNg",
-          "value" : "uhLbX2HkXHN4"
+          "sourceName" : "BzD8lp0olLed",
+          "value" : "V2nrrhGFJgJqmUXYr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IWDPEUBje8",
-          "value" : "7OQTDEcShNqn8VQovD"
+          "sourceName" : "0I3D7Q5kfHk",
+          "value" : "yQW3MW8EoOQC8d6BH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/21854365-c638-4491-8e16-b014949266c5"
+        "id" : "https://www.example.org/4e145043-dbf4-4256-83bb-9146c1c9a3f4"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "HostingInstitution"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "bfxYCDaKCRBc"
+      "is" : "DDwoyBJUMK"
     },
-    "npiSubjectHeading" : "uwzmOEZkYgDPgOn0O",
-    "tags" : [ "Jv6irTuJHDBygtAUx" ],
-    "description" : "FJSxKx7yS8Djr0RDdH",
+    "npiSubjectHeading" : "y2ytGWPEOHK6",
+    "tags" : [ "1fKTDEg5dEw" ],
+    "description" : "Pl2LcYEGFeD4zTuaa6r",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/5fcf6b06-5e01-4344-be6e-779853add315",
+      "doi" : "https://www.example.org/69ad3c75-3223-41b8-b839-ec87cab7f2a4",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "DVD"
+            "type" : "Vinyl"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "5HO6yi2NqgXkw5",
+            "name" : "k79mHbHUJWrVwuRUK9k",
             "valid" : true
           },
-          "catalogueNumber" : "T6NDoBZ2glbVjp",
+          "catalogueNumber" : "ecKExLfeFP2",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "eKhIoOivgTmr",
-            "composer" : "p8cEpyGJJgdai6Wy",
-            "extent" : "kn5x2vGDZu"
+            "title" : "Fd5gR6kXX61Lhchd",
+            "composer" : "jqlu58gizr86",
+            "extent" : "QTpW7659nlbc6ER5CZr"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,30 +126,29 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "4OGkG7L1xuxxVkMVz",
-            "country" : "mwIBVEJ9pFXyvJj"
+            "label" : "wVjv1vbiUx",
+            "country" : "QslvuCjPaET"
           },
           "time" : {
-            "type" : "Period",
-            "from" : "1981-05-16T22:50:45.195Z",
-            "to" : "1993-09-08T17:34:01.179Z"
+            "type" : "Instant",
+            "value" : "1997-11-03T03:23:24.563Z"
           },
-          "extent" : "LChQvzDjh3",
+          "extent" : "5mM4PNOQA50H",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "t49Qy4zzcvTEh2r",
-            "composer" : "TvzjX9rbKc5Bm1eS0w",
-            "premiere" : true
+            "title" : "2df0nFZvH0j1q",
+            "composer" : "e5xkoGnHfkQ",
+            "premiere" : false
           } ],
-          "concertSeries" : "yZRJ6nK9M0fjWGrpu7"
+          "concertSeries" : "RtGTM6BKYxaR"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "m9El6xCigzxg0",
-          "movements" : "rcXQsY4DgEVGzs7",
-          "extent" : "4Mgu9liUuD",
+          "ensemble" : "V3o1g9K6Q2smiS",
+          "movements" : "qJOBm257RqopvFr",
+          "extent" : "l5eFWQahTo",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "kxExqL6RvAIwo63u",
+            "name" : "RqH0oTqSsZoJ",
             "valid" : true
           },
           "ismn" : {
@@ -159,17 +158,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "hk9aID7aq2N2i02d",
+          "performanceType" : "aXqIdbE8mncGuQ43",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "u6dQJ1G9guh7nyG9P",
-            "country" : "L0qeLXvqBU9HaoeA"
+            "label" : "dqUzXNsS4t",
+            "country" : "RN5P537gS4ko7RoBn2w"
           },
-          "extent" : "EnGnbqL4mGpdk9of",
+          "extent" : "LD4pFph7HgCwYOHCrfk",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "dMQJ5Iw7uKuDYXx3dW7",
-            "composer" : "7KXmijQxrm3vx5YTeGf"
+            "title" : "AKYWXRmZBC",
+            "composer" : "8YpEPCGmvGv50KBb"
           } ]
         } ],
         "pages" : {
@@ -177,93 +176,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/74a186b1-6c07-434c-8d64-3b534697d6aa",
-    "abstract" : "Ww6muVHPp4fK7dYq5LP"
+    "metadataSource" : "https://www.example.org/0097397d-6940-4e7e-aa94-f3c82bc01e86",
+    "abstract" : "D8uxRW0I71"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a824518c-344f-4327-b733-79a1be63676d",
-    "name" : "7krGPgD2ppE8",
+    "id" : "https://www.example.org/10e4db10-f296-482b-9be5-e539f1cd95f4",
+    "name" : "H0UCuLzA6oOZhxxYyq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-09-14T23:57:42.606Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "yA8Wv81DStb1mrDL"
+      "approvalDate" : "1991-02-26T01:27:36.265Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "O5MjM9JHDWHwLEDEMYl"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ba93f866-e946-4199-8fe3-b29aaa19f014",
-    "identifier" : "0wghq3WMdGU9GLZ5s",
+    "source" : "https://www.example.org/9ff039cb-314e-4b0d-8c14-479199216783",
+    "identifier" : "9k2TcyrjyscMAKJ7sO",
     "labels" : {
-      "ru" : "dk56s3Vk1rMq"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 174250206
-    },
-    "activeFrom" : "1988-09-12T07:33:05.870Z",
-    "activeTo" : "2003-12-04T01:47:12.110Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e8d5b254-2dc7-452b-890f-90dde564908b",
-    "id" : "https://www.example.org/a4778276-bf7d-4d25-9c59-a196c436ce04",
-    "identifier" : "gcRzvUdRPR",
-    "labels" : {
-      "zh" : "dCboot5EmlqKX901p6S"
+      "is" : "UWzPL9068SFNWeeqMNc"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1625447129
+      "amount" : 32981855
     },
-    "activeFrom" : "2012-03-12T10:03:47.309Z",
-    "activeTo" : "2012-04-09T15:34:44.117Z"
+    "activeFrom" : "1997-02-07T09:12:52.714Z",
+    "activeTo" : "1999-11-16T09:41:10.557Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/39750c79-19c6-4db0-9e4b-05815656b589",
+    "id" : "https://www.example.org/1bf5ae9b-49ea-4e0a-a7ae-c90a40e87331",
+    "identifier" : "2VqE0bGSgY",
+    "labels" : {
+      "ru" : "MRCUwNcC0fRkqEn"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 548475169
+    },
+    "activeFrom" : "1980-08-20T21:34:42.614Z",
+    "activeTo" : "1997-03-19T01:31:20.351Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4967e511-e214-45a5-a0af-1b444c699b4a" ],
+  "subjects" : [ "https://www.example.org/5317d09c-0c49-4286-8884-61d487845398" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "cda93532-bfad-4604-9e6b-5b4afa9fe50b",
-    "name" : "Slh2b1JYVa21",
-    "mimeType" : "W5bCTHXJiGaYVpaidMI",
-    "size" : 974073019,
-    "license" : "https://www.example.com/2xgxwpuiyu4vf",
+    "identifier" : "f4783cf1-0c71-4005-bb5d-ed45e4125edd",
+    "name" : "iHqsgKIne8PUp",
+    "mimeType" : "9AnDTd7vvvVEoj",
+    "size" : 79703196,
+    "license" : "https://www.example.com/hhu2dy6syqaagv",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "g6CwF4VwTjOh0",
-    "publishedDate" : "1995-10-26T19:02:33.427Z",
+    "legalNote" : "72GIhJA91vvYOVR",
+    "publishedDate" : "1980-07-26T04:24:42.119Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "p8OFvnqbavUTYZpoUH",
-      "uploadedDate" : "2015-02-04T08:48:31.931Z"
+      "uploadedBy" : "VnNX8ozKbyP36Y5wkvx",
+      "uploadedDate" : "1978-12-27T01:10:57.286Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3fWOQyHUtw7VV913l",
-    "name" : "MkS40GV2iok5",
-    "description" : "coGglde2g5oRZZQG"
+    "id" : "https://www.example.com/HpbbRLroP2Pg98d8B",
+    "name" : "3oIhFGCan0JzImmVz2A",
+    "description" : "rBejKbBJ1LjOopb"
   } ],
-  "rightsHolder" : "ZqCLC3kG9JvDOVF2",
-  "duplicateOf" : "https://www.example.org/9da23eff-c28b-4a31-9aa8-d6ba0a3889d2",
+  "rightsHolder" : "UAyI3PqPRrdzht",
+  "duplicateOf" : "https://www.example.org/a8adcc1e-9124-4e74-b533-a3c1ab3417fc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "g89iMslgibWFOsHuQ"
+    "note" : "icjK3qChfJt5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "k9IE34sryqSQWCRKJQ",
-    "createdBy" : "aMxyyDdgMqIk",
-    "createdDate" : "1980-12-26T18:44:45.897Z"
+    "note" : "iBIS8MrO9pI",
+    "createdBy" : "m7BVvleItpkotnZ",
+    "createdDate" : "2006-04-09T11:54:25.018Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2f7ffbb1-137c-4e08-aee8-6d615a0abde2" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/8001c836-d0f4-454f-8a45-b4fb3847491a" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "mWovgLYzujfD",
-    "ownerAffiliation" : "https://www.example.org/288ba03b-6362-4078-9416-1b7503208aa7"
+    "owner" : "HJitZxdcgr39pW",
+    "ownerAffiliation" : "https://www.example.org/e174f979-d3b6-4cc8-a312-f43ff0eeb428"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7cd9f221-029a-45d9-a5f9-5f497e420b3c"
+    "id" : "https://www.example.org/71ac4d7b-2667-4869-8bd5-4580980f6d06"
   },
-  "createdDate" : "2019-01-12T12:14:01.474Z",
-  "modifiedDate" : "1976-06-04T20:17:16.764Z",
-  "publishedDate" : "2007-10-23T21:36:34.196Z",
-  "indexedDate" : "1996-06-28T05:44:26.637Z",
-  "handle" : "https://www.example.org/014a647e-713a-4ad1-a878-4044f540b24e",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/559bb4de-8312-4c4d-a5b5-f8236f86a9e6",
+  "createdDate" : "1992-05-22T16:15:10.382Z",
+  "modifiedDate" : "2001-03-15T18:34:42.771Z",
+  "publishedDate" : "2009-12-08T17:30:45.536Z",
+  "indexedDate" : "2001-01-16T11:50:21.779Z",
+  "handle" : "https://www.example.org/14dd8b07-1d09-498e-9907-5ecf85ab75b8",
+  "doi" : "https://doi.org/10.1234/autem",
+  "link" : "https://www.example.org/3bb5e7a5-4722-48ec-874f-da41e9267858",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DJ582Ut7EXi3CZ8",
+    "mainTitle" : "s5L8sUwsXzcCnOWQ",
     "alternativeTitles" : {
-      "ca" : "5Q9H5KG8y87GJcJ"
+      "es" : "veoMUbGznsoLzTBhPCi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "pfCMa9CQiqA",
-      "month" : "y7mxeIKQJuJ",
-      "day" : "W8tohIAdVpF"
+      "year" : "tO1TQLcmML16a",
+      "month" : "OsJljVucSxrlbz1FP",
+      "day" : "u8NtBESbMF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0a91f8b4-aa70-40d0-b45b-1c0a192e75d8",
-        "name" : "a0AnZyPtLC2zbNiwt",
+        "id" : "https://www.example.org/86e77aba-2814-44c0-a12a-1a9a273753ac",
+        "name" : "1FroQSBOrCQjO7",
         "nameType" : "Organizational",
-        "orcId" : "ZgfzPOHeqi3Kbf",
-        "verificationStatus" : "Verified",
+        "orcId" : "X2DXgyXo3Kdx7",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0ps24QHw5VtISp3vH",
-          "value" : "UAnAQBMiQM"
+          "sourceName" : "RkZvERvIDK88zvaop",
+          "value" : "pOTC1TTUftUAiFg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8P70rYUIUk",
-          "value" : "cKd7cvP2iPvcXoKa"
+          "sourceName" : "SdW3eIPHnV9",
+          "value" : "vgtz7U6uwHxeIQvZL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/15a0370f-ed19-4144-a298-53da769c5b73"
+        "id" : "https://www.example.org/11bff9a0-358e-48aa-9276-978b7c5cd822"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,61 +62,62 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5d913233-3084-4940-9d82-190d309c70d8",
-        "name" : "VQz9GgKHx1",
+        "id" : "https://www.example.org/1e153834-135f-4eba-9f0d-2df1a6160a9b",
+        "name" : "Bn4FCwpRihrFmtaceID",
         "nameType" : "Organizational",
-        "orcId" : "WBUX4O1z8W4JoAXW",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "xPc9lTd9Nbc",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BzD8lp0olLed",
-          "value" : "V2nrrhGFJgJqmUXYr"
+          "sourceName" : "SjKt8sbT48nGkc8ruCG",
+          "value" : "AGG8T2gvMqoCj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0I3D7Q5kfHk",
-          "value" : "yQW3MW8EoOQC8d6BH"
+          "sourceName" : "JMWyVcWm0QmFSrAwMBU",
+          "value" : "RhymeMiohRwu0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4e145043-dbf4-4256-83bb-9146c1c9a3f4"
+        "id" : "https://www.example.org/2c2fa9c5-f7aa-4375-b70b-9f73fe68f6b4"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Designer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "DDwoyBJUMK"
+      "en" : "Z9DAU8w6trCtx"
     },
-    "npiSubjectHeading" : "y2ytGWPEOHK6",
-    "tags" : [ "1fKTDEg5dEw" ],
-    "description" : "Pl2LcYEGFeD4zTuaa6r",
+    "npiSubjectHeading" : "MiKCo6AeYRIKVeig",
+    "tags" : [ "6gkLDQZCjcmNf" ],
+    "description" : "PSMikf3nWB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/69ad3c75-3223-41b8-b839-ec87cab7f2a4",
+      "doi" : "https://www.example.org/66a6dbd0-510f-4248-bab7-a207efae1be4",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "Vinyl"
+            "type" : "MusicMediaOther",
+            "description" : "MymByessDc"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "k79mHbHUJWrVwuRUK9k",
+            "name" : "umJIXLe5oXbm5DXev",
             "valid" : true
           },
-          "catalogueNumber" : "ecKExLfeFP2",
+          "catalogueNumber" : "dGc6nz1nhd6MqPmCz16",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "Fd5gR6kXX61Lhchd",
-            "composer" : "jqlu58gizr86",
-            "extent" : "QTpW7659nlbc6ER5CZr"
+            "title" : "vTYuNdyRt94YnZTvKh4",
+            "composer" : "r5I5IkSMLcLW17FOqm",
+            "extent" : "BGBPsdMRv4Nf"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,49 +127,50 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "wVjv1vbiUx",
-            "country" : "QslvuCjPaET"
+            "label" : "UQl3ZW6vwDl7U",
+            "country" : "eoSaBqZY7ZzMBjsj8"
           },
           "time" : {
-            "type" : "Instant",
-            "value" : "1997-11-03T03:23:24.563Z"
+            "type" : "Period",
+            "from" : "2013-07-14T09:34:37.568Z",
+            "to" : "2024-05-04T14:15:44.967Z"
           },
-          "extent" : "5mM4PNOQA50H",
+          "extent" : "B7a0b59cLnb",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "2df0nFZvH0j1q",
-            "composer" : "e5xkoGnHfkQ",
-            "premiere" : false
+            "title" : "0CUTyci71Uc9DGb8l9z",
+            "composer" : "zgjWyUx5cAF",
+            "premiere" : true
           } ],
-          "concertSeries" : "RtGTM6BKYxaR"
+          "concertSeries" : "0o8KO9xARRcpP"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "V3o1g9K6Q2smiS",
-          "movements" : "qJOBm257RqopvFr",
-          "extent" : "l5eFWQahTo",
+          "ensemble" : "yHK7Z1r5nmoFa",
+          "movements" : "hQT3EDvmYMBquJfYEk",
+          "extent" : "1N0Xpl8WnRnBhi",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "RqH0oTqSsZoJ",
+            "name" : "r9qeNWDVb9wZ",
             "valid" : true
           },
           "ismn" : {
             "type" : "Ismn",
-            "value" : "M230671187",
-            "formatted" : "M-2306-7118-7"
+            "value" : "9790901679177",
+            "formatted" : "979-0-9016791-7-7"
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "aXqIdbE8mncGuQ43",
+          "performanceType" : "lO7lt71X7sc",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "dqUzXNsS4t",
-            "country" : "RN5P537gS4ko7RoBn2w"
+            "label" : "6t46ZcIpqKryM05",
+            "country" : "8fyFi07m3u4mCUXUf"
           },
-          "extent" : "LD4pFph7HgCwYOHCrfk",
+          "extent" : "SrvYLC134cw6ln5ma",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "AKYWXRmZBC",
-            "composer" : "8YpEPCGmvGv50KBb"
+            "title" : "o7sSb92SHfD",
+            "composer" : "niLeqQxpo5928D6"
           } ]
         } ],
         "pages" : {
@@ -176,93 +178,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0097397d-6940-4e7e-aa94-f3c82bc01e86",
-    "abstract" : "D8uxRW0I71"
+    "metadataSource" : "https://www.example.org/22e83215-0319-47a7-8203-142371be85e8",
+    "abstract" : "65Blgu2HHE"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/10e4db10-f296-482b-9be5-e539f1cd95f4",
-    "name" : "H0UCuLzA6oOZhxxYyq",
+    "id" : "https://www.example.org/0603e7a2-16b9-4240-8d7d-69ebbacf2262",
+    "name" : "duRvFEHCVMpnBXdRl",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-02-26T01:27:36.265Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "O5MjM9JHDWHwLEDEMYl"
+      "approvalDate" : "2011-09-25T14:22:36.342Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "eoi0UVLr4CNYFK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9ff039cb-314e-4b0d-8c14-479199216783",
-    "identifier" : "9k2TcyrjyscMAKJ7sO",
+    "source" : "https://www.example.org/917ac845-bfa1-47a3-9e47-faceca117865",
+    "identifier" : "ILhIDOaBzo",
     "labels" : {
-      "is" : "UWzPL9068SFNWeeqMNc"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 32981855
-    },
-    "activeFrom" : "1997-02-07T09:12:52.714Z",
-    "activeTo" : "1999-11-16T09:41:10.557Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/39750c79-19c6-4db0-9e4b-05815656b589",
-    "id" : "https://www.example.org/1bf5ae9b-49ea-4e0a-a7ae-c90a40e87331",
-    "identifier" : "2VqE0bGSgY",
-    "labels" : {
-      "ru" : "MRCUwNcC0fRkqEn"
+      "se" : "Bym85y0OKAa"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 548475169
+      "amount" : 986230541
     },
-    "activeFrom" : "1980-08-20T21:34:42.614Z",
-    "activeTo" : "1997-03-19T01:31:20.351Z"
+    "activeFrom" : "2007-01-11T08:49:15.960Z",
+    "activeTo" : "2014-09-19T16:12:11.593Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/767e24d9-e3df-4d36-a5f1-af5ac0918302",
+    "id" : "https://www.example.org/cfd2653c-9d1d-4eba-acca-129db4f67c14",
+    "identifier" : "kEivAhKj7rHF",
+    "labels" : {
+      "zh" : "kmd3JLwVZlvj5D"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 646434355
+    },
+    "activeFrom" : "1988-06-12T06:55:53.455Z",
+    "activeTo" : "2011-08-07T10:56:31.117Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5317d09c-0c49-4286-8884-61d487845398" ],
+  "subjects" : [ "https://www.example.org/752e17c3-9cfc-4c08-a91f-f1b9b70b3aed" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f4783cf1-0c71-4005-bb5d-ed45e4125edd",
-    "name" : "iHqsgKIne8PUp",
-    "mimeType" : "9AnDTd7vvvVEoj",
-    "size" : 79703196,
-    "license" : "https://www.example.com/hhu2dy6syqaagv",
+    "identifier" : "d0a564b9-803f-478b-a6e3-246990c3effe",
+    "name" : "QlFOnOpX9q54B8k10K",
+    "mimeType" : "XM91w9rcXM",
+    "size" : 1586659430,
+    "license" : "https://www.example.com/zj6yq1rqjfg4q",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "72GIhJA91vvYOVR",
-    "publishedDate" : "1980-07-26T04:24:42.119Z",
+    "legalNote" : "VPTYWonPjhslhT7fyv2",
+    "publishedDate" : "1989-08-06T10:44:39.032Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "VnNX8ozKbyP36Y5wkvx",
-      "uploadedDate" : "1978-12-27T01:10:57.286Z"
+      "uploadedBy" : "h0zObbgjrNs",
+      "uploadedDate" : "2014-02-01T18:12:47.045Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HpbbRLroP2Pg98d8B",
-    "name" : "3oIhFGCan0JzImmVz2A",
-    "description" : "rBejKbBJ1LjOopb"
+    "id" : "https://www.example.com/MA15WwNWlLAYm0M0",
+    "name" : "dlo4BqL0fMfuesbupk",
+    "description" : "kX7qRbRvWkEvOzW"
   } ],
-  "rightsHolder" : "UAyI3PqPRrdzht",
-  "duplicateOf" : "https://www.example.org/a8adcc1e-9124-4e74-b533-a3c1ab3417fc",
+  "rightsHolder" : "S5wdctWo17w0",
+  "duplicateOf" : "https://www.example.org/1503e44c-5d5f-4377-8293-771a5058581e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "icjK3qChfJt5"
+    "note" : "bBrpsVqfjH6IycAr6c"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iBIS8MrO9pI",
-    "createdBy" : "m7BVvleItpkotnZ",
-    "createdDate" : "2006-04-09T11:54:25.018Z"
+    "note" : "lT8pZxc1dVQ",
+    "createdBy" : "5PRm1GN4MO",
+    "createdDate" : "1996-11-23T07:58:10.708Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8001c836-d0f4-454f-8a45-b4fb3847491a" ],
+  "curatingInstitutions" : [ "https://www.example.org/45286ea5-6850-4879-8811-0342bcdf189e" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "uo2YQZkS9472a",
-    "ownerAffiliation" : "https://www.example.org/52260706-d979-4b82-b90b-54954263f867"
+    "owner" : "tg8Ra15nvNMuXYuj",
+    "ownerAffiliation" : "https://www.example.org/57ff240e-c3ff-438c-8018-89b8905b2d9c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/86d69297-168c-42fb-b651-23f3bbec9841"
+    "id" : "https://www.example.org/e4b6edb0-a62e-4439-bf65-4c3807c7c455"
   },
-  "createdDate" : "1985-09-22T00:59:35.188Z",
-  "modifiedDate" : "2023-08-19T19:04:33.580Z",
-  "publishedDate" : "1987-03-01T09:07:00.516Z",
-  "indexedDate" : "2001-04-30T01:48:46.883Z",
-  "handle" : "https://www.example.org/caad18de-2318-4f0a-93c8-debd4546b211",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/51bdd98d-222b-43cb-b337-03cf9e549352",
+  "createdDate" : "2019-10-02T06:08:34.856Z",
+  "modifiedDate" : "2017-01-27T11:55:56.602Z",
+  "publishedDate" : "1973-12-15T23:44:06.997Z",
+  "indexedDate" : "1985-02-23T09:40:35.781Z",
+  "handle" : "https://www.example.org/e783f656-1b77-47ac-81a9-503d41a31da7",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/79ce59d8-3acf-4c3a-b30f-9a0e17d7dec1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6wsgP2XoTFtlU",
+    "mainTitle" : "6GvEp5JyvIrL8X14h",
     "alternativeTitles" : {
-      "pt" : "vRMM4vYO9Z"
+      "fr" : "nCDhLk67V182"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "pq9t0v6XtQUyo",
-      "month" : "MVDG5VYGfLeH",
-      "day" : "9sJ27jt7uVr"
+      "year" : "HkJUnwCDRHLXOBsU",
+      "month" : "2EXHnHYIc5c6Bg3b",
+      "day" : "s8NaFtEIxwl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/793e8aca-59a9-4c43-8028-38ffb1241932",
-        "name" : "iSwkGEqL4LTf",
+        "id" : "https://www.example.org/12389d18-c6f7-487c-afa1-6d22b010dc17",
+        "name" : "wcodFb3La2YKx",
         "nameType" : "Organizational",
-        "orcId" : "CYyr6zVM0f",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "JjGhWSPtbhFrgM4",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3tBZS5Y1EI0vWOmNREz",
-          "value" : "AZeVZQIwY5S"
+          "sourceName" : "66Dh5G1Sxan",
+          "value" : "Iuk4MjUhJE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mLgTbLiWaR41EvgMvn",
-          "value" : "sPDgsIqDVF216aiGLk"
+          "sourceName" : "6ZoJHNCoYEwsNDa4",
+          "value" : "UzvQS6Etkt8PB2n8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f462893e-2a38-4f9e-bc9a-b40f926784cb"
+        "id" : "https://www.example.org/e6226137-99e6-413f-9eda-51ff491ab345"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Dramaturge"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3a17d71c-7235-4228-9f70-c2760bdafa60",
-        "name" : "7SJSdx8hdnoySKk",
+        "id" : "https://www.example.org/c4b5de70-e472-48ab-bb16-cf7549374c35",
+        "name" : "Ai3BesjfWKwp",
         "nameType" : "Personal",
-        "orcId" : "pU2GgEcGC1fFnu2ewy",
+        "orcId" : "YNEkxBm5SpyYnT6V",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HD55lMUDmqGgO7J",
-          "value" : "SAX8FQZ3wKwY"
+          "sourceName" : "Q7IhsxiyPpRj",
+          "value" : "ohcJS3EeJL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xFYcB7Wq1GSR",
-          "value" : "QcrZgoGJYQ1wvtzR7"
+          "sourceName" : "muEb7FBtUYZ",
+          "value" : "nSCH5CN5Xr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4490471b-7b0c-4a8f-9017-9d2bfed5c9b7"
+        "id" : "https://www.example.org/db256714-324b-465b-8acd-913d799c53c9"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "VdjTGcSgyeh2xn"
+      "bg" : "LEdD53VYaGaXD"
     },
-    "npiSubjectHeading" : "SWFaYUfIEkAdaZDLkx",
-    "tags" : [ "FLvc5qusKY" ],
-    "description" : "n5kP6CRGGbFjMJlmla",
+    "npiSubjectHeading" : "i1wh6BdwWpNvvgvTPG",
+    "tags" : [ "ytxhyZUmGdj" ],
+    "description" : "hiEInduTrMHjjaKM7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/7Tkm5UyjiW"
+        "id" : "https://www.example.com/eBkTMC1hLs"
       },
-      "doi" : "https://www.example.org/f0cc1751-bfaf-4c0c-a781-9d856d1866b9",
+      "doi" : "https://www.example.org/95596f9e-5e32-40ca-b469-62fcff68471a",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "NXs8boAlj33",
-          "end" : "WKjZrFVoWaZeeXk"
+          "begin" : "JUXp3Kmdu0U",
+          "end" : "ebSOiDCzF547"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f86a881d-4c88-4fe3-9336-75b3ca755be9",
-    "abstract" : "mxBBEpRYa5"
+    "metadataSource" : "https://www.example.org/850a3538-a90e-4c0a-98dd-9d10113b6ed2",
+    "abstract" : "xKgUhqaMKyEgzT"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1aa06c78-b12c-4e78-aeb4-e650291f7d13",
-    "name" : "Va6WRkVGFBbygl",
+    "id" : "https://www.example.org/96896e1f-9343-4c7c-a0c2-4cf12394c0e8",
+    "name" : "nVM81slXjLHmwdGJ52",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-11-01T22:56:59.332Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "UoyCqnkUm5kcDwi3"
+      "approvalDate" : "2013-10-11T00:18:09.351Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "P5zwFdAjWWZclsFZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6cdb229c-e6af-44fd-9e89-eeaa693efc70",
-    "identifier" : "uNiIligyZCU9Az",
+    "source" : "https://www.example.org/7462e33f-fc86-4e63-ab03-335e3bd61898",
+    "identifier" : "WTpeHgBGQZnNRfvcr",
     "labels" : {
-      "nl" : "HdPiQVZMbc"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1228022293
-    },
-    "activeFrom" : "2017-04-07T05:18:40.919Z",
-    "activeTo" : "2021-01-29T22:20:27.316Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f3fbda72-2869-43f9-a143-354b074f547c",
-    "id" : "https://www.example.org/dbcfee78-396a-4085-824e-31aa26c740c9",
-    "identifier" : "vdbkQnQVhoyz4iFc",
-    "labels" : {
-      "ru" : "dAF0W2mgtHnz0deJRpn"
+      "ru" : "PVj5O1hz8rCyYLBWqX"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1803824233
+      "amount" : 471792538
     },
-    "activeFrom" : "1983-07-31T19:31:04.047Z",
-    "activeTo" : "2023-08-08T08:31:38.152Z"
+    "activeFrom" : "2022-03-13T10:05:31.995Z",
+    "activeTo" : "2023-09-30T23:36:15.785Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/132d936c-5e8c-45a2-b910-bff5aa31e882",
+    "id" : "https://www.example.org/6603afca-937f-4741-aecf-ad1b991f5b71",
+    "identifier" : "iLL9psfsGty1jTp",
+    "labels" : {
+      "is" : "AsBok2wmtS"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1862750686
+    },
+    "activeFrom" : "2005-01-08T20:32:23.979Z",
+    "activeTo" : "2020-11-17T08:27:55.557Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/22703212-0c08-4aef-b620-c5f4f740338f" ],
+  "subjects" : [ "https://www.example.org/fb00199e-3bcd-48d8-bfcb-09e975a75bfe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "98473a7f-70bb-4198-b525-4fc3f97f2a28",
-    "name" : "u3jGB4yWA2Zn",
-    "mimeType" : "AzlkDiWahKgqGdAPV",
-    "size" : 1223406482,
-    "license" : "https://www.example.com/fzaovk2cplx",
+    "identifier" : "d5b9f4ef-ab24-4f44-b976-3e423b9bd8f5",
+    "name" : "9XH8tL5uQHV2Mf2tu8W",
+    "mimeType" : "Ribjk4YKKH",
+    "size" : 73618514,
+    "license" : "https://www.example.com/baaoy6z6j4f5sfvqm",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "tsjBVTUSGEGMgH",
-    "publishedDate" : "2008-03-13T06:30:29.384Z",
+    "legalNote" : "RLED0DluguDwUTHXtoD",
+    "publishedDate" : "2015-04-03T01:49:33.340Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "FYeShGtPFdPta0Qo",
-      "uploadedDate" : "1996-04-17T23:31:24.736Z"
+      "uploadedBy" : "SPSlyGytbZ",
+      "uploadedDate" : "2015-06-15T21:27:10.255Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/OCKgjSWqu2bXPyM",
-    "name" : "jbzFup867R9B0GaLc",
-    "description" : "J3dVuBVbx5tI"
+    "id" : "https://www.example.com/Yp0UCS2opToCIltWCVQ",
+    "name" : "3pJz3Rira6",
+    "description" : "x6kyPdhAhyKqQbNsBZ"
   } ],
-  "rightsHolder" : "A6wTbYECye",
-  "duplicateOf" : "https://www.example.org/b79709a5-30eb-4d55-ad02-2877c4ecc0ef",
+  "rightsHolder" : "SLMygqGgvEXyHMLUqCc",
+  "duplicateOf" : "https://www.example.org/46d7dcec-819a-4ff5-a81a-8f2cc3b6ad04",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QsRTTJ2RTyH9bk"
+    "note" : "M2rTCAi1P4W5zr3s4V"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1vJ0nGOjKos5dN8",
-    "createdBy" : "NAIqJwFvhdx",
-    "createdDate" : "1991-11-01T07:39:17.861Z"
+    "note" : "EPSAO6cJRMQ",
+    "createdBy" : "goKuzs09cx4B",
+    "createdDate" : "1977-10-10T16:38:52.018Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8ff73e6c-e186-4df4-bb05-04f70f3e3820" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/f0d0952d-c7bc-4797-a7bd-1f4f283ff02d" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "tg8Ra15nvNMuXYuj",
-    "ownerAffiliation" : "https://www.example.org/57ff240e-c3ff-438c-8018-89b8905b2d9c"
+    "owner" : "CctMltsGCj",
+    "ownerAffiliation" : "https://www.example.org/c2377c24-cb08-4324-bc21-7be6f5c43272"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e4b6edb0-a62e-4439-bf65-4c3807c7c455"
+    "id" : "https://www.example.org/8eca94d1-81a6-4fb9-83ec-c2145a943c7e"
   },
-  "createdDate" : "2019-10-02T06:08:34.856Z",
-  "modifiedDate" : "2017-01-27T11:55:56.602Z",
-  "publishedDate" : "1973-12-15T23:44:06.997Z",
-  "indexedDate" : "1985-02-23T09:40:35.781Z",
-  "handle" : "https://www.example.org/e783f656-1b77-47ac-81a9-503d41a31da7",
-  "doi" : "https://doi.org/10.1234/id",
-  "link" : "https://www.example.org/79ce59d8-3acf-4c3a-b30f-9a0e17d7dec1",
+  "createdDate" : "2003-08-04T05:02:09.579Z",
+  "modifiedDate" : "1979-08-18T00:34:36.654Z",
+  "publishedDate" : "1982-01-24T18:07:33.525Z",
+  "indexedDate" : "1971-11-14T06:19:23.500Z",
+  "handle" : "https://www.example.org/44158430-6d24-4b09-8c77-0a0cbe832bdf",
+  "doi" : "https://doi.org/10.1234/deleniti",
+  "link" : "https://www.example.org/4c452d74-d16d-4f34-800e-ba3829cb1227",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "6GvEp5JyvIrL8X14h",
+    "mainTitle" : "30Xtpu2XNlrNO4Ja",
     "alternativeTitles" : {
-      "fr" : "nCDhLk67V182"
+      "de" : "PKaTKN4Qw1aRo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HkJUnwCDRHLXOBsU",
-      "month" : "2EXHnHYIc5c6Bg3b",
-      "day" : "s8NaFtEIxwl"
+      "year" : "7NWf4ynjK2iopHC",
+      "month" : "kaz9jQteRc",
+      "day" : "VtDsXmFwiHCl9p"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/12389d18-c6f7-487c-afa1-6d22b010dc17",
-        "name" : "wcodFb3La2YKx",
+        "id" : "https://www.example.org/72f30a2b-d18f-48ba-a4aa-065845b7ec24",
+        "name" : "P84hVoZmdtOpxFzQz",
         "nameType" : "Organizational",
-        "orcId" : "JjGhWSPtbhFrgM4",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "b3dffImxXlV9v",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "66Dh5G1Sxan",
-          "value" : "Iuk4MjUhJE"
+          "sourceName" : "KG51MhsiXma",
+          "value" : "xGogUNtolVvn8JKHvE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6ZoJHNCoYEwsNDa4",
-          "value" : "UzvQS6Etkt8PB2n8"
+          "sourceName" : "EviwdQdp63uFkUaGyb",
+          "value" : "K40BXjZoSTJBko5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e6226137-99e6-413f-9eda-51ff491ab345"
+        "id" : "https://www.example.org/322966a3-3da2-4768-be79-583f409acee1"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "Architect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c4b5de70-e472-48ab-bb16-cf7549374c35",
-        "name" : "Ai3BesjfWKwp",
+        "id" : "https://www.example.org/24d14a22-77a9-4ad8-94d5-d525462a8a9b",
+        "name" : "ep4PY5QVgLAZDm0lQYd",
         "nameType" : "Personal",
-        "orcId" : "YNEkxBm5SpyYnT6V",
+        "orcId" : "8VwT3Qi49qEc1285hoe",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Q7IhsxiyPpRj",
-          "value" : "ohcJS3EeJL"
+          "sourceName" : "1ELwaObRufeuqorKx",
+          "value" : "nSRsFjtLb2LfxXoi41"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "muEb7FBtUYZ",
-          "value" : "nSCH5CN5Xr"
+          "sourceName" : "8WVImnIWSfFCDL",
+          "value" : "jo4sv6J8t4JHLIiP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/db256714-324b-465b-8acd-913d799c53c9"
+        "id" : "https://www.example.org/1fc2d2a9-030f-437e-bb70-f148d79b1de7"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "DataCurator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "LEdD53VYaGaXD"
+      "nb" : "9a4vRNfuGMM8ZEoQ"
     },
-    "npiSubjectHeading" : "i1wh6BdwWpNvvgvTPG",
-    "tags" : [ "ytxhyZUmGdj" ],
-    "description" : "hiEInduTrMHjjaKM7",
+    "npiSubjectHeading" : "peV5fnNvNoucBe7kg0",
+    "tags" : [ "EQzrlBbjkhkQtJvw" ],
+    "description" : "WfqXAPzFbxp2eyjMV3y",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/eBkTMC1hLs"
+        "id" : "https://www.example.com/kPOBT2uV83"
       },
-      "doi" : "https://www.example.org/95596f9e-5e32-40ca-b469-62fcff68471a",
+      "doi" : "https://www.example.org/0cf925ed-2a95-426d-8b97-6e2fddb349cb",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "JUXp3Kmdu0U",
-          "end" : "ebSOiDCzF547"
+          "begin" : "UT6VuXgxQfd",
+          "end" : "YwxzJ7ydoiVwD4Z"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/850a3538-a90e-4c0a-98dd-9d10113b6ed2",
-    "abstract" : "xKgUhqaMKyEgzT"
+    "metadataSource" : "https://www.example.org/00057176-8a09-4805-86f1-c0c8652490b5",
+    "abstract" : "XaadkfZ6YSbH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/96896e1f-9343-4c7c-a0c2-4cf12394c0e8",
-    "name" : "nVM81slXjLHmwdGJ52",
+    "id" : "https://www.example.org/77e66ef3-1e92-4f0b-b1a1-7fb1706c0c0c",
+    "name" : "0HOvutxYpW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-10-11T00:18:09.351Z",
+      "approvalDate" : "2002-06-24T13:02:15.336Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "P5zwFdAjWWZclsFZ"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "DGGmPD5F58Sj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7462e33f-fc86-4e63-ab03-335e3bd61898",
-    "identifier" : "WTpeHgBGQZnNRfvcr",
+    "source" : "https://www.example.org/10615816-bb05-481b-9b28-31c78c680d10",
+    "identifier" : "KBMPTquZyzbXcM",
     "labels" : {
-      "ru" : "PVj5O1hz8rCyYLBWqX"
+      "fr" : "ec5dUDwP8so"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 471792538
+      "amount" : 2111333248
     },
-    "activeFrom" : "2022-03-13T10:05:31.995Z",
-    "activeTo" : "2023-09-30T23:36:15.785Z"
+    "activeFrom" : "1972-05-31T04:23:21.340Z",
+    "activeTo" : "2014-07-16T20:24:39.403Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/132d936c-5e8c-45a2-b910-bff5aa31e882",
-    "id" : "https://www.example.org/6603afca-937f-4741-aecf-ad1b991f5b71",
-    "identifier" : "iLL9psfsGty1jTp",
+    "source" : "https://www.example.org/14f55ded-ceef-4080-bf3f-5d4b661e67cd",
+    "id" : "https://www.example.org/edb8a4dd-a886-4eee-ab3f-bfa1cb86b1d0",
+    "identifier" : "Mmbn5qDMlbDgM",
     "labels" : {
-      "is" : "AsBok2wmtS"
+      "pt" : "17XZtIaVR0H5yzTy"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1862750686
+      "amount" : 873366326
     },
-    "activeFrom" : "2005-01-08T20:32:23.979Z",
-    "activeTo" : "2020-11-17T08:27:55.557Z"
+    "activeFrom" : "2021-03-16T01:16:33.579Z",
+    "activeTo" : "2024-04-16T21:03:11.593Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fb00199e-3bcd-48d8-bfcb-09e975a75bfe" ],
+  "subjects" : [ "https://www.example.org/aea2859f-895f-4ccf-8e7f-b0b7d483412b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d5b9f4ef-ab24-4f44-b976-3e423b9bd8f5",
-    "name" : "9XH8tL5uQHV2Mf2tu8W",
-    "mimeType" : "Ribjk4YKKH",
-    "size" : 73618514,
-    "license" : "https://www.example.com/baaoy6z6j4f5sfvqm",
+    "identifier" : "1d86ba2d-0d76-400c-9001-31e448b0ebf5",
+    "name" : "KXc7gd1oTozV3",
+    "mimeType" : "Be5R6NYrpiz3wUeY",
+    "size" : 1256594948,
+    "license" : "https://www.example.com/icfauax3girrrxbyts",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "DsJ4PjeBFc61ANA"
     },
-    "legalNote" : "RLED0DluguDwUTHXtoD",
-    "publishedDate" : "2015-04-03T01:49:33.340Z",
+    "legalNote" : "BXDB3bfQnUUSMOqj",
+    "publishedDate" : "1996-12-08T11:28:13.440Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "SPSlyGytbZ",
-      "uploadedDate" : "2015-06-15T21:27:10.255Z"
+      "uploadedBy" : "Rjt03CUvzM7xZcm",
+      "uploadedDate" : "2016-02-17T04:13:41.788Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Yp0UCS2opToCIltWCVQ",
-    "name" : "3pJz3Rira6",
-    "description" : "x6kyPdhAhyKqQbNsBZ"
+    "id" : "https://www.example.com/I9ITVIlS2VhJ7CTLua",
+    "name" : "jYJ1Hsl3gIS",
+    "description" : "yTYshAykzrRWqZ"
   } ],
-  "rightsHolder" : "SLMygqGgvEXyHMLUqCc",
-  "duplicateOf" : "https://www.example.org/46d7dcec-819a-4ff5-a81a-8f2cc3b6ad04",
+  "rightsHolder" : "QkW7MZEwrrfV5iYP",
+  "duplicateOf" : "https://www.example.org/b1bf5686-f16b-426a-a6a1-f6d60a15cbfb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "M2rTCAi1P4W5zr3s4V"
+    "note" : "Qi0bWiQBBsvIyqDo"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "EPSAO6cJRMQ",
-    "createdBy" : "goKuzs09cx4B",
-    "createdDate" : "1977-10-10T16:38:52.018Z"
+    "note" : "kMXJnSvzHb5R8TeVx8h",
+    "createdBy" : "auqJv7xjT1gNPzp6ZdW",
+    "createdDate" : "1986-12-16T12:02:27.569Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f0d0952d-c7bc-4797-a7bd-1f4f283ff02d" ],
+  "curatingInstitutions" : [ "https://www.example.org/22f508f0-cd9a-4431-9564-0d458bf79a82" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "T9WroGvsJomFiod6",
-    "ownerAffiliation" : "https://www.example.org/82350986-a112-4a4a-8cf9-fffc3ae04bd1"
+    "owner" : "8PFW8bdXQGiqWTvHN",
+    "ownerAffiliation" : "https://www.example.org/81bac8db-bf32-45a4-8a98-57082b4a6d58"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dd1e6da9-0bd0-4ca6-bcc4-b71eef5a9663"
+    "id" : "https://www.example.org/51000ba4-b319-4f9a-b102-08379ab70026"
   },
-  "createdDate" : "2011-01-01T22:24:05.238Z",
-  "modifiedDate" : "1983-05-11T23:19:15.551Z",
-  "publishedDate" : "2015-08-18T17:43:29.220Z",
-  "indexedDate" : "2013-02-24T15:46:23.901Z",
-  "handle" : "https://www.example.org/f0c17ba0-61bd-46e8-a4b5-b993840fe790",
-  "doi" : "https://doi.org/10.1234/eligendi",
-  "link" : "https://www.example.org/4ceb781d-ba52-4391-a0bd-516e7d0dea62",
+  "createdDate" : "2005-06-27T11:20:05.040Z",
+  "modifiedDate" : "1996-04-04T17:00:25.394Z",
+  "publishedDate" : "1992-07-12T12:29:37.298Z",
+  "indexedDate" : "1992-05-28T22:22:53.672Z",
+  "handle" : "https://www.example.org/a5260ce1-b605-488d-a41f-2f47ce33c7a5",
+  "doi" : "https://doi.org/10.1234/nulla",
+  "link" : "https://www.example.org/9dd720b5-3389-4e59-b128-ec52654866b4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4vWoYV6TmTlbLp",
+    "mainTitle" : "sHaOVFVLL9BrYD",
     "alternativeTitles" : {
-      "de" : "t2EU2a4gelmWVi"
+      "is" : "e6CUYs5mEMKjt8bZjW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bk8Gql5by55BTZA1",
-      "month" : "ylDq2FcBJAcewp2i",
-      "day" : "9aRYo14hBBharr0vT"
+      "year" : "P21ZDRN1QQ9cCfjM",
+      "month" : "E4kNRhACyi4",
+      "day" : "JKfiqOCL8695f8EIH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c84f7c5a-2017-40a2-bd3f-bfc1f5d79cfb",
-        "name" : "kR10tc6YSgdQoZMJwW",
-        "nameType" : "Organizational",
-        "orcId" : "CYC5zH0ru4LswPgVD",
+        "id" : "https://www.example.org/17564ee0-84b9-4b85-9cb7-077d880027ad",
+        "name" : "4H5NNcrhNVmtxws",
+        "nameType" : "Personal",
+        "orcId" : "XSiMpisoQBXzASoXbj",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ujc7rB7HxwAICh",
-          "value" : "pqo2lJfsYSGTzyy4T"
+          "sourceName" : "8plmg2d2BrU0AlGik",
+          "value" : "Cqt7uRZc3x1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QzmxOpPgTftsIzB9Go",
-          "value" : "fxrYO54ecEi0nNSVF"
+          "sourceName" : "qHTGay48cs3PF1TvQH",
+          "value" : "5L5P6j41zuonEeusmkH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/af22bb84-e6db-4ba1-929b-d0ffacbf85f2"
+        "id" : "https://www.example.org/501b8e87-4f89-4e93-a13e-d7413b43aa0f"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/718fe944-1dc0-44d8-a66d-0b598a28909c",
-        "name" : "zcCXp6P56lsRB",
+        "id" : "https://www.example.org/cbcdd83c-79c3-4739-bac4-aa78735d9917",
+        "name" : "T2sB6yyNW9obpmeHvM",
         "nameType" : "Organizational",
-        "orcId" : "uKa8Rj1GoPuDao5CbdM",
+        "orcId" : "g7rXFy4ML3v",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BH3cIwVWBjqGVsolK",
-          "value" : "bWvbsqDOFR33"
+          "sourceName" : "RegSpQg62urSTGRz0",
+          "value" : "8a2EmGmrPykovg8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WActjZbRcfyRiU0OsWC",
-          "value" : "vZbnYrLjWYjLFP5TMV"
+          "sourceName" : "BkWTmfaY8Tso6",
+          "value" : "Tap5mQzNFHnuj0MOH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/721fa85d-5b94-4b4d-887e-14fefabdfc43"
+        "id" : "https://www.example.org/295c941b-add9-431d-b48b-92dc4d191ec8"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "5Bu23wMkBdn"
+        "type" : "Curator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "HOpzFifR04K2SdZLJ"
+      "nn" : "xzCLgpvDy4pu"
     },
-    "npiSubjectHeading" : "IDWAFVOWy9",
-    "tags" : [ "3rOzmVKdYo2xRkX6z7e" ],
-    "description" : "rFqeL5rop9FEo6jO0w",
+    "npiSubjectHeading" : "wwypiPt1GEC1u8o18fk",
+    "tags" : [ "yEii4cdsrgq" ],
+    "description" : "OncaJiI4UED1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/73d22620-a260-415f-8b75-2809fcd6dec6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af29265c-090b-4899-98fa-77dd41fa5bf8"
         },
-        "seriesNumber" : "zndihTAGyZ3dKw7",
+        "seriesNumber" : "sYFUH4hAexckbv9u",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e4129e79-9db2-4bfd-a2ac-5773cf3c862f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cb627fcb-3ac4-4d23-bf1f-c90ec1080cc6",
           "valid" : true
         },
-        "isbnList" : [ "9780799853285", "9780929456522" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781299051683", "9780711486133" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0929456521"
+          "value" : "0711486131"
         } ]
       },
-      "doi" : "https://www.example.org/290fc211-7cff-49a5-adf0-cc551b3fbcb5",
+      "doi" : "https://www.example.org/400c2e68-2aa2-402a-a6c1-4f2f8daa2000",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "uFqBx0YCPucPhfV",
-            "end" : "m7xuTAd5U59lDzTznI"
+            "begin" : "PCYejegVCeVE1rzvb0",
+            "end" : "EvNDprfPYLme"
           },
-          "pages" : "ZsoktBDbrhsy9D2ES4b",
+          "pages" : "uL1C8YzOpFXhtMeyQiX",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8fd35601-d957-4a6d-9b31-6e618da163f1",
-    "abstract" : "CoNeoyoAvKm"
+    "metadataSource" : "https://www.example.org/8fba97f4-2150-4d39-b7d2-311b575126b3",
+    "abstract" : "XlJPBF8lslSOc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d9560b31-f083-4acc-b157-676c07a37f4e",
-    "name" : "jRIF4GH0QEOYA6G1cmk",
+    "id" : "https://www.example.org/a95d6aeb-3648-475c-a456-c0d93423bb8a",
+    "name" : "DG4x5IvkMJG3kZ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-02-03T09:08:06.896Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "nCbvGWuetI6XxjAz"
+      "approvalDate" : "2003-11-04T06:54:32.798Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "LEDph7k3UabL"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1a2468fe-7501-4832-ba14-0732f4636301",
-    "identifier" : "CRo2j8Tzq930rbYctI",
+    "source" : "https://www.example.org/5ea7b365-7fa4-44a0-a3c4-5edc466d5516",
+    "identifier" : "FPArpn64Xn",
     "labels" : {
-      "pt" : "rw4qFIXk6Dv"
+      "nb" : "qwGsOv6UqI3bAgQ7Z"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1859767605
+      "amount" : 1369308669
     },
-    "activeFrom" : "1994-08-07T14:22:39.283Z",
-    "activeTo" : "1998-01-11T17:08:07.515Z"
+    "activeFrom" : "1980-05-25T06:03:35.050Z",
+    "activeTo" : "1992-05-27T13:02:21.870Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f89ad89e-cf05-4d1c-9e29-31e945581fe0",
-    "id" : "https://www.example.org/bb6aa75a-a052-4a73-8321-3969a61a2466",
-    "identifier" : "cha5B6EnoKII9kFDx",
+    "source" : "https://www.example.org/bda9e21d-7e22-4282-98b5-de8d5e9d7424",
+    "id" : "https://www.example.org/c3fcc024-d0b6-458e-9fb8-2d43b3c5fc77",
+    "identifier" : "cLybj15qotc",
     "labels" : {
-      "nl" : "OTlyyJKtRAq"
+      "ru" : "frxs6PkZzNM"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1449944199
+      "currency" : "EUR",
+      "amount" : 467749600
     },
-    "activeFrom" : "2012-10-23T11:57:05.353Z",
-    "activeTo" : "2018-06-18T00:50:46.634Z"
+    "activeFrom" : "2023-12-09T07:10:36.991Z",
+    "activeTo" : "2024-05-16T06:34:41.436Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7b30430c-c520-41b4-98ea-5c562a432ec0" ],
+  "subjects" : [ "https://www.example.org/e5d761c4-8259-477e-ab98-85e8d1e43c60" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4c50c9f2-c9a9-4b24-9aa5-779c225ac919",
-    "name" : "UQD7wRzq0jnyXqI",
-    "mimeType" : "kDh1GfLV29ya47N3z",
-    "size" : 1132129423,
-    "license" : "https://www.example.com/ojmjdtbqrlu",
+    "identifier" : "9bd10a3a-2e4b-49b0-bf6a-dfbe78d00561",
+    "name" : "ZaVZ26ZZ17lfBDRN",
+    "mimeType" : "JrVSRcRg3kBkgsI4",
+    "size" : 387565092,
+    "license" : "https://www.example.com/aymd7zwvqgp",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mYAoJpwMkeCI",
-    "publishedDate" : "2017-11-18T13:47:31.650Z",
+    "legalNote" : "ow8hBgaZzVR6Qz6f",
+    "publishedDate" : "1993-11-16T16:32:54.219Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "gi5p2Bv72pCWMuNo",
-      "uploadedDate" : "1996-02-26T14:46:32.515Z"
+      "uploadedBy" : "gsazh1sOAT",
+      "uploadedDate" : "1996-05-22T07:24:02.346Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nxGquLKhXfRgSzBV",
-    "name" : "kY9gvbcL15pPllNt",
-    "description" : "CeoCmu0yvp9lhR5"
+    "id" : "https://www.example.com/mP4yng5gFa",
+    "name" : "6TcseEgc2B",
+    "description" : "566Ip8gFnUWP3"
   } ],
-  "rightsHolder" : "ZRbPrI91ENQ4JkPT",
-  "duplicateOf" : "https://www.example.org/0ffb9a1f-9ff9-442c-a9cd-ce419b994bff",
+  "rightsHolder" : "IWgOqKLfnW6sLALE51",
+  "duplicateOf" : "https://www.example.org/d0a1dea6-088d-43a4-99f5-c5ee2d76a1d3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "GinhvOnfu3d"
+    "note" : "uC3nAdUuzc4UYOL9nq"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "OnZu4GJjkNn",
-    "createdBy" : "nHWP2vwdepYmM0dsB",
-    "createdDate" : "2011-04-14T05:07:38.480Z"
+    "note" : "L43cKgv8xKi1",
+    "createdBy" : "Asp24bCiyAt",
+    "createdDate" : "2013-12-18T06:46:35.357Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c2564085-48f0-44df-bc44-6da9fa97bade" ],
+  "curatingInstitutions" : [ "https://www.example.org/46c04483-0ee2-4337-ab90-1cd859495cc6" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "OKhczHyfDcinru6",
-    "ownerAffiliation" : "https://www.example.org/bc19c6e3-1130-4c66-a96b-1ae3f13e5232"
+    "owner" : "T9WroGvsJomFiod6",
+    "ownerAffiliation" : "https://www.example.org/82350986-a112-4a4a-8cf9-fffc3ae04bd1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/caeb90a5-c8bb-442f-ac38-894e47962240"
+    "id" : "https://www.example.org/dd1e6da9-0bd0-4ca6-bcc4-b71eef5a9663"
   },
-  "createdDate" : "2022-01-16T20:56:41.203Z",
-  "modifiedDate" : "2003-10-11T13:53:17.460Z",
-  "publishedDate" : "2010-08-15T05:30:42.964Z",
-  "indexedDate" : "1976-05-06T17:03:56.614Z",
-  "handle" : "https://www.example.org/ad861707-672b-4431-a9e1-52ac6e2c138c",
-  "doi" : "https://doi.org/10.1234/beatae",
-  "link" : "https://www.example.org/cd84c034-0a30-4c56-936e-632b3963f4f3",
+  "createdDate" : "2011-01-01T22:24:05.238Z",
+  "modifiedDate" : "1983-05-11T23:19:15.551Z",
+  "publishedDate" : "2015-08-18T17:43:29.220Z",
+  "indexedDate" : "2013-02-24T15:46:23.901Z",
+  "handle" : "https://www.example.org/f0c17ba0-61bd-46e8-a4b5-b993840fe790",
+  "doi" : "https://doi.org/10.1234/eligendi",
+  "link" : "https://www.example.org/4ceb781d-ba52-4391-a0bd-516e7d0dea62",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EB0EYwU5o9Py5wli",
+    "mainTitle" : "4vWoYV6TmTlbLp",
     "alternativeTitles" : {
-      "hu" : "lULWPIt1AZ"
+      "de" : "t2EU2a4gelmWVi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "unpkSmkOIlRMvU5",
-      "month" : "ZHU3CENPU39",
-      "day" : "cqCycl9gV5H"
+      "year" : "bk8Gql5by55BTZA1",
+      "month" : "ylDq2FcBJAcewp2i",
+      "day" : "9aRYo14hBBharr0vT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d1e9eea6-d802-405d-9e7d-f5c220603fb2",
-        "name" : "QYoXWcExVpoS",
+        "id" : "https://www.example.org/c84f7c5a-2017-40a2-bd3f-bfc1f5d79cfb",
+        "name" : "kR10tc6YSgdQoZMJwW",
         "nameType" : "Organizational",
-        "orcId" : "wGe5LmslWG1pGE",
-        "verificationStatus" : "Verified",
+        "orcId" : "CYC5zH0ru4LswPgVD",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5BwxOmEna4MVRI",
-          "value" : "shBU3juL9dSAG2Xu2"
+          "sourceName" : "Ujc7rB7HxwAICh",
+          "value" : "pqo2lJfsYSGTzyy4T"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hhYT4SVkLj7fWnSHH",
-          "value" : "R3EYDGK8sa"
+          "sourceName" : "QzmxOpPgTftsIzB9Go",
+          "value" : "fxrYO54ecEi0nNSVF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/003778d2-5892-4085-b9b6-bf02e2edefb4"
+        "id" : "https://www.example.org/af22bb84-e6db-4ba1-929b-d0ffacbf85f2"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/325dfe84-85a5-4e1c-beaf-22b5246160e1",
-        "name" : "414APIx46deZjK94k",
-        "nameType" : "Personal",
-        "orcId" : "NEWVlz1n0KMD5",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/718fe944-1dc0-44d8-a66d-0b598a28909c",
+        "name" : "zcCXp6P56lsRB",
+        "nameType" : "Organizational",
+        "orcId" : "uKa8Rj1GoPuDao5CbdM",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hzf7IRFaowswqnsh",
-          "value" : "Z6B6Kn2haIBJw4hzryw"
+          "sourceName" : "BH3cIwVWBjqGVsolK",
+          "value" : "bWvbsqDOFR33"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LxWU4pQN7f",
-          "value" : "0WjtOr0jNfdlDh"
+          "sourceName" : "WActjZbRcfyRiU0OsWC",
+          "value" : "vZbnYrLjWYjLFP5TMV"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ff3ecc4c-35c3-497f-9ed3-4d5e23f87dec"
+        "id" : "https://www.example.org/721fa85d-5b94-4b4d-887e-14fefabdfc43"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "RoleOther",
+        "description" : "5Bu23wMkBdn"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "HWgWq2C8HxVbNKu02"
+      "bg" : "HOpzFifR04K2SdZLJ"
     },
-    "npiSubjectHeading" : "H4ugxdpuHsr5XzDo",
-    "tags" : [ "ZNUAzJDhW0q3aNEHZWf" ],
-    "description" : "wZpfYIsZL9oSY",
+    "npiSubjectHeading" : "IDWAFVOWy9",
+    "tags" : [ "3rOzmVKdYo2xRkX6z7e" ],
+    "description" : "rFqeL5rop9FEo6jO0w",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0346175a-8e84-49ea-990c-6537044caee6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/73d22620-a260-415f-8b75-2809fcd6dec6"
         },
-        "seriesNumber" : "lKpE8WymvU",
+        "seriesNumber" : "zndihTAGyZ3dKw7",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0e1e094c-d2db-4e77-bb62-861ed7f42eb0",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e4129e79-9db2-4bfd-a2ac-5773cf3c862f",
           "valid" : true
         },
-        "isbnList" : [ "9791904646715" ],
+        "isbnList" : [ "9780799853285", "9780929456522" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "U0ns76xvU6"
+          "value" : "0929456521"
         } ]
       },
-      "doi" : "https://www.example.org/d6a4bb61-b61a-4b6a-9ddf-52e301e367cc",
+      "doi" : "https://www.example.org/290fc211-7cff-49a5-adf0-cc551b3fbcb5",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "L6M37x9xO0",
-            "end" : "LXcDYUBQgZqMRFM0jT"
+            "begin" : "uFqBx0YCPucPhfV",
+            "end" : "m7xuTAd5U59lDzTznI"
           },
-          "pages" : "3UEYAg7QxBRUB",
+          "pages" : "ZsoktBDbrhsy9D2ES4b",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0751343d-560c-4e04-9594-3de72161b0b6",
-    "abstract" : "SwcoWOH5ybrG7h"
+    "metadataSource" : "https://www.example.org/8fd35601-d957-4a6d-9b31-6e618da163f1",
+    "abstract" : "CoNeoyoAvKm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/151f3330-bac0-48df-9d6a-0788b2f432c5",
-    "name" : "dY1n1eL4NvpM2",
+    "id" : "https://www.example.org/d9560b31-f083-4acc-b157-676c07a37f4e",
+    "name" : "jRIF4GH0QEOYA6G1cmk",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-08-16T01:59:37.191Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "8JY3Vc8G7FzWK"
+      "approvalDate" : "1978-02-03T09:08:06.896Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "nCbvGWuetI6XxjAz"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7f8387c1-8dae-4ef5-819c-bbe17d021e39",
-    "identifier" : "NwHrHrCE5w",
+    "source" : "https://www.example.org/1a2468fe-7501-4832-ba14-0732f4636301",
+    "identifier" : "CRo2j8Tzq930rbYctI",
     "labels" : {
-      "it" : "SuyKULewDvb"
+      "pt" : "rw4qFIXk6Dv"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 264374794
+      "currency" : "EUR",
+      "amount" : 1859767605
     },
-    "activeFrom" : "1972-12-05T14:12:55.928Z",
-    "activeTo" : "2023-11-24T20:47:10.958Z"
+    "activeFrom" : "1994-08-07T14:22:39.283Z",
+    "activeTo" : "1998-01-11T17:08:07.515Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/31f70551-961d-477b-8a5d-3839fb33a287",
-    "id" : "https://www.example.org/cf4132fd-185a-4119-b572-1c81e62b1b9c",
-    "identifier" : "nyDpnJtA0iq",
+    "source" : "https://www.example.org/f89ad89e-cf05-4d1c-9e29-31e945581fe0",
+    "id" : "https://www.example.org/bb6aa75a-a052-4a73-8321-3969a61a2466",
+    "identifier" : "cha5B6EnoKII9kFDx",
     "labels" : {
-      "da" : "Hvwmt2zQmCmP"
+      "nl" : "OTlyyJKtRAq"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 288896119
+      "amount" : 1449944199
     },
-    "activeFrom" : "2018-04-29T10:14:54.273Z",
-    "activeTo" : "2019-12-05T12:44:53.676Z"
+    "activeFrom" : "2012-10-23T11:57:05.353Z",
+    "activeTo" : "2018-06-18T00:50:46.634Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/98b4d08a-77d6-421e-b332-9212069bf2bc" ],
+  "subjects" : [ "https://www.example.org/7b30430c-c520-41b4-98ea-5c562a432ec0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "42575a0d-a99f-41f9-a970-91f584adfa0f",
-    "name" : "OHIjmmRnYkdiTq",
-    "mimeType" : "egSQbEzzhiqV1P",
-    "size" : 1035989540,
-    "license" : "https://www.example.com/oaonockficsyb",
+    "identifier" : "4c50c9f2-c9a9-4b24-9aa5-779c225ac919",
+    "name" : "UQD7wRzq0jnyXqI",
+    "mimeType" : "kDh1GfLV29ya47N3z",
+    "size" : 1132129423,
+    "license" : "https://www.example.com/ojmjdtbqrlu",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Yah9lA37EAfo4P"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "SBi1BLTGhafZTqGe7",
-    "publishedDate" : "2015-09-09T01:25:05.779Z",
+    "legalNote" : "mYAoJpwMkeCI",
+    "publishedDate" : "2017-11-18T13:47:31.650Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "kcd73jDgUhkmBj",
-      "uploadedDate" : "1985-11-16T04:42:48.992Z"
+      "uploadedBy" : "gi5p2Bv72pCWMuNo",
+      "uploadedDate" : "1996-02-26T14:46:32.515Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/If1WMCK948DqMZDGbgY",
-    "name" : "0jdXXYTwfOACTAmTn",
-    "description" : "SHdg5ZnrdGdXF"
+    "id" : "https://www.example.com/nxGquLKhXfRgSzBV",
+    "name" : "kY9gvbcL15pPllNt",
+    "description" : "CeoCmu0yvp9lhR5"
   } ],
-  "rightsHolder" : "JKoGPA8yXkl",
-  "duplicateOf" : "https://www.example.org/59f8d544-0243-418f-b631-9d289f8b690a",
+  "rightsHolder" : "ZRbPrI91ENQ4JkPT",
+  "duplicateOf" : "https://www.example.org/0ffb9a1f-9ff9-442c-a9cd-ce419b994bff",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KEKtJf2FDXAqI"
+    "note" : "GinhvOnfu3d"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CmZIR77hLXPpW",
-    "createdBy" : "USQJxZSTlfywia",
-    "createdDate" : "1989-06-29T08:10:42.227Z"
+    "note" : "OnZu4GJjkNn",
+    "createdBy" : "nHWP2vwdepYmM0dsB",
+    "createdDate" : "2011-04-14T05:07:38.480Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f2269e94-3982-4c13-81a0-9410c29e20ad" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/c2564085-48f0-44df-bc44-6da9fa97bade" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "MMj2nlKWYLktr8fl",
-    "ownerAffiliation" : "https://www.example.org/ddecaafb-4214-4781-bbff-a01fd24d3410"
+    "owner" : "kcBcmqjLZXKBz",
+    "ownerAffiliation" : "https://www.example.org/8c279ab4-92de-49f7-bb31-12604173fc4e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6eee2512-5426-427d-91e5-c6518050828c"
+    "id" : "https://www.example.org/2784e628-dd6a-4680-a7c4-ada7d8b4f309"
   },
-  "createdDate" : "2008-10-29T20:52:27.964Z",
-  "modifiedDate" : "2015-02-16T19:36:50.976Z",
-  "publishedDate" : "1985-12-08T00:32:09.726Z",
-  "indexedDate" : "1988-03-04T11:53:09.745Z",
-  "handle" : "https://www.example.org/a5e96bb9-742e-4b1d-8f03-1172426579aa",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/f8fd1ba9-a344-4539-b7eb-99020895a9e0",
+  "createdDate" : "2011-05-14T04:46:02.312Z",
+  "modifiedDate" : "1981-12-10T10:56:54.516Z",
+  "publishedDate" : "1971-10-22T02:55:59.786Z",
+  "indexedDate" : "1996-05-17T22:04:32.753Z",
+  "handle" : "https://www.example.org/44d14169-b63c-46e2-af90-c81da3a8041a",
+  "doi" : "https://doi.org/10.1234/labore",
+  "link" : "https://www.example.org/1c7322f2-49c5-451d-beaf-d0a5c333d747",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Wt6IG6E6U9",
+    "mainTitle" : "MZX59Jb4nAgFOYHMo5",
     "alternativeTitles" : {
-      "nn" : "qojzvlAIsEf81"
+      "zh" : "t6wxYIyIq2HH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0qThLkaPJj3SZ6l5",
-      "month" : "51LMvnmMgzj",
-      "day" : "9DM1eLAbqWAp1e8OG"
+      "year" : "ZIWk6uVZs5s9wC",
+      "month" : "DnPX88fWREC",
+      "day" : "oIxnNcwSuySh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ec4a71b-b1d7-4f78-8db2-e91f636c7417",
-        "name" : "6PSMLw88rCQA",
-        "nameType" : "Personal",
-        "orcId" : "YOonExvU00AV",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/b5fb5f74-b31b-4bde-af0d-a6b9264da180",
+        "name" : "UWxi3JF7ulSbC",
+        "nameType" : "Organizational",
+        "orcId" : "ZHx3WKlUvH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "r5buDFH8RXX",
-          "value" : "WA1XG8iH7DvCzK"
+          "sourceName" : "P1Lq0adZHn0K7AGSc",
+          "value" : "DLTm6kms2F0Woz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bX5buQZTSmRYsNcy",
-          "value" : "CnZzh22FBka6t4Q2"
+          "sourceName" : "P0AKeV8G8kyaOio22W",
+          "value" : "1VXjveEShh6VFn0QU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ec23e3e5-fe82-43f5-bcaa-1b3a01663be2"
+        "id" : "https://www.example.org/4b2665cc-9d42-422b-9334-c122835d66dd"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "omj0jSGfowUIb"
+        "type" : "Composer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0536fceb-c81a-4dd1-baf3-758f72907fa3",
-        "name" : "VT8Q84WUiG7EVhsk9",
-        "nameType" : "Organizational",
-        "orcId" : "bWyXequlDVo75eCG1",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/b8b9ee2a-f28a-40eb-914c-a96f0d5e951f",
+        "name" : "Wibm7tbPGz",
+        "nameType" : "Personal",
+        "orcId" : "oqzyaOWasuy8w",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jgmxGTbG7VWaqpbiWjN",
-          "value" : "1yt52CbmNT"
+          "sourceName" : "izPEhoazHmvwEeZuZ",
+          "value" : "ltoIOXvBk4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6boJ5JvmCd",
-          "value" : "ovOUoA0xqtjzz9eXz"
+          "sourceName" : "vz9KGYHVzpba",
+          "value" : "ddONyUnVgMbHErtXk5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/458c150b-b975-4e74-9564-e2bf1a728815"
+        "id" : "https://www.example.org/9d5e753f-ddf6-474b-962b-364b5d621e6d"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Artist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "hYSdbLGNtID0ya"
+      "fi" : "24URyhRRgLceZV1V"
     },
-    "npiSubjectHeading" : "JYjpwZK5m5XCKiAPVQs",
-    "tags" : [ "umyJcnohkc" ],
-    "description" : "oa1ketx3cwcdICz96j",
+    "npiSubjectHeading" : "TQIWEfUTAo7gHFBtc1z",
+    "tags" : [ "awz3x7xC7Yoo" ],
+    "description" : "HgIkN2oEzU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "4VueSy1n5Li5BhT",
+        "label" : "Djiqk798DuIQKAasJ",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "WYcm4KowZjDS",
-          "country" : "kgENK4I46q0j49ywZ"
+          "label" : "eyB0xCfIxDA10y8Hp",
+          "country" : "W1Jzmizu4EkweUJ"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2001-03-17T13:31:52.958Z",
-          "to" : "2024-01-22T04:29:42.503Z"
+          "type" : "Instant",
+          "value" : "1977-10-17T19:06:45.628Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/Ody6pe4LIuDgSFPNaY1"
+          "id" : "https://www.example.com/vNpnUPgJ2CNoJk"
         },
-        "product" : "https://www.example.com/zGixxcqdmQBSIkpjPF"
+        "product" : "https://www.example.com/YdxfHiGjg18dmxn"
       },
-      "doi" : "https://www.example.org/809b73e7-d068-4d0a-b0a0-6c100596fd9f",
+      "doi" : "https://www.example.org/3e57d35c-894d-4f08-8866-e40598c1d873",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -123,93 +121,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ed616ca4-5a31-435d-a5d2-7e035d9f7d1b",
-    "abstract" : "dCvf73BXGeEs"
+    "metadataSource" : "https://www.example.org/8dd91ecb-6c06-4f11-8aae-138288df8ff5",
+    "abstract" : "1IhgkrhjVemFhc0v"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1b6d249d-d5d5-49ef-9379-75b0bbb6414f",
-    "name" : "S8KL8dFWci",
+    "id" : "https://www.example.org/bc03d796-67d5-4c49-bb3e-4156e7ab216d",
+    "name" : "3m2MO0AqFQQK8MW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-09-13T07:42:14.799Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "XUsoZTKIiku07ZpjA"
+      "approvalDate" : "1996-03-31T14:10:39.117Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "22WBW4MJj2ybT2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a132dc48-9dbf-4d17-825e-bebd8f75db01",
-    "identifier" : "DE5qiOvBkksc",
+    "source" : "https://www.example.org/b516a284-f3dd-4ec7-9055-3412127e3766",
+    "identifier" : "D0jBLyTbP7U6TF6XI",
     "labels" : {
-      "nl" : "vqXE5OOI9IOi9XB6H"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1458357242
-    },
-    "activeFrom" : "1982-07-02T15:59:23.920Z",
-    "activeTo" : "1994-12-21T04:29:55.378Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/43d5476a-ec15-48f0-87f0-f246c7f340e4",
-    "id" : "https://www.example.org/e135556c-29c5-440a-b6a5-c802fb3912ba",
-    "identifier" : "heiZcMAV68aeBQmW",
-    "labels" : {
-      "ca" : "FcpJIbiTHytE1v"
+      "en" : "IJg4TtAA1NlNs5MXJOs"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1069236956
+      "amount" : 1590523131
     },
-    "activeFrom" : "1981-06-29T17:16:34.369Z",
-    "activeTo" : "1998-03-28T01:40:37.256Z"
+    "activeFrom" : "2023-07-20T09:22:16.408Z",
+    "activeTo" : "2023-08-10T17:44:35.931Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/e76696fc-abc5-49a9-806b-322308134200",
+    "id" : "https://www.example.org/d5d9778c-6011-4a4f-bbef-5355f054daa8",
+    "identifier" : "pFmLcrJYCnaBho",
+    "labels" : {
+      "nb" : "f7BsODllk68fZ"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 879274803
+    },
+    "activeFrom" : "1982-10-29T00:33:52.779Z",
+    "activeTo" : "2020-05-04T05:59:49.587Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9e83cf68-2f51-412f-8a68-047754d75630" ],
+  "subjects" : [ "https://www.example.org/09f747a6-7df2-4e04-bc11-97dcea9e1a28" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4eb6b810-93ff-4f05-83d4-ca91877ac183",
-    "name" : "ylld4sz6ZHI9",
-    "mimeType" : "NmssO9ZZ1VJVG",
-    "size" : 57372693,
-    "license" : "https://www.example.com/1hdgvfnuyvbvn",
+    "identifier" : "9a5c69e9-0206-424a-baef-8336050d9b04",
+    "name" : "3867glEx1XhJUPLWC",
+    "mimeType" : "BmhsrZuEnQx06Ctz",
+    "size" : 35440370,
+    "license" : "https://www.example.com/v8608wzyjx",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "S5XybETqE8WHzo",
-    "publishedDate" : "2008-04-26T23:52:14.531Z",
+    "legalNote" : "J3HWDaCG5cnBLduuz",
+    "publishedDate" : "2021-11-11T21:43:57.820Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "txkRtHUaQUzcoG",
-      "uploadedDate" : "2024-04-13T11:01:40.289Z"
+      "uploadedBy" : "fYDc2v6EAAqipH",
+      "uploadedDate" : "1981-12-15T19:36:23.962Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JkXgho3TAvZTTU1vyf",
-    "name" : "b2MD9kj843vNBjhBb",
-    "description" : "Jlyc5sghajZq7t4t"
+    "id" : "https://www.example.com/XMlOhtR9Eic2bXbS",
+    "name" : "DWo72nLesQwNNeoy5K",
+    "description" : "JVCt9joqit8hkB1L"
   } ],
-  "rightsHolder" : "saaGSMCLPacMLc",
-  "duplicateOf" : "https://www.example.org/ff008094-1679-4ac8-8108-a00792509a0a",
+  "rightsHolder" : "1WtptxjlASi0Fz",
+  "duplicateOf" : "https://www.example.org/d0e40a01-0147-4b32-9074-ff3f364d6f44",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "L3IcnP1UJLW4N"
+    "note" : "PYXlE9gTcIkdxCI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fEhUVaBKfuMBza",
-    "createdBy" : "j8wrWgNWfKx",
-    "createdDate" : "2021-05-13T08:12:28.760Z"
+    "note" : "gPcbQxx4WwwJDWS5",
+    "createdBy" : "a5xOG5hkDxk",
+    "createdDate" : "2001-01-23T06:38:40.673Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/98d22adb-7c42-473f-9a57-bf9a5e0ca378" ],
+  "curatingInstitutions" : [ "https://www.example.org/28bd353b-81ea-4c90-bc5c-f3b95354a066" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "t4ieyt7qjeXzma48P1",
-    "ownerAffiliation" : "https://www.example.org/8737b437-a6ce-4a6f-846d-d091683becd2"
+    "owner" : "MMj2nlKWYLktr8fl",
+    "ownerAffiliation" : "https://www.example.org/ddecaafb-4214-4781-bbff-a01fd24d3410"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/21b12a97-0deb-4635-a54a-98925ce8d66e"
+    "id" : "https://www.example.org/6eee2512-5426-427d-91e5-c6518050828c"
   },
-  "createdDate" : "2010-08-16T04:08:09.068Z",
-  "modifiedDate" : "1977-08-19T01:30:18.244Z",
-  "publishedDate" : "1996-03-13T22:47:49.489Z",
-  "indexedDate" : "1971-10-04T01:42:55.322Z",
-  "handle" : "https://www.example.org/320d4bed-e3cf-4f5b-854b-30314f9cc30c",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/8a59c1ae-4268-486b-a2fb-d4c980ca0e80",
+  "createdDate" : "2008-10-29T20:52:27.964Z",
+  "modifiedDate" : "2015-02-16T19:36:50.976Z",
+  "publishedDate" : "1985-12-08T00:32:09.726Z",
+  "indexedDate" : "1988-03-04T11:53:09.745Z",
+  "handle" : "https://www.example.org/a5e96bb9-742e-4b1d-8f03-1172426579aa",
+  "doi" : "https://doi.org/10.1234/dolorem",
+  "link" : "https://www.example.org/f8fd1ba9-a344-4539-b7eb-99020895a9e0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oq4uD4p1a2e",
+    "mainTitle" : "Wt6IG6E6U9",
     "alternativeTitles" : {
-      "fi" : "8NfrtqsFfcEFYWZ78YS"
+      "nn" : "qojzvlAIsEf81"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "98fGgB4sln",
-      "month" : "LAaJB6FjYW",
-      "day" : "nNu016a3CrBeKw4"
+      "year" : "0qThLkaPJj3SZ6l5",
+      "month" : "51LMvnmMgzj",
+      "day" : "9DM1eLAbqWAp1e8OG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c0a2b897-d217-43e2-b434-821ce8049799",
-        "name" : "mC9UJ1sILPzzEG3S",
+        "id" : "https://www.example.org/7ec4a71b-b1d7-4f78-8db2-e91f636c7417",
+        "name" : "6PSMLw88rCQA",
         "nameType" : "Personal",
-        "orcId" : "2NFoTB9BfVTa5W",
-        "verificationStatus" : "Verified",
+        "orcId" : "YOonExvU00AV",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aUVV2ckBvPy6ApCPnoy",
-          "value" : "70AFAYQpueZi"
+          "sourceName" : "r5buDFH8RXX",
+          "value" : "WA1XG8iH7DvCzK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ByTU25BXpU8X9T",
-          "value" : "RoHxxn22hZrLtesVN6"
+          "sourceName" : "bX5buQZTSmRYsNcy",
+          "value" : "CnZzh22FBka6t4Q2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a8825d2b-2e28-4148-9e5a-ecce217b1a3d"
+        "id" : "https://www.example.org/ec23e3e5-fe82-43f5-bcaa-1b3a01663be2"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "RoleOther",
+        "description" : "omj0jSGfowUIb"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +63,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b4369c9b-1ecf-4894-9c06-f5d8c5b6aaa9",
-        "name" : "gjNe665OCnVelzMNCn",
+        "id" : "https://www.example.org/0536fceb-c81a-4dd1-baf3-758f72907fa3",
+        "name" : "VT8Q84WUiG7EVhsk9",
         "nameType" : "Organizational",
-        "orcId" : "FChi8aPPLBBU",
-        "verificationStatus" : "Verified",
+        "orcId" : "bWyXequlDVo75eCG1",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JmMj8WEWNQ",
-          "value" : "yruMP75I64V"
+          "sourceName" : "jgmxGTbG7VWaqpbiWjN",
+          "value" : "1yt52CbmNT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tcuJ333sXH7NJq",
-          "value" : "x79Fqt53nL7Uz"
+          "sourceName" : "6boJ5JvmCd",
+          "value" : "ovOUoA0xqtjzz9eXz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c58b29ef-9e01-445b-93b0-8b8e99346092"
+        "id" : "https://www.example.org/458c150b-b975-4e74-9564-e2bf1a728815"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "8zmL4Yokyr"
+      "cs" : "hYSdbLGNtID0ya"
     },
-    "npiSubjectHeading" : "SpXlPwR9XiQttMl3P",
-    "tags" : [ "Sa87VibOrrWiAU" ],
-    "description" : "7hoTJxSPDX",
+    "npiSubjectHeading" : "JYjpwZK5m5XCKiAPVQs",
+    "tags" : [ "umyJcnohkc" ],
+    "description" : "oa1ketx3cwcdICz96j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "vRVDMaULiaqKp",
+        "label" : "4VueSy1n5Li5BhT",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "jlrL5Vqt1E6",
-          "country" : "c0H9gr7uuI"
+          "label" : "WYcm4KowZjDS",
+          "country" : "kgENK4I46q0j49ywZ"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1994-07-05T23:05:37.619Z",
-          "to" : "2001-08-06T07:55:34.747Z"
+          "from" : "2001-03-17T13:31:52.958Z",
+          "to" : "2024-01-22T04:29:42.503Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/UnL9JeSA7rGJS"
+          "id" : "https://www.example.com/Ody6pe4LIuDgSFPNaY1"
         },
-        "product" : "https://www.example.com/8dDsXTnYoK"
+        "product" : "https://www.example.com/zGixxcqdmQBSIkpjPF"
       },
-      "doi" : "https://www.example.org/c8f8403f-86fc-42c3-9a99-be5491bd4e0b",
+      "doi" : "https://www.example.org/809b73e7-d068-4d0a-b0a0-6c100596fd9f",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -122,93 +123,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9d7a6958-6b51-45c5-b08f-092655042d44",
-    "abstract" : "w6PUoHA5mn"
+    "metadataSource" : "https://www.example.org/ed616ca4-5a31-435d-a5d2-7e035d9f7d1b",
+    "abstract" : "dCvf73BXGeEs"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/bea08731-0cf2-4dba-9887-dbf5c81ab926",
-    "name" : "jCJMuBr7nZay6AHy6Ns",
+    "id" : "https://www.example.org/1b6d249d-d5d5-49ef-9379-75b0bbb6414f",
+    "name" : "S8KL8dFWci",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-09-03T20:33:53.641Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "JXZKDa0CimDv0IXR"
+      "approvalDate" : "2004-09-13T07:42:14.799Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "XUsoZTKIiku07ZpjA"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/53dc59e1-4250-41c1-bf73-a190f4c9d7e2",
-    "identifier" : "dlW4Ia3rwviGNmlC",
+    "source" : "https://www.example.org/a132dc48-9dbf-4d17-825e-bebd8f75db01",
+    "identifier" : "DE5qiOvBkksc",
     "labels" : {
-      "pt" : "7onY2Dwnxifah"
+      "nl" : "vqXE5OOI9IOi9XB6H"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 210352854
+      "currency" : "USD",
+      "amount" : 1458357242
     },
-    "activeFrom" : "1998-08-05T04:35:23.639Z",
-    "activeTo" : "2017-08-05T22:12:55.815Z"
+    "activeFrom" : "1982-07-02T15:59:23.920Z",
+    "activeTo" : "1994-12-21T04:29:55.378Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7e72a55b-1340-478f-87b2-9c9a41243bf2",
-    "id" : "https://www.example.org/66b0cfe2-f09c-4006-9060-08384295c012",
-    "identifier" : "ZL6usUYDbdg2",
+    "source" : "https://www.example.org/43d5476a-ec15-48f0-87f0-f246c7f340e4",
+    "id" : "https://www.example.org/e135556c-29c5-440a-b6a5-c802fb3912ba",
+    "identifier" : "heiZcMAV68aeBQmW",
     "labels" : {
-      "es" : "dgmfVmmNRsQWWrQP"
+      "ca" : "FcpJIbiTHytE1v"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 313718828
+      "currency" : "NOK",
+      "amount" : 1069236956
     },
-    "activeFrom" : "2020-01-01T21:37:57.194Z",
-    "activeTo" : "2023-02-10T18:26:41.639Z"
+    "activeFrom" : "1981-06-29T17:16:34.369Z",
+    "activeTo" : "1998-03-28T01:40:37.256Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d7ca68a4-7a71-410f-880f-cf99019f4718" ],
+  "subjects" : [ "https://www.example.org/9e83cf68-2f51-412f-8a68-047754d75630" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7173155d-69d1-44e7-b29c-cc5b400aa6b9",
-    "name" : "BlhjU6tKKPlvEQfwVT",
-    "mimeType" : "KG0piS8BwH59cUQEru",
-    "size" : 1875606604,
-    "license" : "https://www.example.com/2dg2skff62",
+    "identifier" : "4eb6b810-93ff-4f05-83d4-ca91877ac183",
+    "name" : "ylld4sz6ZHI9",
+    "mimeType" : "NmssO9ZZ1VJVG",
+    "size" : 57372693,
+    "license" : "https://www.example.com/1hdgvfnuyvbvn",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "JtqpFG2Mhl",
-    "publishedDate" : "1991-12-13T19:02:56.598Z",
+    "legalNote" : "S5XybETqE8WHzo",
+    "publishedDate" : "2008-04-26T23:52:14.531Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "SGid3U1aJXFdHS3IV",
-      "uploadedDate" : "1985-12-08T15:08:58.972Z"
+      "uploadedBy" : "txkRtHUaQUzcoG",
+      "uploadedDate" : "2024-04-13T11:01:40.289Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/cl4NuYgTG0njV1z",
-    "name" : "oUbI8rfU3mwBy7F3rbc",
-    "description" : "Hlc41DqiFe1midkFv4"
+    "id" : "https://www.example.com/JkXgho3TAvZTTU1vyf",
+    "name" : "b2MD9kj843vNBjhBb",
+    "description" : "Jlyc5sghajZq7t4t"
   } ],
-  "rightsHolder" : "d2NHgOByUY6qm9Fc0g",
-  "duplicateOf" : "https://www.example.org/be5594f0-f606-406e-8730-c2ecc2067a4e",
+  "rightsHolder" : "saaGSMCLPacMLc",
+  "duplicateOf" : "https://www.example.org/ff008094-1679-4ac8-8108-a00792509a0a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gkOn8FpBFrgm"
+    "note" : "L3IcnP1UJLW4N"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "BLu70gdUyct0AaJ7Hh",
-    "createdBy" : "44UIO5tj7qo2YzP68",
-    "createdDate" : "2019-02-19T22:06:34.686Z"
+    "note" : "fEhUVaBKfuMBza",
+    "createdBy" : "j8wrWgNWfKx",
+    "createdDate" : "2021-05-13T08:12:28.760Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/371edc32-9a12-4d52-bdae-39c0fcca9c10" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/98d22adb-7c42-473f-9a57-bf9a5e0ca378" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "XsDJul1JlA9lPf",
-    "ownerAffiliation" : "https://www.example.org/d872b90b-69a5-47f7-a934-b5127d8cbb50"
+    "owner" : "Gq4MIrc3AmVUkjn",
+    "ownerAffiliation" : "https://www.example.org/03febe61-f3dc-4548-b15a-c205577d15af"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8d971be9-7b02-481b-afdf-95fdd030e9db"
+    "id" : "https://www.example.org/2838837d-728e-47f8-9353-e22dc3101f9d"
   },
-  "createdDate" : "2000-04-30T05:26:58.129Z",
-  "modifiedDate" : "2022-12-02T22:24:09.618Z",
-  "publishedDate" : "1972-02-05T17:10:07.121Z",
-  "indexedDate" : "2003-08-14T00:10:38.846Z",
-  "handle" : "https://www.example.org/dbee5d28-ac41-45ad-a84b-09f8adf2c159",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/bb9a595d-f2ca-41e8-bf3f-51f28949e2ed",
+  "createdDate" : "2008-08-27T18:19:34.067Z",
+  "modifiedDate" : "1978-01-03T21:49:54.570Z",
+  "publishedDate" : "1971-07-09T11:27:15.745Z",
+  "indexedDate" : "2018-04-11T09:55:42.738Z",
+  "handle" : "https://www.example.org/487ab2f5-2223-49d5-b96c-51be4f6b5c0f",
+  "doi" : "https://doi.org/10.1234/amet",
+  "link" : "https://www.example.org/9b049c9a-1cd1-41f6-9ef7-d9483469ca08",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FZ2txdgQdqtcTv0JJ",
+    "mainTitle" : "vlmvmEtEJuMvM",
     "alternativeTitles" : {
-      "fi" : "5pCxui9PWD31ZBQ"
+      "af" : "5DNkBRhIu44OBA6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ww05IAbG93",
-      "month" : "QRGMv2NE0rt",
-      "day" : "Yf9LaETlEdlNHYBc"
+      "year" : "0AnHK6C6fLbzrjhN",
+      "month" : "MFoWV1do6NXX2ciS",
+      "day" : "pTSbqLZKpvuFdiUH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e46a7450-205d-4784-a080-3e37f66fa87a",
-        "name" : "J86b43fpF8Mq9",
-        "nameType" : "Personal",
-        "orcId" : "GMfdKH5oXgElR",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/4ad7fb81-c51d-4e8c-a935-9b3ec055af7c",
+        "name" : "dt5fIBkNL5A",
+        "nameType" : "Organizational",
+        "orcId" : "92u7sP8gypQ6E",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yXaSF4fc6RTH",
-          "value" : "EOwVeB6u0VLJ"
+          "sourceName" : "xziEB4F15hqP",
+          "value" : "FAYKlOvHQMA4lue9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rEhIGeW4qXHQ9",
-          "value" : "Za7g1EwoiOb09n"
+          "sourceName" : "85mcm45GkFsLVcsx",
+          "value" : "UxQU32Bj0Z"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1bbc608c-2c7f-4f5a-82da-128b1ecad279"
+        "id" : "https://www.example.org/a6ae259b-a052-4f39-9873-ac831dcedc83"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,167 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a8d5826b-5732-48e1-b1e8-007e9341f298",
-        "name" : "N8HjWv1oGPa",
-        "nameType" : "Personal",
-        "orcId" : "YmMSb66GulApogL4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2f36d274-532e-4d63-94aa-b10262bd805b",
+        "name" : "jZRpGQhTMAJnr3ss",
+        "nameType" : "Organizational",
+        "orcId" : "RkUQw3iw6pBUcbkl5Qy",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "67Ee3oJaaq",
-          "value" : "iCiGUWP0RhF"
+          "sourceName" : "HIEfiPfhfYLaAzTOL3",
+          "value" : "1dBFMLuMGWnr8Y6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7dLuNFHrIY",
-          "value" : "OOLYh52mfajuUMtY"
+          "sourceName" : "BvtOTQjiMx",
+          "value" : "nAmxOPHSTrpMnz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ac844bd9-b495-42d5-962e-8a8af2616da6"
+        "id" : "https://www.example.org/e9c6e7de-ecc2-4c30-a840-3e3bd21ea052"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "wefcEPHnreAzGIG"
+      "ca" : "UVZ9UgldB50OB"
     },
-    "npiSubjectHeading" : "8oaanoFCUso1plo1",
-    "tags" : [ "N62yIOm45JWu0suT0" ],
-    "description" : "fdVH72FnRCXl",
+    "npiSubjectHeading" : "yz9Jk711WD",
+    "tags" : [ "zUhqr8C0VJvAPsL" ],
+    "description" : "unK7dxAkyEo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/200362ec-a287-4a15-86ee-307ff9239770"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4ead4f4f-69b5-4966-8f71-68134afbef36"
         },
-        "seriesNumber" : "wdF7EEqoUGprc3JUs",
+        "seriesNumber" : "0IkF8AxXfOu",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/529066dd-623a-4ccf-af27-59c9dbf9347b",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d4fb9fee-3f14-4d22-a703-f3639e90d62e",
           "valid" : true
         },
-        "isbnList" : [ "9781063409900" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781083344137", "9781066389568" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "O4WdUifkjTIhpSS3e"
+          "value" : "106638956X"
         } ]
       },
-      "doi" : "https://www.example.org/22509248-3558-4bc3-8398-ee5c00ce34b6",
+      "doi" : "https://www.example.org/54ae2284-5c0a-4ecd-b9b1-d4c2c2781695",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "dh5yxdeeAZ",
-            "end" : "mE6ICbU15PkwCWkduhr"
+            "begin" : "OQ8RinHiVQaZGIx5d9e",
+            "end" : "mvCYZvipBepdEQaA2R"
           },
-          "pages" : "8yOcZo6hrPYb",
-          "illustrated" : true
+          "pages" : "FYT3VPerl3IR3m",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "p3H3293YRnc8tMwNOY",
-          "month" : "8lVmOBLM19",
-          "day" : "aIpHN0VVzddXCX38z"
+          "year" : "8tR59Sgi04W3Dx8uP26",
+          "month" : "cvJKU5IeN0Bqrrp",
+          "day" : "RLgzYnfZ2LHOK8"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f6799b2f-b364-4192-ba97-62849b3d5b4b",
-    "abstract" : "rBBv0XKFr8hsg"
+    "metadataSource" : "https://www.example.org/a39cfe36-3957-4340-9b29-44cc116f6944",
+    "abstract" : "GX2uMhh4qEYRNF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f4b1dd55-ea10-4050-8a61-bcc467a719a7",
-    "name" : "LXzJNDAXFa33",
+    "id" : "https://www.example.org/075c0787-31ad-4d0d-818d-e5c1798889e9",
+    "name" : "NW2xMaWqBWcNYTfpnC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1988-11-03T09:59:07.835Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2011-01-02T09:30:16.447Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "48F7NIaTmvXzCtjQYf"
+      "applicationCode" : "UrowLWv0IdscvIU0N"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/898eff0e-8856-4feb-963a-98b1b4bce483",
-    "identifier" : "nBqohsNLp2LQsiWb",
+    "source" : "https://www.example.org/710b9a18-9d0a-41f6-a384-bbaa4c5c4bc8",
+    "identifier" : "XnJ5ht7N6VX",
     "labels" : {
-      "nn" : "y2gMAYkBLtCzs0bW"
+      "da" : "xLnzxNZpW1D4"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 699652181
+      "amount" : 7735850
     },
-    "activeFrom" : "1996-02-08T10:54:05.724Z",
-    "activeTo" : "1999-05-31T06:52:30.596Z"
+    "activeFrom" : "1983-02-22T07:59:46.028Z",
+    "activeTo" : "2014-05-08T01:16:11.498Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f38ecf9e-56bb-4218-8786-c3e8ebeb79c1",
-    "id" : "https://www.example.org/d56aa94e-87b6-42bd-b68e-2436a6a50158",
-    "identifier" : "2PBUQ8sM3eVXbf",
+    "source" : "https://www.example.org/4eccb3b2-786c-492b-a075-ef67b2150c28",
+    "id" : "https://www.example.org/25d1d4c4-32d9-44cd-827d-67fca0029d1b",
+    "identifier" : "Sr06AfZsISO5S2",
     "labels" : {
-      "da" : "3KM3dt6KSRDaiSs"
+      "pt" : "PxSVkwfM1LkHgMOX5"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2062257704
+      "currency" : "GBP",
+      "amount" : 1684542612
     },
-    "activeFrom" : "2013-04-06T15:54:59.411Z",
-    "activeTo" : "2014-12-11T15:35:00.231Z"
+    "activeFrom" : "1984-08-10T02:30:33.673Z",
+    "activeTo" : "1999-05-19T10:17:20.063Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ae0e9857-b88a-41b6-b509-78f53ca4fb20" ],
+  "subjects" : [ "https://www.example.org/01fec45a-54f0-4030-b901-bc077c7d7c7d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fc980838-dcbd-4973-87d3-6fd0d37bd2b3",
-    "name" : "GuvTDfkHYMVDJdLaQbA",
-    "mimeType" : "5swH0DTFmfOuvo",
-    "size" : 1061910760,
-    "license" : "https://www.example.com/owzabmswrtw",
+    "identifier" : "1bd0e2a1-e574-4705-980c-ae0908682a24",
+    "name" : "hIXKmQRYyfZeji",
+    "mimeType" : "YWZrp2oiQbQCum",
+    "size" : 448816192,
+    "license" : "https://www.example.com/9l7nf89fom",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "GYaQkw3yHcYQ93GX6K"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Yh9C2Kochxh4kToh1JC",
-    "publishedDate" : "2003-07-31T14:21:59.087Z",
+    "legalNote" : "ZGkC35IO3oUZ",
+    "publishedDate" : "2000-02-20T11:36:44.642Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "gNB5XSj8wCDLNZO8n9",
-      "uploadedDate" : "1985-01-14T15:59:12.764Z"
+      "uploadedBy" : "GESceFkSaKCTK",
+      "uploadedDate" : "1987-03-31T23:42:40.762Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/4N7e3wUIoFLM0krv",
-    "name" : "tEYYWnmrgZnDu1BKr",
-    "description" : "1wGtZIJx4UciTd7XT"
+    "id" : "https://www.example.com/bqxsdWONhjo",
+    "name" : "VWCwgokF0GRrnk",
+    "description" : "nNrofSjxFkSmg47Cs4"
   } ],
-  "rightsHolder" : "03dihJnOyxPBBn",
-  "duplicateOf" : "https://www.example.org/fcefbee1-1bd5-4165-81fd-c6837490d410",
+  "rightsHolder" : "hllCtBXGOlwtefR5",
+  "duplicateOf" : "https://www.example.org/4f341073-cb82-42c4-8227-ff85bcf7b300",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9rB6q4gB8s1"
+    "note" : "tWgSK5dxInmt0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "yJpdPC6bLdYOLVD",
-    "createdBy" : "0CZZ3T7cCX3X",
-    "createdDate" : "2021-05-09T12:13:29.366Z"
+    "note" : "jbXicdSPCN1ggH09D",
+    "createdBy" : "uFh8uJTByTuA3dKy7W",
+    "createdDate" : "1979-06-15T02:07:53.208Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dd0b53f7-fab4-4fe6-9550-770e68a79bf1" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/74897516-66ba-490e-90e8-fb094ce6f24b" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Gq4MIrc3AmVUkjn",
-    "ownerAffiliation" : "https://www.example.org/03febe61-f3dc-4548-b15a-c205577d15af"
+    "owner" : "lyJfiOz3fo",
+    "ownerAffiliation" : "https://www.example.org/89d558e0-4803-405c-aa6b-c557f0dcf41c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2838837d-728e-47f8-9353-e22dc3101f9d"
+    "id" : "https://www.example.org/99964d9d-54f5-4b42-92ca-ccafb315ea6f"
   },
-  "createdDate" : "2008-08-27T18:19:34.067Z",
-  "modifiedDate" : "1978-01-03T21:49:54.570Z",
-  "publishedDate" : "1971-07-09T11:27:15.745Z",
-  "indexedDate" : "2018-04-11T09:55:42.738Z",
-  "handle" : "https://www.example.org/487ab2f5-2223-49d5-b96c-51be4f6b5c0f",
-  "doi" : "https://doi.org/10.1234/amet",
-  "link" : "https://www.example.org/9b049c9a-1cd1-41f6-9ef7-d9483469ca08",
+  "createdDate" : "1971-08-02T04:19:11.448Z",
+  "modifiedDate" : "1991-06-29T07:55:16.880Z",
+  "publishedDate" : "2010-08-06T15:12:20.715Z",
+  "indexedDate" : "1983-09-16T16:38:54.847Z",
+  "handle" : "https://www.example.org/afe03588-02e6-456f-a0b9-5677bc5328c3",
+  "doi" : "https://doi.org/10.1234/quae",
+  "link" : "https://www.example.org/136261df-d8ee-4048-ab32-24ad78923686",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vlmvmEtEJuMvM",
+    "mainTitle" : "ANaacXE9Gwe4m",
     "alternativeTitles" : {
-      "af" : "5DNkBRhIu44OBA6"
+      "af" : "oiQ2Hum2qW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0AnHK6C6fLbzrjhN",
-      "month" : "MFoWV1do6NXX2ciS",
-      "day" : "pTSbqLZKpvuFdiUH"
+      "year" : "ReNoenHkuFOtshzI0j",
+      "month" : "Dh9hISsqdJkPA",
+      "day" : "kykKmZYLrmfsP1CCk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4ad7fb81-c51d-4e8c-a935-9b3ec055af7c",
-        "name" : "dt5fIBkNL5A",
+        "id" : "https://www.example.org/4bf80538-c228-4fcb-93cd-d5098156d9d4",
+        "name" : "QYj8XQ6BPXlm",
         "nameType" : "Organizational",
-        "orcId" : "92u7sP8gypQ6E",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "TP8E9Bv1ulCq",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xziEB4F15hqP",
-          "value" : "FAYKlOvHQMA4lue9"
+          "sourceName" : "3yEqYbA651I8gmXp",
+          "value" : "6PCtNk3TO3SSacJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "85mcm45GkFsLVcsx",
-          "value" : "UxQU32Bj0Z"
+          "sourceName" : "xgEXliIDQh1",
+          "value" : "SbJqqhIRzsW6i"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a6ae259b-a052-4f39-9873-ac831dcedc83"
+        "id" : "https://www.example.org/a881cec2-c056-409d-aff4-78e63607f9b6"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,24 +62,24 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2f36d274-532e-4d63-94aa-b10262bd805b",
-        "name" : "jZRpGQhTMAJnr3ss",
+        "id" : "https://www.example.org/bdf3d807-84a6-45d4-b342-bf445a80a93e",
+        "name" : "tEGzIxRVtYO5J7b",
         "nameType" : "Organizational",
-        "orcId" : "RkUQw3iw6pBUcbkl5Qy",
-        "verificationStatus" : "Verified",
+        "orcId" : "t3vWrc2iVNFuzMVClpk",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HIEfiPfhfYLaAzTOL3",
-          "value" : "1dBFMLuMGWnr8Y6"
+          "sourceName" : "Xj3vh48XI81zTy7",
+          "value" : "BBXjLQwU2RBQdY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BvtOTQjiMx",
-          "value" : "nAmxOPHSTrpMnz"
+          "sourceName" : "Ebr1Rk7EtsimnN",
+          "value" : "U7e0dbJuigH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e9c6e7de-ecc2-4c30-a840-3e3bd21ea052"
+        "id" : "https://www.example.org/ab9566e1-88ae-4883-b7ad-eda2f9555eb9"
       } ],
       "role" : {
         "type" : "RegistrationAuthority"
@@ -88,141 +88,141 @@
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "UVZ9UgldB50OB"
+      "af" : "75WOrDtOWnWLripD"
     },
-    "npiSubjectHeading" : "yz9Jk711WD",
-    "tags" : [ "zUhqr8C0VJvAPsL" ],
-    "description" : "unK7dxAkyEo",
+    "npiSubjectHeading" : "8k4juYf3W4",
+    "tags" : [ "RCccF2AgdFdJ1AmQ5" ],
+    "description" : "omjuCxrUnq3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4ead4f4f-69b5-4966-8f71-68134afbef36"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/044577f4-1010-43e4-ae5d-a83d3e72d66a"
         },
-        "seriesNumber" : "0IkF8AxXfOu",
+        "seriesNumber" : "KQpeAIBBVEto",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d4fb9fee-3f14-4d22-a703-f3639e90d62e",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7276b415-1b84-4ff9-b7b7-50dec4904eb3",
           "valid" : true
         },
-        "isbnList" : [ "9781083344137", "9781066389568" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9780043763841", "9780055069689" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "106638956X"
+          "value" : "0055069681"
         } ]
       },
-      "doi" : "https://www.example.org/54ae2284-5c0a-4ecd-b9b1-d4c2c2781695",
+      "doi" : "https://www.example.org/b3c6c70b-842e-4bf8-a1f3-02e76e540d81",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "OQ8RinHiVQaZGIx5d9e",
-            "end" : "mvCYZvipBepdEQaA2R"
+            "begin" : "OEPFxQaygW",
+            "end" : "z0sqmVOeZqKIo7"
           },
-          "pages" : "FYT3VPerl3IR3m",
-          "illustrated" : false
+          "pages" : "NUjkwd9P1ziLMI",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "8tR59Sgi04W3Dx8uP26",
-          "month" : "cvJKU5IeN0Bqrrp",
-          "day" : "RLgzYnfZ2LHOK8"
+          "year" : "SPhWw8GX51cq5iee",
+          "month" : "06EsDKxRooumwbdwRo",
+          "day" : "C9qrX3FM9cf"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a39cfe36-3957-4340-9b29-44cc116f6944",
-    "abstract" : "GX2uMhh4qEYRNF"
+    "metadataSource" : "https://www.example.org/7f2141b2-9042-469e-945c-6a56e589d4f2",
+    "abstract" : "OOOpynUhOOLcZpQ3v"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/075c0787-31ad-4d0d-818d-e5c1798889e9",
-    "name" : "NW2xMaWqBWcNYTfpnC",
+    "id" : "https://www.example.org/8ad9cdc5-2184-4650-b233-829cd133d664",
+    "name" : "X6vAguWsBPBg7P",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-01-02T09:30:16.447Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "UrowLWv0IdscvIU0N"
+      "approvalDate" : "1978-10-04T11:15:45.240Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "TZf1XnEK6uLlP2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/710b9a18-9d0a-41f6-a384-bbaa4c5c4bc8",
-    "identifier" : "XnJ5ht7N6VX",
+    "source" : "https://www.example.org/b381fa68-c83a-48f5-9ede-73e112a931e1",
+    "identifier" : "JDDY1jqL5M",
     "labels" : {
-      "da" : "xLnzxNZpW1D4"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 7735850
-    },
-    "activeFrom" : "1983-02-22T07:59:46.028Z",
-    "activeTo" : "2014-05-08T01:16:11.498Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4eccb3b2-786c-492b-a075-ef67b2150c28",
-    "id" : "https://www.example.org/25d1d4c4-32d9-44cd-827d-67fca0029d1b",
-    "identifier" : "Sr06AfZsISO5S2",
-    "labels" : {
-      "pt" : "PxSVkwfM1LkHgMOX5"
+      "da" : "R24LOTjT9v657G"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1684542612
+      "amount" : 1010762243
     },
-    "activeFrom" : "1984-08-10T02:30:33.673Z",
-    "activeTo" : "1999-05-19T10:17:20.063Z"
+    "activeFrom" : "1981-02-11T06:16:38.597Z",
+    "activeTo" : "1999-12-23T01:52:44.374Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/ad6cfb5a-430d-4c53-a3f8-e8d4ad1d1808",
+    "id" : "https://www.example.org/1d968a3b-c0e8-460d-8f43-d24fcd106bce",
+    "identifier" : "I8MQ0H8YnZH",
+    "labels" : {
+      "nl" : "gnGugZBynb9D3Z"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 158410696
+    },
+    "activeFrom" : "2002-09-11T21:10:03.231Z",
+    "activeTo" : "2022-08-13T20:03:17.469Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/01fec45a-54f0-4030-b901-bc077c7d7c7d" ],
+  "subjects" : [ "https://www.example.org/7f47567f-1e63-4ea1-9360-0cbad375f10a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1bd0e2a1-e574-4705-980c-ae0908682a24",
-    "name" : "hIXKmQRYyfZeji",
-    "mimeType" : "YWZrp2oiQbQCum",
-    "size" : 448816192,
-    "license" : "https://www.example.com/9l7nf89fom",
+    "identifier" : "d85d9c6a-b939-408b-b983-6bc7d7d149c9",
+    "name" : "RZLmZiMDLn",
+    "mimeType" : "bVnaNjz3tODGxS",
+    "size" : 364734114,
+    "license" : "https://www.example.com/jspuxogrqsastdjle",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ZGkC35IO3oUZ",
-    "publishedDate" : "2000-02-20T11:36:44.642Z",
+    "legalNote" : "PytSQvtE1ATqBuA",
+    "publishedDate" : "1988-05-29T14:49:02.947Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GESceFkSaKCTK",
-      "uploadedDate" : "1987-03-31T23:42:40.762Z"
+      "uploadedBy" : "wv7xGxwYn9dttE5vekH",
+      "uploadedDate" : "1987-07-07T09:02:42.163Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/bqxsdWONhjo",
-    "name" : "VWCwgokF0GRrnk",
-    "description" : "nNrofSjxFkSmg47Cs4"
+    "id" : "https://www.example.com/dM4R03migt4Y",
+    "name" : "MmVPHak4TA",
+    "description" : "V9W47ahgYnaBhPLPxG"
   } ],
-  "rightsHolder" : "hllCtBXGOlwtefR5",
-  "duplicateOf" : "https://www.example.org/4f341073-cb82-42c4-8227-ff85bcf7b300",
+  "rightsHolder" : "IiiwPA5pYtwH",
+  "duplicateOf" : "https://www.example.org/2e163baa-608a-49f2-8e64-b8942df81582",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tWgSK5dxInmt0"
+    "note" : "ilojz5YalIdeGC"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jbXicdSPCN1ggH09D",
-    "createdBy" : "uFh8uJTByTuA3dKy7W",
-    "createdDate" : "1979-06-15T02:07:53.208Z"
+    "note" : "GG3UOyxgrEnhUjTZ",
+    "createdBy" : "HP2ADP4UaFCWGMzXaGV",
+    "createdDate" : "1974-04-09T16:10:42.407Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/74897516-66ba-490e-90e8-fb094ce6f24b" ],
+  "curatingInstitutions" : [ "https://www.example.org/36dea6aa-e46e-47a8-9de2-1aff47f8ae07" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "8ofL1Ra1C83i5axbI2",
-    "ownerAffiliation" : "https://www.example.org/accbbda8-ad1a-456b-8392-61a2f937121d"
+    "owner" : "B3TbYsjgLyaRhrkxsr",
+    "ownerAffiliation" : "https://www.example.org/3b71c832-4687-4631-9237-f610bf48a584"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b633448b-21a5-4624-bd7c-b068eedc8a4b"
+    "id" : "https://www.example.org/5d2ee340-82ae-470d-bcff-451e2a25ea52"
   },
-  "createdDate" : "2007-07-31T04:30:27.634Z",
-  "modifiedDate" : "1974-07-13T04:18:32.418Z",
-  "publishedDate" : "2014-04-29T10:32:15.500Z",
-  "indexedDate" : "2016-07-29T12:49:18.573Z",
-  "handle" : "https://www.example.org/6dc4a657-06a7-44c7-a8ab-0a26b4524fdc",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/ecfabc2b-bb76-4f1f-8c54-53d18ec978b0",
+  "createdDate" : "2014-11-02T13:16:45.676Z",
+  "modifiedDate" : "2001-03-03T11:26:30.693Z",
+  "publishedDate" : "1999-03-29T00:50:04.582Z",
+  "indexedDate" : "2016-06-23T18:05:25.752Z",
+  "handle" : "https://www.example.org/12c2bbef-b5be-456a-821c-f1ecdfebc637",
+  "doi" : "https://doi.org/10.1234/quasi",
+  "link" : "https://www.example.org/c9b22d3e-5e2c-447f-a4f1-4a0e917f5f01",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kIg6X66PdHx9RX3sif",
+    "mainTitle" : "Ipr9V3nemMqT",
     "alternativeTitles" : {
-      "es" : "nazHipegSONYFN0itr"
+      "it" : "4TwoYQYVT9tc3vwOTg8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "rDkK4cx7wllPP",
-      "month" : "mrmd1oOFuIw",
-      "day" : "VBjdTpY53bmCFD0zIpZ"
+      "year" : "WNoGtM6uChet",
+      "month" : "nBWTIf01ihzQcCK",
+      "day" : "k4Wnw4QW3EXBhbVJ2z7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1094b70a-1a3d-4299-863a-bca3942b5d67",
-        "name" : "i5QK4LhxUWB",
-        "nameType" : "Personal",
-        "orcId" : "M4LpX7qZP8",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/8443a580-8e0f-42d9-9501-0bf748c8c313",
+        "name" : "Pxs0pGISLbsGke05nV8",
+        "nameType" : "Organizational",
+        "orcId" : "X0nYbQmnkiG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FwBbL4Z22R2Q",
-          "value" : "gl03h4AcMjdjhdTV0"
+          "sourceName" : "9HhIW3imElIHA9",
+          "value" : "cvwaKiJJRj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v5CF2LRiGehOm4",
-          "value" : "P6X3hVXekY"
+          "sourceName" : "9lZ249MWEXG3MHWwEFa",
+          "value" : "cIgQAE51Td"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d80a7c3b-fe89-44ba-bc8c-074dd21d3532"
+        "id" : "https://www.example.org/cbae5373-ceb9-49f1-8f2b-cf019aed70ac"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/22d6cc3c-7edd-4e62-8618-434b5ddb6d02",
-        "name" : "hCkN3lU4UYwj1D",
+        "id" : "https://www.example.org/66beb1b6-b377-47fe-9555-6d9b23c46280",
+        "name" : "YctH6nRfj3KPVLDb",
         "nameType" : "Organizational",
-        "orcId" : "cwHOqnqGN8",
+        "orcId" : "LlUWQ6WUHxS8ec",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fJ1LOVTVMvBH7",
-          "value" : "fvYjtLQoFocz8Fo0"
+          "sourceName" : "huQGOaxloOQ",
+          "value" : "AwUTraregR6HMs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fT8Aj4sGxk20eF",
-          "value" : "JZWl6mx0gwph"
+          "sourceName" : "gUtDXNk3MyA",
+          "value" : "hT0SWMi2x5vmzw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/11a48a4a-0edc-4d22-b3b4-cf0e72ee6d40"
+        "id" : "https://www.example.org/23cf1a3a-e526-4e91-a2cd-066a95892599"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "iLfACZEmvdt2xVO"
+      "es" : "bvI2t3IDQR"
     },
-    "npiSubjectHeading" : "Yd0YZWWfFyegm",
-    "tags" : [ "Dv1nEoqRp0gf" ],
-    "description" : "haQ9gCItHgRu",
+    "npiSubjectHeading" : "KfgX6LgBNrWGNXp9RrW",
+    "tags" : [ "GDX7bT0wVpMc7FpSub" ],
+    "description" : "iKyIFRfGAIO21PDNt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/517c28bb-bf00-41b2-a620-535b1b67d031",
+      "doi" : "https://www.example.org/46f6e960-31cf-4d3c-b451-72385813bc20",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "TheatricalProduction"
+          "type" : "Broadcast"
         },
-        "description" : "qeox1MJiym",
+        "description" : "WR93dXzQBmAdo5",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "pIQSxUSujLpUt",
-            "country" : "na4wcypIUn1oC7SI"
+            "label" : "F2twYbQLeaenaWJ",
+            "country" : "UDF6qBp2CokJFQ2J"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2008-04-10T18:31:29.636Z",
-            "to" : "2009-11-29T13:36:54.220Z"
+            "from" : "2013-05-11T09:27:31.650Z",
+            "to" : "2022-09-08T19:02:04.047Z"
           },
-          "sequence" : 1319008902
+          "sequence" : 345946781
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/68a46bcd-4eb5-4105-8368-9abe337e4beb",
-    "abstract" : "g0JrN2JuVH840j8"
+    "metadataSource" : "https://www.example.org/9d0a0a23-68b0-4173-b6b2-9d2691216e81",
+    "abstract" : "dOU5JXFamz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/706cb5f3-e1fb-4372-9893-aa196c4124c9",
-    "name" : "ee2bSI6kI9565Hwv15",
+    "id" : "https://www.example.org/9e4381d1-6e65-4b79-aacc-a47cc8e1a785",
+    "name" : "xGBtLHBbtqNcEARp0F",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-04-10T09:25:43.864Z",
+      "approvalDate" : "1997-01-03T14:23:52.444Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "57B9fJSUR5N5zXU"
+      "applicationCode" : "XOSi6vzgoJwEyo0"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c4a9cf75-cd61-45c0-be4f-89fa8b4235ae",
-    "identifier" : "Fn3fZEb3QHVS",
+    "source" : "https://www.example.org/83e09489-8374-49e7-9c59-1c040fd23783",
+    "identifier" : "8ELwXgiHXuk1lE",
     "labels" : {
-      "cs" : "TdHtutzs5sw8V"
+      "es" : "8p7xcl0OfbLj2R"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1881076455
+    },
+    "activeFrom" : "2015-05-18T20:11:00.268Z",
+    "activeTo" : "2019-12-09T15:19:37.430Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/cbd7f9a4-4383-48fc-a19c-30f827ceda5c",
+    "id" : "https://www.example.org/9c2c13fd-1b4a-408e-ad94-3b584ac666f0",
+    "identifier" : "PW8LjqZgYZGb",
+    "labels" : {
+      "es" : "ixhhrqORYByNmtgJ"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1834631123
+      "amount" : 1415946547
     },
-    "activeFrom" : "1975-12-09T16:54:30.504Z",
-    "activeTo" : "1985-03-19T01:38:43.373Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a6eaee5b-8133-4246-bf78-601876b5c62d",
-    "id" : "https://www.example.org/5e6744d5-521b-48b1-9567-2b73b7653563",
-    "identifier" : "x5M0LmBEsR",
-    "labels" : {
-      "en" : "rw7i3D6gqzSK"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1547700757
-    },
-    "activeFrom" : "2020-11-24T09:52:20.900Z",
-    "activeTo" : "2022-03-14T01:31:20.843Z"
+    "activeFrom" : "2011-05-07T03:12:13.885Z",
+    "activeTo" : "2023-07-26T22:37:36.597Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/904ab45a-20b0-480a-bb08-c5eb21955457" ],
+  "subjects" : [ "https://www.example.org/b4f17242-473d-4be0-83e3-194147e0c818" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a07031fe-9b47-49bc-aded-9d76486d38a5",
-    "name" : "74v0zrKFWg5lfU",
-    "mimeType" : "myaluxGIVk6",
-    "size" : 1146258042,
-    "license" : "https://www.example.com/ftaofcsjbi7igrcaxyt",
+    "identifier" : "0ecd86c2-afa5-4f67-8507-3e3f05788e3f",
+    "name" : "o4DrobCdzjiftTq",
+    "mimeType" : "pMyUXrxPHdwQDvibtgw",
+    "size" : 1707347956,
+    "license" : "https://www.example.com/uig5ay083fl9glkhym",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "xOLQlu5KY4KLNK17"
     },
-    "legalNote" : "ykNIAomNSw46F",
-    "publishedDate" : "1974-11-19T18:07:05.902Z",
+    "legalNote" : "DH8BzkIeIZY4WOP",
+    "publishedDate" : "2006-03-11T09:51:57.095Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DthRP6O08yErSskno",
-      "uploadedDate" : "1988-01-08T15:41:01.173Z"
+      "uploadedBy" : "VvfJy86F6Ve4Nz",
+      "uploadedDate" : "2001-04-16T21:12:27.426Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/IwWkOmMCuq",
-    "name" : "7SZg4XHtULgp",
-    "description" : "HRArpF2nk1M"
+    "id" : "https://www.example.com/X7agrcvtYCqZQ2bQK",
+    "name" : "dN9i0hrAFseZk3QH5",
+    "description" : "FEVTZZDdFd1Qp6fDJy"
   } ],
-  "rightsHolder" : "hdxUAWo9PAZV",
-  "duplicateOf" : "https://www.example.org/9b1cbab4-3ad3-4571-9f13-e3d4dfec86c2",
+  "rightsHolder" : "3nhFhovHHW4JqgGUB",
+  "duplicateOf" : "https://www.example.org/29f3bbaf-be5e-453f-832f-c34819b48eb0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vsvxswxU6r"
+    "note" : "M8aP8PoYbpYFI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "nPsBojyThM4DzWz38",
-    "createdBy" : "pchU84DEbewIE0OeCR",
-    "createdDate" : "1991-08-12T18:06:33.632Z"
+    "note" : "4pBBdSi8IIQC",
+    "createdBy" : "FewGn9oao1PY",
+    "createdDate" : "1974-03-27T19:22:46.509Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0ec6d368-5f90-4fff-9cb7-1a6fd6b0d5ba" ],
+  "curatingInstitutions" : [ "https://www.example.org/c84ab879-e169-435f-aa68-3e4f72e59678" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "MaVBZaCD6dYV0",
-    "ownerAffiliation" : "https://www.example.org/ea128365-e16a-4e3e-98c5-79dd10bbd288"
+    "owner" : "8ofL1Ra1C83i5axbI2",
+    "ownerAffiliation" : "https://www.example.org/accbbda8-ad1a-456b-8392-61a2f937121d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/088aa21f-38c2-407e-adc2-a22fe45b9b84"
+    "id" : "https://www.example.org/b633448b-21a5-4624-bd7c-b068eedc8a4b"
   },
-  "createdDate" : "2008-03-19T08:09:46.104Z",
-  "modifiedDate" : "1987-08-08T16:03:55.506Z",
-  "publishedDate" : "1991-03-13T03:27:42.440Z",
-  "indexedDate" : "1993-06-09T05:50:58.464Z",
-  "handle" : "https://www.example.org/532a01a1-f295-4751-b439-b5786bf8812b",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/98fc8c0c-2f65-4e46-b453-233b79e8f72d",
+  "createdDate" : "2007-07-31T04:30:27.634Z",
+  "modifiedDate" : "1974-07-13T04:18:32.418Z",
+  "publishedDate" : "2014-04-29T10:32:15.500Z",
+  "indexedDate" : "2016-07-29T12:49:18.573Z",
+  "handle" : "https://www.example.org/6dc4a657-06a7-44c7-a8ab-0a26b4524fdc",
+  "doi" : "https://doi.org/10.1234/minus",
+  "link" : "https://www.example.org/ecfabc2b-bb76-4f1f-8c54-53d18ec978b0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HC1yncW0ecO2",
+    "mainTitle" : "kIg6X66PdHx9RX3sif",
     "alternativeTitles" : {
-      "fi" : "RbjAEacqF6Knqc"
+      "es" : "nazHipegSONYFN0itr"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "T0sm5Wd4VvQ",
-      "month" : "gsINrShyZB5iMhfNo3N",
-      "day" : "g4q4YkhIuZSoB"
+      "year" : "rDkK4cx7wllPP",
+      "month" : "mrmd1oOFuIw",
+      "day" : "VBjdTpY53bmCFD0zIpZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c96ef218-9749-40df-b9b8-42a33bc3eef4",
-        "name" : "2ZEk6ZqgOx",
+        "id" : "https://www.example.org/1094b70a-1a3d-4299-863a-bca3942b5d67",
+        "name" : "i5QK4LhxUWB",
         "nameType" : "Personal",
-        "orcId" : "cHhSyKZD9JfQzT2w4",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "M4LpX7qZP8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "37ih8DCnFlFK",
-          "value" : "84TyMoMoQlxo2wo"
+          "sourceName" : "FwBbL4Z22R2Q",
+          "value" : "gl03h4AcMjdjhdTV0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jn08xDYBZlIqm",
-          "value" : "BcFoSziHz6jiG2gU0hZ"
+          "sourceName" : "v5CF2LRiGehOm4",
+          "value" : "P6X3hVXekY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2e50deb3-a4eb-455e-ab18-6c7d8800ddd3"
+        "id" : "https://www.example.org/d80a7c3b-fe89-44ba-bc8c-074dd21d3532"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Librettist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,155 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bf83493c-9d19-4a64-a02b-edb8bbd41bf7",
-        "name" : "yVshyfKxGcsHqh",
+        "id" : "https://www.example.org/22d6cc3c-7edd-4e62-8618-434b5ddb6d02",
+        "name" : "hCkN3lU4UYwj1D",
         "nameType" : "Organizational",
-        "orcId" : "7SgXVxVxg58DZjB4",
-        "verificationStatus" : "Verified",
+        "orcId" : "cwHOqnqGN8",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rTROm6QVrsS",
-          "value" : "60kuwiT1eMPx6"
+          "sourceName" : "fJ1LOVTVMvBH7",
+          "value" : "fvYjtLQoFocz8Fo0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m8IzRFQ5WH4kctn56Mk",
-          "value" : "faPHx4RqHIMPd5GfgU"
+          "sourceName" : "fT8Aj4sGxk20eF",
+          "value" : "JZWl6mx0gwph"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/46172536-e4dc-4c56-9e9b-963f1e5499de"
+        "id" : "https://www.example.org/11a48a4a-0edc-4d22-b3b4-cf0e72ee6d40"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "iOIqdGjZibi9QGEhwMu"
+      "se" : "iLfACZEmvdt2xVO"
     },
-    "npiSubjectHeading" : "3IvOQQNruoXDah",
-    "tags" : [ "PveBShTK5R" ],
-    "description" : "iHcQz0Xdd8",
+    "npiSubjectHeading" : "Yd0YZWWfFyegm",
+    "tags" : [ "Dv1nEoqRp0gf" ],
+    "description" : "haQ9gCItHgRu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/6587aba4-aa8b-4bde-a9b6-cdcd57892ac0",
+      "doi" : "https://www.example.org/517c28bb-bf00-41b2-a620-535b1b67d031",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "Broadcast"
+          "type" : "TheatricalProduction"
         },
-        "description" : "DQykW2JZ92XuLr",
+        "description" : "qeox1MJiym",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "RpNbtiYsev",
-            "country" : "AGLvV9GGsU6Ju9OG"
+            "label" : "pIQSxUSujLpUt",
+            "country" : "na4wcypIUn1oC7SI"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1988-08-06T20:01:59.071Z",
-            "to" : "2002-07-12T16:45:37.853Z"
+            "from" : "2008-04-10T18:31:29.636Z",
+            "to" : "2009-11-29T13:36:54.220Z"
           },
-          "sequence" : 2142041908
+          "sequence" : 1319008902
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/277e7cc9-31b6-435d-b424-fb3809b63191",
-    "abstract" : "4DquoWZJraCP9a4ZGS"
+    "metadataSource" : "https://www.example.org/68a46bcd-4eb5-4105-8368-9abe337e4beb",
+    "abstract" : "g0JrN2JuVH840j8"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/35fc2d95-cc34-4ebc-b9f0-e069afcc3ce3",
-    "name" : "ifv3lS4erab",
+    "id" : "https://www.example.org/706cb5f3-e1fb-4372-9893-aa196c4124c9",
+    "name" : "ee2bSI6kI9565Hwv15",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-08-24T04:30:24.024Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "0oKiN3inaOYa8LHeD0D"
+      "approvalDate" : "2000-04-10T09:25:43.864Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "57B9fJSUR5N5zXU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b9f7dbb9-526b-4d45-ae6d-43d998b10679",
-    "identifier" : "7PLbfO6zYt",
+    "source" : "https://www.example.org/c4a9cf75-cd61-45c0-be4f-89fa8b4235ae",
+    "identifier" : "Fn3fZEb3QHVS",
     "labels" : {
-      "pt" : "67LWVKpABmRue"
+      "cs" : "TdHtutzs5sw8V"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1614299873
+      "currency" : "GBP",
+      "amount" : 1834631123
     },
-    "activeFrom" : "2018-10-28T22:46:19.159Z",
-    "activeTo" : "2019-02-11T20:45:20.336Z"
+    "activeFrom" : "1975-12-09T16:54:30.504Z",
+    "activeTo" : "1985-03-19T01:38:43.373Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9688a97e-d6dc-494d-bae0-1caf922f1727",
-    "id" : "https://www.example.org/e1cab040-3475-452f-8157-22ad77e47edd",
-    "identifier" : "u9kCEi4pmjD",
+    "source" : "https://www.example.org/a6eaee5b-8133-4246-bf78-601876b5c62d",
+    "id" : "https://www.example.org/5e6744d5-521b-48b1-9567-2b73b7653563",
+    "identifier" : "x5M0LmBEsR",
     "labels" : {
-      "nb" : "ERXdrD7A1F"
+      "en" : "rw7i3D6gqzSK"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1188076377
+      "amount" : 1547700757
     },
-    "activeFrom" : "1998-08-23T14:20:26.527Z",
-    "activeTo" : "2019-01-01T20:57:24.372Z"
+    "activeFrom" : "2020-11-24T09:52:20.900Z",
+    "activeTo" : "2022-03-14T01:31:20.843Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/58b06bb5-fc12-46f5-8c51-7559426d1fa4" ],
+  "subjects" : [ "https://www.example.org/904ab45a-20b0-480a-bb08-c5eb21955457" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e9a1a2af-0686-41e5-9833-19c6cf846fbf",
-    "name" : "voH3gqbGa12x7I9c",
-    "mimeType" : "v5UVb6Lh2aTbbFpwb",
-    "size" : 1371888949,
-    "license" : "https://www.example.com/qddnx5emdreo",
+    "identifier" : "a07031fe-9b47-49bc-aded-9d76486d38a5",
+    "name" : "74v0zrKFWg5lfU",
+    "mimeType" : "myaluxGIVk6",
+    "size" : 1146258042,
+    "license" : "https://www.example.com/ftaofcsjbi7igrcaxyt",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "sCjD3WVp2G",
-    "publishedDate" : "2007-03-01T15:45:30.728Z",
+    "legalNote" : "ykNIAomNSw46F",
+    "publishedDate" : "1974-11-19T18:07:05.902Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "hnbY938y52Ygh0S6",
-      "uploadedDate" : "1985-01-16T02:21:12.398Z"
+      "uploadedBy" : "DthRP6O08yErSskno",
+      "uploadedDate" : "1988-01-08T15:41:01.173Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/AWdV5EBHABDEKeimP",
-    "name" : "Vri5PwlpMoHxf8L",
-    "description" : "Y6KyF7wQusym08"
+    "id" : "https://www.example.com/IwWkOmMCuq",
+    "name" : "7SZg4XHtULgp",
+    "description" : "HRArpF2nk1M"
   } ],
-  "rightsHolder" : "nvBdVxsJdIIyS",
-  "duplicateOf" : "https://www.example.org/3f505285-6d66-4ad5-b633-206c3e510fa5",
+  "rightsHolder" : "hdxUAWo9PAZV",
+  "duplicateOf" : "https://www.example.org/9b1cbab4-3ad3-4571-9f13-e3d4dfec86c2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "fC0iaA6NN3"
+    "note" : "vsvxswxU6r"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "nqDI2BzqRPWEXhl",
-    "createdBy" : "uLDnswQpsmN",
-    "createdDate" : "2019-09-28T21:13:19.072Z"
+    "note" : "nPsBojyThM4DzWz38",
+    "createdBy" : "pchU84DEbewIE0OeCR",
+    "createdDate" : "1991-08-12T18:06:33.632Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f94dedad-9567-4b24-9988-5f3db25a8f88" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/0ec6d368-5f90-4fff-9cb7-1a6fd6b0d5ba" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "NhCBJg2IdwdWAXMPdeE",
-    "ownerAffiliation" : "https://www.example.org/8373b152-99cf-49af-b488-316c00c957b6"
+    "owner" : "HqC5bpqp8A",
+    "ownerAffiliation" : "https://www.example.org/93e7d49f-6462-45c1-a194-294cc9ef99ed"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/29bdef1e-a202-43a0-9b3d-0f7f0acd27e9"
+    "id" : "https://www.example.org/91dbc592-e94f-4fe2-be1c-6fa321c98c7d"
   },
-  "createdDate" : "2024-01-21T18:16:32.719Z",
-  "modifiedDate" : "2024-04-30T22:15:11.248Z",
-  "publishedDate" : "1978-02-01T16:53:28.079Z",
-  "indexedDate" : "1988-02-07T16:20:51.584Z",
-  "handle" : "https://www.example.org/8514ca71-9416-4657-a30d-089cd328ba94",
-  "doi" : "https://doi.org/10.1234/nam",
-  "link" : "https://www.example.org/449a8b34-93b3-4c4f-8795-883d5601924e",
+  "createdDate" : "1994-11-28T02:49:01.998Z",
+  "modifiedDate" : "2004-01-12T11:35:49.455Z",
+  "publishedDate" : "1989-10-24T09:04:56.121Z",
+  "indexedDate" : "1992-03-14T07:55:36.499Z",
+  "handle" : "https://www.example.org/bb04b6e0-406c-4ab0-b25d-640a1747e338",
+  "doi" : "https://doi.org/10.1234/magnam",
+  "link" : "https://www.example.org/84a79f23-b7dd-4862-a734-60caf91a3e6f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GD2AbTebWZI",
+    "mainTitle" : "47xEN6acMQOEX",
     "alternativeTitles" : {
-      "af" : "ji7ZZ81tqwDBf"
+      "pt" : "2jFk6HrQariCJ7CfB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Kyeu6zLUKa5WD3",
-      "month" : "bbdUxw3LjCvk",
-      "day" : "3Ap98U837FjBOrB0j"
+      "year" : "Tt9f8ZeF0QR",
+      "month" : "4SeqGoqoBwdtXVm5Z",
+      "day" : "8eIaNwN6zoSVnIujOWU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4529b2ec-1ef0-4b2b-b8cd-b21bb23820e7",
-        "name" : "3YSG8BLWf56m0eLEs",
+        "id" : "https://www.example.org/4fbf3069-b4b7-4c85-b7a8-d9abbfc09065",
+        "name" : "HHldGDBOAXjIZzES",
         "nameType" : "Organizational",
-        "orcId" : "IFZI3PrfuR6lUNr69z",
-        "verificationStatus" : "Verified",
+        "orcId" : "cGAKhek1OE0UZgvFF0",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VE74X4MvbVN8R",
-          "value" : "nRV4SEtV0o"
+          "sourceName" : "MRqQdqHToGWad6",
+          "value" : "THQaXu5xiaDUF7VTg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cUCucKBlBNniYHwI",
-          "value" : "nkR7MdSfr9e"
+          "sourceName" : "q8FdQEKfxKC4SddhiV",
+          "value" : "OrhHfZVZcG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a9e560fd-f813-4d6e-9302-2d78290521cf"
+        "id" : "https://www.example.org/b616ba6b-7f1c-4413-bacf-eaa95d6e2235"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/084dbaf5-be2a-4a33-8186-cf1becaf896b",
-        "name" : "PXTEYxkHqKSh0XizR",
+        "id" : "https://www.example.org/ae7dce4a-2a95-40a2-b4b1-74e6586c8dce",
+        "name" : "1CuvDs5VyD32zUkua",
         "nameType" : "Personal",
-        "orcId" : "VyetJWtvZHq",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "89Rh6mdhnoKFEpk8p",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DzL40ZuaBF6p",
-          "value" : "OV67ooeGZSjwJ"
+          "sourceName" : "SzpcRL0KMYhA3VIe7Yg",
+          "value" : "DPQSd75wRVL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "c8vzf4SP6sxnbikjO2I",
-          "value" : "TCSwcq1YMT"
+          "sourceName" : "b7fIXv1rtZoXLDDXx",
+          "value" : "Ls3sfW7u9ZBIkDoINdq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1ea00075-f22a-480e-ae98-b22a0583f05d"
+        "id" : "https://www.example.org/9f730492-d143-460a-97d0-50abb613c87c"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "DataManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "WY25saPFfpJk"
+      "el" : "9zauTLZUhR8mtr"
     },
-    "npiSubjectHeading" : "RhtOGaDovYeXEe4Jj",
-    "tags" : [ "tAjNwQPQXja" ],
-    "description" : "3Zo2oTChLaYHJsoj",
+    "npiSubjectHeading" : "Ffa5MRAD6oDbW",
+    "tags" : [ "AGRoWWgbPZcpaWOeR2" ],
+    "description" : "s3ZuCVdjQ8FWG2Rd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/820b3e79-dc47-4c40-a0de-9ad4b437124d"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c6d102b0-e282-4b3a-bbfc-62dfccbf0edb"
       },
-      "doi" : "https://www.example.org/eb3185d4-1ad3-4978-9852-89ea9204ae86",
+      "doi" : "https://www.example.org/5d455bbc-a4e8-453e-a66f-9699453fb167",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "DJ8UFd6Nt8dN",
-          "end" : "j5uckqpEGhwoUQkKGG"
+          "begin" : "9pJ7zX0StT",
+          "end" : "kaJ3EBCdosv"
         },
-        "volume" : "l9Uxao92ldhlgXwp0",
-        "issue" : "3bPsSFUSUJ",
-        "articleNumber" : "YcDfcURtQt"
+        "volume" : "Ko32QZPY7hBe",
+        "issue" : "U9ycG9IPtepw",
+        "articleNumber" : "S0eBwo7T7q"
       }
     },
-    "metadataSource" : "https://www.example.org/d43f530d-ec11-40ea-bef1-4321c3f756fe",
-    "abstract" : "ZlfMZfOB1mEORi"
+    "metadataSource" : "https://www.example.org/f1724486-e7ee-4df6-88df-ef6c14f1b11e",
+    "abstract" : "eblM2Hdp6KRIS7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/916bde8c-7d12-4881-80d0-af14877707bb",
-    "name" : "zDq3OGMxG0t9LzVQfF7",
+    "id" : "https://www.example.org/3704ee3b-6446-4625-80ba-96fe475e737b",
+    "name" : "MdJndQkW5BQeGzJBLb",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-04-09T20:14:21.741Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "hSQnHiwTM4Du7a"
+      "approvalDate" : "1972-09-02T06:02:54.771Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "zIgWFqnfcpOgwBi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1f31e2cd-f251-4f7f-86b5-fec28434e404",
-    "identifier" : "SEVdW7IDER",
+    "source" : "https://www.example.org/1d458b27-3f08-40f8-ae1a-068988944cf2",
+    "identifier" : "8pOIvgI4NtcFK",
     "labels" : {
-      "ru" : "C764dikZkAqZspF"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1221729149
-    },
-    "activeFrom" : "2019-05-17T04:16:43.472Z",
-    "activeTo" : "2024-01-31T08:29:50.047Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d5521e76-2683-4889-9f1c-f50ab2d3ba15",
-    "id" : "https://www.example.org/920903ee-5718-44f2-8179-ad25e171c151",
-    "identifier" : "atXCvMwNo6upUVz9h",
-    "labels" : {
-      "af" : "n4R7BxKhJLxxaOA"
+      "zh" : "WzkiIfNnZIiCYLPL"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1708324416
+      "amount" : 2138833936
     },
-    "activeFrom" : "2014-05-01T18:41:26.244Z",
-    "activeTo" : "2014-10-04T21:55:18.145Z"
+    "activeFrom" : "2021-01-21T20:36:04.512Z",
+    "activeTo" : "2022-08-13T01:54:54.819Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/2285ee97-b2bb-4638-ad1c-d18568b0df59",
+    "id" : "https://www.example.org/7670277f-4948-456e-85c6-de82be8b40f5",
+    "identifier" : "NIlAv870IdAD0",
+    "labels" : {
+      "fr" : "7DZR4Qp5xrUEdZk"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1044257348
+    },
+    "activeFrom" : "2008-01-23T07:22:21.446Z",
+    "activeTo" : "2019-12-19T19:23:28.198Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4923de84-7219-4ab3-802e-147580a0d003" ],
+  "subjects" : [ "https://www.example.org/8410f6ac-b944-47df-b6a7-21307b59b64e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e6e2265a-e2ad-42c9-8096-326bc5cf0bb6",
-    "name" : "bBxLl3j3Ed4W6dG",
-    "mimeType" : "m38cXhaApgymwY7bf3",
-    "size" : 845723787,
-    "license" : "https://www.example.com/huuepcff0wf8a9uy",
+    "identifier" : "2abc26c5-7296-4497-b0e6-65d7107cabd1",
+    "name" : "l3QSXNvB9me0nipz",
+    "mimeType" : "P1zKUkr7Ei8",
+    "size" : 1374262945,
+    "license" : "https://www.example.com/gudf7hcqxb",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "Draft",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "NqVeRPLr3pof8j",
-    "publishedDate" : "1979-12-02T19:58:35.890Z",
+    "legalNote" : "e2GGeMVyKHLV5a",
+    "publishedDate" : "1991-07-10T08:28:35.895Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GeAwO4xK9XtMlum9cQo",
-      "uploadedDate" : "2017-10-07T03:34:20.911Z"
+      "uploadedBy" : "JXBPQVwjll",
+      "uploadedDate" : "1984-12-13T19:54:23.961Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tL58priDEMk",
-    "name" : "6off3osVRh3dl",
-    "description" : "wSMvPc9r7smr"
+    "id" : "https://www.example.com/JLPYTkZaMTC",
+    "name" : "an5jQ4KR7BNhp",
+    "description" : "Puy03rfvirBUWsVz"
   } ],
-  "rightsHolder" : "PgmcaudyCJhoe",
-  "duplicateOf" : "https://www.example.org/3f429db7-17f7-4433-b946-fd9988fa9d68",
+  "rightsHolder" : "jJO6OIeFOJ4kJCEi",
+  "duplicateOf" : "https://www.example.org/58b88e14-d057-45a5-8b7b-67e5421aba4c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Yk0Xla9RhDsKvGrMO2q"
+    "note" : "GmsSuwqKoQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "BEsUnkQnUszv",
-    "createdBy" : "GtcpeLD6v1EvGhD",
-    "createdDate" : "2019-03-26T04:20:41.234Z"
+    "note" : "ur2TSAb4W8qhAB7X",
+    "createdBy" : "3Is8iTotuhGiJCk",
+    "createdDate" : "1994-12-29T03:46:14.586Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/00de9ff7-e656-49f7-9169-2fbfe15cea86" ],
+  "curatingInstitutions" : [ "https://www.example.org/aaee643b-24a2-4de9-a3aa-b8803c865d36" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "esQtiNyvjvOZR71tW6t",
-    "ownerAffiliation" : "https://www.example.org/ec3d8dfa-2487-4a71-8761-ad3c17bc30d4"
+    "owner" : "NhCBJg2IdwdWAXMPdeE",
+    "ownerAffiliation" : "https://www.example.org/8373b152-99cf-49af-b488-316c00c957b6"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/23f25874-9432-4679-8fdf-461154276b3c"
+    "id" : "https://www.example.org/29bdef1e-a202-43a0-9b3d-0f7f0acd27e9"
   },
-  "createdDate" : "1982-09-12T18:52:54.191Z",
-  "modifiedDate" : "2022-08-24T16:32:33.691Z",
-  "publishedDate" : "1978-10-22T14:30:30.031Z",
-  "indexedDate" : "1993-09-07T16:24:58.373Z",
-  "handle" : "https://www.example.org/ae0761dd-8fc0-4fdd-bb46-33f377235310",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/34e6060f-4e6c-4ace-843f-77d284cd35f5",
+  "createdDate" : "2024-01-21T18:16:32.719Z",
+  "modifiedDate" : "2024-04-30T22:15:11.248Z",
+  "publishedDate" : "1978-02-01T16:53:28.079Z",
+  "indexedDate" : "1988-02-07T16:20:51.584Z",
+  "handle" : "https://www.example.org/8514ca71-9416-4657-a30d-089cd328ba94",
+  "doi" : "https://doi.org/10.1234/nam",
+  "link" : "https://www.example.org/449a8b34-93b3-4c4f-8795-883d5601924e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8tc1QD8l0V7Yc2x",
+    "mainTitle" : "GD2AbTebWZI",
     "alternativeTitles" : {
-      "zh" : "oqENZSxXiSmeGs"
+      "af" : "ji7ZZ81tqwDBf"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6BYd4HFXFgv",
-      "month" : "lgNdMybx8jY2nN",
-      "day" : "CJqSf6sVSIg8QRJ"
+      "year" : "Kyeu6zLUKa5WD3",
+      "month" : "bbdUxw3LjCvk",
+      "day" : "3Ap98U837FjBOrB0j"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f2ea06f0-2c7a-4647-bced-9f37b5ecd914",
-        "name" : "lvXhbbYHOyeHuaIVb6",
-        "nameType" : "Personal",
-        "orcId" : "136vPK5B8VljH7ZZi6",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/4529b2ec-1ef0-4b2b-b8cd-b21bb23820e7",
+        "name" : "3YSG8BLWf56m0eLEs",
+        "nameType" : "Organizational",
+        "orcId" : "IFZI3PrfuR6lUNr69z",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jUG6Ql0c22",
-          "value" : "szJnEcriw6smj"
+          "sourceName" : "VE74X4MvbVN8R",
+          "value" : "nRV4SEtV0o"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9b70CYNSB6v",
-          "value" : "0k4HkJJZvJdYGL30"
+          "sourceName" : "cUCucKBlBNniYHwI",
+          "value" : "nkR7MdSfr9e"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/73118de5-7651-465d-9b3a-dadb27765b95"
+        "id" : "https://www.example.org/a9e560fd-f813-4d6e-9302-2d78290521cf"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Librettist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d9ed8a1f-c706-4262-8592-932a7297d25f",
-        "name" : "DMQa6DhHkG",
-        "nameType" : "Organizational",
-        "orcId" : "sCio0anAqGC",
+        "id" : "https://www.example.org/084dbaf5-be2a-4a33-8186-cf1becaf896b",
+        "name" : "PXTEYxkHqKSh0XizR",
+        "nameType" : "Personal",
+        "orcId" : "VyetJWtvZHq",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gsZmwRfFlRkg31gL4",
-          "value" : "hADiqk3A1P2S"
+          "sourceName" : "DzL40ZuaBF6p",
+          "value" : "OV67ooeGZSjwJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ssbtaEXBF8ngikI",
-          "value" : "ZflzywCkns"
+          "sourceName" : "c8vzf4SP6sxnbikjO2I",
+          "value" : "TCSwcq1YMT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d2eb5415-fbb9-46b1-8f39-83e608dc7a33"
+        "id" : "https://www.example.org/1ea00075-f22a-480e-ae98-b22a0583f05d"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "juD4OrV96rMX7hejaw2"
+      "de" : "WY25saPFfpJk"
     },
-    "npiSubjectHeading" : "zNYOX615aRpU8Cgzy",
-    "tags" : [ "WLybA6I07kE" ],
-    "description" : "VguOVtPLhu",
+    "npiSubjectHeading" : "RhtOGaDovYeXEe4Jj",
+    "tags" : [ "tAjNwQPQXja" ],
+    "description" : "3Zo2oTChLaYHJsoj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/747c1eb2-bf57-48a1-8f7b-dd7c07fa7d4e"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/820b3e79-dc47-4c40-a0de-9ad4b437124d"
       },
-      "doi" : "https://www.example.org/9dcad6ca-ec51-4e29-9b5d-1c334353ce22",
+      "doi" : "https://www.example.org/eb3185d4-1ad3-4978-9852-89ea9204ae86",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "5RlKhD1PePNWsPUV9f",
-          "end" : "0SmKPgbQgV"
+          "begin" : "DJ8UFd6Nt8dN",
+          "end" : "j5uckqpEGhwoUQkKGG"
         },
-        "volume" : "i1HHo5zkXK2uO7i",
-        "issue" : "XXR4IRtx7ddC",
-        "articleNumber" : "XO6JJQZpuHw0oXTp"
+        "volume" : "l9Uxao92ldhlgXwp0",
+        "issue" : "3bPsSFUSUJ",
+        "articleNumber" : "YcDfcURtQt"
       }
     },
-    "metadataSource" : "https://www.example.org/faa6aa22-0fe2-4b89-95bb-029256d1ff5e",
-    "abstract" : "n7QIc947lfgX1YZ0Rq"
+    "metadataSource" : "https://www.example.org/d43f530d-ec11-40ea-bef1-4321c3f756fe",
+    "abstract" : "ZlfMZfOB1mEORi"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fdc7b5cc-c179-4c99-887a-2b31d973c3c2",
-    "name" : "o6kFfPxLJTHqchrDr69",
+    "id" : "https://www.example.org/916bde8c-7d12-4881-80d0-af14877707bb",
+    "name" : "zDq3OGMxG0t9LzVQfF7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-07-17T20:43:58.117Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1973-04-09T20:14:21.741Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "MLaAnypOrjYj0H"
+      "applicationCode" : "hSQnHiwTM4Du7a"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a1adae8a-5e83-45a7-8724-edac5d66d6db",
-    "identifier" : "zdexs7NYj03sASKqAa1",
+    "source" : "https://www.example.org/1f31e2cd-f251-4f7f-86b5-fec28434e404",
+    "identifier" : "SEVdW7IDER",
     "labels" : {
-      "af" : "B9mWkHajdIfolp"
+      "ru" : "C764dikZkAqZspF"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1170985235
+      "currency" : "GBP",
+      "amount" : 1221729149
     },
-    "activeFrom" : "1991-08-10T10:34:52.457Z",
-    "activeTo" : "2005-05-22T17:12:39.559Z"
+    "activeFrom" : "2019-05-17T04:16:43.472Z",
+    "activeTo" : "2024-01-31T08:29:50.047Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/21bf6cd1-4df2-4156-96a6-cb052f6525de",
-    "id" : "https://www.example.org/be861c5a-dabc-4695-a031-93161044a06b",
-    "identifier" : "P06XT0Xjm4k2BD",
+    "source" : "https://www.example.org/d5521e76-2683-4889-9f1c-f50ab2d3ba15",
+    "id" : "https://www.example.org/920903ee-5718-44f2-8179-ad25e171c151",
+    "identifier" : "atXCvMwNo6upUVz9h",
     "labels" : {
-      "af" : "rVvjXrqHHA1n1nCPV"
+      "af" : "n4R7BxKhJLxxaOA"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1244168785
+      "currency" : "NOK",
+      "amount" : 1708324416
     },
-    "activeFrom" : "1971-11-20T21:15:44.851Z",
-    "activeTo" : "2014-09-28T09:40:10.559Z"
+    "activeFrom" : "2014-05-01T18:41:26.244Z",
+    "activeTo" : "2014-10-04T21:55:18.145Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7b3f24d4-8835-4142-8e76-64b00929e269" ],
+  "subjects" : [ "https://www.example.org/4923de84-7219-4ab3-802e-147580a0d003" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a827f213-d68f-4680-93c5-d55fa2218bc0",
-    "name" : "PjBs6Jq9mOeZq",
-    "mimeType" : "pk1ESKwWANV",
-    "size" : 803922068,
-    "license" : "https://www.example.com/v0lrvh8plcbfigth",
+    "identifier" : "e6e2265a-e2ad-42c9-8096-326bc5cf0bb6",
+    "name" : "bBxLl3j3Ed4W6dG",
+    "mimeType" : "m38cXhaApgymwY7bf3",
+    "size" : 845723787,
+    "license" : "https://www.example.com/huuepcff0wf8a9uy",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "GNuPW3kHZA2UF3wEDL",
-    "publishedDate" : "1981-04-03T04:00:40.546Z",
+    "legalNote" : "NqVeRPLr3pof8j",
+    "publishedDate" : "1979-12-02T19:58:35.890Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dU0CDEHddB6",
-      "uploadedDate" : "1985-01-21T22:38:40.155Z"
+      "uploadedBy" : "GeAwO4xK9XtMlum9cQo",
+      "uploadedDate" : "2017-10-07T03:34:20.911Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FL0WSNqS8r",
-    "name" : "YbrMB8m7zAU50L6r",
-    "description" : "KIDIdUJvfCVGqjXW"
+    "id" : "https://www.example.com/tL58priDEMk",
+    "name" : "6off3osVRh3dl",
+    "description" : "wSMvPc9r7smr"
   } ],
-  "rightsHolder" : "eEyN86frRt21QLssW",
-  "duplicateOf" : "https://www.example.org/ea601800-b01d-4896-826c-def861dbfc0c",
+  "rightsHolder" : "PgmcaudyCJhoe",
+  "duplicateOf" : "https://www.example.org/3f429db7-17f7-4433-b946-fd9988fa9d68",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dvWaeYPBcw8kW"
+    "note" : "Yk0Xla9RhDsKvGrMO2q"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jwbzJszifJZO",
-    "createdBy" : "A1PFyb6814C0in",
-    "createdDate" : "1987-04-20T06:45:40.514Z"
+    "note" : "BEsUnkQnUszv",
+    "createdBy" : "GtcpeLD6v1EvGhD",
+    "createdDate" : "2019-03-26T04:20:41.234Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/905bbe56-7ecf-49c0-8c5d-62780695892f" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/00de9ff7-e656-49f7-9169-2fbfe15cea86" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "N3RmZnUNnGI",
-    "ownerAffiliation" : "https://www.example.org/4e037c8c-38fe-42c5-8263-275634e8cbab"
+    "owner" : "xMxdztoLHvyJf8tx",
+    "ownerAffiliation" : "https://www.example.org/4cfc0d95-2174-48f8-a575-f4f185b1c279"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/09066af9-a61c-4b2a-a110-2bc7e1136e3b"
+    "id" : "https://www.example.org/39a4540a-f057-4ecc-801e-7d858c46876f"
   },
-  "createdDate" : "1981-07-04T05:19:50.541Z",
-  "modifiedDate" : "2023-06-21T09:36:22.051Z",
-  "publishedDate" : "1977-10-18T16:39:41.168Z",
-  "indexedDate" : "1994-05-13T05:58:10.482Z",
-  "handle" : "https://www.example.org/f0a4db66-8c69-455d-b9da-a5a31519f844",
-  "doi" : "https://doi.org/10.1234/sapiente",
-  "link" : "https://www.example.org/1ef05a6e-7344-4fe4-9c7c-401a2cd50851",
+  "createdDate" : "2012-04-01T03:09:50.830Z",
+  "modifiedDate" : "2009-11-07T07:15:10.416Z",
+  "publishedDate" : "2023-11-25T14:51:32.385Z",
+  "indexedDate" : "1973-10-20T05:37:13.169Z",
+  "handle" : "https://www.example.org/ce64c54b-8f95-4b5f-bec8-de947f016896",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/fa97ce89-423e-494a-9c37-cf01df0484ff",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pL5dr5kS5UJ4bkFin9",
+    "mainTitle" : "zdOD2BbZ8Sh0Uvs",
     "alternativeTitles" : {
-      "nl" : "Fm9RCqtLj8xa6DeC0Qy"
+      "zh" : "vFMgGvWz3XoUw"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ArawmM6RMyT65ohhR",
-      "month" : "b5Tb0CLFbemKyGyQr",
-      "day" : "qTXiDmQKXY"
+      "year" : "6FzSj04Mxw27slQyJ",
+      "month" : "YW9UvNh09YXzk",
+      "day" : "ytOUHLhyHpEPx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/32fbefc7-779b-406d-bb58-7200dfe90e7d",
-        "name" : "pPrmW8GWoJV",
+        "id" : "https://www.example.org/87e79b61-2665-4efa-b781-6f7151c0034b",
+        "name" : "DVLllbUd5WdsJtAjC9O",
         "nameType" : "Personal",
-        "orcId" : "0VByU3UOpi",
-        "verificationStatus" : "Verified",
+        "orcId" : "IvQ9SxceWohj8zqSsJ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iPsc6ruyh7Jyuziu",
-          "value" : "rdVFeTUmj9Q"
+          "sourceName" : "bZVQRr4suq8UaR",
+          "value" : "2yqq4lAxiaQEeLsrnyW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "34tB2xZkTfZw7",
-          "value" : "r8f2gEpsAjKWTuHAb"
+          "sourceName" : "D8I6dbLbHHsWRD9z",
+          "value" : "G1yQ8ssjXKIQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7b8e8c57-a90b-4ae5-a86b-9461442ff17c"
+        "id" : "https://www.example.org/c8879136-6294-4a36-aaf0-80fe2bc229ed"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/56689550-8c95-43bb-b2ab-69af9ecd28a6",
-        "name" : "39alZUSVmY",
-        "nameType" : "Organizational",
-        "orcId" : "FX0V7iVWAQI5oztsAG",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e472d0a4-6405-43b7-9ca0-a8b7acb8e5b1",
+        "name" : "YVGdJyTp95GLUc9C",
+        "nameType" : "Personal",
+        "orcId" : "J3zvcg5bGvX",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oBWZ5ytqMrl",
-          "value" : "GVkzpqB8zOxUE"
+          "sourceName" : "x77N5rG6VS7qEQO",
+          "value" : "O8yKr7Xr9F"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6q83VoSwK9qNertLl3O",
-          "value" : "9MGm0wXBrMw2tP6Cd"
+          "sourceName" : "CwbJQbmCpOcvNYT",
+          "value" : "ImvemOxbIYCpg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4908f078-e12d-4dec-85e4-3b311e0fc260"
+        "id" : "https://www.example.org/63821215-5ddb-46d1-819f-4c6f23570b35"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Creator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "NYldRDPhVwwbKvAF"
+      "es" : "OAVwahpCuh"
     },
-    "npiSubjectHeading" : "PcQm5dkKx570w",
-    "tags" : [ "ihLhmhOmWUI2UT" ],
-    "description" : "8xgWeYttbWPOTgBw8Co",
+    "npiSubjectHeading" : "5ulJdpD1ZIeJ6bD0x",
+    "tags" : [ "0xIWqS4L2cQtp3Efgac" ],
+    "description" : "G8jhKL94jcKO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/Z31gStAPqZ"
+        "id" : "https://www.example.com/5XhDS4DjyP8vR1t"
       },
-      "doi" : "https://www.example.org/021c5b5e-5e70-4e99-99c5-f0b2df556c7c",
+      "doi" : "https://www.example.org/a5ac5f58-db2d-4ffc-89e2-f554805f1b24",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "ppqsr3u3P9M9k",
-          "end" : "5wCK0p07yyCM"
+          "begin" : "P5mqWkns9rHJEJ",
+          "end" : "ZaFFyRL8qu8zn4iVq"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/434f5784-99bc-4b60-9f0d-60ee81de43f7",
-    "abstract" : "wQDajSMBBAuNC"
+    "metadataSource" : "https://www.example.org/32fff045-ccac-4692-a77b-9507e84ffe4c",
+    "abstract" : "l36xf7vXh3Grrbnhb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/94b3e4ae-39ed-4e25-859a-0d2243daca5b",
-    "name" : "YdOd8MxZAODFasd",
+    "id" : "https://www.example.org/a56e5411-b663-47d8-aae8-4ce7c71e829f",
+    "name" : "xRtFq636eGJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-11-09T02:49:39.324Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1981-01-17T19:55:33.577Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "orOT57fL8pML30fmn"
+      "applicationCode" : "CXVHc5gkUftvfXK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a5810a7b-2140-46f0-8154-f3c791dc64a1",
-    "identifier" : "43NvIXme4ievrIKL1nq",
+    "source" : "https://www.example.org/7b1fca77-2a93-4b52-9ae8-19a5f2158f68",
+    "identifier" : "m44y5dd54kWUVc",
     "labels" : {
-      "zh" : "5LaWkphFK0"
+      "hu" : "5JXIv9mq0GC3tzx"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1499699721
+      "currency" : "USD",
+      "amount" : 988754660
     },
-    "activeFrom" : "2021-01-24T13:10:34.702Z",
-    "activeTo" : "2023-06-16T05:59:29.627Z"
+    "activeFrom" : "2012-06-30T12:46:24.360Z",
+    "activeTo" : "2015-02-19T00:46:37.330Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cca63acf-f979-468a-a3b3-801b3e29f9b7",
-    "id" : "https://www.example.org/996a5970-e438-45c3-8907-6545645aedaa",
-    "identifier" : "kHAUG2vc3YvcgcZw",
+    "source" : "https://www.example.org/b06587a6-1d91-414a-880a-7f84bdd06429",
+    "id" : "https://www.example.org/9758a52d-c317-494a-95ca-11744298e71a",
+    "identifier" : "saNb6JjJgESVOL67GP",
     "labels" : {
-      "el" : "K2JiQrBD5WxwsSS"
+      "is" : "I6MSSptuwp"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1326862172
+      "currency" : "USD",
+      "amount" : 1160597636
     },
-    "activeFrom" : "1986-08-11T16:19:58.712Z",
-    "activeTo" : "2023-08-17T14:04:30.445Z"
+    "activeFrom" : "1971-03-04T17:27:30.205Z",
+    "activeTo" : "2016-01-05T09:14:58.630Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b5da9598-fda7-4d70-9524-b84dbe78c2dc" ],
+  "subjects" : [ "https://www.example.org/dac59b54-ffda-490a-94e6-c4ef567fe418" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ef2bebdd-2ace-4663-9fd9-6786152402a0",
-    "name" : "0eocrClnoiPL",
-    "mimeType" : "34wKezoygjCl0k",
-    "size" : 505049405,
-    "license" : "https://www.example.com/gblvacz4kmmn",
+    "identifier" : "54427a99-4b8c-48b9-b7dd-2a102a10fba0",
+    "name" : "d1CiNc1o0JE",
+    "mimeType" : "PeAWzlEBuQ",
+    "size" : 1375893258,
+    "license" : "https://www.example.com/m0i3spnjf9x",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "t1KENb8H5gmZ",
-    "publishedDate" : "1982-11-10T10:26:51.765Z",
+    "legalNote" : "1lK8TIvNEMpHdO",
+    "publishedDate" : "1988-10-03T18:16:33.649Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "tjOvPMQ2gisvmPVb9",
-      "uploadedDate" : "1992-09-21T01:58:14.693Z"
+      "uploadedBy" : "Vlbb7L8tu6Ax",
+      "uploadedDate" : "1994-01-21T13:42:05.742Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/u2bdLSMkSwXW",
-    "name" : "5li7eZS29facB",
-    "description" : "vBw89H2y0crNHmWCQW"
+    "id" : "https://www.example.com/qQwo4qkZrkJVsZp",
+    "name" : "SE40wnKzm8",
+    "description" : "yHPozvpvJUAIAmGKO"
   } ],
-  "rightsHolder" : "mSKY48JztChc4nHV4s",
-  "duplicateOf" : "https://www.example.org/c2c4642e-5e16-4d77-9e30-58648a057464",
+  "rightsHolder" : "eK2rC2WZ8gspFWbA",
+  "duplicateOf" : "https://www.example.org/bc950297-1aac-436e-9ae8-3e6c6f3135e4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UEH1CaR0Ynf598"
+    "note" : "S5xl6MTZx71johU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "01ERrKTJ4TExxQAY",
-    "createdBy" : "h9Bxp3cVK9",
-    "createdDate" : "2003-12-25T11:50:54.769Z"
+    "note" : "C4wgvIOZ9r1",
+    "createdBy" : "Sy9VtQazpWmPC9",
+    "createdDate" : "1995-09-18T10:15:08.220Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9288443a-413a-4424-a7cf-f40c30a659bd" ],
+  "curatingInstitutions" : [ "https://www.example.org/6a2697b1-1eb0-4bd1-a682-227e6a65c27c" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "MkHWwcHtSei",
-    "ownerAffiliation" : "https://www.example.org/c11fe04e-5d46-4f16-9dd9-19a797582b2a"
+    "owner" : "N3RmZnUNnGI",
+    "ownerAffiliation" : "https://www.example.org/4e037c8c-38fe-42c5-8263-275634e8cbab"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2b5d417d-f920-4763-a551-46da70cf4c9f"
+    "id" : "https://www.example.org/09066af9-a61c-4b2a-a110-2bc7e1136e3b"
   },
-  "createdDate" : "2004-12-26T11:18:06.459Z",
-  "modifiedDate" : "2013-10-23T05:50:25.977Z",
-  "publishedDate" : "1996-04-28T10:31:15.828Z",
-  "indexedDate" : "2021-03-16T02:17:09.774Z",
-  "handle" : "https://www.example.org/6332dbb8-04c5-4023-b9a7-04aaf0cb361c",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/29465b30-173e-45b5-a999-657b6d1abd02",
+  "createdDate" : "1981-07-04T05:19:50.541Z",
+  "modifiedDate" : "2023-06-21T09:36:22.051Z",
+  "publishedDate" : "1977-10-18T16:39:41.168Z",
+  "indexedDate" : "1994-05-13T05:58:10.482Z",
+  "handle" : "https://www.example.org/f0a4db66-8c69-455d-b9da-a5a31519f844",
+  "doi" : "https://doi.org/10.1234/sapiente",
+  "link" : "https://www.example.org/1ef05a6e-7344-4fe4-9c7c-401a2cd50851",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1Ksc62nxuhSrCm7yAe",
+    "mainTitle" : "pL5dr5kS5UJ4bkFin9",
     "alternativeTitles" : {
-      "af" : "nzDAvpGs0HEMpi"
+      "nl" : "Fm9RCqtLj8xa6DeC0Qy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7LkSbSpUPycAvb6GBlB",
-      "month" : "1SYK2gmHSK3UTb",
-      "day" : "tehtyj6VKkOdJG3qTd"
+      "year" : "ArawmM6RMyT65ohhR",
+      "month" : "b5Tb0CLFbemKyGyQr",
+      "day" : "qTXiDmQKXY"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4e7fef80-9374-401d-8771-fe14707b73a0",
-        "name" : "rmlkIrfkUYxDL",
-        "nameType" : "Organizational",
-        "orcId" : "tvChOIWeHC5PYhWUCL",
+        "id" : "https://www.example.org/32fbefc7-779b-406d-bb58-7200dfe90e7d",
+        "name" : "pPrmW8GWoJV",
+        "nameType" : "Personal",
+        "orcId" : "0VByU3UOpi",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gka8axsIjfMz4bhw",
-          "value" : "oRt2WxXmpzs"
+          "sourceName" : "iPsc6ruyh7Jyuziu",
+          "value" : "rdVFeTUmj9Q"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4CSuvQlbHgRYfh1",
-          "value" : "Ol1qKsM8Qlz8Qk1rS0f"
+          "sourceName" : "34tB2xZkTfZw7",
+          "value" : "r8f2gEpsAjKWTuHAb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ac477973-df29-425a-b5d5-86ca92d7ace3"
+        "id" : "https://www.example.org/7b8e8c57-a90b-4ae5-a86b-9461442ff17c"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Musician"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/50deb60d-8278-4cbc-8472-c9374512ebce",
-        "name" : "8KXIIzqw8CX9x9",
+        "id" : "https://www.example.org/56689550-8c95-43bb-b2ab-69af9ecd28a6",
+        "name" : "39alZUSVmY",
         "nameType" : "Organizational",
-        "orcId" : "nTPVS9d4Zo0L1CYLr",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "FX0V7iVWAQI5oztsAG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "waDwgh8w1BTdDoXvH",
-          "value" : "El5mtj34y2m4PgL"
+          "sourceName" : "oBWZ5ytqMrl",
+          "value" : "GVkzpqB8zOxUE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "99g9VRMlUHMt",
-          "value" : "qeOVW7bZkB4cSQ2X"
+          "sourceName" : "6q83VoSwK9qNertLl3O",
+          "value" : "9MGm0wXBrMw2tP6Cd"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1ae4a06b-bfbc-4a42-b328-f8da40f12e57"
+        "id" : "https://www.example.org/4908f078-e12d-4dec-85e4-3b311e0fc260"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "HostingInstitution"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "QxJ9QqYDcIExCh"
+      "zh" : "NYldRDPhVwwbKvAF"
     },
-    "npiSubjectHeading" : "y1diuA0nJW0zg3F2D56",
-    "tags" : [ "Va8nnrkwkUnciJZkx0" ],
-    "description" : "9lWb9wMdobN3dfjx",
+    "npiSubjectHeading" : "PcQm5dkKx570w",
+    "tags" : [ "ihLhmhOmWUI2UT" ],
+    "description" : "8xgWeYttbWPOTgBw8Co",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/d3k7lPatPRCGDNEzDnt"
+        "id" : "https://www.example.com/Z31gStAPqZ"
       },
-      "doi" : "https://www.example.org/bafc91fc-ae83-4b06-9203-0fe795ba6c35",
+      "doi" : "https://www.example.org/021c5b5e-5e70-4e99-99c5-f0b2df556c7c",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "JUigY1y7S1ryuq",
-          "end" : "hA2j8MIzhxMAPZ"
+          "begin" : "ppqsr3u3P9M9k",
+          "end" : "5wCK0p07yyCM"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3f423a2e-c2d1-4607-9249-c1a12541645e",
-    "abstract" : "gsCmTefa5axC"
+    "metadataSource" : "https://www.example.org/434f5784-99bc-4b60-9f0d-60ee81de43f7",
+    "abstract" : "wQDajSMBBAuNC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fa59bfd9-9483-4609-a3c7-728aa4c0f8fb",
-    "name" : "qt8Ec3udqfVeQS",
+    "id" : "https://www.example.org/94b3e4ae-39ed-4e25-859a-0d2243daca5b",
+    "name" : "YdOd8MxZAODFasd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1995-02-05T19:43:23.459Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "fLgb9A7s0w"
+      "approvalDate" : "1981-11-09T02:49:39.324Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "orOT57fL8pML30fmn"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2d514ac5-828d-4f0c-a51e-fca2031fd615",
-    "identifier" : "ko8Jnu9vVi",
+    "source" : "https://www.example.org/a5810a7b-2140-46f0-8154-f3c791dc64a1",
+    "identifier" : "43NvIXme4ievrIKL1nq",
     "labels" : {
-      "en" : "Updgdni473H"
+      "zh" : "5LaWkphFK0"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1856831159
+      "amount" : 1499699721
     },
-    "activeFrom" : "2003-08-15T12:53:26.884Z",
-    "activeTo" : "2015-04-18T10:39:06.210Z"
+    "activeFrom" : "2021-01-24T13:10:34.702Z",
+    "activeTo" : "2023-06-16T05:59:29.627Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/66cddaff-fc8d-4147-a00c-758acb1e869e",
-    "id" : "https://www.example.org/b0d71180-a768-40e8-82a0-782db14554fb",
-    "identifier" : "shrAnRqEbrc",
+    "source" : "https://www.example.org/cca63acf-f979-468a-a3b3-801b3e29f9b7",
+    "id" : "https://www.example.org/996a5970-e438-45c3-8907-6545645aedaa",
+    "identifier" : "kHAUG2vc3YvcgcZw",
     "labels" : {
-      "cs" : "LLadp8tMgXpy0q"
+      "el" : "K2JiQrBD5WxwsSS"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2057068913
+      "amount" : 1326862172
     },
-    "activeFrom" : "2003-01-04T14:44:07.541Z",
-    "activeTo" : "2010-09-21T18:22:27.225Z"
+    "activeFrom" : "1986-08-11T16:19:58.712Z",
+    "activeTo" : "2023-08-17T14:04:30.445Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3d7a60be-3a5f-49eb-a708-a12d69e2da4f" ],
+  "subjects" : [ "https://www.example.org/b5da9598-fda7-4d70-9524-b84dbe78c2dc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c6d6ca18-220a-42bc-baff-554b33574424",
-    "name" : "HamSvXoH2UYF28H",
-    "mimeType" : "TgzgxgOfMvpi5bMQ0",
-    "size" : 218957612,
-    "license" : "https://www.example.com/dy8npebacoxuuos",
+    "identifier" : "ef2bebdd-2ace-4663-9fd9-6786152402a0",
+    "name" : "0eocrClnoiPL",
+    "mimeType" : "34wKezoygjCl0k",
+    "size" : 505049405,
+    "license" : "https://www.example.com/gblvacz4kmmn",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vBr8UX9rruvHV",
-    "publishedDate" : "1978-05-16T03:24:01.571Z",
+    "legalNote" : "t1KENb8H5gmZ",
+    "publishedDate" : "1982-11-10T10:26:51.765Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "6INpFBms9YD2RVEDW",
-      "uploadedDate" : "2006-12-26T05:57:15.515Z"
+      "uploadedBy" : "tjOvPMQ2gisvmPVb9",
+      "uploadedDate" : "1992-09-21T01:58:14.693Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Q75Cdc7zMULjYRJRKaR",
-    "name" : "1uR1MG7UNikZAy7N",
-    "description" : "m89lZM1yBAO6d"
+    "id" : "https://www.example.com/u2bdLSMkSwXW",
+    "name" : "5li7eZS29facB",
+    "description" : "vBw89H2y0crNHmWCQW"
   } ],
-  "rightsHolder" : "YqT9ZGsoht4kBs3",
-  "duplicateOf" : "https://www.example.org/4eab3633-b935-4b00-82a6-772ff62b83e6",
+  "rightsHolder" : "mSKY48JztChc4nHV4s",
+  "duplicateOf" : "https://www.example.org/c2c4642e-5e16-4d77-9e30-58648a057464",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0PmM8PMUJ0BUBt55OPu"
+    "note" : "UEH1CaR0Ynf598"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WaDR6jPuRxNnXXi0",
-    "createdBy" : "tGed38oJZMptCEkcu",
-    "createdDate" : "2011-02-12T20:44:22.433Z"
+    "note" : "01ERrKTJ4TExxQAY",
+    "createdBy" : "h9Bxp3cVK9",
+    "createdDate" : "2003-12-25T11:50:54.769Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/77b8a389-a887-487f-9873-ab80a3350a1e" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/9288443a-413a-4424-a7cf-f40c30a659bd" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "xVAtnw8S1cBl8JTw",
-    "ownerAffiliation" : "https://www.example.org/7678829f-7f34-48d0-88ca-128ba5527ae3"
+    "owner" : "p9NuxrGqvAh",
+    "ownerAffiliation" : "https://www.example.org/f7c3a63b-9624-4954-8aff-256f73139d73"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f7efe863-c6c4-4088-a7ce-62a2789495bc"
+    "id" : "https://www.example.org/002e83a7-0425-47dd-a14e-cb16d2c1319c"
   },
-  "createdDate" : "2019-10-06T11:08:21.575Z",
-  "modifiedDate" : "2007-03-25T19:45:20.889Z",
-  "publishedDate" : "1985-06-22T16:48:59.180Z",
-  "indexedDate" : "1977-06-10T13:19:25.183Z",
-  "handle" : "https://www.example.org/eec00a08-bdb3-4993-a259-018d9299524a",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/3a971c03-f553-407a-bfe5-df75498d6b86",
+  "createdDate" : "2017-04-24T02:13:41.907Z",
+  "modifiedDate" : "2018-08-28T12:39:55.332Z",
+  "publishedDate" : "1996-04-30T20:43:00.077Z",
+  "indexedDate" : "2003-10-01T19:54:02.898Z",
+  "handle" : "https://www.example.org/5ba4c5b7-716f-4028-bba5-2beeb6844c07",
+  "doi" : "https://doi.org/10.1234/commodi",
+  "link" : "https://www.example.org/74fda560-2149-400c-a497-8e09047d50aa",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "a1SwKKx55xQx8",
+    "mainTitle" : "GF6k7434QvIS",
     "alternativeTitles" : {
-      "es" : "hUy5wIFk5T2Sc"
+      "ca" : "VNOGctEvgG40BN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "axmJNn3FTHvUlHy",
-      "month" : "UJtc1FWSGAlX",
-      "day" : "oLH0jFdyoV2Znr73B"
+      "year" : "ep6UFzfJhDZ21E67",
+      "month" : "yuBtGbDyEZfF",
+      "day" : "cYRU3zMYDbWQFBD7H"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/48b2c162-4820-49e7-8fac-f6edac6548bb",
-        "name" : "v8KtykvozXmDum",
+        "id" : "https://www.example.org/fe04329d-f57c-4e1b-94a1-5e7d283103c2",
+        "name" : "9PCzFlyjHnOOaILfB",
         "nameType" : "Personal",
-        "orcId" : "wcmE0A05nj9QvVBsWjW",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "svSriL0hBf",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LWvBTrrtqLoNBA",
-          "value" : "cxCvAefKhZVh6Ijaw"
+          "sourceName" : "ggROgboaOXW6sz",
+          "value" : "71VSpZZd9gya"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ksPmUMLkYH",
-          "value" : "A9aKl1EcBPa4DsDqq46"
+          "sourceName" : "PBoPzUNAJ0",
+          "value" : "lII3J4DHGiy93lCS2Qt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0fcc4e7b-33fb-4acb-a810-5be6db6e155a"
+        "id" : "https://www.example.org/04a1f202-c730-4d3c-b8eb-31d7def35dce"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/75377656-8998-474d-ad90-ebb8af45fb6d",
-        "name" : "hbvwuNWZUYSfo",
+        "id" : "https://www.example.org/11ad7d71-dfc2-4de0-92a4-6859fb713df1",
+        "name" : "8KuW9wWHc5h1ly3rVwE",
         "nameType" : "Personal",
-        "orcId" : "BhXaRObit9JfHW9TBgP",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CIfTcCau5Ju",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TibUqCiw5i9yrde40c2",
-          "value" : "GR7fkDoUjQ906nlKtBf"
+          "sourceName" : "SbOFNEZtB7VOi8qJv",
+          "value" : "T5N78nLQb1MTvnsr6F"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fhZYXGUQ07Qh",
-          "value" : "u05qzOQiOp7n"
+          "sourceName" : "ChqwbgKWd94vmRRIMhG",
+          "value" : "YeZzI6mfC69JP95Q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b84aee84-bdec-42b7-ade3-985bd83166ca"
+        "id" : "https://www.example.org/4cd8221e-945d-472d-a7d8-ca1ca041ce48"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "cEAXoVSJjdRIo"
+      "af" : "2EzvYt5BwsP8Y6fUP"
     },
-    "npiSubjectHeading" : "DEym1GXjtfIFUQqdn4s",
-    "tags" : [ "smqpECi8xLTAdCM6u" ],
-    "description" : "KUHOtlEKuQsAXc1VnI",
+    "npiSubjectHeading" : "SbcTbAGa7A",
+    "tags" : [ "oXcsB5zagn7CF5ntDUq" ],
+    "description" : "DnH2rHKLBSI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0fb27b74-ebea-4e0e-a586-9ea0bff561fc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d505dfa8-769a-4819-b95c-700383eae0f8"
         },
-        "seriesNumber" : "D9MPafSjV4lc",
+        "seriesNumber" : "IHLds0ZtuY",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9f4edb0c-a551-4e4c-9a70-cb25219b2763",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f1fef8a2-4ec8-44be-988a-86ee72d81448",
           "valid" : true
         },
-        "isbnList" : [ "9791918375427", "9781585064670" ],
+        "isbnList" : [ "9791673612973", "9780813444215" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "158506467X"
+          "value" : "0813444217"
         } ]
       },
-      "doi" : "https://www.example.org/4a6a01b1-23ae-403d-91c9-12017d85eacd",
+      "doi" : "https://www.example.org/7f37aea7-e9f4-4bf7-8c06-b044b6802e07",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "5wMi7CovOnwmd3vRqx",
-            "end" : "zIpTROY8QuRMGY8eC"
+            "begin" : "mYhdtoRfEDEW",
+            "end" : "zxUYAA4qO5RM99mSyqp"
           },
-          "pages" : "i7clwKm8eNkg77",
-          "illustrated" : false
+          "pages" : "bXoCe2J2NYDpeq",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/98641521-2b02-4a4f-a258-2f1a7f028769",
-    "abstract" : "iEZ94H7OUdnw"
+    "metadataSource" : "https://www.example.org/abf1fac5-aa5b-46ed-b790-3c2b2b571b46",
+    "abstract" : "ys7x9KvyA7SwbiFn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ec7365cc-0595-424b-9931-d51c2786a6e4",
-    "name" : "4PU1QAm5NV",
+    "id" : "https://www.example.org/ebe86fca-0c74-421f-8426-2d6f05c0aa0d",
+    "name" : "0o8iWiAgmR1W1ZI5d",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-10-27T07:41:24.573Z",
+      "approvalDate" : "1983-03-31T15:06:33.979Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "lFBuM2U2mzW"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "dheKmicxR2QlyAi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ce6ccba3-17ef-4dc7-b608-c46643569b3e",
-    "identifier" : "XaJdB0p2c3fIm",
+    "source" : "https://www.example.org/d0eff919-09db-481c-af5f-d87a77d0d8df",
+    "identifier" : "om3dllY7DxpzVbM",
     "labels" : {
-      "se" : "zjJA2sHkXzNqgS"
+      "pl" : "GBL511nVtkX"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 219013548
+      "amount" : 1916296686
     },
-    "activeFrom" : "1988-11-14T07:28:33.225Z",
-    "activeTo" : "1993-08-19T22:00:13.862Z"
+    "activeFrom" : "1985-02-09T08:15:27.414Z",
+    "activeTo" : "2001-10-07T09:52:21.888Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f66f65ff-e6d3-489b-9289-569bbe49538b",
-    "id" : "https://www.example.org/f1b6172b-1afb-4608-898c-7e9a2a5d8397",
-    "identifier" : "aPaMWS1Gso7ywjasLwW",
+    "source" : "https://www.example.org/3d237bdd-8858-4c62-a331-77e3a9504d21",
+    "id" : "https://www.example.org/92a90116-0e99-4656-b209-e9ceee7f48d4",
+    "identifier" : "3o2nI2dxXBjv",
     "labels" : {
-      "zh" : "SznuwPXcefupRvRa9S"
+      "nb" : "l1RGclIsF9ua2O"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 307856403
+      "currency" : "GBP",
+      "amount" : 354123092
     },
-    "activeFrom" : "1996-08-19T18:15:46.002Z",
-    "activeTo" : "1999-01-08T20:46:00.032Z"
+    "activeFrom" : "1986-12-24T22:02:34.629Z",
+    "activeTo" : "2010-12-02T01:45:48.291Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1005fe8f-81b7-49ea-b3cd-8a40ddde16d3" ],
+  "subjects" : [ "https://www.example.org/d764266a-8bb3-423b-a668-f0e52b946d4c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "da29864c-fddd-41b1-8354-b372b69efa64",
-    "name" : "0MaGPXP0A7",
-    "mimeType" : "XSxQYP0QUtu",
-    "size" : 1346262248,
-    "license" : "https://www.example.com/djasidhay24weg94qkv",
+    "identifier" : "fcbbdd6a-fa00-4457-9c27-43e5a2898eb9",
+    "name" : "ywbwTcE21qtH",
+    "mimeType" : "mUwijfwg5I2SmJ",
+    "size" : 1584826695,
+    "license" : "https://www.example.com/ft1lzvi2urbcpnephf",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "oWD5ffxSm9RBvu26T",
-    "publishedDate" : "2020-10-29T02:02:18.299Z",
+    "legalNote" : "RrWihs8V6zGP",
+    "publishedDate" : "2008-08-13T15:44:56.206Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "vvfNw8MUHFw74G5G",
-      "uploadedDate" : "2021-05-10T00:11:21.664Z"
+      "uploadedBy" : "26lrmyhw6KDH5mR84",
+      "uploadedDate" : "2004-04-06T22:52:38.588Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/A9Q5Twe8KHHQEe",
-    "name" : "aVLFuywUc5q",
-    "description" : "NBRsRyJJ73iay"
+    "id" : "https://www.example.com/uzAAvQmmcEur",
+    "name" : "KgjDSjzN1L6",
+    "description" : "OZia55EeCDkve63w"
   } ],
-  "rightsHolder" : "VltfXU6HJlNJvz4E4kQ",
-  "duplicateOf" : "https://www.example.org/6c924317-2844-4666-ae3f-f9e414a2f69b",
+  "rightsHolder" : "k5xEHCjcdVflt",
+  "duplicateOf" : "https://www.example.org/bb92583e-b7ac-47c3-a098-1b0fd53c3eb6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "R4laKew0AdPiSJGX3"
+    "note" : "gS4zS2OHLoiKT8WJswU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "reoKoKLq1G0b",
-    "createdBy" : "6nwdK8jaGd6t1T7c9",
-    "createdDate" : "1998-11-16T01:28:09.377Z"
+    "note" : "CIf9C4d8QtmK7",
+    "createdBy" : "bXDrPbdoTYEg",
+    "createdDate" : "2010-05-29T19:12:58.978Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f67dce2e-7130-41d6-81a5-c4ed00bc405f" ],
+  "curatingInstitutions" : [ "https://www.example.org/12a29beb-6449-4f36-87e8-70f41da66188" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "uNoUKFWYKV4DTS",
-    "ownerAffiliation" : "https://www.example.org/4584206e-e5ed-4719-bc43-1a41d38d55f1"
+    "owner" : "xVAtnw8S1cBl8JTw",
+    "ownerAffiliation" : "https://www.example.org/7678829f-7f34-48d0-88ca-128ba5527ae3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/259afe3e-1e28-4275-b412-ecfb2c05aeca"
+    "id" : "https://www.example.org/f7efe863-c6c4-4088-a7ce-62a2789495bc"
   },
-  "createdDate" : "2008-03-12T18:00:47.923Z",
-  "modifiedDate" : "2018-09-21T20:09:13.829Z",
-  "publishedDate" : "1988-01-23T14:36:06.352Z",
-  "indexedDate" : "2019-06-02T10:54:07.338Z",
-  "handle" : "https://www.example.org/f7f109d7-1ba3-4a2a-ae99-3ab4a26d9a4a",
-  "doi" : "https://doi.org/10.1234/tenetur",
-  "link" : "https://www.example.org/39eb5e9f-b76f-4f56-9b6a-c266eb0f74fd",
+  "createdDate" : "2019-10-06T11:08:21.575Z",
+  "modifiedDate" : "2007-03-25T19:45:20.889Z",
+  "publishedDate" : "1985-06-22T16:48:59.180Z",
+  "indexedDate" : "1977-06-10T13:19:25.183Z",
+  "handle" : "https://www.example.org/eec00a08-bdb3-4993-a259-018d9299524a",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/3a971c03-f553-407a-bfe5-df75498d6b86",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZJ8z8mpcf1ao",
+    "mainTitle" : "a1SwKKx55xQx8",
     "alternativeTitles" : {
-      "fr" : "golRDjhPWQRP"
+      "es" : "hUy5wIFk5T2Sc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bteQSPZ2rbOITC9C",
-      "month" : "i8GVIAIbJb8oF6OrL0N",
-      "day" : "V34N3JPJ9BtoWHbIRke"
+      "year" : "axmJNn3FTHvUlHy",
+      "month" : "UJtc1FWSGAlX",
+      "day" : "oLH0jFdyoV2Znr73B"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/334dd8a1-ceab-4697-91e1-37fcfaf6eef7",
-        "name" : "6xqFdxduK0U6tu",
+        "id" : "https://www.example.org/48b2c162-4820-49e7-8fac-f6edac6548bb",
+        "name" : "v8KtykvozXmDum",
         "nameType" : "Personal",
-        "orcId" : "azmmmopWEk5",
+        "orcId" : "wcmE0A05nj9QvVBsWjW",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MncFXZvC565N",
-          "value" : "9snLxgO2B8Znl"
+          "sourceName" : "LWvBTrrtqLoNBA",
+          "value" : "cxCvAefKhZVh6Ijaw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4LFAMF1roiIJdg5x3SP",
-          "value" : "xMHDmFvkzIzxy"
+          "sourceName" : "ksPmUMLkYH",
+          "value" : "A9aKl1EcBPa4DsDqq46"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/95888bf9-4023-4914-8275-4d6c61460880"
+        "id" : "https://www.example.org/0fcc4e7b-33fb-4acb-a810-5be6db6e155a"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b0dce5e2-5285-47de-873f-f4263ed0ee2b",
-        "name" : "qRuFJMWwBxzWzHX6l",
+        "id" : "https://www.example.org/75377656-8998-474d-ad90-ebb8af45fb6d",
+        "name" : "hbvwuNWZUYSfo",
         "nameType" : "Personal",
-        "orcId" : "82HyKBEc3j",
-        "verificationStatus" : "Verified",
+        "orcId" : "BhXaRObit9JfHW9TBgP",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wlGLIrHRgaYu1S",
-          "value" : "oK6SvAfGRYvJDvxmZW7"
+          "sourceName" : "TibUqCiw5i9yrde40c2",
+          "value" : "GR7fkDoUjQ906nlKtBf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t9sKYCxPT2c2EPmWa",
-          "value" : "xOO3Qtr9DSw3HrnehV"
+          "sourceName" : "fhZYXGUQ07Qh",
+          "value" : "u05qzOQiOp7n"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d1f33624-eedd-4153-9f8c-773432b0aecb"
+        "id" : "https://www.example.org/b84aee84-bdec-42b7-ade3-985bd83166ca"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "nsp77TDCbacjnpaVQ"
+      "bg" : "cEAXoVSJjdRIo"
     },
-    "npiSubjectHeading" : "jAbuCbAwC3s",
-    "tags" : [ "4DgDbywHnjvSq7KVwRJ" ],
-    "description" : "wwXQxBlppBYfdf",
+    "npiSubjectHeading" : "DEym1GXjtfIFUQqdn4s",
+    "tags" : [ "smqpECi8xLTAdCM6u" ],
+    "description" : "KUHOtlEKuQsAXc1VnI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/70be10f5-2c9e-4770-85e0-ffafb49faf98"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0fb27b74-ebea-4e0e-a586-9ea0bff561fc"
         },
-        "seriesNumber" : "4OHlXluSQGFOdLybV",
+        "seriesNumber" : "D9MPafSjV4lc",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dcee8d8f-17e7-4e51-b79d-2d783197f13c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9f4edb0c-a551-4e4c-9a70-cb25219b2763",
           "valid" : true
         },
-        "isbnList" : [ "9791844128340" ],
+        "isbnList" : [ "9791918375427", "9781585064670" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "OxaJxOOXOoR"
+          "value" : "158506467X"
         } ]
       },
-      "doi" : "https://www.example.org/d828d033-2b59-40da-ba44-6b3f377e09a2",
+      "doi" : "https://www.example.org/4a6a01b1-23ae-403d-91c9-12017d85eacd",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "oPUhHWjkB7oRhvKgDfs",
-            "end" : "OgIQYg242qTs26"
+            "begin" : "5wMi7CovOnwmd3vRqx",
+            "end" : "zIpTROY8QuRMGY8eC"
           },
-          "pages" : "PErroNcWJDLF3y",
+          "pages" : "i7clwKm8eNkg77",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f8529191-a168-4e93-9281-021bf59260df",
-    "abstract" : "vDcJ4HUIW1W75Hwtkq"
+    "metadataSource" : "https://www.example.org/98641521-2b02-4a4f-a258-2f1a7f028769",
+    "abstract" : "iEZ94H7OUdnw"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3078e69f-8bde-421b-a2b8-71632598aa95",
-    "name" : "EmAXHAtFLddoY",
+    "id" : "https://www.example.org/ec7365cc-0595-424b-9931-d51c2786a6e4",
+    "name" : "4PU1QAm5NV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-05-10T13:38:44.789Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "Kbp7qrhtEHRRBrbHUi"
+      "approvalDate" : "2011-10-27T07:41:24.573Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "lFBuM2U2mzW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cd56df8a-d31a-4016-8e76-628abc0c9477",
-    "identifier" : "Q873Po4dQUxOQTWlrLD",
+    "source" : "https://www.example.org/ce6ccba3-17ef-4dc7-b608-c46643569b3e",
+    "identifier" : "XaJdB0p2c3fIm",
     "labels" : {
-      "en" : "TE0Bc2ZUpu2g6mHr8o"
+      "se" : "zjJA2sHkXzNqgS"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1093433008
+      "amount" : 219013548
     },
-    "activeFrom" : "2004-10-06T21:40:12.013Z",
-    "activeTo" : "2011-02-13T16:14:43.183Z"
+    "activeFrom" : "1988-11-14T07:28:33.225Z",
+    "activeTo" : "1993-08-19T22:00:13.862Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ecd6d1cf-880e-4c61-be6d-de3899a5d8e8",
-    "id" : "https://www.example.org/a03fc11d-0c9a-473f-a241-f40e56e64fb6",
-    "identifier" : "C9it6VvIGZ3hAd8fQjc",
+    "source" : "https://www.example.org/f66f65ff-e6d3-489b-9289-569bbe49538b",
+    "id" : "https://www.example.org/f1b6172b-1afb-4608-898c-7e9a2a5d8397",
+    "identifier" : "aPaMWS1Gso7ywjasLwW",
     "labels" : {
-      "nb" : "Ey8K7h9FcIFc5Mo8W"
+      "zh" : "SznuwPXcefupRvRa9S"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1732618755
+      "currency" : "USD",
+      "amount" : 307856403
     },
-    "activeFrom" : "1990-08-18T17:51:58.712Z",
-    "activeTo" : "2021-10-05T20:16:12.092Z"
+    "activeFrom" : "1996-08-19T18:15:46.002Z",
+    "activeTo" : "1999-01-08T20:46:00.032Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/defbed1a-0c26-40c5-b951-ecc3d2f9ab04" ],
+  "subjects" : [ "https://www.example.org/1005fe8f-81b7-49ea-b3cd-8a40ddde16d3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5da7923f-2b19-463a-9dfd-5c5342d9c932",
-    "name" : "w2Xroc2Tr1",
-    "mimeType" : "L2qAZ6JNwMDdXwsZ",
-    "size" : 1478252774,
-    "license" : "https://www.example.com/yhqgkwjpzi",
+    "identifier" : "da29864c-fddd-41b1-8354-b372b69efa64",
+    "name" : "0MaGPXP0A7",
+    "mimeType" : "XSxQYP0QUtu",
+    "size" : 1346262248,
+    "license" : "https://www.example.com/djasidhay24weg94qkv",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "urLMvgYzjAihQrJ"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "qUb1MUBH7hKpM",
-    "publishedDate" : "1978-10-22T04:46:08.413Z",
+    "legalNote" : "oWD5ffxSm9RBvu26T",
+    "publishedDate" : "2020-10-29T02:02:18.299Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ihvdoAY7ZFPX",
-      "uploadedDate" : "1989-06-07T00:00:03.427Z"
+      "uploadedBy" : "vvfNw8MUHFw74G5G",
+      "uploadedDate" : "2021-05-10T00:11:21.664Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/lLKHYo3w1km97lod5",
-    "name" : "AMs8rZWQaK",
-    "description" : "8rf0s3MBqHvrKz2UT"
+    "id" : "https://www.example.com/A9Q5Twe8KHHQEe",
+    "name" : "aVLFuywUc5q",
+    "description" : "NBRsRyJJ73iay"
   } ],
-  "rightsHolder" : "RWOufyU2Dbto",
-  "duplicateOf" : "https://www.example.org/a51ab99f-7afe-4ce2-bb7c-fa603a5a6b88",
+  "rightsHolder" : "VltfXU6HJlNJvz4E4kQ",
+  "duplicateOf" : "https://www.example.org/6c924317-2844-4666-ae3f-f9e414a2f69b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "raBRq51mGx0TaYEXgx"
+    "note" : "R4laKew0AdPiSJGX3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GAy1QY8G8tAzTtRF",
-    "createdBy" : "CxOB5PTixBj57zk",
-    "createdDate" : "1973-07-18T12:24:49.326Z"
+    "note" : "reoKoKLq1G0b",
+    "createdBy" : "6nwdK8jaGd6t1T7c9",
+    "createdDate" : "1998-11-16T01:28:09.377Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/53be58ed-6931-4da2-9f6d-e3c43bbf0401" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/f67dce2e-7130-41d6-81a5-c4ed00bc405f" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "7Rjzw3rcPnmlCEWzE9f",
-    "ownerAffiliation" : "https://www.example.org/c35d1384-2395-4480-aeaf-d068115872ca"
+    "owner" : "DbdFiaMK6Zy0woEro",
+    "ownerAffiliation" : "https://www.example.org/fe3ad466-24fa-492e-867f-3a79e44211de"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1ada7f10-b956-429e-9a0d-0da6f1716921"
+    "id" : "https://www.example.org/8fa67d65-3f27-4e0d-bfa6-ccf8062774af"
   },
-  "createdDate" : "2004-10-25T15:00:25.778Z",
-  "modifiedDate" : "2022-12-21T07:31:07.505Z",
-  "publishedDate" : "1991-12-25T13:19:12.594Z",
-  "indexedDate" : "2003-09-19T12:02:15.475Z",
-  "handle" : "https://www.example.org/2610776b-f521-407a-8c89-9d06a3687a8b",
-  "doi" : "https://doi.org/10.1234/aliquam",
-  "link" : "https://www.example.org/a4a038dc-019f-495d-a97f-c22a3f328269",
+  "createdDate" : "2008-03-30T10:28:14.605Z",
+  "modifiedDate" : "2014-07-23T16:54:49.676Z",
+  "publishedDate" : "1974-03-03T03:25:57.661Z",
+  "indexedDate" : "1973-09-06T19:47:02.578Z",
+  "handle" : "https://www.example.org/4e99df77-972d-4fe0-9ca8-3e63764ee2bd",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/43cfc783-33ea-49f2-bc07-98cecb392cd6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jjYCVpfRzXc1np3qdaP",
+    "mainTitle" : "hWYJ768aS7QpEVMIqBe",
     "alternativeTitles" : {
-      "de" : "to9Cqpu5mQiqU"
+      "hu" : "IH9xNmN3qpaDZlaOFov"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "YfQDUEpQkj",
-      "month" : "JftIl8B2iASSI4IkwCT",
-      "day" : "BLo53Hrm3vE8VphY4"
+      "year" : "zCnXC3L4Bsdb4",
+      "month" : "NKoYgHUKOoS",
+      "day" : "QtNahhfdDcu4Xu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1f438777-1af2-4bde-a90e-5c7fe5478d70",
-        "name" : "ePqw84TQ1JZ8arV",
-        "nameType" : "Organizational",
-        "orcId" : "TuGeowAnzUlA",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/b1d7acdb-4fdb-44c3-aecc-3748929e4219",
+        "name" : "nJTz0uN4P9hHa7Zg",
+        "nameType" : "Personal",
+        "orcId" : "LYYd3KJFpDlwP",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xiNry8V1SaD1fty3C",
-          "value" : "DgyqeF362VsIVvNjekx"
+          "sourceName" : "D0MZWA5m9t",
+          "value" : "NXmOlHm1LQujoq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8yj7Zzcfy6WgOB1Qo",
-          "value" : "Nbzvxrh5n7Ts57"
+          "sourceName" : "Jhha1wUFUFszISXZl8u",
+          "value" : "GDeLmGSfJWXAS0utv2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9d3b75ad-ccf9-4009-a8fb-5a5724783509"
+        "id" : "https://www.example.org/03f93a8a-b779-4f3a-956a-a94921b9ec7c"
       } ],
       "role" : {
         "type" : "WorkPackageLeader"
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f989161a-bf28-435e-8297-034fc809983f",
-        "name" : "HNGdObAORfBcgJzyV",
-        "nameType" : "Organizational",
-        "orcId" : "aFPwBkb0rHGLt",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/0cbbe7d2-14e9-4dae-9d40-19ea3c925998",
+        "name" : "gx2arcSU3o",
+        "nameType" : "Personal",
+        "orcId" : "UtjVm6OkshUE",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NgiltMOPclGWCpB9W2X",
-          "value" : "DLhswIEFVn"
+          "sourceName" : "u7S4uPlapxDDzOx6",
+          "value" : "Ifbw2F9zN9H"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5W1cqChgY16",
-          "value" : "p6m46YKBRi3LPbzXC81"
+          "sourceName" : "QAWyH7pgYcaIL",
+          "value" : "oM2DpjZNXUIwRD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1f785850-e4af-4c46-b40d-57c3c72b971e"
+        "id" : "https://www.example.org/1072ef82-d9db-45aa-8f3e-933e8e3b265c"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "zcD2F0ZZPGP"
+        "type" : "Curator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "RyDfFU0Y597d9KkoIw"
+      "de" : "J5QL60m9oVcyoO8V7"
     },
-    "npiSubjectHeading" : "mmBzJUjnQBF",
-    "tags" : [ "jCVo8vJ182C" ],
-    "description" : "arzM9ttzNIl",
+    "npiSubjectHeading" : "8wUJxFl4H0kjROOa",
+    "tags" : [ "fxuKUwWKZmtO" ],
+    "description" : "wMy8f8tyzTlaty1js",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/943de947-268e-456f-a133-9236808911ab"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d55c6222-0762-42cb-85d1-0fa7ecb967ad"
       },
-      "doi" : "https://www.example.org/aef641f4-98aa-4f51-886c-cb06e0ab3f61",
+      "doi" : "https://www.example.org/345c9614-86e0-4703-aa4c-309245c27f6e",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "SNiz7SGVE1gGarrW7B",
-          "end" : "GXOaBK4yp8"
+          "begin" : "4ecrpx9ocAklx7wL",
+          "end" : "0ocZtJBNTaXVGc7us"
         },
-        "volume" : "eEULjh7vA8wMU",
-        "issue" : "46uZek80fn11CXKd3aI",
-        "articleNumber" : "VOcvVhMI7PhPiz"
+        "volume" : "rTg8xQ7jypZCEsYurVX",
+        "issue" : "zgwyxJvxupqwFqBC",
+        "articleNumber" : "bsT18hkedO"
       }
     },
-    "metadataSource" : "https://www.example.org/99e0d9b7-d3fd-4e16-9e90-ea3480416a6f",
-    "abstract" : "hE5KC913rhj"
+    "metadataSource" : "https://www.example.org/104ed488-7e0f-4197-a024-bcd357cad9a4",
+    "abstract" : "qecxcxm7DG8roIts"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/72080033-bf05-43f6-94b2-15f322a8008f",
-    "name" : "VelaZ2HZtGrXjSoP",
+    "id" : "https://www.example.org/b86b5d9a-1388-49d5-a6f0-54701e346ceb",
+    "name" : "lnQ67diYCGEfc9ZC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-06-05T01:45:02.525Z",
+      "approvalDate" : "2017-12-12T21:23:41.624Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "X2jyJnbQFaQQ85T"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "uEmPpY9keGxC"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/45586d5a-083b-42dd-aef9-7c22d9f8f6d3",
-    "identifier" : "4FRluzTz2U3pYUl",
+    "source" : "https://www.example.org/5cab3843-8f2a-4cd9-8bd6-0dcefab6678f",
+    "identifier" : "omxoc7WXM3W3fI",
     "labels" : {
-      "bg" : "Ls4p1Rw3ioT4LVgIMz"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 353494266
-    },
-    "activeFrom" : "1985-08-13T15:00:11.613Z",
-    "activeTo" : "1997-06-15T13:27:21.666Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e437c534-b31f-423f-9b12-b972216e8718",
-    "id" : "https://www.example.org/c459e6b0-292a-4646-9bc4-aae8a3b06322",
-    "identifier" : "fgxubfusdSBd7h",
-    "labels" : {
-      "it" : "BmXs7ySlSxDkwrTCsa6"
+      "fr" : "uE61IyyzgMLqk5OtER"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 765599608
+      "amount" : 34391226
     },
-    "activeFrom" : "1997-06-01T17:02:10.970Z",
-    "activeTo" : "2003-07-31T21:27:33.156Z"
+    "activeFrom" : "2018-03-05T13:47:22.302Z",
+    "activeTo" : "2019-02-04T10:56:45.549Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/90d023b3-a097-4909-afd2-6e04ba3d9a78",
+    "id" : "https://www.example.org/dbf9c22d-5427-4b82-a6e4-45b96435c6d5",
+    "identifier" : "tDtRgmhbYq2F58",
+    "labels" : {
+      "sv" : "PNE472qDS5Yye"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1110139077
+    },
+    "activeFrom" : "1985-09-22T23:42:19.994Z",
+    "activeTo" : "1987-08-21T14:42:12.272Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4cb2a200-098c-4c11-934e-849b40c54326" ],
+  "subjects" : [ "https://www.example.org/f55d6c93-1df6-4f25-975d-fcd264427914" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e0a17872-8e0b-4ee0-ac20-74bf60d11356",
-    "name" : "XvgapeeVC2Qr9XETjH5",
-    "mimeType" : "Txfo7BGitkXcWt74",
-    "size" : 352150238,
-    "license" : "https://www.example.com/adhminusun",
+    "identifier" : "b8359792-9605-4fe1-a196-9efa46623057",
+    "name" : "peqZiDXzHqeiI",
+    "mimeType" : "gaIAOoNqA3l27QtA24",
+    "size" : 1477500990,
+    "license" : "https://www.example.com/dyjjlwi81txp",
     "administrativeAgreement" : false,
     "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "gSWYTbQ5YNKuTnP",
-    "publishedDate" : "1998-07-18T00:51:01.570Z",
+    "legalNote" : "sAFgK9XQPHg7N3zst",
+    "publishedDate" : "2016-04-04T20:47:12.734Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "xRhywtKNiZI",
-      "uploadedDate" : "1990-06-11T16:47:46.910Z"
+      "uploadedBy" : "cB0nhO6XR06OodXp9K3",
+      "uploadedDate" : "2001-04-28T02:06:31.145Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TbOxxI7RpC7Nn78",
-    "name" : "l2j9nwexYpT6",
-    "description" : "cRZWeeEVUVY"
+    "id" : "https://www.example.com/s76cDO1QFmVk2yk",
+    "name" : "m9CipSiZ0HO",
+    "description" : "KBhsbDVjlFM6paZk"
   } ],
-  "rightsHolder" : "eMWGprVwGb",
-  "duplicateOf" : "https://www.example.org/16de7aa2-40fa-4410-907c-c09c169419d3",
+  "rightsHolder" : "ohBRAwcxHFZKC",
+  "duplicateOf" : "https://www.example.org/67c16533-390a-4287-a45e-cd4e288926fb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "OGbOZW6dOHsIty"
+    "note" : "ZuxSoc0hdhWISMBst"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8JQAEaZmbx",
-    "createdBy" : "0YgXyYFgZ1rUEvf",
-    "createdDate" : "2000-03-25T09:34:10.514Z"
+    "note" : "cgEFWVGXtd",
+    "createdBy" : "bech1QBL9XUEgV",
+    "createdDate" : "2008-03-02T22:13:50.429Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/113fa86b-b20d-41f8-b0c2-19a966ee022b" ],
+  "curatingInstitutions" : [ "https://www.example.org/d40a88f8-ed26-43ec-a2b2-a7e5e99747bc" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "iP3pII9Bl6iatp",
-    "ownerAffiliation" : "https://www.example.org/e413cf48-de55-411e-a65a-838b94edaf22"
+    "owner" : "7Rjzw3rcPnmlCEWzE9f",
+    "ownerAffiliation" : "https://www.example.org/c35d1384-2395-4480-aeaf-d068115872ca"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1e513af8-e3e4-46b5-bfea-6f8d6570c091"
+    "id" : "https://www.example.org/1ada7f10-b956-429e-9a0d-0da6f1716921"
   },
-  "createdDate" : "2005-01-17T18:40:16.984Z",
-  "modifiedDate" : "2012-04-15T01:24:51.211Z",
-  "publishedDate" : "1994-01-21T01:53:47.612Z",
-  "indexedDate" : "1991-08-26T17:12:02.126Z",
-  "handle" : "https://www.example.org/e64958ae-3342-4ba2-88d3-be4c53ff5f02",
-  "doi" : "https://doi.org/10.1234/cumque",
-  "link" : "https://www.example.org/2aeafb19-df41-4709-9fbb-fd3446664212",
+  "createdDate" : "2004-10-25T15:00:25.778Z",
+  "modifiedDate" : "2022-12-21T07:31:07.505Z",
+  "publishedDate" : "1991-12-25T13:19:12.594Z",
+  "indexedDate" : "2003-09-19T12:02:15.475Z",
+  "handle" : "https://www.example.org/2610776b-f521-407a-8c89-9d06a3687a8b",
+  "doi" : "https://doi.org/10.1234/aliquam",
+  "link" : "https://www.example.org/a4a038dc-019f-495d-a97f-c22a3f328269",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AA4Zq8AXuZwz",
+    "mainTitle" : "jjYCVpfRzXc1np3qdaP",
     "alternativeTitles" : {
-      "ca" : "pzM2QqtuMpKJ"
+      "de" : "to9Cqpu5mQiqU"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ASaHqEb7aoU",
-      "month" : "LDsnevnVWZsppBx",
-      "day" : "ziOuI05lXx6VhN7"
+      "year" : "YfQDUEpQkj",
+      "month" : "JftIl8B2iASSI4IkwCT",
+      "day" : "BLo53Hrm3vE8VphY4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/91f4a4b5-0025-4fea-a835-1f64a3a675d1",
-        "name" : "cOqzTCMz6wI",
-        "nameType" : "Personal",
-        "orcId" : "gyMPMkYnxkcAoeSp4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1f438777-1af2-4bde-a90e-5c7fe5478d70",
+        "name" : "ePqw84TQ1JZ8arV",
+        "nameType" : "Organizational",
+        "orcId" : "TuGeowAnzUlA",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WF9IRWe2X1IlNYROS5M",
-          "value" : "g7vuDPOwWESN7nCyLC"
+          "sourceName" : "xiNry8V1SaD1fty3C",
+          "value" : "DgyqeF362VsIVvNjekx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FIdzm04wyUwtJZSfzYK",
-          "value" : "KrJyPnLABzRIME3E"
+          "sourceName" : "8yj7Zzcfy6WgOB1Qo",
+          "value" : "Nbzvxrh5n7Ts57"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1becc055-9f7b-46b9-92b1-b8018fe3854a"
+        "id" : "https://www.example.org/9d3b75ad-ccf9-4009-a8fb-5a5724783509"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/52935552-4105-4f18-be10-964740e182ef",
-        "name" : "NuwrQ6TewOT1HS",
+        "id" : "https://www.example.org/f989161a-bf28-435e-8297-034fc809983f",
+        "name" : "HNGdObAORfBcgJzyV",
         "nameType" : "Organizational",
-        "orcId" : "NUr29TvTK8z8P",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "aFPwBkb0rHGLt",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7sYgdjoVHjtlc",
-          "value" : "hXzTVXye2vgRXlPx9h"
+          "sourceName" : "NgiltMOPclGWCpB9W2X",
+          "value" : "DLhswIEFVn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JtES2wCSwFuP2M",
-          "value" : "hQbN0FXREp3"
+          "sourceName" : "5W1cqChgY16",
+          "value" : "p6m46YKBRi3LPbzXC81"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4eab535a-f918-42f3-b842-15921759a2f2"
+        "id" : "https://www.example.org/1f785850-e4af-4c46-b40d-57c3c72b971e"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "RoleOther",
+        "description" : "zcD2F0ZZPGP"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "Ot567LpSwaHYr3rj60R"
+      "pt" : "RyDfFU0Y597d9KkoIw"
     },
-    "npiSubjectHeading" : "zaqBxOimYcD",
-    "tags" : [ "82D58ALjeWdlk" ],
-    "description" : "R7xHZl5JexWQPt",
+    "npiSubjectHeading" : "mmBzJUjnQBF",
+    "tags" : [ "jCVo8vJ182C" ],
+    "description" : "arzM9ttzNIl",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/98f53b33-2d19-4af8-b188-c3c5a87ebd20"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/943de947-268e-456f-a133-9236808911ab"
       },
-      "doi" : "https://www.example.org/06e5e69f-00a0-46ef-82c0-c8f0f43b006e",
+      "doi" : "https://www.example.org/aef641f4-98aa-4f51-886c-cb06e0ab3f61",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "IL67vjvtXS",
-          "end" : "HuH02Z3f4yuzVar8Y"
+          "begin" : "SNiz7SGVE1gGarrW7B",
+          "end" : "GXOaBK4yp8"
         },
-        "volume" : "9lDCxMORFpG3FBvOZj",
-        "issue" : "MzRxMyS4II",
-        "articleNumber" : "p0K1hxcH3qfI"
+        "volume" : "eEULjh7vA8wMU",
+        "issue" : "46uZek80fn11CXKd3aI",
+        "articleNumber" : "VOcvVhMI7PhPiz"
       }
     },
-    "metadataSource" : "https://www.example.org/56e16613-4e10-45c7-837f-e75e17fcd725",
-    "abstract" : "WS1ehXcd9Nj4xM1IR9j"
+    "metadataSource" : "https://www.example.org/99e0d9b7-d3fd-4e16-9e90-ea3480416a6f",
+    "abstract" : "hE5KC913rhj"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4a9e8419-e465-487c-8b6f-b7816eba0d83",
-    "name" : "bRMwzCrsqNqDhKzfY",
+    "id" : "https://www.example.org/72080033-bf05-43f6-94b2-15f322a8008f",
+    "name" : "VelaZ2HZtGrXjSoP",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-11-21T01:38:41.053Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "Pwi84xYe2b"
+      "approvalDate" : "2001-06-05T01:45:02.525Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "X2jyJnbQFaQQ85T"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e81423d2-f19b-46a7-94cd-dfd1a6a172ab",
-    "identifier" : "sbhE0ZnZAvvtoCcHcDg",
+    "source" : "https://www.example.org/45586d5a-083b-42dd-aef9-7c22d9f8f6d3",
+    "identifier" : "4FRluzTz2U3pYUl",
     "labels" : {
-      "el" : "SmksIvlByiG8cYCMd"
+      "bg" : "Ls4p1Rw3ioT4LVgIMz"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1489713001
+      "currency" : "USD",
+      "amount" : 353494266
     },
-    "activeFrom" : "2009-08-29T01:36:41.268Z",
-    "activeTo" : "2016-09-18T23:11:12.824Z"
+    "activeFrom" : "1985-08-13T15:00:11.613Z",
+    "activeTo" : "1997-06-15T13:27:21.666Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/45acd418-5159-4a9b-afa2-3f6447565ae3",
-    "id" : "https://www.example.org/c0425a1c-cca2-4aa3-ac42-0511e2ab8f03",
-    "identifier" : "wECphLg7XdFX",
+    "source" : "https://www.example.org/e437c534-b31f-423f-9b12-b972216e8718",
+    "id" : "https://www.example.org/c459e6b0-292a-4646-9bc4-aae8a3b06322",
+    "identifier" : "fgxubfusdSBd7h",
     "labels" : {
-      "it" : "MMH8C1cFSWwTgc"
+      "it" : "BmXs7ySlSxDkwrTCsa6"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1758351276
+      "amount" : 765599608
     },
-    "activeFrom" : "2020-11-08T10:35:15.375Z",
-    "activeTo" : "2021-04-23T07:42:15.274Z"
+    "activeFrom" : "1997-06-01T17:02:10.970Z",
+    "activeTo" : "2003-07-31T21:27:33.156Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a6ea4b31-8e10-4d58-b6c0-03f842cdd636" ],
+  "subjects" : [ "https://www.example.org/4cb2a200-098c-4c11-934e-849b40c54326" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "db7a9d87-b5ed-4401-baf5-1f884223fa58",
-    "name" : "ipA1obWiur8v",
-    "mimeType" : "pTs3UHLFBNnxWong",
-    "size" : 1733884839,
-    "license" : "https://www.example.com/mb6qk74bhaescix",
+    "identifier" : "e0a17872-8e0b-4ee0-ac20-74bf60d11356",
+    "name" : "XvgapeeVC2Qr9XETjH5",
+    "mimeType" : "Txfo7BGitkXcWt74",
+    "size" : 352150238,
+    "license" : "https://www.example.com/adhminusun",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "nOWwtDTFz2"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "H5dUUFKVYBKIb",
-    "publishedDate" : "2006-10-01T14:02:20.663Z",
+    "legalNote" : "gSWYTbQ5YNKuTnP",
+    "publishedDate" : "1998-07-18T00:51:01.570Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "X07NDqgkhfT47W",
-      "uploadedDate" : "2010-08-11T08:27:21.377Z"
+      "uploadedBy" : "xRhywtKNiZI",
+      "uploadedDate" : "1990-06-11T16:47:46.910Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zCI95jUTT3g5fy",
-    "name" : "Q0amlOnV8gIVeqZGgM",
-    "description" : "fjSg7NnWiMDj"
+    "id" : "https://www.example.com/TbOxxI7RpC7Nn78",
+    "name" : "l2j9nwexYpT6",
+    "description" : "cRZWeeEVUVY"
   } ],
-  "rightsHolder" : "NsGVFle7ScxgQXVme",
-  "duplicateOf" : "https://www.example.org/12a4067f-c82d-43d5-bc22-87e3dfaf0e72",
+  "rightsHolder" : "eMWGprVwGb",
+  "duplicateOf" : "https://www.example.org/16de7aa2-40fa-4410-907c-c09c169419d3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "uvv5akmjW9m1"
+    "note" : "OGbOZW6dOHsIty"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ouRGSjAUxVlbJOb",
-    "createdBy" : "s17AW0IoQCs2fhl9",
-    "createdDate" : "1983-03-26T21:59:46.294Z"
+    "note" : "8JQAEaZmbx",
+    "createdBy" : "0YgXyYFgZ1rUEvf",
+    "createdDate" : "2000-03-25T09:34:10.514Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/cc862f58-400f-4330-ad06-4ced6239bc05" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/113fa86b-b20d-41f8-b0c2-19a966ee022b" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "BAnraIch8mP",
-    "ownerAffiliation" : "https://www.example.org/a3a9ab14-5e88-4379-984b-decec1eb12e8"
+    "owner" : "wjGudGNBysRefeTy7e",
+    "ownerAffiliation" : "https://www.example.org/92b186eb-fe13-4c52-bd50-5d7f3219f13c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cb0112ec-9f59-4d41-87eb-07661df864cd"
+    "id" : "https://www.example.org/0a7b7448-166e-4eef-b569-29b59acaae5a"
   },
-  "createdDate" : "2013-09-05T07:40:41.496Z",
-  "modifiedDate" : "2020-01-04T21:30:43.099Z",
-  "publishedDate" : "1985-06-11T20:27:38.644Z",
-  "indexedDate" : "1972-11-30T11:50:37.349Z",
-  "handle" : "https://www.example.org/72dc776c-0116-4795-b832-94a12668ff34",
-  "doi" : "https://doi.org/10.1234/adipisci",
-  "link" : "https://www.example.org/99d82164-fdcd-4629-9d30-0022920acf55",
+  "createdDate" : "2018-02-16T08:44:47.849Z",
+  "modifiedDate" : "1990-12-21T18:23:21.392Z",
+  "publishedDate" : "2019-06-01T03:18:24.135Z",
+  "indexedDate" : "2010-12-31T06:01:24.579Z",
+  "handle" : "https://www.example.org/2ebe841d-e9de-4483-ad3f-022b31478de2",
+  "doi" : "https://doi.org/10.1234/asperiores",
+  "link" : "https://www.example.org/25de5ce5-82d3-470c-aa20-13170b3269f5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zG7DC6kVHCj7",
+    "mainTitle" : "Xsla55eDLGgW4J9FCR0",
     "alternativeTitles" : {
-      "el" : "9z7mf9nMwRL"
+      "it" : "wOt0c0tA4vXUTxpUG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3NzEgMhdfB",
-      "month" : "OQrViesM3pPn9xpAe3",
-      "day" : "EMfQKzdflkZ5"
+      "year" : "E1TzMjhEkvZxlXXR",
+      "month" : "N1mZ2eSYAfn",
+      "day" : "VLclK0wl4E6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/32d04523-be46-4b2e-b1ed-74b218fe3a44",
-        "name" : "k38wWXCYjkeU",
-        "nameType" : "Organizational",
-        "orcId" : "3c9iwlBzRJAgokg6F",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/c04dfe4e-eaa8-46bb-9db8-d66befdf9ae5",
+        "name" : "iINfNelXL0",
+        "nameType" : "Personal",
+        "orcId" : "3m9xLVlz8ywRDn",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8RykCKTRuvzUED36d",
-          "value" : "OFk8REdmJR"
+          "sourceName" : "eoB4JXww6Gi",
+          "value" : "gPIDkjAPrC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KmdBtR5xDQ4G976ODm",
-          "value" : "WReRcnB7q9D"
+          "sourceName" : "UgsGqOiFlxHp4",
+          "value" : "smoBvVvK0a0EbFiTmy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/129204a7-64a9-4788-afff-6ffa4398dc13"
+        "id" : "https://www.example.org/2328f2f0-5bf9-4d6e-95a5-86655a5d4953"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/60673421-6949-43a7-8a08-da5f0d0950b4",
-        "name" : "oZ0mlPPfICoZZPOW",
+        "id" : "https://www.example.org/d1b3a44d-103c-4e48-8464-8c253c882034",
+        "name" : "I7t7sWdYhvpKIn",
         "nameType" : "Organizational",
-        "orcId" : "VNVTmaPUZv4uWGhnY6",
-        "verificationStatus" : "Verified",
+        "orcId" : "hYUzN2p8wW8vsQ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "q9jGIeIiVYan",
-          "value" : "c3QVzS4mJi"
+          "sourceName" : "WkP2nMj7WaQYtEDPG",
+          "value" : "G0QUKudSntg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jvxdC8eVJtbM",
-          "value" : "vT2aWmnUBwrxoOv"
+          "sourceName" : "7dXWEyjrCYARelCDiSc",
+          "value" : "9ChUM5EsHvYAFY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a35cb37c-c644-4d4f-89ce-415de5a3e2a4"
+        "id" : "https://www.example.org/7a1e3c72-d6d8-4c44-a1a3-992af128855b"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "XnqiOOAtjqe"
+      "hu" : "DcKuaydFFdyiwdfe"
     },
-    "npiSubjectHeading" : "T1zRerFaUAnZEzF1",
-    "tags" : [ "mCA5EWXItWNh" ],
-    "description" : "IlMYwmZdeLC7bYOX",
+    "npiSubjectHeading" : "Z2BeVFZn2eoVxgTIK",
+    "tags" : [ "8Dm9tjReCt" ],
+    "description" : "dkilVXHenHlGcy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/96b4a121-2ebb-4043-8642-4fbac6ccf2ca"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4f9611e3-7d91-4f45-bcad-cce124f5860c"
         },
-        "seriesNumber" : "PLSzcwJbiwRz6P",
+        "seriesNumber" : "MVrpXvJk1QjiH77",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/509101fe-981a-4aa1-a8b7-0e51777302d0",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e5283a4d-5c87-4284-8a44-97f0c72685ff",
           "valid" : true
         },
-        "isbnList" : [ "9781298996954", "9781968222536" ],
+        "isbnList" : [ "9780850390254", "9780992534288" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1968222537"
+          "value" : "0992534283"
         } ]
       },
-      "doi" : "https://www.example.org/6ec172bb-7d89-4f4d-878f-200b8668028d",
+      "doi" : "https://www.example.org/604f0a80-9f57-444f-ade1-9fcc63672a93",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ZhOqGBWc0MhpMXVdd",
-            "end" : "XRS9vmfhbTMKvrx"
+            "begin" : "wi8CuS8hbsDAlxf2",
+            "end" : "lNIJH99rDpZm8JE3gi"
           },
-          "pages" : "81fR5Wx9JnY",
-          "illustrated" : true
+          "pages" : "JJOSt9gf4KYNs6",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4d24f4a5-bbaa-44a8-86ed-3686a849be2a",
-    "abstract" : "01ssrVQktU02d43C"
+    "metadataSource" : "https://www.example.org/45f3d7f4-7cf9-40d6-912c-dd3a39ebdebd",
+    "abstract" : "lu2Bxq6N8r"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cee39928-562a-450a-9377-a0e7c61aeed3",
-    "name" : "Xi3egH7NLdl",
+    "id" : "https://www.example.org/88eccc10-1011-4cdf-b61d-70c14722f9e1",
+    "name" : "GnqYdgmt9g",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-11-01T14:04:45.872Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "dA5CK2T5dFxnKVDKS"
+      "approvalDate" : "2016-05-15T10:25:33.091Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "rKLhUKlz0s6Eg6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8633f313-aaa3-4632-b11c-cc3a760efe64",
-    "identifier" : "MW7AZr6K9ksQRnPJOCW",
+    "source" : "https://www.example.org/2512ba37-8cc5-4294-a465-e1f5fdf8b851",
+    "identifier" : "T9I2s4KYA7q7Vlr2",
     "labels" : {
-      "se" : "HoEiyrlAlhbXA7Au7q"
+      "nn" : "Xzp6rdv7P0uK6"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1879545760
+      "currency" : "USD",
+      "amount" : 1834614662
     },
-    "activeFrom" : "2010-01-25T03:19:06.912Z",
-    "activeTo" : "2020-01-23T23:35:29.038Z"
+    "activeFrom" : "2017-07-02T01:48:44.232Z",
+    "activeTo" : "2022-10-07T23:59:25.945Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/54e6bd2e-4c9d-4756-844f-857d8965c3c2",
-    "id" : "https://www.example.org/2b986a2c-ccda-454a-a4df-ded26086c763",
-    "identifier" : "I5khrBbPzKdq6mYS",
+    "source" : "https://www.example.org/e5b0635f-2ae6-473d-bf23-62a8db5c78aa",
+    "id" : "https://www.example.org/dc82e1be-cd91-4678-8e29-7689c152c70b",
+    "identifier" : "FLb9ESKluJ",
     "labels" : {
-      "nb" : "x2KDJOOHSetV9T4"
+      "pt" : "FLwZJr8e5O8vIu8LZD"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 359369511
+      "amount" : 1222643664
     },
-    "activeFrom" : "1982-07-21T23:19:15.776Z",
-    "activeTo" : "2007-06-03T02:59:46.984Z"
+    "activeFrom" : "2006-01-30T02:14:44.462Z",
+    "activeTo" : "2020-03-27T18:50:11.410Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/695313dd-47be-4b4e-b421-17c7194f59dc" ],
+  "subjects" : [ "https://www.example.org/34781596-e9d2-47bc-8984-21f14517e4c9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "eb6a518b-0df5-42e8-979e-7eae92ab460a",
-    "name" : "Ru6OEYNivGC",
-    "mimeType" : "xFhJ2UFyk3Bv",
-    "size" : 1393892283,
-    "license" : "https://www.example.com/0a5wid4lbbuieu",
+    "identifier" : "e90756ae-cc52-42f2-b0a8-f94a40c558ea",
+    "name" : "PKnS00G7Ojc",
+    "mimeType" : "nwAsq1qakKsiZqUlgn",
+    "size" : 1030596868,
+    "license" : "https://www.example.com/ot4zqgxk7o6i",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kwc1PufhtJlZ",
-    "publishedDate" : "2021-05-29T16:33:11.335Z",
+    "legalNote" : "LmiSYfxz4hkIa0s",
+    "publishedDate" : "1976-09-12T11:15:00.406Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "G4RK314cxZ",
-      "uploadedDate" : "1975-06-14T09:59:35.367Z"
+      "uploadedBy" : "ZA2JbaGtD9XeNaBR",
+      "uploadedDate" : "2023-05-21T08:22:11.987Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/sM6MuDAJF9yZO7q",
-    "name" : "60UUW3CjlgSUIv",
-    "description" : "b6jGTSq9BW8NmwMx"
+    "id" : "https://www.example.com/xuZFJdWA8wQA",
+    "name" : "XHVYwci1AG",
+    "description" : "V4R4KZTbCW0A"
   } ],
-  "rightsHolder" : "WAHvclzPJS5nLVF",
-  "duplicateOf" : "https://www.example.org/e417862d-0fb2-4e11-8e07-bd5e1e6a8118",
+  "rightsHolder" : "JmHHoP3NNf7o",
+  "duplicateOf" : "https://www.example.org/89d529c1-9e22-4d4a-9dc2-7ed013ed92f7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tYuWDq2APKOEjB"
+    "note" : "5EQ3dZJKUByo5R"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VWaPsDrz00yBcM",
-    "createdBy" : "q14GCzlfg9LM",
-    "createdDate" : "2015-05-01T05:46:24.525Z"
+    "note" : "8Ozu3f5DY37o",
+    "createdBy" : "ooilntBmKlEMeVqnDPt",
+    "createdDate" : "2003-01-04T11:15:29.700Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ee53c4b4-8254-4d5f-8624-f1af9321dad3" ],
+  "curatingInstitutions" : [ "https://www.example.org/462f1042-b41c-4064-b558-8f8a5939c5ea" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "j23Z7BS7sXupw",
-    "ownerAffiliation" : "https://www.example.org/4132deed-3338-4d7c-809a-041e0124e5fe"
+    "owner" : "BAnraIch8mP",
+    "ownerAffiliation" : "https://www.example.org/a3a9ab14-5e88-4379-984b-decec1eb12e8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4d3a282f-41ee-4633-a781-b26843458de5"
+    "id" : "https://www.example.org/cb0112ec-9f59-4d41-87eb-07661df864cd"
   },
-  "createdDate" : "1995-11-29T00:07:28.489Z",
-  "modifiedDate" : "1972-11-18T10:55:21.414Z",
-  "publishedDate" : "2003-12-23T18:28:33.843Z",
-  "indexedDate" : "2005-01-07T18:57:41.120Z",
-  "handle" : "https://www.example.org/431d9fbd-82cf-44c0-a4b9-f30ca96fae5f",
-  "doi" : "https://doi.org/10.1234/dolor",
-  "link" : "https://www.example.org/7b63484e-8747-410c-b1fb-c2fd97ab7baf",
+  "createdDate" : "2013-09-05T07:40:41.496Z",
+  "modifiedDate" : "2020-01-04T21:30:43.099Z",
+  "publishedDate" : "1985-06-11T20:27:38.644Z",
+  "indexedDate" : "1972-11-30T11:50:37.349Z",
+  "handle" : "https://www.example.org/72dc776c-0116-4795-b832-94a12668ff34",
+  "doi" : "https://doi.org/10.1234/adipisci",
+  "link" : "https://www.example.org/99d82164-fdcd-4629-9d30-0022920acf55",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "hsW6Jys3kPwzoojeCi2",
+    "mainTitle" : "zG7DC6kVHCj7",
     "alternativeTitles" : {
-      "se" : "livmmvjtNDn3ylfbovA"
+      "el" : "9z7mf9nMwRL"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HwDUftI8m2M",
-      "month" : "PNhPWqh2lc1usD5jS",
-      "day" : "MZBBBwBA1Z8NVj"
+      "year" : "3NzEgMhdfB",
+      "month" : "OQrViesM3pPn9xpAe3",
+      "day" : "EMfQKzdflkZ5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/62456f19-f15d-4ce9-b167-0087eec718c7",
-        "name" : "XX5OeidQns55Un",
+        "id" : "https://www.example.org/32d04523-be46-4b2e-b1ed-74b218fe3a44",
+        "name" : "k38wWXCYjkeU",
         "nameType" : "Organizational",
-        "orcId" : "sZ7rxMSxYxU8A",
-        "verificationStatus" : "Verified",
+        "orcId" : "3c9iwlBzRJAgokg6F",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yM8FnnsghrKYeN8ICG",
-          "value" : "8UKJExKUKPFeOVAonA"
+          "sourceName" : "8RykCKTRuvzUED36d",
+          "value" : "OFk8REdmJR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "B9XfbTNlcHOu5bZh",
-          "value" : "H5rBasf9RfvUdkA"
+          "sourceName" : "KmdBtR5xDQ4G976ODm",
+          "value" : "WReRcnB7q9D"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3e7e77cc-e938-464e-855a-2041932d0b43"
+        "id" : "https://www.example.org/129204a7-64a9-4788-afff-6ffa4398dc13"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "PWAULGSJQvBusn2K"
+        "type" : "VideoEditor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/16bafe61-4443-4851-a75e-5b9697c12cbb",
-        "name" : "pG7hiPL7CirfUa0pfz",
-        "nameType" : "Personal",
-        "orcId" : "mAzACkyj5P6VC9JC6wm",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/60673421-6949-43a7-8a08-da5f0d0950b4",
+        "name" : "oZ0mlPPfICoZZPOW",
+        "nameType" : "Organizational",
+        "orcId" : "VNVTmaPUZv4uWGhnY6",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bCvw5NpoxyUJLbFZ",
-          "value" : "C82mZS3oaU"
+          "sourceName" : "q9jGIeIiVYan",
+          "value" : "c3QVzS4mJi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p5z2GN5aCkvjWh",
-          "value" : "9O2ePtnYn2d"
+          "sourceName" : "jvxdC8eVJtbM",
+          "value" : "vT2aWmnUBwrxoOv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/eb09419d-fbdf-432e-b897-dc91d72676bf"
+        "id" : "https://www.example.org/a35cb37c-c644-4d4f-89ce-415de5a3e2a4"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "F9OvPE3wFr0qJPzHD"
+      "fr" : "XnqiOOAtjqe"
     },
-    "npiSubjectHeading" : "6BdmhcU8udpoxcnshWg",
-    "tags" : [ "JjF3qGoJWezsF" ],
-    "description" : "vfHH1hqBn0G",
+    "npiSubjectHeading" : "T1zRerFaUAnZEzF1",
+    "tags" : [ "mCA5EWXItWNh" ],
+    "description" : "IlMYwmZdeLC7bYOX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/18450070-7992-45c4-83b8-0b7976950ccd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/96b4a121-2ebb-4043-8642-4fbac6ccf2ca"
         },
-        "seriesNumber" : "NhpliaYG1mSzL",
+        "seriesNumber" : "PLSzcwJbiwRz6P",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e1aba0fe-ac5d-4218-ae01-cf93f5c0c617",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/509101fe-981a-4aa1-a8b7-0e51777302d0",
           "valid" : true
         },
-        "isbnList" : [ "9791888691701" ],
+        "isbnList" : [ "9781298996954", "9781968222536" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "eafI3DdVWEH"
+          "value" : "1968222537"
         } ]
       },
-      "doi" : "https://www.example.org/bc89a600-d304-448f-9af5-b6ac337b7348",
+      "doi" : "https://www.example.org/6ec172bb-7d89-4f4d-878f-200b8668028d",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7RWZGpmFo9nK0pcSR7M",
-            "end" : "HfNg9SWDBT3t0"
+            "begin" : "ZhOqGBWc0MhpMXVdd",
+            "end" : "XRS9vmfhbTMKvrx"
           },
-          "pages" : "Ya55vTIodg2eL7",
+          "pages" : "81fR5Wx9JnY",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/48d1e795-f3e3-4541-abe2-6f9c5c0b929d",
-    "abstract" : "zh7gckmB7p5ai8"
+    "metadataSource" : "https://www.example.org/4d24f4a5-bbaa-44a8-86ed-3686a849be2a",
+    "abstract" : "01ssrVQktU02d43C"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7fb5d1d9-5028-4149-9867-27c56bfcf3f6",
-    "name" : "bLT6QeOMDcSH7v",
+    "id" : "https://www.example.org/cee39928-562a-450a-9377-a0e7c61aeed3",
+    "name" : "Xi3egH7NLdl",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1988-09-18T15:58:55.634Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1997-11-01T14:04:45.872Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "6RNWXZB8S5G"
+      "applicationCode" : "dA5CK2T5dFxnKVDKS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c84c554e-8298-4f0c-a74e-8bbe16f4e336",
-    "identifier" : "hk4bAvD4FQFRQ",
+    "source" : "https://www.example.org/8633f313-aaa3-4632-b11c-cc3a760efe64",
+    "identifier" : "MW7AZr6K9ksQRnPJOCW",
     "labels" : {
-      "pl" : "E3FNBZyxHJfbX"
+      "se" : "HoEiyrlAlhbXA7Au7q"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 657976824
+      "amount" : 1879545760
     },
-    "activeFrom" : "1973-05-13T21:36:42.431Z",
-    "activeTo" : "1985-11-05T13:36:17.764Z"
+    "activeFrom" : "2010-01-25T03:19:06.912Z",
+    "activeTo" : "2020-01-23T23:35:29.038Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/df8f5d78-5c9e-4edc-b3ca-71324ad0b794",
-    "id" : "https://www.example.org/fba9fc53-4499-4551-ae00-06bfd619d9d7",
-    "identifier" : "8swEwPGZLyR7Z",
+    "source" : "https://www.example.org/54e6bd2e-4c9d-4756-844f-857d8965c3c2",
+    "id" : "https://www.example.org/2b986a2c-ccda-454a-a4df-ded26086c763",
+    "identifier" : "I5khrBbPzKdq6mYS",
     "labels" : {
-      "sv" : "Mi9h4fZjOzum6V8T3k"
+      "nb" : "x2KDJOOHSetV9T4"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2022485637
+      "amount" : 359369511
     },
-    "activeFrom" : "1989-10-25T01:23:55.077Z",
-    "activeTo" : "2014-04-07T10:01:59.903Z"
+    "activeFrom" : "1982-07-21T23:19:15.776Z",
+    "activeTo" : "2007-06-03T02:59:46.984Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/00c4c55d-f2ab-4368-b0aa-3f4ef3f3f6c5" ],
+  "subjects" : [ "https://www.example.org/695313dd-47be-4b4e-b421-17c7194f59dc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f1a034ba-3062-4cdb-b3a5-f1f09a19c329",
-    "name" : "sY9G1fTzRq",
-    "mimeType" : "WZTkIlrbKxm9F4BjO",
-    "size" : 1507183221,
-    "license" : "https://www.example.com/k3v1j2ypurksy4uo",
+    "identifier" : "eb6a518b-0df5-42e8-979e-7eae92ab460a",
+    "name" : "Ru6OEYNivGC",
+    "mimeType" : "xFhJ2UFyk3Bv",
+    "size" : 1393892283,
+    "license" : "https://www.example.com/0a5wid4lbbuieu",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "YXtXPyFM5pjnXSlVV",
-    "publishedDate" : "2012-11-23T17:21:40.173Z",
+    "legalNote" : "kwc1PufhtJlZ",
+    "publishedDate" : "2021-05-29T16:33:11.335Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "alxqukAFloQMlty",
-      "uploadedDate" : "1989-01-10T07:12:26.389Z"
+      "uploadedBy" : "G4RK314cxZ",
+      "uploadedDate" : "1975-06-14T09:59:35.367Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HIHA78PRwF",
-    "name" : "JLoOFpxidcn",
-    "description" : "lJ2nxq9cnT"
+    "id" : "https://www.example.com/sM6MuDAJF9yZO7q",
+    "name" : "60UUW3CjlgSUIv",
+    "description" : "b6jGTSq9BW8NmwMx"
   } ],
-  "rightsHolder" : "01ijx0m4k8oV6KRH8",
-  "duplicateOf" : "https://www.example.org/aed9324e-dc63-4175-8cbb-a3e3fc721af6",
+  "rightsHolder" : "WAHvclzPJS5nLVF",
+  "duplicateOf" : "https://www.example.org/e417862d-0fb2-4e11-8e07-bd5e1e6a8118",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "iFYihOPg9i"
+    "note" : "tYuWDq2APKOEjB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ITzaWAzkkBqvi",
-    "createdBy" : "SBleabHzJ3jV0g",
-    "createdDate" : "2019-03-18T02:52:16.599Z"
+    "note" : "VWaPsDrz00yBcM",
+    "createdBy" : "q14GCzlfg9LM",
+    "createdDate" : "2015-05-01T05:46:24.525Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3c4af48f-4a28-47f0-8073-fb468fb2f27a" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/ee53c4b4-8254-4d5f-8624-f1af9321dad3" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "weSsrE3EkztckbNqG6S",
-    "ownerAffiliation" : "https://www.example.org/36ce27d5-ebbf-40d0-aa66-0144ac3dce52"
+    "owner" : "pf6KwxCWR8z9",
+    "ownerAffiliation" : "https://www.example.org/adc0e4b8-d1e1-464e-b30f-de578331f6c3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/35a214ac-d127-43ec-9e7f-a1e6ee923d12"
+    "id" : "https://www.example.org/f4c4f7b7-abbd-4d5d-ace8-ca0f11025284"
   },
-  "createdDate" : "2000-01-17T19:30:58.844Z",
-  "modifiedDate" : "2003-03-17T09:27:46.076Z",
-  "publishedDate" : "1976-11-11T20:09:07.892Z",
-  "indexedDate" : "1990-03-15T01:43:38.479Z",
-  "handle" : "https://www.example.org/a428b445-198f-4ef2-8c11-20bd441e13c2",
-  "doi" : "https://doi.org/10.1234/itaque",
-  "link" : "https://www.example.org/a37b12b7-92cb-4cd8-988d-9e6358e0e563",
+  "createdDate" : "2005-11-25T04:26:29.138Z",
+  "modifiedDate" : "1998-01-12T20:04:46.029Z",
+  "publishedDate" : "1977-03-27T19:49:57.734Z",
+  "indexedDate" : "1979-03-16T19:33:21.129Z",
+  "handle" : "https://www.example.org/d4b3f092-7d34-49ee-be07-d04a81cbfac5",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/7b4ba097-d7d3-448b-a7bd-69a438bd5da2",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kAuIjkDQrJMWX",
+    "mainTitle" : "xXBqg8PHWxEt6hOM",
     "alternativeTitles" : {
-      "hu" : "uphHMfgO2sQ2CNH"
+      "el" : "7CCqJbzPlnp"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "jXqLRpirYTONn",
-      "month" : "XtFNyFQ6uysPru",
-      "day" : "h2MD2dZ8PI"
+      "year" : "KjkGdUGg5bQm",
+      "month" : "dP8Tcbgkg7",
+      "day" : "AcKn8qYQ1VWF204SyS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/60ce47db-d07c-43db-b5e7-e880c4fdc9fa",
-        "name" : "BBB3yDGLAtstsqCpde",
+        "id" : "https://www.example.org/0bebb32c-f1d9-475a-a43b-0a83b2fee230",
+        "name" : "SiyytCEpaNahh4uE",
         "nameType" : "Personal",
-        "orcId" : "VOg7Vq3W9u6vYGmfO",
-        "verificationStatus" : "Verified",
+        "orcId" : "UdNilZ33ksB9jUPZI",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GEQXq3mrVLsUaP",
-          "value" : "IKSSv78HuUhmYQNq"
+          "sourceName" : "iDJrZyrytCY1o2",
+          "value" : "MQ5c7hLiwUU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2Seld7kNSD5",
-          "value" : "6VH2zLFwi5"
+          "sourceName" : "hWP3lJHz8yFgrrGNO9",
+          "value" : "zSD1QWKlLZDZtii"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bb6b67f7-a0f8-4d5d-abdf-7c582ea3c237"
+        "id" : "https://www.example.org/57d821cf-a21d-461a-b3a0-2f2480968155"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9b7b64a3-9dbe-4cf2-b7a5-0198c24b8cc1",
-        "name" : "Mfg1TNBvT19",
-        "nameType" : "Personal",
-        "orcId" : "QNrIKc9MEYfvQQQjaW6",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/2c199d46-57a5-4f19-80bb-f5eea768f5cb",
+        "name" : "P4kkEyJ5cV",
+        "nameType" : "Organizational",
+        "orcId" : "Sw7KWKuYXD",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "opNFDT3I4mU7Jaz1",
-          "value" : "YJf0RAvbMPrKpEYgK"
+          "sourceName" : "rOSbXgwJwDDCJbGD01v",
+          "value" : "cMxS5ixiMy2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wM63Y9GQzuBRlZMK4M",
-          "value" : "fafaNzYBpTD2ssTU5"
+          "sourceName" : "RG7V1rsZmvW",
+          "value" : "ASdzIOFrWgnO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/37744b00-9805-4752-b3ed-2f9aef684e09"
+        "id" : "https://www.example.org/0b491bfd-4b9b-495f-8ac3-c6a253e578f4"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "juPjzYURqt1sysjzUYW"
+      "se" : "nBBivTZoKq0ec"
     },
-    "npiSubjectHeading" : "a3Lz6K0lubnRI95nlry",
-    "tags" : [ "CPdCr4QgSs3uEtS3Old" ],
-    "description" : "JWPrrCzTjiYjvJrvwn",
+    "npiSubjectHeading" : "f29hR2hSPMt6IkZS",
+    "tags" : [ "sKF0kaGbSjC0lb3" ],
+    "description" : "rGa2zdGbU5",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7407c0d6-bba3-4baa-b91f-2babd8a6b451"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/995f4292-fa63-4db6-9db4-d06c2e130d74"
         },
-        "seriesNumber" : "KiamCGk2Xp",
+        "seriesNumber" : "lXweCga17ISQy5h4AQ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3c4a4af1-4e31-4da5-952b-e68672aa0917",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d02b0fd7-4da5-44ac-baf4-85a35c192b1d",
           "valid" : true
         },
-        "isbnList" : [ "9790028255186" ],
+        "isbnList" : [ "9791955687408", "9780760894422" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "f3TaSfK3ZwJnZ6rcZU"
+          "value" : "0760894426"
         } ]
       },
-      "doi" : "https://www.example.org/b1b69505-9c08-4a20-9ae1-d3fc8648993f",
+      "doi" : "https://www.example.org/03fe4079-a153-4aa6-a32f-7f4ffb45c783",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "4AM7t2Rt7I0Sv1",
-            "end" : "sYmZv8OCHdcVUDZsc"
+            "begin" : "K296SkoYBi",
+            "end" : "WvF97Ortr5QOtO8q7At"
           },
-          "pages" : "68OztspH1zD1",
-          "illustrated" : true
+          "pages" : "GgHFLkHr08k",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5398aa40-736a-4e57-b294-64914517ae40",
-    "abstract" : "sSKhwJZruvW8wOh"
+    "metadataSource" : "https://www.example.org/d1aa2994-a4ce-418d-a699-40a4bb25b63a",
+    "abstract" : "IGlhY8FZFdmj5gqaH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fa0ba958-88a6-4ac0-806a-a6875f87a03d",
-    "name" : "C6JrdYxzJxni2jt",
+    "id" : "https://www.example.org/cf014175-1f9e-44df-8ab4-4e4edfe72154",
+    "name" : "YJ2tySUgw90",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-09-15T02:54:40.569Z",
+      "approvalDate" : "1990-04-12T14:42:56.175Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "7VrQU3jeAo2UrSy4"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "sLmqjbMC4pjLxt4n"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/72c3769d-d619-4234-9eb2-b087766ce72e",
-    "identifier" : "liI3nPPyOzbBppYO",
+    "source" : "https://www.example.org/899ca921-09c5-4ec6-a27d-b21b6691cadd",
+    "identifier" : "lIE7of0X0ALu4DEXHfG",
     "labels" : {
-      "it" : "NHxH0zIqNF"
+      "da" : "CyqXx4Q4tG58Xf"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2131685847
+      "currency" : "USD",
+      "amount" : 646717307
     },
-    "activeFrom" : "2015-08-03T03:52:05.798Z",
-    "activeTo" : "2021-12-20T14:06:31.558Z"
+    "activeFrom" : "2012-01-22T10:44:20.024Z",
+    "activeTo" : "2020-12-03T14:35:59.143Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e1aa4c59-11c9-451d-95f4-48266cf74d7e",
-    "id" : "https://www.example.org/ce4e4fbc-80c4-419a-a4b1-39b80cbef6d8",
-    "identifier" : "3afDCMZns9hlb9J2Tt",
+    "source" : "https://www.example.org/8c49548a-5d3e-4c0c-b510-a1c122538a2c",
+    "id" : "https://www.example.org/c19da6a6-a44e-4b9f-8a8f-2f7e18ad9cea",
+    "identifier" : "bwzy5qBe1HvsdgKRNG",
     "labels" : {
-      "pl" : "ae2mEuaFfhkbyF"
+      "fr" : "8yKtNaWk2bpGcgJ"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 689818604
+      "amount" : 889623681
     },
-    "activeFrom" : "2011-11-13T17:13:08.102Z",
-    "activeTo" : "2014-12-03T17:35:34.382Z"
+    "activeFrom" : "1984-04-27T02:14:51.325Z",
+    "activeTo" : "2007-09-17T19:01:46.387Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5753d5c0-0964-4dab-bd14-3f7313301481" ],
+  "subjects" : [ "https://www.example.org/ee0a40bb-c09a-4fca-9d70-1114abb3831f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "31f896c7-06e7-4ba9-ae40-ffb56d2a6a93",
-    "name" : "UjlKSjZkcjJ8AIgqfzk",
-    "mimeType" : "rhvb6vvPdsQl1iKr",
-    "size" : 195117468,
-    "license" : "https://www.example.com/tl8qas96i3",
+    "identifier" : "74a98625-ea7e-477f-864b-9c4b83da14c3",
+    "name" : "EkrA0yjMhTnxm",
+    "mimeType" : "uwL2SwO37T110z90nKy",
+    "size" : 727792266,
+    "license" : "https://www.example.com/inwrw0kzbkfrym",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "FIXiUJOlUb9RDlNdWd",
-    "publishedDate" : "1991-10-07T23:09:22.005Z",
+    "legalNote" : "80yrANzDIL",
+    "publishedDate" : "1998-09-05T10:27:23.852Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "0iqam9n8qX8F6",
-      "uploadedDate" : "1987-11-30T18:03:19.524Z"
+      "uploadedBy" : "ubi5lqbge2Zr92hTUIl",
+      "uploadedDate" : "2018-03-04T08:23:00.519Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/6x3S9YFaaevPiJc",
-    "name" : "02SU35XlqM4Lc",
-    "description" : "ALtXLRMbUlCG"
+    "id" : "https://www.example.com/oeFJnyLsHwfOoLDH",
+    "name" : "tnmC5V7trWY",
+    "description" : "SUHnruX63nGrJ1oyE"
   } ],
-  "rightsHolder" : "jv4pNvq6k8d",
-  "duplicateOf" : "https://www.example.org/c9408441-eb21-41d3-88c5-b7e4b9af1213",
+  "rightsHolder" : "6wfclTjPbxkYOp30di",
+  "duplicateOf" : "https://www.example.org/2df7ca4c-bd6c-4c94-8ea5-66516a9b2abb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TbSVyoxxqGbM"
+    "note" : "k3VS34imtGAY3HvH"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vPi4UmemyWJa7UC",
-    "createdBy" : "2leteVNF48uPNZH",
-    "createdDate" : "1980-07-04T18:48:10.278Z"
+    "note" : "N8EyAEp7k08pnDn",
+    "createdBy" : "DIkzg7O7qKkw",
+    "createdDate" : "2020-01-09T22:31:58.173Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ca913a56-f09a-4a51-9060-fbe3c1da9d3b" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/dc638e78-8d2c-42e2-a984-a7b498db2dcb" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "pf6KwxCWR8z9",
-    "ownerAffiliation" : "https://www.example.org/adc0e4b8-d1e1-464e-b30f-de578331f6c3"
+    "owner" : "HhvmgWIzGbkE6se2n",
+    "ownerAffiliation" : "https://www.example.org/ea44d14e-37c7-49cf-9b4d-b593debe5dc3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f4c4f7b7-abbd-4d5d-ace8-ca0f11025284"
+    "id" : "https://www.example.org/14af8bae-1bcc-40ba-af22-b0fcdffc9bb3"
   },
-  "createdDate" : "2005-11-25T04:26:29.138Z",
-  "modifiedDate" : "1998-01-12T20:04:46.029Z",
-  "publishedDate" : "1977-03-27T19:49:57.734Z",
-  "indexedDate" : "1979-03-16T19:33:21.129Z",
-  "handle" : "https://www.example.org/d4b3f092-7d34-49ee-be07-d04a81cbfac5",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/7b4ba097-d7d3-448b-a7bd-69a438bd5da2",
+  "createdDate" : "2011-04-03T21:37:10.270Z",
+  "modifiedDate" : "2005-10-08T04:47:29.669Z",
+  "publishedDate" : "2012-12-21T20:49:00.504Z",
+  "indexedDate" : "1991-01-13T02:09:51.701Z",
+  "handle" : "https://www.example.org/6db3cb79-c15b-48aa-bcf6-e4bbf83db9eb",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/c32e5710-f6c8-43ac-9817-09f18749dd75",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xXBqg8PHWxEt6hOM",
+    "mainTitle" : "jKfJhqHUvBrR",
     "alternativeTitles" : {
-      "el" : "7CCqJbzPlnp"
+      "nl" : "0A3sW9XR1puDg"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KjkGdUGg5bQm",
-      "month" : "dP8Tcbgkg7",
-      "day" : "AcKn8qYQ1VWF204SyS"
+      "year" : "YlZf95AP0ZOoIyCDQPG",
+      "month" : "dP6x89AOvQyh8m3",
+      "day" : "XbNxrHGXCPurtt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0bebb32c-f1d9-475a-a43b-0a83b2fee230",
-        "name" : "SiyytCEpaNahh4uE",
+        "id" : "https://www.example.org/986c4f03-8352-4f2d-abf0-c63b394e9ff5",
+        "name" : "wvF9lKU6OchObDEuJM",
         "nameType" : "Personal",
-        "orcId" : "UdNilZ33ksB9jUPZI",
+        "orcId" : "XYYqoYOoUC",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iDJrZyrytCY1o2",
-          "value" : "MQ5c7hLiwUU"
+          "sourceName" : "SPW5sJynWm",
+          "value" : "Q8BoIvurSME0v"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hWP3lJHz8yFgrrGNO9",
-          "value" : "zSD1QWKlLZDZtii"
+          "sourceName" : "EA4xgTVzrzIA8",
+          "value" : "KB1BXetKlgOLe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/57d821cf-a21d-461a-b3a0-2f2480968155"
+        "id" : "https://www.example.org/8846e813-9041-4133-9024-c88f8f2ac97e"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2c199d46-57a5-4f19-80bb-f5eea768f5cb",
-        "name" : "P4kkEyJ5cV",
+        "id" : "https://www.example.org/bb4d0332-1184-48ed-b022-f94e7d2becdb",
+        "name" : "2Lx1NcfEVIRa8NOXgTu",
         "nameType" : "Organizational",
-        "orcId" : "Sw7KWKuYXD",
-        "verificationStatus" : "Verified",
+        "orcId" : "RkKG8f4EkMZq9jIUs",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rOSbXgwJwDDCJbGD01v",
-          "value" : "cMxS5ixiMy2"
+          "sourceName" : "OiX685DqJMpim",
+          "value" : "vFFg2yvL1AVKDrB7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RG7V1rsZmvW",
-          "value" : "ASdzIOFrWgnO"
+          "sourceName" : "lXAqumxb7eABpU",
+          "value" : "FagPxxvs4QHMWHvAiD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0b491bfd-4b9b-495f-8ac3-c6a253e578f4"
+        "id" : "https://www.example.org/caf10284-9d6f-4ed3-acd8-2387b5afda55"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "nBBivTZoKq0ec"
+      "nb" : "oRc4lTRcuHMLS"
     },
-    "npiSubjectHeading" : "f29hR2hSPMt6IkZS",
-    "tags" : [ "sKF0kaGbSjC0lb3" ],
-    "description" : "rGa2zdGbU5",
+    "npiSubjectHeading" : "1p4qccbNgrn",
+    "tags" : [ "LUq1HRDJfq53wlZc" ],
+    "description" : "uscr4LQKoNdYe",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/995f4292-fa63-4db6-9db4-d06c2e130d74"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1060c5f8-dc26-4745-b296-75b45a8f0f9b"
         },
-        "seriesNumber" : "lXweCga17ISQy5h4AQ",
+        "seriesNumber" : "G8DQ429qcjm9W9I",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d02b0fd7-4da5-44ac-baf4-85a35c192b1d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e6a45d3c-5b26-4c27-acb9-4365f3f0ee83",
           "valid" : true
         },
-        "isbnList" : [ "9791955687408", "9780760894422" ],
+        "isbnList" : [ "9780911006612", "9781003536451" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0760894426"
+          "value" : "100353645X"
         } ]
       },
-      "doi" : "https://www.example.org/03fe4079-a153-4aa6-a32f-7f4ffb45c783",
+      "doi" : "https://www.example.org/d4a249cd-0558-4f7a-8153-38b6c76c9f03",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "K296SkoYBi",
-            "end" : "WvF97Ortr5QOtO8q7At"
+            "begin" : "AJ1jhbBUEKLsnFRD6m",
+            "end" : "kx4TDkYiBs"
           },
-          "pages" : "GgHFLkHr08k",
-          "illustrated" : false
+          "pages" : "BBkK7oaaGaD",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d1aa2994-a4ce-418d-a699-40a4bb25b63a",
-    "abstract" : "IGlhY8FZFdmj5gqaH"
+    "metadataSource" : "https://www.example.org/ccf7b984-071d-401b-b31d-16eb0252ba27",
+    "abstract" : "ezDfzz4nqTCKXJJf4fW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cf014175-1f9e-44df-8ab4-4e4edfe72154",
-    "name" : "YJ2tySUgw90",
+    "id" : "https://www.example.org/a38da0f7-8a8b-48ac-9817-e424459de7e0",
+    "name" : "TjxvQHH3yXkscvdEqCh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-04-12T14:42:56.175Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "sLmqjbMC4pjLxt4n"
+      "approvalDate" : "1973-07-19T05:35:38.195Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "u16KToebUOz4D6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/899ca921-09c5-4ec6-a27d-b21b6691cadd",
-    "identifier" : "lIE7of0X0ALu4DEXHfG",
+    "source" : "https://www.example.org/1f13c443-b3b8-4261-8105-bb5e3b9fea2d",
+    "identifier" : "yisvk3QM8u1a",
     "labels" : {
-      "da" : "CyqXx4Q4tG58Xf"
+      "fi" : "uvgqe2kIMHn7"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1822832345
+    },
+    "activeFrom" : "1997-02-13T15:03:56.298Z",
+    "activeTo" : "2015-03-06T01:01:26.990Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/f80cea3e-0557-41e8-978e-f33dea28b572",
+    "id" : "https://www.example.org/ffd134ec-9d72-4e3a-a9e2-6703e06a3c3f",
+    "identifier" : "lDIiElDvAoEAHqnA",
+    "labels" : {
+      "se" : "5UK4CKvWeGv0"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 646717307
+      "amount" : 304412867
     },
-    "activeFrom" : "2012-01-22T10:44:20.024Z",
-    "activeTo" : "2020-12-03T14:35:59.143Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8c49548a-5d3e-4c0c-b510-a1c122538a2c",
-    "id" : "https://www.example.org/c19da6a6-a44e-4b9f-8a8f-2f7e18ad9cea",
-    "identifier" : "bwzy5qBe1HvsdgKRNG",
-    "labels" : {
-      "fr" : "8yKtNaWk2bpGcgJ"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 889623681
-    },
-    "activeFrom" : "1984-04-27T02:14:51.325Z",
-    "activeTo" : "2007-09-17T19:01:46.387Z"
+    "activeFrom" : "2001-07-01T18:13:35.123Z",
+    "activeTo" : "2012-03-03T21:28:05.020Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ee0a40bb-c09a-4fca-9d70-1114abb3831f" ],
+  "subjects" : [ "https://www.example.org/d010af79-ad84-4117-9524-062a44da4ac9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "74a98625-ea7e-477f-864b-9c4b83da14c3",
-    "name" : "EkrA0yjMhTnxm",
-    "mimeType" : "uwL2SwO37T110z90nKy",
-    "size" : 727792266,
-    "license" : "https://www.example.com/inwrw0kzbkfrym",
+    "identifier" : "4cd1fdc4-a28a-46e2-9bdb-cd5aafcdb550",
+    "name" : "fuC03duLkf4Oj9",
+    "mimeType" : "kW5lxOJEzI7HVx91",
+    "size" : 1250186868,
+    "license" : "https://www.example.com/ngkxnawgbgy75g02ho",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Xtn2GXEc0MF6DKyxg"
     },
-    "legalNote" : "80yrANzDIL",
-    "publishedDate" : "1998-09-05T10:27:23.852Z",
+    "legalNote" : "GG6JzwCG6K4SUSXkHeH",
+    "publishedDate" : "2005-08-13T20:18:36.883Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ubi5lqbge2Zr92hTUIl",
-      "uploadedDate" : "2018-03-04T08:23:00.519Z"
+      "uploadedBy" : "NuwWb3RLbQA",
+      "uploadedDate" : "1996-09-24T01:38:06.820Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/oeFJnyLsHwfOoLDH",
-    "name" : "tnmC5V7trWY",
-    "description" : "SUHnruX63nGrJ1oyE"
+    "id" : "https://www.example.com/9nb8gUvDftMeI4RbwE",
+    "name" : "PGcqMJGHf3cxdOwj",
+    "description" : "WnsCp3nFYidE"
   } ],
-  "rightsHolder" : "6wfclTjPbxkYOp30di",
-  "duplicateOf" : "https://www.example.org/2df7ca4c-bd6c-4c94-8ea5-66516a9b2abb",
+  "rightsHolder" : "vYxCTRC0dK5oSKpVgR",
+  "duplicateOf" : "https://www.example.org/3e72a981-762e-4230-9ec1-69b61b00b858",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "k3VS34imtGAY3HvH"
+    "note" : "OiYpqJqJnIRIh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "N8EyAEp7k08pnDn",
-    "createdBy" : "DIkzg7O7qKkw",
-    "createdDate" : "2020-01-09T22:31:58.173Z"
+    "note" : "EEnh6iN0dredSFz",
+    "createdBy" : "u3lHcZ90FP",
+    "createdDate" : "1982-12-06T04:54:25.307Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dc638e78-8d2c-42e2-a984-a7b498db2dcb" ],
+  "curatingInstitutions" : [ "https://www.example.org/ea3f5491-a5c7-4751-92a9-ae3ffd388c1b" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "NtNfkH1Vwxr",
-    "ownerAffiliation" : "https://www.example.org/f7053342-d91d-4788-8b1f-144c080a0fe9"
+    "owner" : "CaQtPM7SmA8zVi",
+    "ownerAffiliation" : "https://www.example.org/9277380e-5fdc-4978-b040-f5ebe2b29c57"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9f46ba9d-9790-4894-b972-a1312836f003"
+    "id" : "https://www.example.org/db7000c2-a016-4bfc-9bf8-78c8066c386e"
   },
-  "createdDate" : "1989-10-18T22:46:09.575Z",
-  "modifiedDate" : "1982-04-20T21:59:28.479Z",
-  "publishedDate" : "1983-09-24T17:45:40.924Z",
-  "indexedDate" : "2020-05-09T09:44:02.046Z",
-  "handle" : "https://www.example.org/fc36faa6-916e-43dc-8f29-cc865d34ccc5",
-  "doi" : "https://doi.org/10.1234/officia",
-  "link" : "https://www.example.org/6bb528ba-c026-42b5-873c-266b40a0df85",
+  "createdDate" : "1990-08-29T00:26:20.831Z",
+  "modifiedDate" : "1975-09-17T02:43:49.305Z",
+  "publishedDate" : "1997-12-01T22:27:14.038Z",
+  "indexedDate" : "2017-06-18T07:11:42.386Z",
+  "handle" : "https://www.example.org/a5fe098e-78c8-42ae-8071-28b2a0ab0591",
+  "doi" : "https://doi.org/10.1234/perferendis",
+  "link" : "https://www.example.org/62467033-3335-4f50-b220-fb74edb263b9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "84VNAxetVvP",
+    "mainTitle" : "reQWZx882L",
     "alternativeTitles" : {
-      "af" : "KzyEh5RGck0qHhK"
+      "ru" : "1d29LhvUnnqBJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "RWhF820jbcTG",
-      "month" : "QBgyXguWe3cnOVdMTC",
-      "day" : "F9tKz4NWydK"
+      "year" : "R1X5778KG5",
+      "month" : "raxDlJGs00enbX2oW",
+      "day" : "0WCn7QLvxgFaWFsiB3x"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ba64fb12-4d72-409b-b708-71883f60d46a",
-        "name" : "x7hqGFX1TDlLfGeOur0",
+        "id" : "https://www.example.org/d53f880a-86fa-4100-93a4-4f5c86ea1713",
+        "name" : "PUygM8vgFa",
         "nameType" : "Organizational",
-        "orcId" : "uChk94wVYxlcdVXG8A",
+        "orcId" : "OqUVtUBsMl",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jVpH3gcX3OYN32lROyx",
-          "value" : "4caCPeOJmKSZ7M03H"
+          "sourceName" : "khUJzfSwuMGbOEQs",
+          "value" : "7GyyKH5HR0SLV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rxFFykUuwkrmQfK",
-          "value" : "2AV3vGqOzeGQ1NEUxi"
+          "sourceName" : "Mjx3EXHnp1RbpTq",
+          "value" : "UirGCRVsWNUYd"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e11ee128-54dd-4adb-beb4-e8f3a535ae81"
+        "id" : "https://www.example.org/427d8555-db58-4719-8aa0-13f83e054495"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4b78c80e-4629-49c8-9568-1bd2864f2e69",
-        "name" : "YebUgT1JrSZ",
-        "nameType" : "Organizational",
-        "orcId" : "5PvGBmtdFpVvtoL",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e07073bb-d9a4-4193-ba3a-693a0bc93372",
+        "name" : "h0TeQeuJDT",
+        "nameType" : "Personal",
+        "orcId" : "US2EzFGu0ShuBRqmSP",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XhC8bTYfywL2ISUA5",
-          "value" : "sVnlzEror2DM1"
+          "sourceName" : "P0aGmj8fhyFt",
+          "value" : "vwBlWqdEXxKqjps"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YDNFn415b6OO9",
-          "value" : "DqOybAnMlSQ2dn"
+          "sourceName" : "MvbZYsNS427RxMgld",
+          "value" : "8Bw4H24nz1FJbtzVjV"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8ff25c20-4d05-4f76-870d-f602c805b41e"
+        "id" : "https://www.example.org/92b31c17-f36c-4012-a05b-bf3bc558e955"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "Co2pPz62ICq8"
+      "pl" : "7tkjdifq1Qsz"
     },
-    "npiSubjectHeading" : "lB96HBSCjqf",
-    "tags" : [ "ad4qL8czAyHAe" ],
-    "description" : "zoZlxU7PNguk6dKBusS",
+    "npiSubjectHeading" : "GNkbiQd9otp6t3mXuA",
+    "tags" : [ "I73OCS7rotc9mAfenRx" ],
+    "description" : "1P4ifTIzMA7Yi9k5OZ0",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/415bad30-99c4-45e8-877e-f566fdc75dd3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/517353b5-7c16-4292-8823-e94c225a85f5"
         },
-        "seriesNumber" : "puQ0oAymcjtRA1JW",
+        "seriesNumber" : "XTtNhEZiGMrH",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/96b057ca-4f58-458a-87d0-ba241fb00f11",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4569d124-0e2c-436e-9f5c-5c79b3576bcc",
           "valid" : true
         },
-        "isbnList" : [ "9780914072232", "9781535199353" ],
+        "isbnList" : [ "9780886003173", "9781448414253" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1535199350"
+          "value" : "1448414253"
         } ]
       },
-      "doi" : "https://www.example.org/d39bce98-f007-48fb-82b5-0cc86d9cc1ee",
+      "doi" : "https://www.example.org/9ebfd4d1-c0d7-40d7-9dd0-c8c1ec1933aa",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "frwTN4l1faUuKzx6V",
-            "end" : "bkX6lJfeju"
+            "begin" : "eD5NbYCL5gbK5",
+            "end" : "E6JCRtVOjkf8"
           },
-          "pages" : "LhF2BSYBh369yHQAfp",
-          "illustrated" : true
+          "pages" : "juGWSu9S6u",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1f0f0736-4e69-43a4-9f6d-dd7abd9cbd6e",
-    "abstract" : "Co8bcSVYyO53jWW1335"
+    "metadataSource" : "https://www.example.org/a1da1c16-0493-4032-844e-d6b21e810665",
+    "abstract" : "mA7spLOxBCkpQyQPc5h"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e5548098-fa79-4bba-bed1-b9ca411e6441",
-    "name" : "XzOSIcY8mc",
+    "id" : "https://www.example.org/b33a6c4d-af3d-4e34-97f5-6e964471015f",
+    "name" : "FiIZ2WU623A",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-05-02T21:13:51.725Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "YjHM84DUvag6cR6YVF"
+      "approvalDate" : "1977-12-14T21:49:30.992Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ydToD3kdM1kYr2O"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/687f0363-abcc-423c-bb5f-6dd010f528c9",
-    "identifier" : "dHlkGwChQu3mERv",
+    "source" : "https://www.example.org/3a94cdc8-cc43-40a6-92d6-2e7c331b413c",
+    "identifier" : "lyvo4U6U4AXuFbw",
     "labels" : {
-      "hu" : "bN2FYqB601"
+      "is" : "XLOKwHITLMvQsR"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1668953522
+    },
+    "activeFrom" : "1976-12-07T02:58:11.815Z",
+    "activeTo" : "2008-05-28T02:26:47.568Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/c196adb7-ec28-452d-aa0c-c5a4fbcbbd5d",
+    "id" : "https://www.example.org/7f47ac5b-94eb-4b6b-9988-7773c0bcfb3f",
+    "identifier" : "ocEWTMZGhfK253oXXI",
+    "labels" : {
+      "en" : "8fuLQmWTqI4fKZtWXO"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2057885200
+      "amount" : 1881035929
     },
-    "activeFrom" : "1989-09-20T08:46:55.059Z",
-    "activeTo" : "2016-03-09T13:13:11.846Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/08ec1cca-6678-4992-b672-c71bad471e84",
-    "id" : "https://www.example.org/746576b0-a11a-4d8a-ac9a-85c301fc7ea0",
-    "identifier" : "b2EdfpfyzZb",
-    "labels" : {
-      "es" : "zliZwCKIFQ15"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 450804781
-    },
-    "activeFrom" : "1986-07-06T01:58:30.898Z",
-    "activeTo" : "2019-05-06T22:27:35.843Z"
+    "activeFrom" : "1989-12-30T20:38:20.788Z",
+    "activeTo" : "1990-09-12T08:20:10.024Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/839042e2-53ce-47dd-a610-602f9d6c1103" ],
+  "subjects" : [ "https://www.example.org/bd8c9814-65ea-44ac-8633-298a630095cd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "cce9a2db-aa63-4bdb-bfa9-24fc57f1ce7f",
-    "name" : "ndRyfYaEAsHxB4E",
-    "mimeType" : "sDJVXsTfg1iNB2hGEl",
-    "size" : 865150751,
-    "license" : "https://www.example.com/ehlgeibevq",
+    "identifier" : "62dd8518-0e11-4bf7-a822-46b2fb8b23c5",
+    "name" : "5a2IiNYFvnF6cZx",
+    "mimeType" : "yyL7G1lM0eGQOag",
+    "size" : 316803631,
+    "license" : "https://www.example.com/1jrercwyptci6swa",
     "administrativeAgreement" : false,
-    "publisherVersion" : "UpdatedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QRaQomBYuZ",
-    "publishedDate" : "1979-09-04T03:23:51.223Z",
+    "legalNote" : "BucbQjHYPxwUqW8",
+    "publishedDate" : "1978-06-12T06:53:50.852Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "aYe5d8T6Qe4VaaAI",
-      "uploadedDate" : "1976-03-02T23:26:45.127Z"
+      "uploadedBy" : "ncKWHAeOxA",
+      "uploadedDate" : "2006-07-30T13:23:49.098Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/AEFkFY9T3X0lD6LNHt",
-    "name" : "oGZjXXHSQMA",
-    "description" : "HnqbsCnBo9S78J"
+    "id" : "https://www.example.com/lWxptojHVQZD3",
+    "name" : "8XN66HgblO0BTFoXz",
+    "description" : "l5ikx2pi3q5BQ0yd"
   } ],
-  "rightsHolder" : "hcfy8Ayo5TEQ",
-  "duplicateOf" : "https://www.example.org/06f5b286-54bd-4acf-8e6a-09ef9f83c496",
+  "rightsHolder" : "KtTLQysc5CdSoZs4m",
+  "duplicateOf" : "https://www.example.org/d8309787-8add-44d1-a589-dfe9b2e686e8",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "4Oi3MmtNgg6bphsY"
+    "note" : "y0d3DAZGtyn8B"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Mk3jt8N8qP9x030DCi",
-    "createdBy" : "JQTzjPPERdNob",
-    "createdDate" : "2011-06-21T01:58:04.652Z"
+    "note" : "cJuBLVsXFu9Hq",
+    "createdBy" : "EYQ8PdRHONxU0cwSfz6",
+    "createdDate" : "1986-01-29T02:19:47.959Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/358e8aa0-9f43-4e53-9739-05e51c0b2521" ],
+  "curatingInstitutions" : [ "https://www.example.org/be67fd4c-dabc-4539-9c1a-bf22db0f4088" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "DHLYeR29brD0uR",
-    "ownerAffiliation" : "https://www.example.org/59dfb419-93df-4068-a721-2197b38aeca9"
+    "owner" : "NtNfkH1Vwxr",
+    "ownerAffiliation" : "https://www.example.org/f7053342-d91d-4788-8b1f-144c080a0fe9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b0ea9b17-8e22-4803-96b9-16f5175f19a2"
+    "id" : "https://www.example.org/9f46ba9d-9790-4894-b972-a1312836f003"
   },
-  "createdDate" : "1976-06-16T06:44:16.035Z",
-  "modifiedDate" : "2007-07-25T08:08:12.863Z",
-  "publishedDate" : "2022-12-13T18:16:04.903Z",
-  "indexedDate" : "2007-12-04T10:15:45.343Z",
-  "handle" : "https://www.example.org/5f7ea04f-a48a-47f6-93e5-f0e91b062d8e",
-  "doi" : "https://doi.org/10.1234/blanditiis",
-  "link" : "https://www.example.org/76d2c054-875a-4e21-b9e5-e6466d35ba05",
+  "createdDate" : "1989-10-18T22:46:09.575Z",
+  "modifiedDate" : "1982-04-20T21:59:28.479Z",
+  "publishedDate" : "1983-09-24T17:45:40.924Z",
+  "indexedDate" : "2020-05-09T09:44:02.046Z",
+  "handle" : "https://www.example.org/fc36faa6-916e-43dc-8f29-cc865d34ccc5",
+  "doi" : "https://doi.org/10.1234/officia",
+  "link" : "https://www.example.org/6bb528ba-c026-42b5-873c-266b40a0df85",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Ch6Sl46xAEMY",
+    "mainTitle" : "84VNAxetVvP",
     "alternativeTitles" : {
-      "nn" : "DZqAHRtK4TtKEfA9ac"
+      "af" : "KzyEh5RGck0qHhK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zoK16ezZuotYKZ0",
-      "month" : "yzyuKkvLs5EedpLXlvO",
-      "day" : "oQUguqbyth1XQMrR"
+      "year" : "RWhF820jbcTG",
+      "month" : "QBgyXguWe3cnOVdMTC",
+      "day" : "F9tKz4NWydK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/79886f39-0595-402e-a940-564529f8c605",
-        "name" : "eRSxFCPWYaA0",
+        "id" : "https://www.example.org/ba64fb12-4d72-409b-b708-71883f60d46a",
+        "name" : "x7hqGFX1TDlLfGeOur0",
         "nameType" : "Organizational",
-        "orcId" : "M5ZLvYemKGJKjcJu",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "uChk94wVYxlcdVXG8A",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OMB9O4I2rgb",
-          "value" : "yrHChIefojUf6J"
+          "sourceName" : "jVpH3gcX3OYN32lROyx",
+          "value" : "4caCPeOJmKSZ7M03H"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xCzdJfX7oesXKvcwC",
-          "value" : "fF8DJZSJohKALtL"
+          "sourceName" : "rxFFykUuwkrmQfK",
+          "value" : "2AV3vGqOzeGQ1NEUxi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c8c67f7d-b2f8-4a21-a5ef-ac698cd31042"
+        "id" : "https://www.example.org/e11ee128-54dd-4adb-beb4-e8f3a535ae81"
       } ],
       "role" : {
         "type" : "SoundDesigner"
@@ -62,161 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/52769df3-df48-4df1-8bd5-0e5dcf267ab3",
-        "name" : "12v8SP84h5o0V6NS5T",
+        "id" : "https://www.example.org/4b78c80e-4629-49c8-9568-1bd2864f2e69",
+        "name" : "YebUgT1JrSZ",
         "nameType" : "Organizational",
-        "orcId" : "T6hSyWp2Id7rD6",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "5PvGBmtdFpVvtoL",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Kh7He9BU6A",
-          "value" : "knA1DlrC2T"
+          "sourceName" : "XhC8bTYfywL2ISUA5",
+          "value" : "sVnlzEror2DM1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UTAGP8N1Vj",
-          "value" : "cZnfmPStx7lqvox6"
+          "sourceName" : "YDNFn415b6OO9",
+          "value" : "DqOybAnMlSQ2dn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3f6400f1-2ddb-43e7-80b1-375b80a67964"
+        "id" : "https://www.example.org/8ff25c20-4d05-4f76-870d-f602c805b41e"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "e89jqmOF9Br6aF"
+      "it" : "Co2pPz62ICq8"
     },
-    "npiSubjectHeading" : "BiWu4TsE4NqFTMD",
-    "tags" : [ "0Z0LDqtMmpn9PfTfD4" ],
-    "description" : "rLaEKb2c34",
+    "npiSubjectHeading" : "lB96HBSCjqf",
+    "tags" : [ "ad4qL8czAyHAe" ],
+    "description" : "zoZlxU7PNguk6dKBusS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3dc6bb67-f66f-429f-90a8-84f786df0ae5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/415bad30-99c4-45e8-877e-f566fdc75dd3"
         },
-        "seriesNumber" : "UJ1C5w8Fou7JBoDuEJ",
+        "seriesNumber" : "puQ0oAymcjtRA1JW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/da508b75-69da-4a76-88d3-ff5efa93f81f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/96b057ca-4f58-458a-87d0-ba241fb00f11",
           "valid" : true
         },
-        "isbnList" : [ "9780445132160" ],
+        "isbnList" : [ "9780914072232", "9781535199353" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "xqGTGUmQKi9HwLa"
+          "value" : "1535199350"
         } ]
       },
-      "doi" : "https://www.example.org/baaca1cd-87a4-4589-9635-b294b0ff0ee9",
+      "doi" : "https://www.example.org/d39bce98-f007-48fb-82b5-0cc86d9cc1ee",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "2QRBkTIkeO1HYBO99",
-            "end" : "rqgVJ2KNsPMJhx1T"
+            "begin" : "frwTN4l1faUuKzx6V",
+            "end" : "bkX6lJfeju"
           },
-          "pages" : "OxVZjHhvmVl",
-          "illustrated" : false
+          "pages" : "LhF2BSYBh369yHQAfp",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b4ff4ecf-227e-481d-b191-0f8dbb001e6a",
-    "abstract" : "JX2sg3CbxW"
+    "metadataSource" : "https://www.example.org/1f0f0736-4e69-43a4-9f6d-dd7abd9cbd6e",
+    "abstract" : "Co8bcSVYyO53jWW1335"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/245daa6c-7c08-43c5-962d-d1e58f99ed1d",
-    "name" : "W6JJRerNlNioBQT",
+    "id" : "https://www.example.org/e5548098-fa79-4bba-bed1-b9ca411e6441",
+    "name" : "XzOSIcY8mc",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-01-30T23:04:49.635Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "kErMdYSfPNHcrH9"
+      "approvalDate" : "1984-05-02T21:13:51.725Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "YjHM84DUvag6cR6YVF"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/de7393b8-d1dd-416a-b24d-e33a627514bc",
-    "identifier" : "FzFCbxtWSBj58",
+    "source" : "https://www.example.org/687f0363-abcc-423c-bb5f-6dd010f528c9",
+    "identifier" : "dHlkGwChQu3mERv",
     "labels" : {
-      "is" : "PW3KhRZmZyR"
+      "hu" : "bN2FYqB601"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 136350927
+      "currency" : "EUR",
+      "amount" : 2057885200
     },
-    "activeFrom" : "1977-08-07T18:13:30.078Z",
-    "activeTo" : "1992-11-01T11:02:40.234Z"
+    "activeFrom" : "1989-09-20T08:46:55.059Z",
+    "activeTo" : "2016-03-09T13:13:11.846Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9c02b8a5-a896-4ac5-90cf-956690826d2e",
-    "id" : "https://www.example.org/5cd942be-7a10-4ca5-a5d3-80c785b76ccc",
-    "identifier" : "H1KLHwgNHHpoaknIERy",
+    "source" : "https://www.example.org/08ec1cca-6678-4992-b672-c71bad471e84",
+    "id" : "https://www.example.org/746576b0-a11a-4d8a-ac9a-85c301fc7ea0",
+    "identifier" : "b2EdfpfyzZb",
     "labels" : {
-      "cs" : "XNRkb6lqW9"
+      "es" : "zliZwCKIFQ15"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1935280788
+      "amount" : 450804781
     },
-    "activeFrom" : "1980-12-19T12:06:13.204Z",
-    "activeTo" : "1985-04-07T14:42:09.004Z"
+    "activeFrom" : "1986-07-06T01:58:30.898Z",
+    "activeTo" : "2019-05-06T22:27:35.843Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9e122b9f-fcc2-4d71-8b8e-ba6bae7e1963" ],
+  "subjects" : [ "https://www.example.org/839042e2-53ce-47dd-a610-602f9d6c1103" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "99a93719-2892-49a3-8e80-b788b5616a89",
-    "name" : "7um08ZBdEckYY9r",
-    "mimeType" : "picilbsQpopzhos",
-    "size" : 33723918,
-    "license" : "https://www.example.com/znb1qftzxiyfkolc",
+    "identifier" : "cce9a2db-aa63-4bdb-bfa9-24fc57f1ce7f",
+    "name" : "ndRyfYaEAsHxB4E",
+    "mimeType" : "sDJVXsTfg1iNB2hGEl",
+    "size" : 865150751,
+    "license" : "https://www.example.com/ehlgeibevq",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "QgsuLWn01IQp"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "auqlXzRwRe",
-    "publishedDate" : "2003-11-14T22:51:29.717Z",
+    "legalNote" : "QRaQomBYuZ",
+    "publishedDate" : "1979-09-04T03:23:51.223Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "YtRFJTkLb4bH6",
-      "uploadedDate" : "2007-04-22T14:40:37.984Z"
+      "uploadedBy" : "aYe5d8T6Qe4VaaAI",
+      "uploadedDate" : "1976-03-02T23:26:45.127Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NqypgtR7ok99v",
-    "name" : "xmOiigokvPq",
-    "description" : "gTJDZOIRQSj"
+    "id" : "https://www.example.com/AEFkFY9T3X0lD6LNHt",
+    "name" : "oGZjXXHSQMA",
+    "description" : "HnqbsCnBo9S78J"
   } ],
-  "rightsHolder" : "MCoZsL3bm8a9",
-  "duplicateOf" : "https://www.example.org/11ebb7ec-bbf4-4079-9bd1-50bb519868ca",
+  "rightsHolder" : "hcfy8Ayo5TEQ",
+  "duplicateOf" : "https://www.example.org/06f5b286-54bd-4acf-8e6a-09ef9f83c496",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "IcTpq824gRtEc9"
+    "note" : "4Oi3MmtNgg6bphsY"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2Ig6jrBdZsWZQbF",
-    "createdBy" : "HBvpNj1ixHf",
-    "createdDate" : "1973-05-02T05:29:43.475Z"
+    "note" : "Mk3jt8N8qP9x030DCi",
+    "createdBy" : "JQTzjPPERdNob",
+    "createdDate" : "2011-06-21T01:58:04.652Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fa611420-bb46-4423-ab62-09578fa60506" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/358e8aa0-9f43-4e53-9739-05e51c0b2521" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "E5jPuyZ2CHSL71heoWP",
-    "ownerAffiliation" : "https://www.example.org/5e3cca12-5cee-476d-8d44-19474d2245ae"
+    "owner" : "97vHsNyepDYMOUeq",
+    "ownerAffiliation" : "https://www.example.org/f10350f8-2994-41cc-b30d-d33d9392dd66"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cc41387b-4f02-4c8d-8891-d8a7c7d48894"
+    "id" : "https://www.example.org/54234b76-4376-49e0-b18f-f00d11392d4b"
   },
-  "createdDate" : "2018-12-28T19:44:45.327Z",
-  "modifiedDate" : "2015-12-08T05:03:59.034Z",
-  "publishedDate" : "1994-02-02T22:20:24.790Z",
-  "indexedDate" : "1997-07-16T04:14:37.561Z",
-  "handle" : "https://www.example.org/d62a706d-9563-4de6-8ee2-f767a376f004",
-  "doi" : "https://doi.org/10.1234/magnam",
-  "link" : "https://www.example.org/324899e5-0498-4593-b92c-f90c5e9bbf4a",
+  "createdDate" : "1981-08-13T08:22:34.757Z",
+  "modifiedDate" : "2011-04-16T18:31:47.782Z",
+  "publishedDate" : "2001-06-24T11:37:51.116Z",
+  "indexedDate" : "2012-07-08T11:24:01.543Z",
+  "handle" : "https://www.example.org/4b92a8f3-7350-4f03-a3f8-31793a2f187c",
+  "doi" : "https://doi.org/10.1234/delectus",
+  "link" : "https://www.example.org/f83a56ae-1f73-463b-b0a2-d6f426115e42",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WIBfdeBlLtQPUv",
+    "mainTitle" : "xI4m0zGyugu0i4yX8F",
     "alternativeTitles" : {
-      "nn" : "9q8inXMmzYI"
+      "is" : "Ik7F6Qzyd4yIO6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NWWHtSivGag",
-      "month" : "5mLdO2FZKrXA",
-      "day" : "bnDT1MNJwaalE1ma"
+      "year" : "YSaumGU6eb",
+      "month" : "3oRVP6NqlZvaN37qv",
+      "day" : "DCp3Lf6XknT9OJtfi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e0364c22-5d8d-43e8-ba1b-6e2fd774d749",
-        "name" : "KtUK8tPcQTIaP",
-        "nameType" : "Personal",
-        "orcId" : "7ARxEqXn0fHk3Qz5yWH",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/9db9542e-c032-418a-b63e-5b5d694ab90d",
+        "name" : "bty8WtFx0ZPz3",
+        "nameType" : "Organizational",
+        "orcId" : "0cYXBpUk1JMNEuKYIY",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qe92kkIXhc7",
-          "value" : "EJVSxE6zlZCs5Ua5SuV"
+          "sourceName" : "wBwQQRUI9NuRaoFz",
+          "value" : "lyany1obmL11tKPJF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gbOxfzfFM33",
-          "value" : "cmtEwkjF2KDxZOX"
+          "sourceName" : "Sc7S1MVJ5ST",
+          "value" : "kXcKqqbWDcZQJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0e5c7190-cf27-4554-9c79-7c7d0aba9d30"
+        "id" : "https://www.example.org/cf9516b1-debf-4956-9a0d-51903feb8183"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bd70a136-1635-4b31-b112-d4301d2b1319",
-        "name" : "Lsr55idQTi24GmZfU",
+        "id" : "https://www.example.org/5f30e981-c4b2-4fcf-901e-9200b36131e7",
+        "name" : "O61uOqYyjn7Qk",
         "nameType" : "Organizational",
-        "orcId" : "c9LvkwAX6AxJe",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "73HHTLVwLzASlkjwZtB",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QAHpzyNUoKgX",
-          "value" : "mpD0pxu9oh2R6"
+          "sourceName" : "WouBmGJ70lH",
+          "value" : "wNFIy0DjDNNql9GORGb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yWwzQAKqJeKnhd",
-          "value" : "Y73KlHEm3nfrRtfNL"
+          "sourceName" : "1sEtnywmEXmv",
+          "value" : "NBlWDHr6US1EE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/52a1c31b-0c7e-45b0-a4c7-0176d1961b4f"
+        "id" : "https://www.example.org/a6a9ec60-5dd2-4148-b16e-04f515f7ce34"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Creator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "x3K1S3P2fpLWYN"
+      "bg" : "wFjxWkU2rxWX337WO"
     },
-    "npiSubjectHeading" : "VQf1iYTuFeSXDlTB",
-    "tags" : [ "twOlYck6xpsC" ],
-    "description" : "v0ukwToS9eYFLQVa",
+    "npiSubjectHeading" : "6llhLYLXXW1D8CxObY1",
+    "tags" : [ "9xWwmpg5McRHOhB9" ],
+    "description" : "X4Ij2bIyOCrq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1715bfe9-b1ad-4248-a515-708a1491bf13"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5e0a4d77-6ae9-45e8-8300-7e0ee6ce81a4"
         },
-        "seriesNumber" : "KxBfQGdcArU",
+        "seriesNumber" : "vsCIKdTw3tc2iBIUVi",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a91a02d9-ddb5-4898-8513-d216b479d746",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c455c1b6-0afb-48bd-b090-62f48b042eff",
           "valid" : true
         },
-        "isbnList" : [ "9790876768302", "9780078762550" ],
+        "isbnList" : [ "9780692306376", "9780061919343" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0078762553"
+          "value" : "0061919349"
         } ]
       },
-      "doi" : "https://www.example.org/95064ca7-6e17-4756-84d1-48c28dd74f46",
+      "doi" : "https://www.example.org/4419f8a4-eba4-4a6c-ae7e-97e0fa3627df",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7sblf5KcuScL9z",
-            "end" : "2fYVC1fFkIr6K"
+            "begin" : "PyvLWdpvq9FP",
+            "end" : "7aHOWp4PlIxfIg"
           },
-          "pages" : "dIcamD6i57W4IvQjCu9",
-          "illustrated" : true
+          "pages" : "hqBjF2YeD3gtyjx",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/603b1250-2566-4d13-85cf-0371a4db1135",
-    "abstract" : "0YDFK2T7ZFQZX9aLC"
+    "metadataSource" : "https://www.example.org/f0d57a53-02c0-451c-93d1-399825417c66",
+    "abstract" : "kIJYe1AZaJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/78d69561-e313-4963-baa7-afe59d154d2c",
-    "name" : "6IcgR3rr15eDr7XWY7",
+    "id" : "https://www.example.org/e7f39869-0b86-434a-8adc-121a1d333855",
+    "name" : "GDzwIHxTsAr2Q",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-03-25T10:29:58.204Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2014-05-28T08:29:47.634Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "uZsVgNbxlDG03C8k"
+      "applicationCode" : "lhKJ0opbkep"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dfa5f420-1597-49d2-b660-cf1341d86c47",
-    "identifier" : "Mqi0RJfevii",
+    "source" : "https://www.example.org/a93de909-17e6-4a61-aa2c-35a5fef7f406",
+    "identifier" : "Mw2hQtN8RnYQ51",
     "labels" : {
-      "se" : "CYbwl1yLEfx9a"
+      "nl" : "DrdglC3CoGBNHWvBVn"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 799084
+      "currency" : "NOK",
+      "amount" : 1767846392
     },
-    "activeFrom" : "1987-12-10T01:11:36.912Z",
-    "activeTo" : "2022-05-07T01:32:21.830Z"
+    "activeFrom" : "1999-05-27T03:49:05.896Z",
+    "activeTo" : "2018-08-20T21:15:52.515Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cdc8b15c-7837-4e39-b843-b99dc2f25a5f",
-    "id" : "https://www.example.org/04246840-3b91-4866-96ee-3e94e4d3abb8",
-    "identifier" : "1zMZ8Ma1nb",
+    "source" : "https://www.example.org/6e1eebaf-ff5d-4f0b-9e0a-b909f20829b4",
+    "id" : "https://www.example.org/822cacad-aecc-4866-abb7-01a3607b436b",
+    "identifier" : "BbRwII0dp9cm1klJjjk",
     "labels" : {
-      "da" : "wITkCNTnEQQ"
+      "nl" : "8evp4QZXCV6H"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1365571157
+      "currency" : "EUR",
+      "amount" : 525929300
     },
-    "activeFrom" : "2003-10-01T17:57:18.416Z",
-    "activeTo" : "2005-05-09T11:04:05.551Z"
+    "activeFrom" : "1980-03-05T05:59:50.543Z",
+    "activeTo" : "1997-05-15T18:35:58.965Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0e1aad5a-d16f-4611-b8cf-b7c5f2c36ef9" ],
+  "subjects" : [ "https://www.example.org/bcde7c98-3d96-4e96-975d-2516eb24d75e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2ca4feaf-3fad-437d-a267-dcbd6e080324",
-    "name" : "H4rCGW1a50xlW64",
-    "mimeType" : "8YVwdbcME69IgGDNW",
-    "size" : 1332588849,
-    "license" : "https://www.example.com/52v29wku4g",
+    "identifier" : "687b00e4-2849-42e1-9fa9-87b1287946c0",
+    "name" : "IhzxLEcqomfJCdu",
+    "mimeType" : "xecHqWiuWmweBS",
+    "size" : 1188916662,
+    "license" : "https://www.example.com/v01dfdno54rvkhjp",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "no3qhs3anH4ESS0jU",
-    "publishedDate" : "1994-12-20T02:43:36.541Z",
+    "legalNote" : "gFsiKhsxudJDCG",
+    "publishedDate" : "1976-03-10T22:41:14.560Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "zjpkny4tqcngzAWln",
-      "uploadedDate" : "2000-12-15T23:41:16.262Z"
+      "uploadedBy" : "ves9ncmT29",
+      "uploadedDate" : "1994-04-01T16:37:30.399Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NaI3bVSiDJt08Bglw",
-    "name" : "GeL5iJ9NXkyMk2OJgL",
-    "description" : "JXcUQUoniPjvA"
+    "id" : "https://www.example.com/nLSTJyMFWv99f2iSEY",
+    "name" : "3kX1sTw9XHc",
+    "description" : "gkFUwSapaIJCXSuWh"
   } ],
-  "rightsHolder" : "4XQcYMDOuwqj",
-  "duplicateOf" : "https://www.example.org/7d10ac61-c1d2-49d5-9bba-8e6fb4aba22a",
+  "rightsHolder" : "7KZZANpzFSpABcGC2",
+  "duplicateOf" : "https://www.example.org/c417e6d4-98be-4fad-afdb-a327d6afd1e6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "doC4WVuhysua6kxy0"
+    "note" : "xkdpmNcqR4"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1ti2uPrtNOkhKU",
-    "createdBy" : "hMtGkmEy7GdM2G88d",
-    "createdDate" : "2001-12-25T03:01:36.518Z"
+    "note" : "ISK8eqQ30AbbqvDUm",
+    "createdBy" : "emwBID14sIdvS",
+    "createdDate" : "2005-04-17T21:08:52.906Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7a0a7952-ed21-408e-9e67-79a217dc8116" ],
+  "curatingInstitutions" : [ "https://www.example.org/08e99282-3fac-4d23-85f9-b9f12c6e82ac" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "H43u0zxXFCDzQHK",
-    "ownerAffiliation" : "https://www.example.org/778ba3c4-eb9f-4789-8666-29d86a1183d6"
+    "owner" : "E5jPuyZ2CHSL71heoWP",
+    "ownerAffiliation" : "https://www.example.org/5e3cca12-5cee-476d-8d44-19474d2245ae"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/42ae2144-79f3-46e5-8d87-5f4e1f225c2b"
+    "id" : "https://www.example.org/cc41387b-4f02-4c8d-8891-d8a7c7d48894"
   },
-  "createdDate" : "1999-01-11T14:08:49.198Z",
-  "modifiedDate" : "2009-10-27T10:13:00.269Z",
-  "publishedDate" : "1979-10-06T14:36:44.959Z",
-  "indexedDate" : "1988-06-06T19:34:40.080Z",
-  "handle" : "https://www.example.org/2adc702e-3797-48c8-877a-bf84ebbba833",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/51891a97-6dfd-45e2-99f6-24cead8bb374",
+  "createdDate" : "2018-12-28T19:44:45.327Z",
+  "modifiedDate" : "2015-12-08T05:03:59.034Z",
+  "publishedDate" : "1994-02-02T22:20:24.790Z",
+  "indexedDate" : "1997-07-16T04:14:37.561Z",
+  "handle" : "https://www.example.org/d62a706d-9563-4de6-8ee2-f767a376f004",
+  "doi" : "https://doi.org/10.1234/magnam",
+  "link" : "https://www.example.org/324899e5-0498-4593-b92c-f90c5e9bbf4a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "PXBBsEhCcI",
+    "mainTitle" : "WIBfdeBlLtQPUv",
     "alternativeTitles" : {
-      "fr" : "fI2Ei2OOk65reX9fa"
+      "nn" : "9q8inXMmzYI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "W5qlOpwrhvbMJqGjG",
-      "month" : "fYezwskanIe",
-      "day" : "qfOTvyPoRhDF67Wg"
+      "year" : "NWWHtSivGag",
+      "month" : "5mLdO2FZKrXA",
+      "day" : "bnDT1MNJwaalE1ma"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/565f672d-4c04-481a-acba-d3740a635186",
-        "name" : "zZ7FKRULHCL",
+        "id" : "https://www.example.org/e0364c22-5d8d-43e8-ba1b-6e2fd774d749",
+        "name" : "KtUK8tPcQTIaP",
         "nameType" : "Personal",
-        "orcId" : "cj3LVqLtD5KThLd",
-        "verificationStatus" : "Verified",
+        "orcId" : "7ARxEqXn0fHk3Qz5yWH",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8vwyr3RHKNn0s7IV8wR",
-          "value" : "9nVVsWDS6bnp2"
+          "sourceName" : "qe92kkIXhc7",
+          "value" : "EJVSxE6zlZCs5Ua5SuV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2ADWH1xKaqKt",
-          "value" : "IB6IZudz5g"
+          "sourceName" : "gbOxfzfFM33",
+          "value" : "cmtEwkjF2KDxZOX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2b4ffb1a-cbbf-4c4d-ae55-d0735af1fc55"
+        "id" : "https://www.example.org/0e5c7190-cf27-4554-9c79-7c7d0aba9d30"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3f62d638-1b2d-4a27-a7ea-3048c6062cbd",
-        "name" : "EGYNgQC0tBV4PFkzMI",
+        "id" : "https://www.example.org/bd70a136-1635-4b31-b112-d4301d2b1319",
+        "name" : "Lsr55idQTi24GmZfU",
         "nameType" : "Organizational",
-        "orcId" : "PO59wjHTYHd",
-        "verificationStatus" : "Verified",
+        "orcId" : "c9LvkwAX6AxJe",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3ZkRVSkXNr",
-          "value" : "PiyGHo5auP5UB5N1OL"
+          "sourceName" : "QAHpzyNUoKgX",
+          "value" : "mpD0pxu9oh2R6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EIUgeFokh0Fw6BEPf65",
-          "value" : "rb9UBsm6FJaUAe"
+          "sourceName" : "yWwzQAKqJeKnhd",
+          "value" : "Y73KlHEm3nfrRtfNL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/283f41b4-b2a0-47dc-ab03-a4eea5140498"
+        "id" : "https://www.example.org/52a1c31b-0c7e-45b0-a4c7-0176d1961b4f"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "LDQL7zsxYto8EZmBz"
+      "sv" : "x3K1S3P2fpLWYN"
     },
-    "npiSubjectHeading" : "JM7WaZ5mLY",
-    "tags" : [ "1IrEjMZCe8" ],
-    "description" : "hCscwgZe052bi",
+    "npiSubjectHeading" : "VQf1iYTuFeSXDlTB",
+    "tags" : [ "twOlYck6xpsC" ],
+    "description" : "v0ukwToS9eYFLQVa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/77065a70-d20b-4ced-a502-8f79ce85ffb1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1715bfe9-b1ad-4248-a515-708a1491bf13"
         },
-        "seriesNumber" : "Iv4HkLHQ1s",
+        "seriesNumber" : "KxBfQGdcArU",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/52718be9-044d-48cc-9062-20203b59ae46",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a91a02d9-ddb5-4898-8513-d216b479d746",
           "valid" : true
         },
-        "isbnList" : [ "9781911407942" ],
+        "isbnList" : [ "9790876768302", "9780078762550" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "fMHI9hRrCNWFP"
+          "value" : "0078762553"
         } ]
       },
-      "doi" : "https://www.example.org/a9727908-843d-4028-8e02-f4a21b59e2b5",
+      "doi" : "https://www.example.org/95064ca7-6e17-4756-84d1-48c28dd74f46",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Y2RgCQa1dfuVGDAL0",
-            "end" : "HphCB8H0o5ZUtGNjv"
+            "begin" : "7sblf5KcuScL9z",
+            "end" : "2fYVC1fFkIr6K"
           },
-          "pages" : "th50Nr8IyaOD7",
+          "pages" : "dIcamD6i57W4IvQjCu9",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2a7c863e-36e6-4dba-9189-7dbca452b99b",
-    "abstract" : "KO2z6poa0n8DK"
+    "metadataSource" : "https://www.example.org/603b1250-2566-4d13-85cf-0371a4db1135",
+    "abstract" : "0YDFK2T7ZFQZX9aLC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/75e41d51-4955-4645-aba7-42f737570e15",
-    "name" : "38vE0vcxtMp2QS50CFD",
+    "id" : "https://www.example.org/78d69561-e313-4963-baa7-afe59d154d2c",
+    "name" : "6IcgR3rr15eDr7XWY7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2024-03-24T21:16:39.978Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "flSHrDmssByxFIu"
+      "approvalDate" : "1998-03-25T10:29:58.204Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "uZsVgNbxlDG03C8k"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ffb3810d-5249-4c05-b7d6-eae946ae9dff",
-    "identifier" : "k6QnggSJKuk",
+    "source" : "https://www.example.org/dfa5f420-1597-49d2-b660-cf1341d86c47",
+    "identifier" : "Mqi0RJfevii",
     "labels" : {
-      "it" : "BqulYa5rYIBp"
+      "se" : "CYbwl1yLEfx9a"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 833806919
+      "currency" : "USD",
+      "amount" : 799084
     },
-    "activeFrom" : "2018-02-01T12:41:30.687Z",
-    "activeTo" : "2019-11-07T02:24:38.942Z"
+    "activeFrom" : "1987-12-10T01:11:36.912Z",
+    "activeTo" : "2022-05-07T01:32:21.830Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1cb9edd0-d14c-4ab2-9efa-cd8011d5dd14",
-    "id" : "https://www.example.org/4979c503-360a-44b4-be89-dad073e70cfb",
-    "identifier" : "oIGFWUiQwNYUNWDg2g",
+    "source" : "https://www.example.org/cdc8b15c-7837-4e39-b843-b99dc2f25a5f",
+    "id" : "https://www.example.org/04246840-3b91-4866-96ee-3e94e4d3abb8",
+    "identifier" : "1zMZ8Ma1nb",
     "labels" : {
-      "ru" : "GjpVzCaEOOirgYbrr"
+      "da" : "wITkCNTnEQQ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 334466134
+      "currency" : "USD",
+      "amount" : 1365571157
     },
-    "activeFrom" : "1986-12-13T16:29:54.261Z",
-    "activeTo" : "1993-03-21T07:02:19.396Z"
+    "activeFrom" : "2003-10-01T17:57:18.416Z",
+    "activeTo" : "2005-05-09T11:04:05.551Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/88d3a504-718e-4afd-a677-ca4114c1a81a" ],
+  "subjects" : [ "https://www.example.org/0e1aad5a-d16f-4611-b8cf-b7c5f2c36ef9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "69a7a303-53cb-426d-909f-6a9badb87e01",
-    "name" : "1QnqIJNY0NdaRw",
-    "mimeType" : "8Ob9sC5zzGoj",
-    "size" : 1274767903,
-    "license" : "https://www.example.com/c7ptuxcqzyqojmel",
+    "identifier" : "2ca4feaf-3fad-437d-a267-dcbd6e080324",
+    "name" : "H4rCGW1a50xlW64",
+    "mimeType" : "8YVwdbcME69IgGDNW",
+    "size" : 1332588849,
+    "license" : "https://www.example.com/52v29wku4g",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "6sCPsveNOUiqVTwM",
-    "publishedDate" : "1977-08-01T07:55:38.316Z",
+    "legalNote" : "no3qhs3anH4ESS0jU",
+    "publishedDate" : "1994-12-20T02:43:36.541Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Esal7pBjcSSfEMzvlMm",
-      "uploadedDate" : "2007-05-01T05:21:27.614Z"
+      "uploadedBy" : "zjpkny4tqcngzAWln",
+      "uploadedDate" : "2000-12-15T23:41:16.262Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/b2pVFCiuNm9IvWz1",
-    "name" : "LGeHkJWp1s87ZeftO",
-    "description" : "4f2TGeLj9sC"
+    "id" : "https://www.example.com/NaI3bVSiDJt08Bglw",
+    "name" : "GeL5iJ9NXkyMk2OJgL",
+    "description" : "JXcUQUoniPjvA"
   } ],
-  "rightsHolder" : "XxN6DkaXBINx7xa5ET",
-  "duplicateOf" : "https://www.example.org/9dcdc0d6-712b-4e0f-a61d-37b7f26688b3",
+  "rightsHolder" : "4XQcYMDOuwqj",
+  "duplicateOf" : "https://www.example.org/7d10ac61-c1d2-49d5-9bba-8e6fb4aba22a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5c5q63OEGaTJFPqp"
+    "note" : "doC4WVuhysua6kxy0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jo4MFMgPNUhYs",
-    "createdBy" : "icqfw8COeniwNa9",
-    "createdDate" : "1977-04-04T07:54:14.507Z"
+    "note" : "1ti2uPrtNOkhKU",
+    "createdBy" : "hMtGkmEy7GdM2G88d",
+    "createdDate" : "2001-12-25T03:01:36.518Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/614f5745-45ab-4b80-9ab5-c3ae2388c614" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/7a0a7952-ed21-408e-9e67-79a217dc8116" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "Mzmy6grcym",
-    "ownerAffiliation" : "https://www.example.org/1f2c4941-6fa0-41e2-88c3-8baca054c1e8"
+    "owner" : "thaqHpglgsrAhfm8CC",
+    "ownerAffiliation" : "https://www.example.org/062f7d13-4a03-4541-bc0e-635ec5daf721"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d96f43f1-5f18-4e21-a145-b74deac86e44"
+    "id" : "https://www.example.org/e031f2f8-c2a6-4293-bef1-b4fc46ae9d4e"
   },
-  "createdDate" : "2022-07-21T04:46:15.334Z",
-  "modifiedDate" : "1997-01-05T18:47:24.584Z",
-  "publishedDate" : "1975-01-12T11:09:15.248Z",
-  "indexedDate" : "1971-09-01T14:14:26.230Z",
-  "handle" : "https://www.example.org/037464bb-5766-45d6-9492-1c3dc4ca9ae4",
-  "doi" : "https://doi.org/10.1234/numquam",
-  "link" : "https://www.example.org/29249ab9-ee9e-42b8-8321-e18850e5130c",
+  "createdDate" : "2020-01-23T19:07:01.990Z",
+  "modifiedDate" : "1972-11-04T05:06:09.916Z",
+  "publishedDate" : "1992-09-25T04:16:41.111Z",
+  "indexedDate" : "2014-06-17T14:43:12.298Z",
+  "handle" : "https://www.example.org/60d7cb8c-48b9-46ca-ba91-344428cd42d0",
+  "doi" : "https://doi.org/10.1234/ipsum",
+  "link" : "https://www.example.org/9187e5c1-edee-4ed5-b9dd-6a6181153dd4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vZpicze9zO1wP",
+    "mainTitle" : "rP6QMRQqSc9b",
     "alternativeTitles" : {
-      "sv" : "bTRRCyt7KMDYzrLbm"
+      "nn" : "7owSMSsMTDDH6Uc2L"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PgKyQJg1g8aP",
-      "month" : "ytiysipxezQDd",
-      "day" : "fhRvkyrNBEF"
+      "year" : "i53RUBBMtSX",
+      "month" : "SArysWtC5TAqmysmm9J",
+      "day" : "31Vb3ROKopl4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5c9551b4-ee2b-4627-a420-2d239ad99e4c",
-        "name" : "PrqboOsE8XAch",
+        "id" : "https://www.example.org/38b8026d-944d-4bd8-82a7-b9b0d36036cc",
+        "name" : "bAJQNiqzh6RqHlwafj",
         "nameType" : "Personal",
-        "orcId" : "UW4iLlP1gF",
-        "verificationStatus" : "Verified",
+        "orcId" : "LKsItuUCvOk",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1kIydPrBGfk",
-          "value" : "Uo86ZWKILs"
+          "sourceName" : "XGdn8znt4G2Y6etWM",
+          "value" : "RVf3bjmyOiunIkB1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aNKnAhqNiOXWUtLi2",
-          "value" : "DpNBCVIiUtI3"
+          "sourceName" : "CTanClXpfDPXAw0",
+          "value" : "smp7brMcbe7hkF3a5YX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5a5e6e08-91bf-4318-aa12-3985b61ff190"
+        "id" : "https://www.example.org/71f771b8-d492-45e2-9f1a-4d5044f9464c"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a1e02cf-5aab-4a2b-a764-f199bd4fbab5",
-        "name" : "eNXLwJ56Z0",
+        "id" : "https://www.example.org/bebfe857-b920-46e9-aec5-52cacd343440",
+        "name" : "EicEwtb82ysSM2",
         "nameType" : "Organizational",
-        "orcId" : "bYrlNT6he84O",
+        "orcId" : "KgF7egSixxP4rq",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bW16RRIlfdSmdG",
-          "value" : "dYJX28gevtwY"
+          "sourceName" : "RzCaliHCUELTkEdp",
+          "value" : "N4bDlsFIiLfCWiMj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "As8RBzUWbEw",
-          "value" : "WX6V2MnlKzcICulk"
+          "sourceName" : "GySP1udXTB8ts",
+          "value" : "lTwLMM2wx2sImu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f8e3545-be14-4ce2-908b-d24a3ada71e7"
+        "id" : "https://www.example.org/17fe82f5-d852-48c9-b0ae-54051352f306"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "hSaUA5DTdK2"
+      "nb" : "YEGsWv1Se4PwT6Ni"
     },
-    "npiSubjectHeading" : "AVGjh4zMHNki",
-    "tags" : [ "fPQiFyTIXfgnMOIz8c" ],
-    "description" : "5VfroOwi4GreBM6",
+    "npiSubjectHeading" : "E1LfIg2kEWm5xE0",
+    "tags" : [ "6OdClFr9qk7qm4AKF" ],
+    "description" : "YjpSMHMsna2tOTi08W1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/26dac969-6ab9-4a3b-844a-5a3ed5db8e1c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ebf469da-8790-4fd6-a7c8-0e72322f360d"
         },
-        "seriesNumber" : "65XHoGQdvwzkajYjC",
+        "seriesNumber" : "QmL3Y9qMxiCXPLgM",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/99bba6af-8f88-4710-a1c8-cdac499d591b",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/510f6392-6448-45a9-af49-af96c615e3be",
           "valid" : true
         },
-        "isbnList" : [ "9790796392366", "9780901776259" ],
+        "isbnList" : [ "9791875831998", "9780324681017" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0901776254"
+          "value" : "0324681011"
         } ]
       },
-      "doi" : "https://www.example.org/0541ba43-6896-4fdc-ab84-4b64b0e06762",
+      "doi" : "https://www.example.org/b583a012-a0a4-426c-af5a-57fb3eb778b7",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "CgCmWzFoaSx",
-            "end" : "a3bVpb4jUGTEKQJu"
+            "begin" : "YtlZW44ESLgcKX2KPae",
+            "end" : "moMDCEbqqNt8K"
           },
-          "pages" : "jEehSTixNJ5jn",
-          "illustrated" : false
+          "pages" : "mSpaouAuA9r6FV",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c9311b4b-dacf-41bc-b420-7b60d1a7ef72",
-    "abstract" : "nbQCYDqT2D"
+    "metadataSource" : "https://www.example.org/e5be77c8-bc27-4bc4-8e79-1390b42c7ae8",
+    "abstract" : "6cX6J8fMdVjvF1h"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cc913566-ce47-4200-8c85-5758b2432e98",
-    "name" : "hNY1DuyHSSGJV7ssD",
+    "id" : "https://www.example.org/3c5cef3a-5c0d-4458-ba35-7bf1f618226e",
+    "name" : "hFCYE22cYMbbGnNT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-07-18T20:17:28.698Z",
+      "approvalDate" : "2021-12-23T01:34:26.645Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "KA791I08PlttoZj"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "kAou9pq5Wnj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6479f02e-ea07-4b06-8b4c-279e85a76c5e",
-    "identifier" : "2fi1g653L1Wv",
+    "source" : "https://www.example.org/0343ac54-e6b8-4b25-b899-077766ddc411",
+    "identifier" : "kHKwb6MgCeZAv7B",
     "labels" : {
-      "pt" : "BfbSQKTOMFb"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1022181964
-    },
-    "activeFrom" : "1976-08-21T23:28:08.534Z",
-    "activeTo" : "1981-04-16T22:44:20.718Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dd5f8d7a-de0e-430e-b81c-32b571ef5c3d",
-    "id" : "https://www.example.org/98029a2b-4732-407f-bba7-4c638d99a7b2",
-    "identifier" : "RAMgd4QjZaFdWe2",
-    "labels" : {
-      "fi" : "LzSHpiCD5h9bBfto"
+      "fi" : "2kwj2UDFCCUZ"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1414552579
+      "amount" : 339686491
     },
-    "activeFrom" : "2016-06-09T12:25:00.248Z",
-    "activeTo" : "2024-04-25T21:47:14.722Z"
+    "activeFrom" : "1983-05-03T23:23:26.599Z",
+    "activeTo" : "2005-08-12T20:11:17.969Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/137c70ec-6a6a-4162-8a02-293f566bd69f",
+    "id" : "https://www.example.org/8319d801-8a38-4d23-8c54-daeca4aa5c4d",
+    "identifier" : "0aHANgQzVPWDkxLJjF",
+    "labels" : {
+      "el" : "jWlJHWkxmJMdnp5I"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1740795989
+    },
+    "activeFrom" : "2010-04-20T09:47:12.840Z",
+    "activeTo" : "2023-04-08T15:23:43.103Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fb738aa4-f13c-43a9-943a-19229a427e5f" ],
+  "subjects" : [ "https://www.example.org/00379409-d308-42b8-98d6-40c5a87bf513" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a21697ff-ba3b-4b13-9141-2c47f9f21806",
-    "name" : "bTPjZa2yGB",
-    "mimeType" : "rFt5wYRmfH2",
-    "size" : 265647935,
-    "license" : "https://www.example.com/rtuqo4dfbkrenwhjsm",
+    "identifier" : "94065823-59bc-4aaf-821e-130f3766bb02",
+    "name" : "PSiQXxnMJrDYTcGFF",
+    "mimeType" : "ofM1HYQlLQ5t9vvT5V",
+    "size" : 1824414429,
+    "license" : "https://www.example.com/mzkv4cbttifrgds",
     "administrativeAgreement" : false,
-    "publisherVersion" : "AcceptedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "zjcYuTihvJ",
-    "publishedDate" : "1985-05-19T21:30:17.290Z",
+    "legalNote" : "fp8rqc4ESHqwYyr",
+    "publishedDate" : "2016-01-21T06:26:58.239Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dsLhAFnYqVabi",
-      "uploadedDate" : "2019-12-01T03:03:22.194Z"
+      "uploadedBy" : "jhgkM3Ir22Rl",
+      "uploadedDate" : "1996-10-30T05:27:59.381Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TCS9DWmZTnR",
-    "name" : "MH1968oslTlH",
-    "description" : "4doDg2aglU5mngDrA"
+    "id" : "https://www.example.com/6Ob2TKLMCKcUoIV",
+    "name" : "lFtmSb0pDlqWaUKZE",
+    "description" : "RJbGHk4vK0MKOgSH"
   } ],
-  "rightsHolder" : "XmyzHDKzcObvfauBd",
-  "duplicateOf" : "https://www.example.org/cd094b75-745c-456c-b5fc-1b0e9f4ddc54",
+  "rightsHolder" : "Vzwf7WrHJjYq",
+  "duplicateOf" : "https://www.example.org/1e79cc55-ba7c-4893-a5ab-fcdf792a7ed0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "znGLFZJwNatB"
+    "note" : "oGIkZOGYj7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "AA254Sa3Qr",
-    "createdBy" : "XZPb9KXhbt9SpRt",
-    "createdDate" : "1986-10-30T22:02:50.869Z"
+    "note" : "7Shw8fFa2tEzSR",
+    "createdBy" : "n5Z4NTNo7hVmViJMaTq",
+    "createdDate" : "1975-05-28T11:48:35.476Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6ac91f60-6f82-4caa-965d-e5a42abb3781" ],
+  "curatingInstitutions" : [ "https://www.example.org/49018d82-82d8-4a44-a002-ec4513ebd182" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "dCPtrq7ITH4DWyhL",
-    "ownerAffiliation" : "https://www.example.org/cf99df6f-4344-403e-82be-b05f27485af6"
+    "owner" : "Mzmy6grcym",
+    "ownerAffiliation" : "https://www.example.org/1f2c4941-6fa0-41e2-88c3-8baca054c1e8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/61ae1e91-ff73-4af9-89f9-4c240dfb992b"
+    "id" : "https://www.example.org/d96f43f1-5f18-4e21-a145-b74deac86e44"
   },
-  "createdDate" : "2003-09-15T13:18:21.792Z",
-  "modifiedDate" : "1988-12-31T08:31:45.338Z",
-  "publishedDate" : "2005-11-29T17:57:54.969Z",
-  "indexedDate" : "2023-04-04T15:04:38.258Z",
-  "handle" : "https://www.example.org/4e7c4dd9-cd5c-4fd5-b37c-8b685912a06e",
-  "doi" : "https://doi.org/10.1234/doloremque",
-  "link" : "https://www.example.org/9773c723-27f0-4586-a2cc-5f3e38816c35",
+  "createdDate" : "2022-07-21T04:46:15.334Z",
+  "modifiedDate" : "1997-01-05T18:47:24.584Z",
+  "publishedDate" : "1975-01-12T11:09:15.248Z",
+  "indexedDate" : "1971-09-01T14:14:26.230Z",
+  "handle" : "https://www.example.org/037464bb-5766-45d6-9492-1c3dc4ca9ae4",
+  "doi" : "https://doi.org/10.1234/numquam",
+  "link" : "https://www.example.org/29249ab9-ee9e-42b8-8321-e18850e5130c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "e37YWm0gWa1Cwe",
+    "mainTitle" : "vZpicze9zO1wP",
     "alternativeTitles" : {
-      "pt" : "y0X9cO3AsOplL"
+      "sv" : "bTRRCyt7KMDYzrLbm"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "thqQLmDjVK",
-      "month" : "ts1DZiTmyWUpS7",
-      "day" : "lk2lh78ETZldjM"
+      "year" : "PgKyQJg1g8aP",
+      "month" : "ytiysipxezQDd",
+      "day" : "fhRvkyrNBEF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a4d71236-34bc-4020-b5e4-297b4512d09b",
-        "name" : "SXuxHpp7UiClW4vsd4",
+        "id" : "https://www.example.org/5c9551b4-ee2b-4627-a420-2d239ad99e4c",
+        "name" : "PrqboOsE8XAch",
         "nameType" : "Personal",
-        "orcId" : "02gyj6SZ0fb1lSWyBJ",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "UW4iLlP1gF",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eX87o5jqxYd8fncuwiC",
-          "value" : "3qoj0JxEBlxR7JxjC"
+          "sourceName" : "1kIydPrBGfk",
+          "value" : "Uo86ZWKILs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CYnIbhQWuqSZM6T2Aqj",
-          "value" : "XzabpbSCR1jr"
+          "sourceName" : "aNKnAhqNiOXWUtLi2",
+          "value" : "DpNBCVIiUtI3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1a29be09-4eb6-4848-b673-60e46036d89a"
+        "id" : "https://www.example.org/5a5e6e08-91bf-4318-aa12-3985b61ff190"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/24c6e9a1-30dc-481e-8203-3f33f708fc1d",
-        "name" : "ymooU01Da3HzH",
-        "nameType" : "Personal",
-        "orcId" : "qXNFPrrhdt",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/8a1e02cf-5aab-4a2b-a764-f199bd4fbab5",
+        "name" : "eNXLwJ56Z0",
+        "nameType" : "Organizational",
+        "orcId" : "bYrlNT6he84O",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v0LO41JemIDiQ",
-          "value" : "yq3ZA8jfduvAYWaPt"
+          "sourceName" : "bW16RRIlfdSmdG",
+          "value" : "dYJX28gevtwY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nVwFyEZCpBESV20Di0U",
-          "value" : "RxJwqrdvzGWSaC4SB"
+          "sourceName" : "As8RBzUWbEw",
+          "value" : "WX6V2MnlKzcICulk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e8172635-2b16-4252-a9da-6f7393d0d535"
+        "id" : "https://www.example.org/9f8e3545-be14-4ce2-908b-d24a3ada71e7"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "jNRba9LmSCZUc"
+      "el" : "hSaUA5DTdK2"
     },
-    "npiSubjectHeading" : "pDPN1gBUIXemikyxvrY",
-    "tags" : [ "SB2VFozghg2" ],
-    "description" : "MzVLLbf7aZW",
+    "npiSubjectHeading" : "AVGjh4zMHNki",
+    "tags" : [ "fPQiFyTIXfgnMOIz8c" ],
+    "description" : "5VfroOwi4GreBM6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/55df27f2-d948-4881-bc20-0244ead7ac6f"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/26dac969-6ab9-4a3b-844a-5a3ed5db8e1c"
         },
-        "seriesNumber" : "q0k0kJJkzUpRW",
+        "seriesNumber" : "65XHoGQdvwzkajYjC",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3c94b4a3-c45d-47a4-b0c7-943a015094de",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/99bba6af-8f88-4710-a1c8-cdac499d591b",
           "valid" : true
         },
-        "isbnList" : [ "9780031823625" ],
+        "isbnList" : [ "9790796392366", "9780901776259" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0VeO43DCIS0ei"
+          "value" : "0901776254"
         } ]
       },
-      "doi" : "https://www.example.org/1b485e85-5089-43c4-8a44-8e103580f8ab",
+      "doi" : "https://www.example.org/0541ba43-6896-4fdc-ab84-4b64b0e06762",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "QcRhesqsMGPA",
-            "end" : "Df2O4z6oNRo3Jn"
+            "begin" : "CgCmWzFoaSx",
+            "end" : "a3bVpb4jUGTEKQJu"
           },
-          "pages" : "oiDdv9N3TkK",
-          "illustrated" : true
+          "pages" : "jEehSTixNJ5jn",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/afab9e82-1e55-43d6-a910-9aa28eba1f6b",
-    "abstract" : "3nJ7ifl6AM"
+    "metadataSource" : "https://www.example.org/c9311b4b-dacf-41bc-b420-7b60d1a7ef72",
+    "abstract" : "nbQCYDqT2D"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/602131f8-dcd7-437e-93ba-c2a05fc076a7",
-    "name" : "Qt5xjBDDf0qZlrXhO",
+    "id" : "https://www.example.org/cc913566-ce47-4200-8c85-5758b2432e98",
+    "name" : "hNY1DuyHSSGJV7ssD",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-08-14T18:28:28.527Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "d7wkUQbNbVC1"
+      "approvalDate" : "2020-07-18T20:17:28.698Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "KA791I08PlttoZj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c2316e57-ce72-45ab-9720-8feae2df79d7",
-    "identifier" : "llp60hCBP66uxb",
+    "source" : "https://www.example.org/6479f02e-ea07-4b06-8b4c-279e85a76c5e",
+    "identifier" : "2fi1g653L1Wv",
     "labels" : {
-      "fi" : "RtuU5zXwxg"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2091330580
-    },
-    "activeFrom" : "1984-11-14T09:17:10.869Z",
-    "activeTo" : "1997-08-15T09:05:52.448Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/514eb148-37c6-4bb9-9686-907478268418",
-    "id" : "https://www.example.org/9c805380-9b78-4d87-8e3d-b994ebba4e25",
-    "identifier" : "lg6bgUSTATA9VC",
-    "labels" : {
-      "it" : "TmmJ3UBOz7vt"
+      "pt" : "BfbSQKTOMFb"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 97020388
+      "amount" : 1022181964
     },
-    "activeFrom" : "1992-10-22T17:40:58.337Z",
-    "activeTo" : "2012-07-02T09:19:17.497Z"
+    "activeFrom" : "1976-08-21T23:28:08.534Z",
+    "activeTo" : "1981-04-16T22:44:20.718Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/dd5f8d7a-de0e-430e-b81c-32b571ef5c3d",
+    "id" : "https://www.example.org/98029a2b-4732-407f-bba7-4c638d99a7b2",
+    "identifier" : "RAMgd4QjZaFdWe2",
+    "labels" : {
+      "fi" : "LzSHpiCD5h9bBfto"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1414552579
+    },
+    "activeFrom" : "2016-06-09T12:25:00.248Z",
+    "activeTo" : "2024-04-25T21:47:14.722Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/62e7e88f-0b9d-41ae-885e-3b6fd50cb145" ],
+  "subjects" : [ "https://www.example.org/fb738aa4-f13c-43a9-943a-19229a427e5f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6a99eb67-55c0-4c0b-9e70-71b987784024",
-    "name" : "woE0pdDP7NI6fo0auxi",
-    "mimeType" : "DAffv44KBbZEg6n9Qix",
-    "size" : 524737237,
-    "license" : "https://www.example.com/werpu0zqagmmxknj",
+    "identifier" : "a21697ff-ba3b-4b13-9141-2c47f9f21806",
+    "name" : "bTPjZa2yGB",
+    "mimeType" : "rFt5wYRmfH2",
+    "size" : 265647935,
+    "license" : "https://www.example.com/rtuqo4dfbkrenwhjsm",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "NTNclapsR2iXnTzUk",
-    "publishedDate" : "2022-10-12T19:16:42.475Z",
+    "legalNote" : "zjcYuTihvJ",
+    "publishedDate" : "1985-05-19T21:30:17.290Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "jjqjq7oLFW0",
-      "uploadedDate" : "2011-01-28T05:19:26.761Z"
+      "uploadedBy" : "dsLhAFnYqVabi",
+      "uploadedDate" : "2019-12-01T03:03:22.194Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2wPcs3w7ESRZRm",
-    "name" : "CUFUYHjXcnKlJg",
-    "description" : "5jubFkPLU8MQlsXX"
+    "id" : "https://www.example.com/TCS9DWmZTnR",
+    "name" : "MH1968oslTlH",
+    "description" : "4doDg2aglU5mngDrA"
   } ],
-  "rightsHolder" : "Ra9x0JZG3i7Wzs",
-  "duplicateOf" : "https://www.example.org/32aac429-2981-4c83-8a00-185b4c059083",
+  "rightsHolder" : "XmyzHDKzcObvfauBd",
+  "duplicateOf" : "https://www.example.org/cd094b75-745c-456c-b5fc-1b0e9f4ddc54",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xYt8YoEGlNCs"
+    "note" : "znGLFZJwNatB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Nq31mO58zmb4bVu",
-    "createdBy" : "XqVdhqb35wQr",
-    "createdDate" : "1982-03-25T02:07:44.801Z"
+    "note" : "AA254Sa3Qr",
+    "createdBy" : "XZPb9KXhbt9SpRt",
+    "createdDate" : "1986-10-30T22:02:50.869Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d0ccf45f-4602-41d6-9f89-9151b0579557" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/6ac91f60-6f82-4caa-965d-e5a42abb3781" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "FUSg8Bsan6",
-    "ownerAffiliation" : "https://www.example.org/53af9d3c-c569-470f-935d-ca5c237f8ef3"
+    "owner" : "BpBweP4vwOogdype",
+    "ownerAffiliation" : "https://www.example.org/972b0068-c547-44b1-a20a-920f57fa8ef9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/793729b1-248e-42f5-8fc1-722f0b6dd894"
+    "id" : "https://www.example.org/7684b174-e37e-4f9c-802e-308476263264"
   },
-  "createdDate" : "1990-06-18T04:31:35.902Z",
-  "modifiedDate" : "1976-07-02T02:07:36.327Z",
-  "publishedDate" : "1984-07-16T05:52:00.292Z",
-  "indexedDate" : "2008-01-10T18:42:33.186Z",
-  "handle" : "https://www.example.org/97a7f1ab-08b2-454f-bc79-188360c4c403",
-  "doi" : "https://doi.org/10.1234/natus",
-  "link" : "https://www.example.org/f6ab093e-07c6-4a5c-b722-3768f4a709db",
+  "createdDate" : "1971-08-13T09:56:37.814Z",
+  "modifiedDate" : "2012-07-28T06:17:32.018Z",
+  "publishedDate" : "1987-10-03T19:15:44.905Z",
+  "indexedDate" : "2002-02-26T04:12:47.952Z",
+  "handle" : "https://www.example.org/482b23c7-f3b2-47d8-8fd4-4b937a6b77ef",
+  "doi" : "https://doi.org/10.1234/error",
+  "link" : "https://www.example.org/3c67cbfc-99f9-45d7-ac47-a2e5fa908643",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rU9MaKEEIDUo2N",
+    "mainTitle" : "Eo9K2eZXtOrNgf1Ca6",
     "alternativeTitles" : {
-      "el" : "3e5yY0NWpV0hu"
+      "de" : "S1XfqaHhOkO8V"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "P0ZHzi0M6Wt",
-      "month" : "sKLYfCUPJFW",
-      "day" : "jIQjxL2G7Pxlp6"
+      "year" : "1Gzgv7leBERv6f6",
+      "month" : "qMX8ZWlmV4z26o",
+      "day" : "EUwOiy9mWO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94f6dbd4-b73c-4c14-b8fe-9e291cac97e0",
-        "name" : "7A1QiUF3lGda0l1c",
-        "nameType" : "Organizational",
-        "orcId" : "1lgoOh2sKp21Qb4klhv",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/cac33386-9d8a-44d6-9380-1e17e15add7e",
+        "name" : "ahLUP3ixFBIjNdeHKD7",
+        "nameType" : "Personal",
+        "orcId" : "XoGdAmQmXu15ZX",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1GJwOGrbNa1KLZ",
-          "value" : "4p230DFGaTTUpHOA"
+          "sourceName" : "ioH8LdMGp3o",
+          "value" : "rxRmDtVgS8gqk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AITddgiEBUlr5",
-          "value" : "nrhQqGcxZOh"
+          "sourceName" : "la3meydBFg8Z9rh",
+          "value" : "gw6YXSaKJJ1CC"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6f6bc761-7d78-430f-964d-9ffb4bbd627b"
+        "id" : "https://www.example.org/89ba82ff-78dc-466a-9b5d-b761828ec0cb"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Architect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ef0e19d9-c41b-4ad6-b8ec-40c6454f6a29",
-        "name" : "Rln26gwd3DWf",
-        "nameType" : "Organizational",
-        "orcId" : "iIiP8cPF27UU",
+        "id" : "https://www.example.org/515c8cbd-5e06-4baf-aa14-2a1bf4c63d91",
+        "name" : "e9iX8UWXg3w4nX",
+        "nameType" : "Personal",
+        "orcId" : "vWsJKpjvOzW0",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8Skzw2eEWx7j",
-          "value" : "03dkYLhYdx63lz3S3s7"
+          "sourceName" : "VGbSHGJijF",
+          "value" : "Pk8MJ5BuHoFO91ZODhP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m9Htk4DJoTlau",
-          "value" : "x1B7bBuiDYq3Rm5b"
+          "sourceName" : "qTIx8sum7GS790",
+          "value" : "WP8204ekP1YP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b7b0ec8b-058d-41d2-818d-fed36d578551"
+        "id" : "https://www.example.org/1ff64da3-fe04-44e8-87d6-661dd00900f9"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "6lZRDJTfkSRDP"
+      "se" : "36N0K8UHewjby"
     },
-    "npiSubjectHeading" : "nOvClxrXDob2ED2QYFm",
-    "tags" : [ "8lxq7GSRgpqABSE" ],
-    "description" : "yqln7RYimEaYf",
+    "npiSubjectHeading" : "lELhawAvVu9",
+    "tags" : [ "Iq3Wz4uE9M4g48uUfZ" ],
+    "description" : "nklOSuIra1T1NI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/74c9fb81-1018-4a5a-b7e8-dbb792c662a2"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8abc6876-0e24-436c-900a-570c00fbe205"
       },
-      "doi" : "https://www.example.org/a77b5f4b-8bdc-4fe9-861c-033f4b8c4a76",
+      "doi" : "https://www.example.org/ef1bd14e-55ce-4945-bb9c-53be1d469d98",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "haAV3cJTzz",
-          "end" : "dRzcrkjnogg0pZfxq1"
+          "begin" : "yrCa1cxnaSsbQrIkYbv",
+          "end" : "5uxSg0GGiIK"
         },
-        "volume" : "1FhJ4COr7myNUT",
-        "issue" : "ZQv1YnuT2g64SitR",
-        "articleNumber" : "AknJdMAqVUoTSHY"
+        "volume" : "Z97lkcKavlNQpv9Q",
+        "issue" : "Hyrk6a5ReS468Dv7Ly",
+        "articleNumber" : "pvLn13JUugjl"
       }
     },
-    "metadataSource" : "https://www.example.org/167003b4-0c4b-41b6-b73b-e0788ab1e296",
-    "abstract" : "Mb2KD3J0EoNAep"
+    "metadataSource" : "https://www.example.org/c020f95e-3239-459e-a49d-f762e71ed4c9",
+    "abstract" : "77lDKzJL27rNHh"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5f2c17d9-c7e4-419a-a271-2877dd0493d8",
-    "name" : "zLulg3AoIzpvG",
+    "id" : "https://www.example.org/99a23fe6-4aea-41a1-81ab-60426bfd56e1",
+    "name" : "pFIZEcHkior",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-06-09T08:04:17.918Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "RwtX8BC27QtpAHk2WN"
+      "approvalDate" : "1975-09-09T07:51:57.626Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Eh7D6gJ76oA8y"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b52efd3d-d9e1-44b6-b93f-6b563d002d36",
-    "identifier" : "d2HAKvIZv5P",
+    "source" : "https://www.example.org/41d532f9-16d2-4fcb-ab76-8d2ef3e66b15",
+    "identifier" : "EKrXHSWQhqn1",
     "labels" : {
-      "is" : "clNyHqzMaD"
+      "se" : "ZIoM0whvjxS"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1849688007
+      "currency" : "GBP",
+      "amount" : 1285300021
     },
-    "activeFrom" : "2004-07-25T18:35:53.263Z",
-    "activeTo" : "2023-04-07T12:26:51.811Z"
+    "activeFrom" : "1999-06-20T23:12:33.428Z",
+    "activeTo" : "2002-07-04T13:06:53.474Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/851c1c41-391a-431d-80ff-535d4f7f5839",
-    "id" : "https://www.example.org/5515ae48-ca43-46c4-85c5-b1f48d605058",
-    "identifier" : "GpWzjMm15ADdb3",
+    "source" : "https://www.example.org/4070b9b0-78b1-445b-a3f2-b0aa3dde2ceb",
+    "id" : "https://www.example.org/d2640794-a423-48eb-b7b6-2644129935c3",
+    "identifier" : "ZPADla2BGmnrqO7pu",
     "labels" : {
-      "af" : "iwqkepUj8yJYvAMm"
+      "da" : "wXpfH9VJWulJ9W"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1833808859
+      "currency" : "GBP",
+      "amount" : 1154827011
     },
-    "activeFrom" : "1971-07-17T02:28:40.212Z",
-    "activeTo" : "1987-12-13T00:29:06.133Z"
+    "activeFrom" : "1989-03-20T15:33:39.774Z",
+    "activeTo" : "1998-09-22T13:07:09.178Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ce0a325d-d4ec-4a03-9062-3dd6a7b69cde" ],
+  "subjects" : [ "https://www.example.org/2e607b3d-9f88-4325-8494-99317ddedb4c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4c69fe6d-43ab-4295-8a22-6770941180e5",
-    "name" : "mbFx7nfQpq85RAykhN0",
-    "mimeType" : "x9aVYi7MkS6",
-    "size" : 339740252,
-    "license" : "https://www.example.com/rvugxlkxrtfl",
+    "identifier" : "fb09d4c4-556c-42fa-9934-2663cb56001d",
+    "name" : "K6dm29VQ5HNbj4LO6ZS",
+    "mimeType" : "7Q7Se6SMrFPAUnl9AG4",
+    "size" : 263757721,
+    "license" : "https://www.example.com/lnzg3qvmhjj7yvs10d",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "lPVaqqKBAwraSm4Ye",
-    "publishedDate" : "1990-08-20T21:32:38.086Z",
+    "legalNote" : "ZV3lGNZaJdqQO5aA",
+    "publishedDate" : "2016-03-09T08:23:49.878Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "v2xa171qeCrha7qQSgm",
-      "uploadedDate" : "1990-06-28T19:36:29.531Z"
+      "uploadedBy" : "xeCeHn49V3ebT4nhrGA",
+      "uploadedDate" : "1997-11-06T02:43:13.261Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/dAr67IqovSEt23i5",
-    "name" : "U1p57jiVnIgpblxT",
-    "description" : "Pg2ebYomjv43LVFu1j"
+    "id" : "https://www.example.com/zDq7dm7ZilrQsCuI2a",
+    "name" : "NMvpMxdQ2ynaVE",
+    "description" : "oqQoAgegnuDtM9cd"
   } ],
-  "rightsHolder" : "nbmSdLAvlq7",
-  "duplicateOf" : "https://www.example.org/ed61079f-eb61-4fb6-94f3-54991556dea4",
+  "rightsHolder" : "jajALfv5msQwtRE",
+  "duplicateOf" : "https://www.example.org/408943ea-1ae9-4b46-b613-2e48a6011167",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "etNxeTBu2xp"
+    "note" : "ZxsrmMU1GFCjCj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "h98hfm2xQyo",
-    "createdBy" : "klZvx6YyefQejV",
-    "createdDate" : "1973-10-13T07:33:44.072Z"
+    "note" : "s27aTNRLVe5rqJ3kHq",
+    "createdBy" : "Z3urNM64EzD",
+    "createdDate" : "1980-08-25T15:08:49.275Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/883750c9-e956-40bf-8db6-fa9c6fd1060a" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/d12fa8eb-8011-4987-81d4-33d6cf2095c4" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "BpBweP4vwOogdype",
-    "ownerAffiliation" : "https://www.example.org/972b0068-c547-44b1-a20a-920f57fa8ef9"
+    "owner" : "BDMji6BHD7QnfiWNAc",
+    "ownerAffiliation" : "https://www.example.org/dc1958af-b0e3-4866-86e0-b08f2714da3a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7684b174-e37e-4f9c-802e-308476263264"
+    "id" : "https://www.example.org/74662294-7ba1-4653-9125-e2bc44fb1220"
   },
-  "createdDate" : "1971-08-13T09:56:37.814Z",
-  "modifiedDate" : "2012-07-28T06:17:32.018Z",
-  "publishedDate" : "1987-10-03T19:15:44.905Z",
-  "indexedDate" : "2002-02-26T04:12:47.952Z",
-  "handle" : "https://www.example.org/482b23c7-f3b2-47d8-8fd4-4b937a6b77ef",
-  "doi" : "https://doi.org/10.1234/error",
-  "link" : "https://www.example.org/3c67cbfc-99f9-45d7-ac47-a2e5fa908643",
+  "createdDate" : "1983-11-04T12:51:01.708Z",
+  "modifiedDate" : "1986-11-20T08:16:04.081Z",
+  "publishedDate" : "2011-01-31T22:30:34.211Z",
+  "indexedDate" : "1996-01-25T20:31:47.889Z",
+  "handle" : "https://www.example.org/8794ecf3-868e-4fbd-b66a-6b88bd040d01",
+  "doi" : "https://doi.org/10.1234/maiores",
+  "link" : "https://www.example.org/81e3e363-31d3-452a-985d-1e7f84c5322d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Eo9K2eZXtOrNgf1Ca6",
+    "mainTitle" : "ROCOVHWEgEme",
     "alternativeTitles" : {
-      "de" : "S1XfqaHhOkO8V"
+      "is" : "lgpvh1P39Q93kewmsen"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1Gzgv7leBERv6f6",
-      "month" : "qMX8ZWlmV4z26o",
-      "day" : "EUwOiy9mWO"
+      "year" : "XZBThXijSD",
+      "month" : "ZEdyv95LKuwkayYWq",
+      "day" : "nLuUqySlCIgyBAMg2SQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cac33386-9d8a-44d6-9380-1e17e15add7e",
-        "name" : "ahLUP3ixFBIjNdeHKD7",
+        "id" : "https://www.example.org/dbf2e599-3aa2-4c6e-be24-95d95c0c08d4",
+        "name" : "FSKdpF9X30xPE1qs8h",
         "nameType" : "Personal",
-        "orcId" : "XoGdAmQmXu15ZX",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "aaL6A9e6wpH6hp6A",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ioH8LdMGp3o",
-          "value" : "rxRmDtVgS8gqk"
+          "sourceName" : "7p3j7DC3H0QHSpcI",
+          "value" : "n580J8V6tDXIHVsr2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "la3meydBFg8Z9rh",
-          "value" : "gw6YXSaKJJ1CC"
+          "sourceName" : "TatUyUHbrCpNJl",
+          "value" : "fPcX8RcvUBAplcdm"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/89ba82ff-78dc-466a-9b5d-b761828ec0cb"
+        "id" : "https://www.example.org/0922519e-2261-488c-b4d8-7b20fdaaf210"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/515c8cbd-5e06-4baf-aa14-2a1bf4c63d91",
-        "name" : "e9iX8UWXg3w4nX",
-        "nameType" : "Personal",
-        "orcId" : "vWsJKpjvOzW0",
+        "id" : "https://www.example.org/94e85752-1e5f-4c0d-8f6d-0e7907b10f9d",
+        "name" : "Kcy8KRvrcZpEZ",
+        "nameType" : "Organizational",
+        "orcId" : "7j6PcTKJyOkncvy",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VGbSHGJijF",
-          "value" : "Pk8MJ5BuHoFO91ZODhP"
+          "sourceName" : "oxzJVqzMsAA7QtdHY",
+          "value" : "N48M4PSq80VHKKBzpX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qTIx8sum7GS790",
-          "value" : "WP8204ekP1YP"
+          "sourceName" : "JhWR602dQpYLV9w",
+          "value" : "0Mz3Op68sJ8pqDO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1ff64da3-fe04-44e8-87d6-661dd00900f9"
+        "id" : "https://www.example.org/1aa0b4d9-c482-491c-9a29-6ae2115a8f1d"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "36N0K8UHewjby"
+      "pl" : "Ohjw6Z28tpFY3vP"
     },
-    "npiSubjectHeading" : "lELhawAvVu9",
-    "tags" : [ "Iq3Wz4uE9M4g48uUfZ" ],
-    "description" : "nklOSuIra1T1NI",
+    "npiSubjectHeading" : "QeXvY4bULhNWb",
+    "tags" : [ "1AFmN4ZG7BGHgj9M0X2" ],
+    "description" : "KHDJQQkszbfoM2i9jR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8abc6876-0e24-436c-900a-570c00fbe205"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8d79f818-f0bd-4e30-b3bc-85c72d9ade9a"
       },
-      "doi" : "https://www.example.org/ef1bd14e-55ce-4945-bb9c-53be1d469d98",
+      "doi" : "https://www.example.org/8d704099-02e7-418b-aba2-1d4238428521",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "yrCa1cxnaSsbQrIkYbv",
-          "end" : "5uxSg0GGiIK"
+          "begin" : "HMeiVdWSxdhMS8qnHbU",
+          "end" : "VWlZHPiQP5"
         },
-        "volume" : "Z97lkcKavlNQpv9Q",
-        "issue" : "Hyrk6a5ReS468Dv7Ly",
-        "articleNumber" : "pvLn13JUugjl"
+        "volume" : "AjSMKV96Rng",
+        "issue" : "o9WcD7aOfJ3mdIXG",
+        "articleNumber" : "w8H0iyJUi0Db0p3nKqh"
       }
     },
-    "metadataSource" : "https://www.example.org/c020f95e-3239-459e-a49d-f762e71ed4c9",
-    "abstract" : "77lDKzJL27rNHh"
+    "metadataSource" : "https://www.example.org/f93181d0-f604-48a1-944b-aa158a3c69f3",
+    "abstract" : "jrgLcn4Rdmgplv5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/99a23fe6-4aea-41a1-81ab-60426bfd56e1",
-    "name" : "pFIZEcHkior",
+    "id" : "https://www.example.org/053fc3e8-0354-418b-975d-a700f6ca7c2b",
+    "name" : "jT4k0yLSUxYJnJg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-09-09T07:51:57.626Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Eh7D6gJ76oA8y"
+      "approvalDate" : "1971-10-31T08:35:34.042Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "uGW8KHcY4LlW6WXI2hX"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/41d532f9-16d2-4fcb-ab76-8d2ef3e66b15",
-    "identifier" : "EKrXHSWQhqn1",
+    "source" : "https://www.example.org/8591520e-893e-4b11-974e-dcab437c8c81",
+    "identifier" : "1PPhV1PVAp",
     "labels" : {
-      "se" : "ZIoM0whvjxS"
+      "el" : "ATtWoctrdRHoPJ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1285300021
+      "currency" : "NOK",
+      "amount" : 285237669
     },
-    "activeFrom" : "1999-06-20T23:12:33.428Z",
-    "activeTo" : "2002-07-04T13:06:53.474Z"
+    "activeFrom" : "1992-06-14T23:43:33.766Z",
+    "activeTo" : "1993-11-21T06:20:26.613Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4070b9b0-78b1-445b-a3f2-b0aa3dde2ceb",
-    "id" : "https://www.example.org/d2640794-a423-48eb-b7b6-2644129935c3",
-    "identifier" : "ZPADla2BGmnrqO7pu",
+    "source" : "https://www.example.org/26adf173-d58f-4b2a-8119-1c908d900623",
+    "id" : "https://www.example.org/f621445a-7b52-4b57-84bd-39dc9e628564",
+    "identifier" : "sNnh7kFmtwuI1Q3Ar",
     "labels" : {
-      "da" : "wXpfH9VJWulJ9W"
+      "pl" : "Sr6EcvwngXd"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1154827011
+      "amount" : 937288854
     },
-    "activeFrom" : "1989-03-20T15:33:39.774Z",
-    "activeTo" : "1998-09-22T13:07:09.178Z"
+    "activeFrom" : "2012-06-12T12:40:13.822Z",
+    "activeTo" : "2016-05-09T08:51:16.680Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2e607b3d-9f88-4325-8494-99317ddedb4c" ],
+  "subjects" : [ "https://www.example.org/46c1114a-a8ee-4362-ab25-5cd08445ec52" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fb09d4c4-556c-42fa-9934-2663cb56001d",
-    "name" : "K6dm29VQ5HNbj4LO6ZS",
-    "mimeType" : "7Q7Se6SMrFPAUnl9AG4",
-    "size" : 263757721,
-    "license" : "https://www.example.com/lnzg3qvmhjj7yvs10d",
+    "identifier" : "35d39e87-0e49-4259-8189-d7ddf5cb5141",
+    "name" : "hBR5cujmvoeRevOw",
+    "mimeType" : "InWOYhSFHKUNOMvz",
+    "size" : 1948457632,
+    "license" : "https://www.example.com/mls4mdds6hu",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ZV3lGNZaJdqQO5aA",
-    "publishedDate" : "2016-03-09T08:23:49.878Z",
+    "legalNote" : "CpWOnXTX080J7",
+    "publishedDate" : "2016-08-14T19:47:02.827Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "xeCeHn49V3ebT4nhrGA",
-      "uploadedDate" : "1997-11-06T02:43:13.261Z"
+      "uploadedBy" : "xkMVu57j7A1",
+      "uploadedDate" : "2023-05-25T13:40:08.464Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zDq7dm7ZilrQsCuI2a",
-    "name" : "NMvpMxdQ2ynaVE",
-    "description" : "oqQoAgegnuDtM9cd"
+    "id" : "https://www.example.com/XhDeQrNWBtF",
+    "name" : "2asgwJ7dC3VV2Qy5vM",
+    "description" : "EhM7nbYduEAFyFSpsfV"
   } ],
-  "rightsHolder" : "jajALfv5msQwtRE",
-  "duplicateOf" : "https://www.example.org/408943ea-1ae9-4b46-b613-2e48a6011167",
+  "rightsHolder" : "5RHgH0kSgLxS2JVj",
+  "duplicateOf" : "https://www.example.org/b981f6e1-1c5d-4e35-9c51-7c0faa0c80ad",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZxsrmMU1GFCjCj"
+    "note" : "PakaqsEK3B5RmZp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "s27aTNRLVe5rqJ3kHq",
-    "createdBy" : "Z3urNM64EzD",
-    "createdDate" : "1980-08-25T15:08:49.275Z"
+    "note" : "OObtFoEfE2yv3VC",
+    "createdBy" : "lSHjWc3PcYZgUCC",
+    "createdDate" : "2024-04-18T03:35:16.219Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d12fa8eb-8011-4987-81d4-33d6cf2095c4" ],
+  "curatingInstitutions" : [ "https://www.example.org/31ab9e49-f5df-40d5-9ea5-75eabc955f65" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "FAuAnA904w8wFaO",
-    "ownerAffiliation" : "https://www.example.org/bdee188f-8ee4-4218-a1e5-ba459ebaba78"
+    "owner" : "pcdlY5npQ6mBrez9q",
+    "ownerAffiliation" : "https://www.example.org/656ea4c3-f423-4096-8b90-d0d9ea031b19"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ef02b19a-1da7-4f63-a82b-788a2063e00c"
+    "id" : "https://www.example.org/3a5f6477-2c7c-4c93-97fa-726f9872e2bb"
   },
-  "createdDate" : "1994-05-24T04:57:35.108Z",
-  "modifiedDate" : "1972-05-07T09:02:18.851Z",
-  "publishedDate" : "1985-05-17T22:21:06.486Z",
-  "indexedDate" : "1982-06-15T01:10:26.417Z",
-  "handle" : "https://www.example.org/8ad54287-bf9b-4ff3-962b-bf475853927f",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/ed8ad46e-6f3c-422b-8859-59c9828e9957",
+  "createdDate" : "1976-12-22T21:36:18.795Z",
+  "modifiedDate" : "2014-06-20T14:49:56.437Z",
+  "publishedDate" : "1998-10-13T13:50:21.837Z",
+  "indexedDate" : "1978-10-15T18:53:19.295Z",
+  "handle" : "https://www.example.org/d8cbb541-9be0-45a9-b145-1a8457a2b5e0",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/41e8652e-c06c-43b0-b535-e122f863a24c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tpni6R48Dofk",
+    "mainTitle" : "iuggRxdtfQ",
     "alternativeTitles" : {
-      "is" : "46ilEjfvixUwN2z0e69"
+      "cs" : "rTwW7OSokkRTs5kPzA"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "jkxtFmAbZl2HH6hR6b",
-      "month" : "Hs0a4M9riD",
-      "day" : "8x3FxniCxFVw78YmAr"
+      "year" : "OCeqrAHcAqPLh",
+      "month" : "lKVbCHuqBbzhm1",
+      "day" : "Ypj582G4a0bQcIWcGXQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/177d6eb8-aad3-488d-8eb5-5b13b69509c4",
-        "name" : "6fvJ7nT2iqo4Fxtij4v",
+        "id" : "https://www.example.org/17ee37dc-fb21-4db2-aced-45013b5f4dc6",
+        "name" : "hzmN1lgWC2KHX0",
         "nameType" : "Personal",
-        "orcId" : "xIGVGWinpzmt",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "zU5dzQ3xTQgIw",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rTkMMysk93XJTG9X4iV",
-          "value" : "kEMWsusT3EkXyZJNj"
+          "sourceName" : "I7ihq1oyFDHcHVmn",
+          "value" : "XA1cIIKMpm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rg5PVEFxBXeX5H6",
-          "value" : "jICexmu10zVCpvf0jbg"
+          "sourceName" : "BBfdpbUYy3GZyf",
+          "value" : "P5HsNA47qdbUd64"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d289b433-eda3-40b1-b037-c70a24f478ed"
+        "id" : "https://www.example.org/ce0902cc-356a-4ec3-875c-a726447c2012"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d943b0ae-c7a3-4d1c-a09c-a77d18c63baa",
-        "name" : "XJ64CqTBg2J",
-        "nameType" : "Personal",
-        "orcId" : "yvJFnA45JioS",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2e6ac0bc-765a-40ad-b333-46d25a6dde55",
+        "name" : "CU98hlFjyZK9gy",
+        "nameType" : "Organizational",
+        "orcId" : "yfdiSRK3ASZ8JWhP",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "f3BR73WGj3aqZIJKmPq",
-          "value" : "xEAySofMLm"
+          "sourceName" : "i9vB8OotoqpBN",
+          "value" : "cn21VqXX5SZ5Zu1eM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kdpOvqwxYgF",
-          "value" : "VccJ2KVk984u"
+          "sourceName" : "6qrBdHVD19RdkCV",
+          "value" : "FeJYCBnLlGQPBXp9J"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/77064c47-af27-4f2a-8290-67ceafce3eac"
+        "id" : "https://www.example.org/bcce10d2-cb8c-4cdd-ae0a-a65060c77c67"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "9kK95SQXNfIryZPyxBu"
+      "de" : "sblPpwXFJDCK08X"
     },
-    "npiSubjectHeading" : "b7pXHP8GJj6wCV",
-    "tags" : [ "6By1BCUO4Tfgcx9" ],
-    "description" : "VQk0OPsqZV1Z6qgh7",
+    "npiSubjectHeading" : "5kgyQifnRrUb3KN2",
+    "tags" : [ "djxQQPLwkjqIWyKKj" ],
+    "description" : "BRwayvXXojbp5FNm7th",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/62bc62a1-b1fd-415f-affc-04ad5ecb6f80"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1bfdd390-7b51-4e73-ad4a-64348608a6d4"
         },
-        "seriesNumber" : "aFqjN6GRX4L5c2A4",
+        "seriesNumber" : "p2f5Y7QphyKDKHdS6Ju",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5188c002-8096-4080-8b10-f5ba3b079831",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7b8b39c2-8568-481f-b6e2-7ba7d32007fa",
           "valid" : true
         },
-        "isbnList" : [ "9791962835960" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781990225826", "9780987399564" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1NUaSd7GPn4mjJVma"
+          "value" : "098739956X"
         } ]
       },
-      "doi" : "https://www.example.org/3391b74e-02f8-4e75-85d3-00c9e2f5dd45",
+      "doi" : "https://www.example.org/7ce64d31-a8c3-4911-a9ec-674bd8d2d3cb",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "na1vHx7bZao",
-            "end" : "LLH12p0BKV0"
+            "begin" : "dPxfBkptcTkS8",
+            "end" : "a5X3VAHLIScTIz5"
           },
-          "pages" : "UGByXqEceNL5rc",
-          "illustrated" : true
+          "pages" : "C8REK5QK73YU",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b77fbfd3-d662-466d-9314-7e80f4da2a51",
-    "abstract" : "yDkagThsafHu"
+    "metadataSource" : "https://www.example.org/7b5df46a-fee8-43db-b040-ee8a3f3a563b",
+    "abstract" : "yzb6hDzZcC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fee9c6f7-4ed0-4e4b-af1b-dcaefc8c54a4",
-    "name" : "gxtkOoq3gXCdZhcdi",
+    "id" : "https://www.example.org/d999b579-5d43-4bf4-968c-f08aa99a4ed0",
+    "name" : "lIP1uBqPDj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-11-04T21:42:07.059Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "I1vJeQvFdQMBO6c"
+      "approvalDate" : "2020-11-14T09:19:29.694Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "g8WuVI5iGgEDHjg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9279dbc5-8439-4017-b8d0-1b261b65cdeb",
-    "identifier" : "9PeeQuMm20SHhGJ3anT",
+    "source" : "https://www.example.org/bcf8f422-3b3d-4715-8a56-a6e941c259b2",
+    "identifier" : "pTYr5KRTnQOO5Gb93t3",
     "labels" : {
-      "de" : "rMqzsFlVDzdid2"
+      "el" : "KeDUAeMf6ZtWbIHp"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1358831492
+      "currency" : "GBP",
+      "amount" : 205351725
     },
-    "activeFrom" : "1994-11-23T02:05:14.435Z",
-    "activeTo" : "2002-09-22T04:45:14.676Z"
+    "activeFrom" : "2015-04-19T21:02:57.654Z",
+    "activeTo" : "2019-01-08T03:07:43.271Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d8bd449c-7c3b-407b-962a-7e839f742d90",
-    "id" : "https://www.example.org/259a7042-79d3-4c6e-bac6-f04837e5f444",
-    "identifier" : "HtMjgzmqEjp3",
+    "source" : "https://www.example.org/97c8b5f8-554b-44f0-82ce-120b41206a8d",
+    "id" : "https://www.example.org/f5fb04ca-13c8-4790-b6ec-964ac2163d91",
+    "identifier" : "rUTzFD7cRLwZv0",
     "labels" : {
-      "pt" : "6SOClmedNtN"
+      "zh" : "JS6W1uX0jq"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 536997237
+      "currency" : "GBP",
+      "amount" : 56503955
     },
-    "activeFrom" : "1989-11-22T22:57:19.818Z",
-    "activeTo" : "2022-01-30T13:51:43.943Z"
+    "activeFrom" : "2014-04-21T08:43:13.042Z",
+    "activeTo" : "2021-06-05T13:36:19.886Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b577babf-88f3-4813-8b2e-dddecc188854" ],
+  "subjects" : [ "https://www.example.org/3c74e284-b193-48fe-96f3-969876286688" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e25edda7-e341-4db0-b4ec-e2293295b824",
-    "name" : "DLTrGsoUpv3",
-    "mimeType" : "6dOGtzAr9W",
-    "size" : 1837253819,
-    "license" : "https://www.example.com/lcsaotej1ufmwsehej",
+    "identifier" : "1da5b851-7ffe-47b2-80fd-cc07aa7e71f9",
+    "name" : "EggbTWtgmGM1fS60T",
+    "mimeType" : "ztDXzxt1Lzz",
+    "size" : 883090070,
+    "license" : "https://www.example.com/dtrgbtey8v8",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "SubmittedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "eBRPlfrZLslt4EKhHf"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "PilsbILNAtWZBC",
-    "publishedDate" : "2014-08-28T19:03:45.084Z",
+    "legalNote" : "4h8kmxOevws",
+    "publishedDate" : "2017-04-18T03:16:35.565Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "F45qwVfeCVDWAiHY",
-      "uploadedDate" : "2023-12-05T04:01:46.078Z"
+      "uploadedBy" : "j0qmVByvrxguA",
+      "uploadedDate" : "2013-10-09T18:19:01.749Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NobsIHn2P0yqDLDJa",
-    "name" : "ssSfGv9Ylso4w",
-    "description" : "waft9p5Z7VgVtIBE"
+    "id" : "https://www.example.com/0fOGcl9q2v",
+    "name" : "FnhnjlpLZx2",
+    "description" : "TJgBC69DUSQYM5"
   } ],
-  "rightsHolder" : "h3DvRGVXVdXdiKf0npT",
-  "duplicateOf" : "https://www.example.org/9d67c982-ade1-4675-aeb6-25d2d66c666d",
+  "rightsHolder" : "p34X3C38w4ijGI",
+  "duplicateOf" : "https://www.example.org/b4c96359-bbb0-4366-89b0-cb2f07ab6cb2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dEUESLnEcfiVi"
+    "note" : "CwJLt12G83g2G"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "LJaI8nybdq6EY8H",
-    "createdBy" : "221SIysJDmgLVtrb9D",
-    "createdDate" : "2020-04-28T03:45:02.846Z"
+    "note" : "cm7FUQPZ1QTCiWw26P",
+    "createdBy" : "ZtPxhyspWG6nRR",
+    "createdDate" : "2003-04-01T00:31:05.875Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b13dc57e-1b49-410c-934c-d5b8cf193eec" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/6ba7ab12-0bf5-4aa1-981e-46da7f2ffed8" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "pcdlY5npQ6mBrez9q",
-    "ownerAffiliation" : "https://www.example.org/656ea4c3-f423-4096-8b90-d0d9ea031b19"
+    "owner" : "BzULaJ5pt0qFa",
+    "ownerAffiliation" : "https://www.example.org/30941a15-bdd0-4943-ae42-1955a3d36446"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3a5f6477-2c7c-4c93-97fa-726f9872e2bb"
+    "id" : "https://www.example.org/f7970098-c28f-4a44-95c7-74601ae154e8"
   },
-  "createdDate" : "1976-12-22T21:36:18.795Z",
-  "modifiedDate" : "2014-06-20T14:49:56.437Z",
-  "publishedDate" : "1998-10-13T13:50:21.837Z",
-  "indexedDate" : "1978-10-15T18:53:19.295Z",
-  "handle" : "https://www.example.org/d8cbb541-9be0-45a9-b145-1a8457a2b5e0",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/41e8652e-c06c-43b0-b535-e122f863a24c",
+  "createdDate" : "1979-01-08T12:44:20.900Z",
+  "modifiedDate" : "1974-03-16T06:20:21.864Z",
+  "publishedDate" : "2013-01-20T19:57:34.562Z",
+  "indexedDate" : "2016-06-09T11:53:33.565Z",
+  "handle" : "https://www.example.org/2045b715-08cc-4b92-b4ea-e361dea7a0ed",
+  "doi" : "https://doi.org/10.1234/impedit",
+  "link" : "https://www.example.org/f5d8c9c5-8145-477c-a7da-ea6c6c222b75",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iuggRxdtfQ",
+    "mainTitle" : "fuOD2h9TjVhAemkS",
     "alternativeTitles" : {
-      "cs" : "rTwW7OSokkRTs5kPzA"
+      "pt" : "N57fvx3A1us0L12BQOm"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OCeqrAHcAqPLh",
-      "month" : "lKVbCHuqBbzhm1",
-      "day" : "Ypj582G4a0bQcIWcGXQ"
+      "year" : "v6mCqBgXgsPWfKTEK",
+      "month" : "4ltu76yS4IE",
+      "day" : "TVfbsQ1EaPHCNACa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/17ee37dc-fb21-4db2-aced-45013b5f4dc6",
-        "name" : "hzmN1lgWC2KHX0",
+        "id" : "https://www.example.org/ef4a71ab-cd73-4686-986a-ea58a8bca85e",
+        "name" : "FFux37kwm6aM",
         "nameType" : "Personal",
-        "orcId" : "zU5dzQ3xTQgIw",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "lzOC54EHiPOlmV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "I7ihq1oyFDHcHVmn",
-          "value" : "XA1cIIKMpm"
+          "sourceName" : "aCAbHyG2HSJ1u59Vcs",
+          "value" : "beSJm03mBAekAIKX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BBfdpbUYy3GZyf",
-          "value" : "P5HsNA47qdbUd64"
+          "sourceName" : "fj6yDs8gP1Ig8qyGXV",
+          "value" : "5IQyCQ8ri8S6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ce0902cc-356a-4ec3-875c-a726447c2012"
+        "id" : "https://www.example.org/ae09b7e9-0be4-4323-8afa-b4e0dbf64331"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2e6ac0bc-765a-40ad-b333-46d25a6dde55",
-        "name" : "CU98hlFjyZK9gy",
+        "id" : "https://www.example.org/0face49f-b8fb-4bd1-ad54-ad745afccfff",
+        "name" : "J9OAZcn41DkhmJw",
         "nameType" : "Organizational",
-        "orcId" : "yfdiSRK3ASZ8JWhP",
+        "orcId" : "9nX9PXJLBy6WO",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "i9vB8OotoqpBN",
-          "value" : "cn21VqXX5SZ5Zu1eM"
+          "sourceName" : "LWf6tmZileBEqFtP4n4",
+          "value" : "QwiCnoMjykKOZE6JRw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6qrBdHVD19RdkCV",
-          "value" : "FeJYCBnLlGQPBXp9J"
+          "sourceName" : "15SojvicAmBg39",
+          "value" : "QePtVepwDz3W27anh2C"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bcce10d2-cb8c-4cdd-ae0a-a65060c77c67"
+        "id" : "https://www.example.org/2238a3b9-bd63-44f8-8968-40af9fdfda3f"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "sblPpwXFJDCK08X"
+      "hu" : "r3yOE6j0XFv7"
     },
-    "npiSubjectHeading" : "5kgyQifnRrUb3KN2",
-    "tags" : [ "djxQQPLwkjqIWyKKj" ],
-    "description" : "BRwayvXXojbp5FNm7th",
+    "npiSubjectHeading" : "erKgMjeJ05Lf",
+    "tags" : [ "I8R0Dt64wxCIS" ],
+    "description" : "4xoEnHPVYfH1QCdtXpf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1bfdd390-7b51-4e73-ad4a-64348608a6d4"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e9703943-c057-496d-a1b2-c1ad2a3f80ff"
         },
-        "seriesNumber" : "p2f5Y7QphyKDKHdS6Ju",
+        "seriesNumber" : "qlhTw5UvFb2",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7b8b39c2-8568-481f-b6e2-7ba7d32007fa",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/adc34867-7af6-4647-b37a-df6d38ffed13",
           "valid" : true
         },
-        "isbnList" : [ "9781990225826", "9780987399564" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9781888864243", "9781069572219" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "098739956X"
+          "value" : "1069572217"
         } ]
       },
-      "doi" : "https://www.example.org/7ce64d31-a8c3-4911-a9ec-674bd8d2d3cb",
+      "doi" : "https://www.example.org/ceda1dad-6049-401e-9f87-db3415a98da5",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "dPxfBkptcTkS8",
-            "end" : "a5X3VAHLIScTIz5"
+            "begin" : "Xite33NEAa",
+            "end" : "cjm8OAqQKXsk"
           },
-          "pages" : "C8REK5QK73YU",
+          "pages" : "yVDtUa2HBBEwwASxbqv",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7b5df46a-fee8-43db-b040-ee8a3f3a563b",
-    "abstract" : "yzb6hDzZcC"
+    "metadataSource" : "https://www.example.org/c383b1a6-2d9d-4a61-a2c4-21121a9a60fe",
+    "abstract" : "PDh9WLQX50BSS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d999b579-5d43-4bf4-968c-f08aa99a4ed0",
-    "name" : "lIP1uBqPDj",
+    "id" : "https://www.example.org/d0cecb85-81ef-4a6c-9229-d2595d61f4c3",
+    "name" : "ZLfEqlYzQgMcb39ou",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-11-14T09:19:29.694Z",
+      "approvalDate" : "2019-02-07T10:57:18.842Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "g8WuVI5iGgEDHjg"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "gylexzOq5vUerkd"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/bcf8f422-3b3d-4715-8a56-a6e941c259b2",
-    "identifier" : "pTYr5KRTnQOO5Gb93t3",
+    "source" : "https://www.example.org/3888488c-ede3-44d5-aad2-fb94c2b38450",
+    "identifier" : "cylYR4ve792LbSGf6",
     "labels" : {
-      "el" : "KeDUAeMf6ZtWbIHp"
+      "pl" : "i2HAafYgi2"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 205351725
+      "currency" : "EUR",
+      "amount" : 1682985296
     },
-    "activeFrom" : "2015-04-19T21:02:57.654Z",
-    "activeTo" : "2019-01-08T03:07:43.271Z"
+    "activeFrom" : "2007-06-20T04:59:34.978Z",
+    "activeTo" : "2020-10-17T04:52:30.935Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/97c8b5f8-554b-44f0-82ce-120b41206a8d",
-    "id" : "https://www.example.org/f5fb04ca-13c8-4790-b6ec-964ac2163d91",
-    "identifier" : "rUTzFD7cRLwZv0",
+    "source" : "https://www.example.org/94129aa7-5ee4-4579-beea-d84ceae4890e",
+    "id" : "https://www.example.org/9cacfe13-3aac-42c1-a0a8-7a9b6934d04f",
+    "identifier" : "kKr68f2ZSenSUp6tq4x",
     "labels" : {
-      "zh" : "JS6W1uX0jq"
+      "ru" : "xdbQik0U7GS1I"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 56503955
+      "amount" : 1021961415
     },
-    "activeFrom" : "2014-04-21T08:43:13.042Z",
-    "activeTo" : "2021-06-05T13:36:19.886Z"
+    "activeFrom" : "2020-01-02T22:10:37.445Z",
+    "activeTo" : "2022-04-18T09:02:52.764Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3c74e284-b193-48fe-96f3-969876286688" ],
+  "subjects" : [ "https://www.example.org/5dc8136a-6de0-4bc4-aa8a-fab3cfc199db" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1da5b851-7ffe-47b2-80fd-cc07aa7e71f9",
-    "name" : "EggbTWtgmGM1fS60T",
-    "mimeType" : "ztDXzxt1Lzz",
-    "size" : 883090070,
-    "license" : "https://www.example.com/dtrgbtey8v8",
+    "identifier" : "95d008b3-63fc-49b5-9bf3-da09e5ce18cd",
+    "name" : "hl57MlVxqafmZobiemC",
+    "mimeType" : "d4KNtPUAv2ORP6Pk",
+    "size" : 1911206691,
+    "license" : "https://www.example.com/943fjkrcvvt5tt5",
     "administrativeAgreement" : false,
-    "publisherVersion" : "SubmittedVersion",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "4h8kmxOevws",
-    "publishedDate" : "2017-04-18T03:16:35.565Z",
+    "legalNote" : "691SEvayFPBlX",
+    "publishedDate" : "1994-02-20T15:22:29.237Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "j0qmVByvrxguA",
-      "uploadedDate" : "2013-10-09T18:19:01.749Z"
+      "uploadedBy" : "zWZAIucCLh5dyT",
+      "uploadedDate" : "2008-02-27T03:36:22.140Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/0fOGcl9q2v",
-    "name" : "FnhnjlpLZx2",
-    "description" : "TJgBC69DUSQYM5"
+    "id" : "https://www.example.com/AGMlTUVkkMouSsn",
+    "name" : "koheyDesu3a54eHUxP",
+    "description" : "EJOAoAErK8DFz4"
   } ],
-  "rightsHolder" : "p34X3C38w4ijGI",
-  "duplicateOf" : "https://www.example.org/b4c96359-bbb0-4366-89b0-cb2f07ab6cb2",
+  "rightsHolder" : "cM5K6MaMMrAFMPZ",
+  "duplicateOf" : "https://www.example.org/ebecdcf4-53b9-4e33-b2bb-efc97deca114",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CwJLt12G83g2G"
+    "note" : "4IjqxvFADT2H9x"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "cm7FUQPZ1QTCiWw26P",
-    "createdBy" : "ZtPxhyspWG6nRR",
-    "createdDate" : "2003-04-01T00:31:05.875Z"
+    "note" : "w6muqjtcnjIg",
+    "createdBy" : "58OpCRrBNDkJqfTJ",
+    "createdDate" : "2022-01-22T08:30:35.634Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6ba7ab12-0bf5-4aa1-981e-46da7f2ffed8" ],
+  "curatingInstitutions" : [ "https://www.example.org/8db3a0cf-3558-4dc5-a3b2-4f63edf08a84" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "RB6FHNdWP3tPplV",
-    "ownerAffiliation" : "https://www.example.org/395a542c-9e89-4613-96b8-d05a13c170d7"
+    "owner" : "dLnJ40eJl1XCdedwyC",
+    "ownerAffiliation" : "https://www.example.org/bcf3805f-f003-4ee2-9984-8de7a4b02b4e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3ab8b2a3-8411-4c99-8b08-2c7afa7f6631"
+    "id" : "https://www.example.org/09dc1bb9-dc81-476f-af1f-09239a72f8cb"
   },
-  "createdDate" : "1993-04-26T01:21:57.132Z",
-  "modifiedDate" : "1990-09-08T00:43:02.686Z",
-  "publishedDate" : "1984-08-08T00:20:11.276Z",
-  "indexedDate" : "1987-03-13T03:21:39.755Z",
-  "handle" : "https://www.example.org/a74c4a1c-2214-4ab4-89b8-12ff037c165a",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/89466462-6c21-4a0a-be0f-8795484226da",
+  "createdDate" : "1989-12-25T02:46:33.569Z",
+  "modifiedDate" : "2023-08-14T23:51:00.976Z",
+  "publishedDate" : "1998-08-28T01:20:29.113Z",
+  "indexedDate" : "2003-12-29T10:20:46.993Z",
+  "handle" : "https://www.example.org/0e2966d8-3f91-4778-8d6d-4a975fc1c4a9",
+  "doi" : "https://doi.org/10.1234/aliquid",
+  "link" : "https://www.example.org/4fb1ab7e-c476-4857-9964-89de336e49b5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GQykDgggQLrDQP",
+    "mainTitle" : "mSLrwMKkeQRgPZSPe",
     "alternativeTitles" : {
-      "it" : "4gTF7HfSaenZf"
+      "el" : "IBipRvivq2d"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Jo9JDwgMRUHBHHUI",
-      "month" : "tpF2UdAD6GyfG7",
-      "day" : "QDeePEkxeMVtHF"
+      "year" : "wmoPmnyBdfCTKBH7Do",
+      "month" : "U41gpzNPLL",
+      "day" : "gZgRgYUIy1JQLMmEul"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5bc64d96-1338-4687-8022-834a3860a7fc",
-        "name" : "DU094ecXDLPhv9Ssg",
+        "id" : "https://www.example.org/06101f58-2170-423d-9432-a23e6ab7c577",
+        "name" : "qLJQapHnsTrA",
         "nameType" : "Organizational",
-        "orcId" : "v9twwZFfbq3",
-        "verificationStatus" : "Verified",
+        "orcId" : "UVYtGvmKiUIP",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "X8YD4u83TEXW",
-          "value" : "FTCDlURQAHLJzGduXw"
+          "sourceName" : "0MgA33AzZSnMq9M9t",
+          "value" : "n46fjKhgmcWlmyWAdW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nsqwpq7Av7avUvecD",
-          "value" : "ldcuK0SxdUcktih"
+          "sourceName" : "wuFhJ0CJMc",
+          "value" : "mwcGtWF32wUeb9x"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/520cfaf5-82fd-4b61-90c8-9ae863fbb476"
+        "id" : "https://www.example.org/17f0ddbb-b42c-4e5b-8be9-557db7f3195d"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/96ae32aa-2bc4-4e50-a4d6-cfa4058fdb80",
-        "name" : "dcitU5RiHRkzfshE",
-        "nameType" : "Personal",
-        "orcId" : "0jgNY7c7filxByRLUbc",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/095c8953-6d08-46c0-a788-3aa70313d378",
+        "name" : "l3gq3Npbxbeuw",
+        "nameType" : "Organizational",
+        "orcId" : "k81Lkgh5Dsy2Eh3Xaj",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QHArBhM10fqU",
-          "value" : "PQqwAUnYSMW8VND"
+          "sourceName" : "TTu1o5dq271pguPFxUu",
+          "value" : "iQ0oox7QjeQzK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EWptP7d6jZsKiNa",
-          "value" : "MBgFDLcvISw"
+          "sourceName" : "nz4H3IzWJa",
+          "value" : "YKFZHssVOjB8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bc167282-0ede-44fa-b74a-797c50e22364"
+        "id" : "https://www.example.org/a6bf5b35-a7d2-4cb3-a28c-903258edb4b5"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "Designer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "6Z5GiIiQES"
+      "da" : "R1sAfrzOxaQlXs4qa"
     },
-    "npiSubjectHeading" : "qPSvfaZNSOGyLKlLd3",
-    "tags" : [ "tvPazep7apdW" ],
-    "description" : "HApGUGVIm1H0sdLeF",
+    "npiSubjectHeading" : "eILlHPFBWvZ",
+    "tags" : [ "gcLgeUIlyk717DSby" ],
+    "description" : "bCl0n1VKExHON",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/gQ76Ovq2JJ0"
+        "id" : "https://www.example.com/veMDRgo7EN92YE6Ujr9"
       },
-      "doi" : "https://www.example.org/4a61d7ef-3213-4b78-a027-ed3c09b9c4b9",
+      "doi" : "https://www.example.org/a8b8dea6-6aaa-40b9-98a6-4ba1b3f2389c",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "ZqaZqFZLPn2lcG0JjbT",
-          "end" : "aVOtwuPfGvO7BnK"
+          "begin" : "z8RxR3s3HSD",
+          "end" : "XtXBnlZxCM1fAT"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f3440833-6234-4f11-82c5-7b1e71331d72",
-    "abstract" : "KkrE3qmHaAjR0AR"
+    "metadataSource" : "https://www.example.org/7f383b40-866b-4878-bfd5-c0d819475eda",
+    "abstract" : "v7cZzoyz34JE1Z"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dc1ba4f7-01f1-43e2-8a85-a0f58ae99a17",
-    "name" : "Yx9FBZjo6s1Lg",
+    "id" : "https://www.example.org/734033be-68b4-4eb5-8f36-9c348b0e56a4",
+    "name" : "h1XJUGDqlAn095ZwpE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-09-26T08:45:36.249Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "8BFdt180S9vKU9Zdtx"
+      "approvalDate" : "1988-04-04T16:22:59.460Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "WHGOONHKcx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3acd215e-cccc-442b-8ed6-6eecfd1af0a9",
-    "identifier" : "BmawYQJbpA4HXwbDJ5",
+    "source" : "https://www.example.org/feb71744-1f22-4d0a-a665-6a6ce4eb1cc9",
+    "identifier" : "dswiPkEWEGezsOR",
     "labels" : {
-      "nb" : "9uqi0ICDVxwQv42H"
+      "hu" : "Az8llhs3vln1A"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1487752184
+      "currency" : "USD",
+      "amount" : 1187263204
     },
-    "activeFrom" : "2014-12-10T15:39:03.028Z",
-    "activeTo" : "2016-03-26T04:20:15.423Z"
+    "activeFrom" : "1976-08-13T19:47:43.971Z",
+    "activeTo" : "2018-07-07T17:03:31.963Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3ec862f5-1806-4b20-9f66-b7e4ecadac75",
-    "id" : "https://www.example.org/77ee4d8a-8ade-480e-8441-e9f6ed32d070",
-    "identifier" : "BlWg8oHoF79c",
+    "source" : "https://www.example.org/2fbd1fe0-612f-4f1f-a8ab-a99fe97822b9",
+    "id" : "https://www.example.org/4191b002-440b-4e65-a0fc-b40f39695c0e",
+    "identifier" : "nUX5jDwItZ",
     "labels" : {
-      "nl" : "Dy4ye9Tc5r"
+      "hu" : "9t3j1viyccTYZbmp"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1867290798
+      "currency" : "USD",
+      "amount" : 2009158958
     },
-    "activeFrom" : "2019-10-04T18:26:00.431Z",
-    "activeTo" : "2022-05-24T21:26:54.854Z"
+    "activeFrom" : "1979-09-18T10:11:06.995Z",
+    "activeTo" : "2023-08-31T14:33:24.693Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/63d50229-4a8e-4851-86e9-a80359317585" ],
+  "subjects" : [ "https://www.example.org/0cc8cd69-f649-435e-8195-60865f4a1f98" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4bdc4786-a140-463e-9acc-4abe6f63e199",
-    "name" : "JDyPicFiYg78L0",
-    "mimeType" : "dzA2I8EJ2u8mpfr",
-    "size" : 2080126730,
-    "license" : "https://www.example.com/zepsnmeyonz8bdwb",
+    "identifier" : "54419880-8fb9-45bd-93c5-bd60620ecbe8",
+    "name" : "wAan46qZW0",
+    "mimeType" : "BjI0XcJW1zql5XpX9FE",
+    "size" : 1091458397,
+    "license" : "https://www.example.com/tbhjfoz3pqrfkx",
     "administrativeAgreement" : false,
     "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ATVO2Cv7IEJikU",
-    "publishedDate" : "2006-02-11T06:48:57.852Z",
+    "legalNote" : "W0NNt55iwuEEz",
+    "publishedDate" : "2001-10-04T04:37:00.411Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "fbscnSTM3G3dgDjei",
-      "uploadedDate" : "2011-08-20T10:54:40.313Z"
+      "uploadedBy" : "RTuTKmkRu7SS",
+      "uploadedDate" : "2005-08-17T11:05:36.185Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YJzoZwv0ZBS0OdT2yz",
-    "name" : "MWKqHWygcmMS2",
-    "description" : "7YEdNCpwDuCUD"
+    "id" : "https://www.example.com/d8lcdBUdxu1yW",
+    "name" : "JIjlvk75hSVWup0G",
+    "description" : "Q5LWZ0PavRmhj1"
   } ],
-  "rightsHolder" : "8wdKUbYfLam8zKAky",
-  "duplicateOf" : "https://www.example.org/54a832ad-0f02-481c-9251-4e3d51886684",
+  "rightsHolder" : "yUSgpQSQIXKWTG6E",
+  "duplicateOf" : "https://www.example.org/481c1afb-2002-4dfd-8050-d4944515bd37",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zDIYzxnt4k6sZvOW"
+    "note" : "OEyibkd1dQZkAtiw0iK"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ZNuypY8L5AwFSr2P",
-    "createdBy" : "5ZbkGM6NhtKpDKXs",
-    "createdDate" : "1990-08-23T15:29:31.251Z"
+    "note" : "j0i6rCI27Hn",
+    "createdBy" : "PCs9MmMskDKGjdD",
+    "createdDate" : "2005-05-22T22:33:27.173Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a9613c60-40c6-4672-b483-22b7b48cb230" ],
+  "curatingInstitutions" : [ "https://www.example.org/5b0e0480-cf41-4647-9de3-3ec737951610" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "P7OMXzxrAZi",
-    "ownerAffiliation" : "https://www.example.org/459f8d92-3f2b-4cdd-b97e-c01ea03e3f14"
+    "owner" : "RB6FHNdWP3tPplV",
+    "ownerAffiliation" : "https://www.example.org/395a542c-9e89-4613-96b8-d05a13c170d7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/686d595d-61d6-451e-abaf-13a211841d66"
+    "id" : "https://www.example.org/3ab8b2a3-8411-4c99-8b08-2c7afa7f6631"
   },
-  "createdDate" : "1982-11-25T04:39:34.768Z",
-  "modifiedDate" : "2022-04-27T05:03:51.210Z",
-  "publishedDate" : "1983-10-31T14:40:40.026Z",
-  "indexedDate" : "1989-05-30T12:27:14.604Z",
-  "handle" : "https://www.example.org/dc4035c8-db1e-4631-ba1f-e2b665c7405b",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/f5345ed7-982b-499c-b9c8-b96d52460a52",
+  "createdDate" : "1993-04-26T01:21:57.132Z",
+  "modifiedDate" : "1990-09-08T00:43:02.686Z",
+  "publishedDate" : "1984-08-08T00:20:11.276Z",
+  "indexedDate" : "1987-03-13T03:21:39.755Z",
+  "handle" : "https://www.example.org/a74c4a1c-2214-4ab4-89b8-12ff037c165a",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/89466462-6c21-4a0a-be0f-8795484226da",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "12UOoxN4z5sjaXDOZ",
+    "mainTitle" : "GQykDgggQLrDQP",
     "alternativeTitles" : {
-      "en" : "ZeqoutK84Y7jc4u"
+      "it" : "4gTF7HfSaenZf"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3Dqin4leacJE",
-      "month" : "8tSvml8mQtgn",
-      "day" : "t6ZAvX4xAkQ88"
+      "year" : "Jo9JDwgMRUHBHHUI",
+      "month" : "tpF2UdAD6GyfG7",
+      "day" : "QDeePEkxeMVtHF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bf945202-f769-4076-a703-bc15cadaee1e",
-        "name" : "VzOhtNspQbHk",
-        "nameType" : "Personal",
-        "orcId" : "z9HHrB7Md5BrqNiBkYi",
+        "id" : "https://www.example.org/5bc64d96-1338-4687-8022-834a3860a7fc",
+        "name" : "DU094ecXDLPhv9Ssg",
+        "nameType" : "Organizational",
+        "orcId" : "v9twwZFfbq3",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yCvQJ5L1u6Yxa",
-          "value" : "TbqSnxXfSPm"
+          "sourceName" : "X8YD4u83TEXW",
+          "value" : "FTCDlURQAHLJzGduXw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LFcs8sBGWLi",
-          "value" : "yfhjPfg1RsQuH9M"
+          "sourceName" : "nsqwpq7Av7avUvecD",
+          "value" : "ldcuK0SxdUcktih"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d9ebe50e-4825-4650-bdde-332a52e74370"
+        "id" : "https://www.example.org/520cfaf5-82fd-4b61-90c8-9ae863fbb476"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/defece0b-7a02-4d39-b629-ec8ca3cf915b",
-        "name" : "asttBIHnZWA1CUBLV",
-        "nameType" : "Organizational",
-        "orcId" : "d7chsbYYGmBrS",
+        "id" : "https://www.example.org/96ae32aa-2bc4-4e50-a4d6-cfa4058fdb80",
+        "name" : "dcitU5RiHRkzfshE",
+        "nameType" : "Personal",
+        "orcId" : "0jgNY7c7filxByRLUbc",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GTDGF5hiIaDjZ",
-          "value" : "nBkJ7ouVnuE"
+          "sourceName" : "QHArBhM10fqU",
+          "value" : "PQqwAUnYSMW8VND"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "avHfbpc5v5uRu",
-          "value" : "tyhW4JzwilIdY"
+          "sourceName" : "EWptP7d6jZsKiNa",
+          "value" : "MBgFDLcvISw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2b70559c-389c-42e0-9a71-fa0a692785aa"
+        "id" : "https://www.example.org/bc167282-0ede-44fa-b74a-797c50e22364"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "FCqAd5edR2K6j"
+      "nb" : "6Z5GiIiQES"
     },
-    "npiSubjectHeading" : "JDBiFFDtlVFbzylNFq",
-    "tags" : [ "Derasd5fiVF5" ],
-    "description" : "kmBMN7YKXRSbK9",
+    "npiSubjectHeading" : "qPSvfaZNSOGyLKlLd3",
+    "tags" : [ "tvPazep7apdW" ],
+    "description" : "HApGUGVIm1H0sdLeF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/u6HBhLUWKSK5jFNmz"
+        "id" : "https://www.example.com/gQ76Ovq2JJ0"
       },
-      "doi" : "https://www.example.org/4d58e6d7-f80a-4d49-84fd-1c3817ea4869",
+      "doi" : "https://www.example.org/4a61d7ef-3213-4b78-a027-ed3c09b9c4b9",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "J3WZlVe64I0",
-          "end" : "CQp432kM2YLofAx"
+          "begin" : "ZqaZqFZLPn2lcG0JjbT",
+          "end" : "aVOtwuPfGvO7BnK"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f2031dee-4b6f-4408-90db-6b8a496fcc7a",
-    "abstract" : "9XAIeWrb8KWKQF"
+    "metadataSource" : "https://www.example.org/f3440833-6234-4f11-82c5-7b1e71331d72",
+    "abstract" : "KkrE3qmHaAjR0AR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0923b031-d63f-4eb0-8f27-1a90f701d806",
-    "name" : "E0DBxn2UBth1lfnpQ",
+    "id" : "https://www.example.org/dc1ba4f7-01f1-43e2-8a85-a0f58ae99a17",
+    "name" : "Yx9FBZjo6s1Lg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-12-22T23:06:51.658Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1993-09-26T08:45:36.249Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "If2mGOBFbkn"
+      "applicationCode" : "8BFdt180S9vKU9Zdtx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0d8e5835-7015-4666-a2f3-5d3dccc019c4",
-    "identifier" : "znPiLF7WUoHm",
+    "source" : "https://www.example.org/3acd215e-cccc-442b-8ed6-6eecfd1af0a9",
+    "identifier" : "BmawYQJbpA4HXwbDJ5",
     "labels" : {
-      "zh" : "tcwFhadMFv"
+      "nb" : "9uqi0ICDVxwQv42H"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 21809319
+      "currency" : "GBP",
+      "amount" : 1487752184
     },
-    "activeFrom" : "1977-05-12T11:54:11.387Z",
-    "activeTo" : "2016-08-31T16:01:48.877Z"
+    "activeFrom" : "2014-12-10T15:39:03.028Z",
+    "activeTo" : "2016-03-26T04:20:15.423Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eaa089b7-38ca-49a0-9cbb-a2762fa8a6ac",
-    "id" : "https://www.example.org/1069cb7c-ec52-43b1-bda2-9fbe0d8114a6",
-    "identifier" : "4smtVlybFfMjzVb",
+    "source" : "https://www.example.org/3ec862f5-1806-4b20-9f66-b7e4ecadac75",
+    "id" : "https://www.example.org/77ee4d8a-8ade-480e-8441-e9f6ed32d070",
+    "identifier" : "BlWg8oHoF79c",
     "labels" : {
-      "hu" : "aikSyQK8Q2pAQS"
+      "nl" : "Dy4ye9Tc5r"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 107692900
+      "currency" : "GBP",
+      "amount" : 1867290798
     },
-    "activeFrom" : "2012-04-17T11:26:24.432Z",
-    "activeTo" : "2019-10-24T19:03:57.654Z"
+    "activeFrom" : "2019-10-04T18:26:00.431Z",
+    "activeTo" : "2022-05-24T21:26:54.854Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/51489121-cb0e-4bb0-92ae-29f8c2ddcf90" ],
+  "subjects" : [ "https://www.example.org/63d50229-4a8e-4851-86e9-a80359317585" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "54263a46-dd65-49f3-853b-b53697755b7b",
-    "name" : "bpYcmJU6KOgSUHGqZd",
-    "mimeType" : "Xy1Qrx8Pr92Ul",
-    "size" : 29476232,
-    "license" : "https://www.example.com/spa8sgkupw7ynlehb9",
+    "identifier" : "4bdc4786-a140-463e-9acc-4abe6f63e199",
+    "name" : "JDyPicFiYg78L0",
+    "mimeType" : "dzA2I8EJ2u8mpfr",
+    "size" : 2080126730,
+    "license" : "https://www.example.com/zepsnmeyonz8bdwb",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "UpdatedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "nQvF3EDUlr7JTKzNm8",
-    "publishedDate" : "1985-09-08T07:09:42.630Z",
+    "legalNote" : "ATVO2Cv7IEJikU",
+    "publishedDate" : "2006-02-11T06:48:57.852Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dckvie1yUdZDkW1",
-      "uploadedDate" : "1995-02-24T15:28:48.419Z"
+      "uploadedBy" : "fbscnSTM3G3dgDjei",
+      "uploadedDate" : "2011-08-20T10:54:40.313Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Tna9wjlu36IWfqP5Ccr",
-    "name" : "ZT6RJztcnSgYm0dXPhG",
-    "description" : "b18t6lEiBEuET6cim"
+    "id" : "https://www.example.com/YJzoZwv0ZBS0OdT2yz",
+    "name" : "MWKqHWygcmMS2",
+    "description" : "7YEdNCpwDuCUD"
   } ],
-  "rightsHolder" : "u1g5RQIS2kAjl70I",
-  "duplicateOf" : "https://www.example.org/ec296f61-18fb-4168-be18-7a7bbf92eee5",
+  "rightsHolder" : "8wdKUbYfLam8zKAky",
+  "duplicateOf" : "https://www.example.org/54a832ad-0f02-481c-9251-4e3d51886684",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pEA7osAf7pMuze85ruo"
+    "note" : "zDIYzxnt4k6sZvOW"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VVtbSOhQRAeKH",
-    "createdBy" : "zYYYzBTLDQhqcg7bSee",
-    "createdDate" : "1991-06-28T11:14:15.459Z"
+    "note" : "ZNuypY8L5AwFSr2P",
+    "createdBy" : "5ZbkGM6NhtKpDKXs",
+    "createdDate" : "1990-08-23T15:29:31.251Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/26646851-0ac1-4890-bf00-41025a6ef2a4" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/a9613c60-40c6-4672-b483-22b7b48cb230" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "GIKMMieYxl",
-    "ownerAffiliation" : "https://www.example.org/602bd8c8-7881-4755-a175-394bf04c4150"
+    "owner" : "9hHqLPPotVx",
+    "ownerAffiliation" : "https://www.example.org/e2d8ee38-aacc-40a5-ac83-cb8d9b3d5c6c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ff752acc-ee07-4a46-8df2-574387fd4f73"
+    "id" : "https://www.example.org/7dee6226-f18c-4e64-9e6b-3a41f8e4f469"
   },
-  "createdDate" : "2023-07-06T21:08:06.312Z",
-  "modifiedDate" : "1976-12-20T13:49:22.696Z",
-  "publishedDate" : "1973-09-21T09:52:27.055Z",
-  "indexedDate" : "1977-07-12T09:14:14.784Z",
-  "handle" : "https://www.example.org/8ce3784e-db22-4c9a-9145-4d4a150b43ed",
-  "doi" : "https://doi.org/10.1234/optio",
-  "link" : "https://www.example.org/8b1608f2-c80c-40de-afbe-a5324349da20",
+  "createdDate" : "1973-04-28T06:18:09.685Z",
+  "modifiedDate" : "1972-09-26T00:32:19.970Z",
+  "publishedDate" : "2022-12-31T02:17:43.583Z",
+  "indexedDate" : "1993-04-17T00:03:54.225Z",
+  "handle" : "https://www.example.org/7c7454f7-27c6-4619-8a9a-6ed46d37826f",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/3603a97e-d247-4773-8feb-5913a94fe24e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bMksU2FEIB",
+    "mainTitle" : "jz4gP76vh4nlgoFcM",
     "alternativeTitles" : {
-      "af" : "ykqidIqEMs6"
+      "el" : "j1nMN459lfOnl0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wa1Xk37mBzAdA6mmO",
-      "month" : "vd6FtFGp9svBDOticoA",
-      "day" : "apId0k4cKVoJrPdOH5"
+      "year" : "mE3E0joVFba",
+      "month" : "wfvobHvEG9l1XO7b",
+      "day" : "ds7aUeWWqTuFfic"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ffe1b669-7803-4e0f-8346-6e508b39b8b3",
-        "name" : "lCm3eD2a4jr",
-        "nameType" : "Personal",
-        "orcId" : "wYLAlbDctrg",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/08f7064e-5e4b-4e18-8a75-e651aee5b29e",
+        "name" : "XrNlK3mHVtOmijH0Ie",
+        "nameType" : "Organizational",
+        "orcId" : "cmQL04zcdl",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JSMUhcGgYOn0Yjkyu",
-          "value" : "nfw374njLuBJmjTpAv"
+          "sourceName" : "DU7h6BSCNQ1GeLH0",
+          "value" : "gPe8uuUAWYABm2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nufACPKMS12fl",
-          "value" : "Xzxi0JLNVb0hppgJ"
+          "sourceName" : "FDzCxH3TFajcAzx2",
+          "value" : "kswHJ3gaYL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ca42a4f9-1f72-4115-b168-031cb05e9571"
+        "id" : "https://www.example.org/766fa191-2b4a-4e9b-907a-3eedada44d81"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,155 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/53109e7c-90ad-4a1a-8f60-2944a7925298",
-        "name" : "Wnr1dyVioNuZB",
-        "nameType" : "Personal",
-        "orcId" : "HsusCTnWgio5",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/dc5eded9-2662-41bb-a59a-4880f5635f31",
+        "name" : "g6vEJK496CC",
+        "nameType" : "Organizational",
+        "orcId" : "eRefAO0zLS7Twa5",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QPHbihwQqVqyuW3S",
-          "value" : "QBchGfMNpC2hz"
+          "sourceName" : "dmsFGUS6FoBEBIzcQY",
+          "value" : "deVfHz5NqnmHn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LOLmccMrXDeNkGgv9J",
-          "value" : "yR8qbWlsNrTA8r4lk"
+          "sourceName" : "1pQbqks2msl4",
+          "value" : "5kxTdllksie"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2c19da9d-e326-4a2e-9a00-e3fb8fe5805f"
+        "id" : "https://www.example.org/29fb835e-94e2-44ca-a414-a1126317ee22"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "Scenographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "WHcCIzZfqKQjEnbF"
+      "nn" : "3UADvRH109g6jpzk26x"
     },
-    "npiSubjectHeading" : "r3gBvGEe4Lejh",
-    "tags" : [ "Om2bMErwM8v5ZTudah" ],
-    "description" : "PupFu630QiSJ7O",
+    "npiSubjectHeading" : "ZvntzmYcgRYme",
+    "tags" : [ "OW9Cv9v41o9a" ],
+    "description" : "mEUEz6ouWmgH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/f3d28b0b-6a78-4dc1-969b-adb30267623a",
+      "doi" : "https://www.example.org/3f0d0ed9-eda2-4867-bea5-606683902d09",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "Performance"
+          "type" : "Installation"
         },
-        "description" : "vc4onXqA8i5tuByPq",
+        "description" : "DJaqFNlIVvE48QW7P",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "cMtyxPfDWsnJE",
-            "country" : "aoNPcmB7IRpUP"
+            "label" : "qMdC4Y4Cns",
+            "country" : "GmZ8JJ5pNtu174"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1985-02-19T20:04:48.232Z",
-            "to" : "2009-01-04T12:03:12.519Z"
+            "from" : "1985-05-30T00:35:28.948Z",
+            "to" : "2014-08-21T10:07:14.712Z"
           },
-          "sequence" : 748915131
+          "sequence" : 1865686888
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/86ca3714-8c5b-43d9-b5cc-221c4124ae64",
-    "abstract" : "eFXAwgVim6"
+    "metadataSource" : "https://www.example.org/bd60cb4b-785e-40cf-a85a-ba375635d6ce",
+    "abstract" : "2trHuquM1YL39SMm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/025fa1d0-cb70-419e-a911-af8429c775d0",
-    "name" : "ksxNbN1EV68MK",
+    "id" : "https://www.example.org/c9fde7f5-d2cd-4b59-b05f-46815632bb33",
+    "name" : "2Zw6O1NKyYcO3Jg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-11-18T07:11:49.862Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1980-07-19T05:40:40.793Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Bv5wcMPK8a07dxjR"
+      "applicationCode" : "1N90DSncixdv3nZCu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ed82d27d-a5f9-47c8-8249-923782e482b4",
-    "identifier" : "ujCRKWeiPCAYst1",
+    "source" : "https://www.example.org/ff8b5e1b-c626-46e2-a708-bc0e040cf5a4",
+    "identifier" : "dNRdgD0wQ2KAIYzAZ",
     "labels" : {
-      "sv" : "p6fEyfP5KA"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1998476937
-    },
-    "activeFrom" : "2007-05-19T04:12:45.436Z",
-    "activeTo" : "2023-04-01T16:41:32.979Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0f6d3672-3998-4be2-802e-02c415da0a17",
-    "id" : "https://www.example.org/95474689-8cfb-4f34-af38-d95c60092352",
-    "identifier" : "ASjXDWcGHmLTb",
-    "labels" : {
-      "nb" : "jmk47SxpXd0BrSpo"
+      "de" : "YcL3hZgiw6"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1349500200
+      "amount" : 1521504563
     },
-    "activeFrom" : "2013-07-07T10:38:50.515Z",
-    "activeTo" : "2018-05-19T17:25:20.400Z"
+    "activeFrom" : "2018-03-12T18:36:07.429Z",
+    "activeTo" : "2018-09-21T15:07:48.506Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/180efa55-7157-4754-b518-6d98e55e5256",
+    "id" : "https://www.example.org/2f4d9df2-0b08-439e-bf07-c4d32f7273c0",
+    "identifier" : "tsO1rQF1pCN9LTTMUyF",
+    "labels" : {
+      "nn" : "wAzcBIYz4lWgRy"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1224725717
+    },
+    "activeFrom" : "2008-07-01T01:24:23.864Z",
+    "activeTo" : "2017-03-20T03:00:32.964Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5b896774-36c1-4c8f-b1ee-889624778175" ],
+  "subjects" : [ "https://www.example.org/c6f3ec4a-7e22-4058-aba1-a340c2cd31ab" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "507c250c-d651-4dd0-b292-6520195f4a81",
-    "name" : "PgQ81zFiYbTQH66rkS",
-    "mimeType" : "9xev7IQumrP9rec",
-    "size" : 2116303237,
-    "license" : "https://www.example.com/a7p0xhei1ytjwqy0",
+    "identifier" : "3c8886da-1deb-4f41-ad9a-22290d1125fa",
+    "name" : "0McV67LsY90",
+    "mimeType" : "TYRWJsb4f60PPCl",
+    "size" : 499739343,
+    "license" : "https://www.example.com/zv41ym5qxf",
     "administrativeAgreement" : false,
-    "publisherVersion" : "draft",
+    "publisherVersion" : "AcceptedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "MslrHOLSgMyFtz6WsV",
-    "publishedDate" : "1976-06-19T02:54:31.872Z",
+    "legalNote" : "tHF0oPGVSN64",
+    "publishedDate" : "2000-12-11T02:48:28.004Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "0PXgK72CVV",
-      "uploadedDate" : "2014-01-06T16:51:07.238Z"
+      "uploadedBy" : "owU1hTC0szGewaN",
+      "uploadedDate" : "1984-03-01T05:09:28.265Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nPXyClKI2JsjV",
-    "name" : "z06lhOsBb1sOT9yUL",
-    "description" : "3kC1CNlXzzAv"
+    "id" : "https://www.example.com/XCN3LVQID6eRA7",
+    "name" : "pQlkYpJBDsf9Le",
+    "description" : "HZjeSJhsP6KYe5DC"
   } ],
-  "rightsHolder" : "zK1HNYDOoG",
-  "duplicateOf" : "https://www.example.org/514248ee-0a88-420b-8d05-766145998796",
+  "rightsHolder" : "XCVlyH3baaUxS",
+  "duplicateOf" : "https://www.example.org/719105f1-e761-4f07-a4c2-e59bac77ae77",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DIO67HhCvA6kjk1e"
+    "note" : "AH5k8W2aFAk4hNrN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "bhjH5kaH1yo7G3m4",
-    "createdBy" : "jWROMURjZ2oNfgapfh1",
-    "createdDate" : "1979-10-05T07:55:59.174Z"
+    "note" : "SI9CNm4taJwHai92t",
+    "createdBy" : "9NDDYBQZGRIG9mjnwV",
+    "createdDate" : "1979-08-03T21:42:39.074Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a2d4aec4-a4b7-4c2d-b46d-f3ea2222409a" ],
+  "curatingInstitutions" : [ "https://www.example.org/6ad029b9-e2af-463d-b2eb-d5368675bb50" ],
   "modelVersion" : "0.22.01"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "8fQkBBcG8o0",
-    "ownerAffiliation" : "https://www.example.org/fe389aec-7556-4c40-ab6b-020633088542"
+    "owner" : "GIKMMieYxl",
+    "ownerAffiliation" : "https://www.example.org/602bd8c8-7881-4755-a175-394bf04c4150"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/46d379b6-0773-458b-bb9e-4933051cbbf0"
+    "id" : "https://www.example.org/ff752acc-ee07-4a46-8df2-574387fd4f73"
   },
-  "createdDate" : "1972-04-12T00:40:14.535Z",
-  "modifiedDate" : "1973-04-16T20:56:17.955Z",
-  "publishedDate" : "2018-08-10T07:33:53.447Z",
-  "indexedDate" : "1992-12-12T10:00:31.724Z",
-  "handle" : "https://www.example.org/1a33c15d-8190-4fae-8c1f-841d7b018f4b",
-  "doi" : "https://doi.org/10.1234/expedita",
-  "link" : "https://www.example.org/30e1c3fe-0063-4349-aec3-4e716eef766c",
+  "createdDate" : "2023-07-06T21:08:06.312Z",
+  "modifiedDate" : "1976-12-20T13:49:22.696Z",
+  "publishedDate" : "1973-09-21T09:52:27.055Z",
+  "indexedDate" : "1977-07-12T09:14:14.784Z",
+  "handle" : "https://www.example.org/8ce3784e-db22-4c9a-9145-4d4a150b43ed",
+  "doi" : "https://doi.org/10.1234/optio",
+  "link" : "https://www.example.org/8b1608f2-c80c-40de-afbe-a5324349da20",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eA4xIXo2ITHwqkO8N",
+    "mainTitle" : "bMksU2FEIB",
     "alternativeTitles" : {
-      "cs" : "20F4hiqFkJvosB1"
+      "af" : "ykqidIqEMs6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uCFGYDtsC7",
-      "month" : "FYL7AjKjt0l",
-      "day" : "Lapzbm7T0OiXQm"
+      "year" : "wa1Xk37mBzAdA6mmO",
+      "month" : "vd6FtFGp9svBDOticoA",
+      "day" : "apId0k4cKVoJrPdOH5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0a950d8c-2cb8-42e4-95e5-00c26185c072",
-        "name" : "0SRkZFtISMHRaLY7P",
-        "nameType" : "Organizational",
-        "orcId" : "Nhrv09WaTuDnuPx",
+        "id" : "https://www.example.org/ffe1b669-7803-4e0f-8346-6e508b39b8b3",
+        "name" : "lCm3eD2a4jr",
+        "nameType" : "Personal",
+        "orcId" : "wYLAlbDctrg",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ByBssH2hqs6hHfmeg",
-          "value" : "MqCQNdUeJMt"
+          "sourceName" : "JSMUhcGgYOn0Yjkyu",
+          "value" : "nfw374njLuBJmjTpAv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "agzh87HwqqP5nH1Jdy",
-          "value" : "TxsLYH1TgM1kUuU3IgR"
+          "sourceName" : "nufACPKMS12fl",
+          "value" : "Xzxi0JLNVb0hppgJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9fb486cb-b9d7-4213-8bfe-acae6b7ad6ed"
+        "id" : "https://www.example.org/ca42a4f9-1f72-4115-b168-031cb05e9571"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "HostingInstitution"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,155 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/680cfa5a-bb0e-4b27-97ad-3eaf4f2fbf90",
-        "name" : "mtJS0MRQ6HJfw",
-        "nameType" : "Organizational",
-        "orcId" : "COm5QK9exZ2DuNN5",
+        "id" : "https://www.example.org/53109e7c-90ad-4a1a-8f60-2944a7925298",
+        "name" : "Wnr1dyVioNuZB",
+        "nameType" : "Personal",
+        "orcId" : "HsusCTnWgio5",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZUXgPHnpPQydlu",
-          "value" : "g9f072ZEMxLEA47cr"
+          "sourceName" : "QPHbihwQqVqyuW3S",
+          "value" : "QBchGfMNpC2hz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wZPWmXf5YrVua",
-          "value" : "veSjwizIIOrLW2PxlZ"
+          "sourceName" : "LOLmccMrXDeNkGgv9J",
+          "value" : "yR8qbWlsNrTA8r4lk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/088dd7a2-bcbd-4890-9061-ffe077bb3c6a"
+        "id" : "https://www.example.org/2c19da9d-e326-4a2e-9a00-e3fb8fe5805f"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "mTE6N4RrXwKQ8AvGsGr"
+      "fr" : "WHcCIzZfqKQjEnbF"
     },
-    "npiSubjectHeading" : "dflgFmalvmKyivVZL",
-    "tags" : [ "npDAWM89MhpbEqK6B9A" ],
-    "description" : "ztYV3SC2qAj",
+    "npiSubjectHeading" : "r3gBvGEe4Lejh",
+    "tags" : [ "Om2bMErwM8v5ZTudah" ],
+    "description" : "PupFu630QiSJ7O",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/0adf8600-3330-4221-819a-2183b1083b60",
+      "doi" : "https://www.example.org/f3d28b0b-6a78-4dc1-969b-adb30267623a",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "AudioArt"
+          "type" : "Performance"
         },
-        "description" : "n1XBe3HAe0iGLvny",
+        "description" : "vc4onXqA8i5tuByPq",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "cXrS2RsYNxiHwb0hY",
-            "country" : "aAQBxwyWT1I7xTlCX"
+            "label" : "cMtyxPfDWsnJE",
+            "country" : "aoNPcmB7IRpUP"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1974-06-11T20:11:28.619Z",
-            "to" : "2013-04-23T12:35:00.250Z"
+            "from" : "1985-02-19T20:04:48.232Z",
+            "to" : "2009-01-04T12:03:12.519Z"
           },
-          "sequence" : 2145918634
+          "sequence" : 748915131
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c441845c-161a-4335-9cd4-862e0be3b6fd",
-    "abstract" : "pNgu6ZlHho"
+    "metadataSource" : "https://www.example.org/86ca3714-8c5b-43d9-b5cc-221c4124ae64",
+    "abstract" : "eFXAwgVim6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cfc7e7fa-1b0b-4605-8867-6b29eb46a6ff",
-    "name" : "Wdl65RbBsuxDGm",
+    "id" : "https://www.example.org/025fa1d0-cb70-419e-a911-af8429c775d0",
+    "name" : "ksxNbN1EV68MK",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-09-27T13:30:48.387Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "1C9lHtbYLO7HZ"
+      "approvalDate" : "1971-11-18T07:11:49.862Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Bv5wcMPK8a07dxjR"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0cb37e2c-3cda-4bb9-9f5e-6250c39622ca",
-    "identifier" : "7kl3cqfeZptXCHg",
+    "source" : "https://www.example.org/ed82d27d-a5f9-47c8-8249-923782e482b4",
+    "identifier" : "ujCRKWeiPCAYst1",
     "labels" : {
-      "pl" : "CzeDyPGW9j"
+      "sv" : "p6fEyfP5KA"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 113593988
+      "currency" : "USD",
+      "amount" : 1998476937
     },
-    "activeFrom" : "1971-06-16T01:19:30.094Z",
-    "activeTo" : "1996-05-26T20:07:54.293Z"
+    "activeFrom" : "2007-05-19T04:12:45.436Z",
+    "activeTo" : "2023-04-01T16:41:32.979Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e961e05a-07a2-4bc5-8b42-c6c1f4f1ff77",
-    "id" : "https://www.example.org/e534951e-37b7-4e2f-971c-270b8cc85b94",
-    "identifier" : "55hIAs2RHpA9d",
+    "source" : "https://www.example.org/0f6d3672-3998-4be2-802e-02c415da0a17",
+    "id" : "https://www.example.org/95474689-8cfb-4f34-af38-d95c60092352",
+    "identifier" : "ASjXDWcGHmLTb",
     "labels" : {
-      "fr" : "xgSNcUkGDu4jEU"
+      "nb" : "jmk47SxpXd0BrSpo"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 716177479
+      "amount" : 1349500200
     },
-    "activeFrom" : "2023-06-13T15:49:53.834Z",
-    "activeTo" : "2023-06-24T15:25:25.272Z"
+    "activeFrom" : "2013-07-07T10:38:50.515Z",
+    "activeTo" : "2018-05-19T17:25:20.400Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e16462c1-ffbf-403f-b0b9-9bb282bf4f0c" ],
+  "subjects" : [ "https://www.example.org/5b896774-36c1-4c8f-b1ee-889624778175" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c6bf2016-d521-441b-b394-50d32721ce33",
-    "name" : "wKYxMwARjruw",
-    "mimeType" : "irXc8kfMFSXwiycA",
-    "size" : 277401828,
-    "license" : "https://www.example.com/xxpjg3yxpu6sq",
+    "identifier" : "507c250c-d651-4dd0-b292-6520195f4a81",
+    "name" : "PgQ81zFiYbTQH66rkS",
+    "mimeType" : "9xev7IQumrP9rec",
+    "size" : 2116303237,
+    "license" : "https://www.example.com/a7p0xhei1ytjwqy0",
     "administrativeAgreement" : false,
-    "publisherVersion" : "PublishedVersion",
+    "publisherVersion" : "draft",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "bB8KGOmPukLDfBeH4",
-    "publishedDate" : "1991-10-23T10:43:06.301Z",
+    "legalNote" : "MslrHOLSgMyFtz6WsV",
+    "publishedDate" : "1976-06-19T02:54:31.872Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "7xOSNRYKuTpamFxs",
-      "uploadedDate" : "2004-08-23T01:30:23.019Z"
+      "uploadedBy" : "0PXgK72CVV",
+      "uploadedDate" : "2014-01-06T16:51:07.238Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/MMUH091eCMMgE",
-    "name" : "4eGbY3KkARN",
-    "description" : "t1gUcNQptmcu2gAmG6Q"
+    "id" : "https://www.example.com/nPXyClKI2JsjV",
+    "name" : "z06lhOsBb1sOT9yUL",
+    "description" : "3kC1CNlXzzAv"
   } ],
-  "rightsHolder" : "TbRFvERKvTnSO4HFgpg",
-  "duplicateOf" : "https://www.example.org/ba7218f9-9cf0-4800-a3e0-e9da5ad50fe8",
+  "rightsHolder" : "zK1HNYDOoG",
+  "duplicateOf" : "https://www.example.org/514248ee-0a88-420b-8d05-766145998796",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "XceOzFGl41"
+    "note" : "DIO67HhCvA6kjk1e"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "n71g8AYQN6V9kSnIqj",
-    "createdBy" : "o55CpobwSiOt3",
-    "createdDate" : "1990-04-08T08:08:09.097Z"
+    "note" : "bhjH5kaH1yo7G3m4",
+    "createdBy" : "jWROMURjZ2oNfgapfh1",
+    "createdDate" : "1979-10-05T07:55:59.174Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ffa8c0e7-e4bc-4f0d-8f0d-3274edf637fc" ],
-  "modelVersion" : "0.21.18"
+  "curatingInstitutions" : [ "https://www.example.org/a2d4aec4-a4b7-4c2d-b46d-f3ea2222409a" ],
+  "modelVersion" : "0.22.01"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -65,10 +65,6 @@ schema:
       properties:
         empty:
           type: boolean
-        first:
-          $ref: '#/components/schemas/AssociatedArtifact'
-        last:
-          $ref: '#/components/schemas/AssociatedArtifact'
       items:
         $ref: '#/components/schemas/AssociatedArtifact'
     rightsHolder:
@@ -355,10 +351,6 @@ referencedSchemas:
     properties:
       empty:
         type: boolean
-      first:
-        $ref: '#/components/schemas/AssociatedArtifact'
-      last:
-        $ref: '#/components/schemas/AssociatedArtifact'
     items:
       $ref: '#/components/schemas/AssociatedArtifact'
   AssociatedLink:
@@ -1201,6 +1193,9 @@ referencedSchemas:
           type: string
           enum:
           - PublishedVersion
+          - draft
+          - SubmittedVersion
+          - UpdatedVersion
           - AcceptedVersion
         embargoDate:
           type: string
@@ -1232,8 +1227,6 @@ referencedSchemas:
     - type
     type: object
     properties:
-      identifier:
-        type: string
       labels:
         type: object
         additionalProperties:
@@ -1241,14 +1234,16 @@ referencedSchemas:
       source:
         type: string
         format: uri
-      fundingAmount:
-        $ref: '#/components/schemas/MonetaryAmount'
-      activeFrom:
-        type: string
-        format: date-time
       activeTo:
         type: string
         format: date-time
+      activeFrom:
+        type: string
+        format: date-time
+      fundingAmount:
+        $ref: '#/components/schemas/MonetaryAmount'
+      identifier:
+        type: string
       type:
         type: string
     discriminator:
@@ -2411,10 +2406,6 @@ referencedSchemas:
         properties:
           empty:
             type: boolean
-          first:
-            $ref: '#/components/schemas/AssociatedArtifact'
-          last:
-            $ref: '#/components/schemas/AssociatedArtifact'
         items:
           $ref: '#/components/schemas/AssociatedArtifact'
       rightsHolder:

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -1193,7 +1193,7 @@ referencedSchemas:
           type: string
           enum:
           - PublishedVersion
-          - draft
+          - Draft
           - SubmittedVersion
           - UpdatedVersion
           - AcceptedVersion
@@ -1234,14 +1234,14 @@ referencedSchemas:
       source:
         type: string
         format: uri
-      activeTo:
-        type: string
-        format: date-time
+      fundingAmount:
+        $ref: '#/components/schemas/MonetaryAmount'
       activeFrom:
         type: string
         format: date-time
-      fundingAmount:
-        $ref: '#/components/schemas/MonetaryAmount'
+      activeTo:
+        type: string
+        format: date-time
       identifier:
         type: string
       type:

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
@@ -1,6 +1,5 @@
 package no.unit.nva.model.associatedartifacts.file;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -38,7 +37,7 @@ public class AdministrativeAgreement extends File {
         @JsonProperty(SIZE_FIELD) Long size,
         @JsonProperty(LICENSE_FIELD) Object license,
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
-        @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
+        @JsonProperty(PUBLISHER_VERSION_FIELD) PublisherVersion publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -2,7 +2,6 @@ package no.unit.nva.model.associatedartifacts.file;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -44,7 +43,6 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     public static final String SIZE_FIELD = "size";
     public static final String LICENSE_FIELD = "license";
     public static final String ADMINISTRATIVE_AGREEMENT_FIELD = "administrativeAgreement";
-    public static final String PUBLISHER_AUTHORITY_FIELD = "publisherAuthority";
     public static final String PUBLISHER_VERSION_FIELD = "publisherVersion";
     public static final String EMBARGO_DATE_FIELD = "embargoDate";
     public static final String RIGTHTS_RETENTION_STRATEGY = "rightsRetentionStrategy";
@@ -105,7 +103,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
      * @param license                 The license for the file, may be null if and only if the file is an administrative
      *                                agreement
      * @param administrativeAgreement True if the file is an administrative agreement
-     * @param publisherAuthority      True if the file owner has publisher authority
+     * @param publisherVersion        The version of the file in relation to publisher
      * @param embargoDate             The date after which the file may be published
      * @param rightsRetentionStrategy The rights retention strategy for the file
      * @param uploadDetails           Information regarding who and when inserted the file into the system
@@ -118,7 +116,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         @JsonProperty(SIZE_FIELD) Long size,
         @JsonProperty(LICENSE_FIELD) Object license,
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
-        @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publisherAuthority,
+        @JsonProperty(PUBLISHER_VERSION_FIELD) PublisherVersion publisherVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
@@ -130,7 +128,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         this.size = size;
         this.license = validateUriLicense(parseLicense(license));
         this.administrativeAgreement = administrativeAgreement;
-        this.publisherVersion = PublisherVersion.parse(publisherAuthority);
+        this.publisherVersion = publisherVersion;
         this.embargoDate = embargoDate;
         this.rightsRetentionStrategy = assignDefaultStrategyIfNull(rightsRetentionStrategy);
         this.legalNote = legalNote;
@@ -380,16 +378,6 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
 
         public Builder withUploadDetails(UploadDetails uploadDetails) {
             this.uploadDetails = uploadDetails;
-            return this;
-        }
-
-        /**
-         * @deprecated (since = "0.21.12") replaced by
-         * {@link #withPublisherVersion(PublisherVersion publisherVersion)}
-         */
-        @Deprecated
-        public Builder withPublisherAuthority(boolean publisherAuthority) {
-            this.publisherVersion = PublisherVersion.parse(publisherAuthority);
             return this;
         }
 

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
@@ -1,6 +1,5 @@
 package no.unit.nva.model.associatedartifacts.file;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -46,7 +45,7 @@ public class PublishedFile extends File {
         @JsonProperty(SIZE_FIELD) Long size,
         @JsonProperty(LICENSE_FIELD) Object license,
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
-        @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
+        @JsonProperty(PUBLISHER_VERSION_FIELD) PublisherVersion publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublisherVersion.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublisherVersion.java
@@ -9,7 +9,7 @@ import nva.commons.core.StringUtils;
 
 public enum PublisherVersion {
     PUBLISHED_VERSION("PublishedVersion"),
-    DRAFT("draft"),
+    DRAFT("Draft"),
     SUBMITTED_VERSION("SubmittedVersion"),
     UPDATED_VERSION("UpdatedVersion"),
     ACCEPTED_VERSION("AcceptedVersion");

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublisherVersion.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublisherVersion.java
@@ -2,18 +2,19 @@ package no.unit.nva.model.associatedartifacts.file;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
-import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.joining;
 import com.fasterxml.jackson.annotation.JsonValue;
 import no.unit.nva.model.Revision;
+import nva.commons.core.StringUtils;
 
 public enum PublisherVersion {
     PUBLISHED_VERSION("PublishedVersion"),
+    DRAFT("draft"),
+    SUBMITTED_VERSION("SubmittedVersion"),
+    UPDATED_VERSION("UpdatedVersion"),
     ACCEPTED_VERSION("AcceptedVersion");
 
     public static final String ERROR_MESSAGE_TEMPLATE = "%s not a valid PublisherVersion, expected one of: %s";
-    public static final String ERROR_MESSAGE_CANNOT_PARSE_THIS_OBJECT = "%s not a valid object, expected either "
-                                                                        + "String or boolean";
     public static final String DELIMITER = ", ";
 
     private final String value;
@@ -22,22 +23,11 @@ public enum PublisherVersion {
         this.value = value;
     }
 
-    public static PublisherVersion parse(Object candidate) {
-        if (candidate instanceof Boolean publisherAuthority) {
-            return parseFromBoolean(publisherAuthority);
-        } else if (candidate instanceof String stringCandidate) {
-            return parseFromString(stringCandidate);
-        } else if (isNull(candidate)) {
+    public static PublisherVersion parse(String candidate) {
+        if (StringUtils.isBlank(candidate)) {
             return null;
-        } else if (candidate instanceof PublisherVersion publisherVersion) {
-            return publisherVersion;
         }
-        throw new UnsupportedOperationException(format(ERROR_MESSAGE_CANNOT_PARSE_THIS_OBJECT,
-                                                       candidate.getClass().getSimpleName()));
-    }
-
-    public static PublisherVersion parseFromBoolean(boolean candidate) {
-        return candidate ? PUBLISHED_VERSION : ACCEPTED_VERSION;
+        return parseFromString(candidate);
     }
 
     public static PublisherVersion parseFromString(String candidate) {

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
@@ -1,6 +1,5 @@
 package no.unit.nva.model.associatedartifacts.file;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -40,7 +39,7 @@ public class UnpublishedFile extends File {
         @JsonProperty(SIZE_FIELD) Long size,
         @JsonProperty(LICENSE_FIELD) Object license,
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
-        @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
+        @JsonProperty(PUBLISHER_VERSION_FIELD) PublisherVersion publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/file/FileModelTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/file/FileModelTest.java
@@ -203,31 +203,6 @@ public class FileModelTest {
         assertThat(unmapped.isVisibleForNonOwner(), equalTo(false));
     }
 
-    @Deprecated
-    @Test
-    void shouldMigrateLegacyFileToUnpublishedFile() throws JsonProcessingException {
-        var fileJson = """
-            {
-                "type" : "File",
-                "identifier" : "df2be965-f628-43fb-914b-e16d6f136e05",
-                "name" : "2-s2.0-85143901828.xml",
-                "mimeType" : "text/xml",
-                "size" : 180088,
-                "license" : {
-                  "type" : "License",
-                  "identifier" : "RightsReserved",
-                  "labels" : {
-                    "nb" : "RightsReserved"
-                  }
-                },
-                "administrativeAgreement" : false,
-                "publisherAuthority" : false,
-                "visibleForNonOwner" : true
-              }""";
-        var file = JsonUtils.dtoObjectMapper.readValue(fileJson, File.class);
-        assertThat(file, instanceOf(UnpublishedFile.class));
-    }
-
     private static UploadDetails randomInserted() {
         return new UploadDetails(randomUsername(), randomInstant());
     }

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/file/FileModelTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/file/FileModelTest.java
@@ -243,7 +243,7 @@ public class FileModelTest {
                 "size" : 1025817,
                 "license" : "https://creativecommons.org/licenses/by-nc/2.0/",
                 "administrativeAgreement" : false,
-                "publisherAuthority" : false,
+                "publisherVersion" : "AcceptedVersion",
                 "publishedDate" : "2023-05-25T19:31:17.302914Z",
                 "visibleForNonOwner" : true
               }""";

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/AdministrativeAgreementGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/AdministrativeAgreementGenerator.java
@@ -17,7 +17,10 @@ public final class AdministrativeAgreementGenerator {
 
     public static AdministrativeAgreement random() {
         return new AdministrativeAgreement(UUID.randomUUID(), randomString(), randomString(),
-                                           randomInteger().longValue(), randomUri(), true, false, null,
+                                           randomInteger().longValue(), randomUri(),
+                                           true,
+                                           null,
+                                           null,
                                            randomInserted());
     }
 

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/PublishedFileGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/PublishedFileGenerator.java
@@ -4,8 +4,10 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import java.util.Random;
 import java.util.UUID;
 import no.unit.nva.model.Username;
+import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
 import no.unit.nva.model.associatedartifacts.file.UploadDetails;
 import no.unit.nva.model.associatedartifacts.file.PublishedFile;
 import no.unit.nva.model.testing.associatedartifacts.util.RightsRetentionStrategyGenerator;
@@ -18,9 +20,13 @@ public final class PublishedFileGenerator {
 
     public static PublishedFile random() {
         return new PublishedFile(UUID.randomUUID(), randomString(), randomString(), randomInteger().longValue(),
-                                 randomUri(), false, true, null,
+                                 randomUri(), false, randomPublisherVersion(), null,
                                  RightsRetentionStrategyGenerator.randomRightsRetentionStrategy(), randomString(),
                                  randomInstant(), randomInserted());
+    }
+
+    private static PublisherVersion randomPublisherVersion() {
+        return PublisherVersion.values()[new Random().nextInt(PublisherVersion.values().length)];
     }
 
     private static UploadDetails randomInserted() {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/UnpublishedFileGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/associatedartifacts/UnpublishedFileGenerator.java
@@ -1,6 +1,8 @@
 package no.unit.nva.model.testing.associatedartifacts;
 
+import java.util.Random;
 import no.unit.nva.model.Username;
+import no.unit.nva.model.associatedartifacts.file.PublisherVersion;
 import no.unit.nva.model.associatedartifacts.file.UploadDetails;
 import no.unit.nva.model.associatedartifacts.file.UnpublishedFile;
 
@@ -20,9 +22,13 @@ public final class UnpublishedFileGenerator {
 
     public static UnpublishedFile random() {
         return new UnpublishedFile(UUID.randomUUID(), randomString(), randomString(), randomInteger().longValue(),
-                                   randomUri(), false, true, null,
+                                   randomUri(), false, randomPublisherVersion(), null,
                                    RightsRetentionStrategyGenerator.randomRightsRetentionStrategy(), randomString(),
                                    randomInserted());
+    }
+
+    private static PublisherVersion randomPublisherVersion() {
+        return PublisherVersion.values()[new Random().nextInt(PublisherVersion.values().length)];
     }
 
     private static UploadDetails randomInserted() {


### PR DESCRIPTION
According to the testers, we need to support "draft", "updatedVersion", and "submittedVersion"

Also removed backwards (and already flagged as deprecated) functionality to parse booleans as accepted / published version. 