### PR TITLE
NP-46821 Add copy method with builder to files

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.21'
+version '0.21.22'
 
 repositories {
     mavenCentral()

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
@@ -42,7 +42,7 @@ public class AdministrativeAgreement extends File {
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
-              embargoDate, null,  NO_LEGAL_NOTE,
+              embargoDate, null,  NO_LEGAL_NOTE, null,
               uploadDetails);
     }
     
@@ -59,5 +59,19 @@ public class AdministrativeAgreement extends File {
     @Override
     public PublishedFile toPublishedFile() {
         throw new IllegalStateException("Cannot make an unpublishable file publishable");
+    }
+
+    @Override
+    public Builder copy() {
+        return builder()
+                   .withIdentifier(this.getIdentifier())
+                   .withName(this.getName())
+                   .withMimeType(this.getMimeType())
+                   .withSize(this.getSize())
+                   .withLicense(this.getLicense())
+                   .withAdministrativeAgreement(this.isAdministrativeAgreement())
+                   .withPublisherVersion(this.getPublisherVersion())
+                   .withEmbargoDate(this.getEmbargoDate().orElse(null))
+                   .withUploadDetails(this.getUploadDetails());
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/AdministrativeAgreement.java
@@ -40,7 +40,7 @@ public class AdministrativeAgreement extends File {
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
         @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
-        @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
+        @JsonProperty(UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
               embargoDate, null,  NO_LEGAL_NOTE, null,
               uploadDetails);

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import no.unit.nva.commons.json.JsonSerializable;
-import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.NullRightsRetentionStrategy;
 import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -47,9 +47,9 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     public static final String PUBLISHER_AUTHORITY_FIELD = "publisherAuthority";
     public static final String PUBLISHER_VERSION_FIELD = "publisherVersion";
     public static final String EMBARGO_DATE_FIELD = "embargoDate";
-    public static final String RIGTHTS_RETENTION_STRATEGY = "rightsRetentionStrategy";
-    public static final String PUBLISHED_DATE = "publishedDate";
-    public static final String UPLOAD_DETAILS = "uploadDetails";
+    public static final String RIGHTS_RETENTION_STRATEGY = "rightsRetentionStrategy";
+    public static final String PUBLISHED_DATE_FIELD = "publishedDate";
+    public static final String UPLOAD_DETAILS_FIELD = "uploadDetails";
     public static final Map<String, URI> LICENSE_MAP = Map.of(
         "CC BY", URI.create("https://creativecommons.org/licenses/by/4.0"),
         "CC BY-NC", URI.create("https://creativecommons.org/licenses/by-nc/4.0"),
@@ -87,14 +87,14 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     private final PublisherVersion publisherVersion;
     @JsonProperty(EMBARGO_DATE_FIELD)
     private final Instant embargoDate;
-    @JsonProperty(RIGTHTS_RETENTION_STRATEGY)
+    @JsonProperty(RIGHTS_RETENTION_STRATEGY)
     private RightsRetentionStrategy rightsRetentionStrategy;
     @JsonProperty(LEGAL_NOTE_FIELD)
     private final String legalNote;
-    @JsonProperty(PUBLISHED_DATE)
+    @JsonProperty(PUBLISHED_DATE_FIELD)
     private final Instant publishedDate;
 
-    @JsonProperty(UPLOAD_DETAILS)
+    @JsonProperty(UPLOAD_DETAILS_FIELD)
     private final UploadDetails uploadDetails;
 
     /**
@@ -123,10 +123,10 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
         @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publisherAuthority,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
-        @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
+        @JsonProperty(RIGHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
-        @JsonProperty(PUBLISHED_DATE) Instant publishedDate,
-        @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
+        @JsonProperty(PUBLISHED_DATE_FIELD) Instant publishedDate,
+        @JsonProperty(UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails) {
 
         this.identifier = identifier;
         this.name = name;
@@ -258,10 +258,9 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof File file)) {
             return false;
         }
-        File file = (File) o;
         return isAdministrativeAgreement() == file.isAdministrativeAgreement()
                && Objects.equals(getIdentifier(), file.getIdentifier())
                && Objects.equals(getName(), file.getName())

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/File.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.model.Username;
 import no.unit.nva.model.associatedartifacts.AssociatedArtifact;
 import no.unit.nva.model.associatedartifacts.NullRightsRetentionStrategy;
 import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
@@ -48,6 +49,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     public static final String PUBLISHER_VERSION_FIELD = "publisherVersion";
     public static final String EMBARGO_DATE_FIELD = "embargoDate";
     public static final String RIGTHTS_RETENTION_STRATEGY = "rightsRetentionStrategy";
+    public static final String PUBLISHED_DATE = "publishedDate";
     public static final String UPLOAD_DETAILS = "uploadDetails";
     public static final Map<String, URI> LICENSE_MAP = Map.of(
         "CC BY", URI.create("https://creativecommons.org/licenses/by/4.0"),
@@ -90,6 +92,8 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
     private RightsRetentionStrategy rightsRetentionStrategy;
     @JsonProperty(LEGAL_NOTE_FIELD)
     private final String legalNote;
+    @JsonProperty(PUBLISHED_DATE)
+    private final Instant publishedDate;
 
     @JsonProperty(UPLOAD_DETAILS)
     private final UploadDetails uploadDetails;
@@ -122,6 +126,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
         @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
+        @JsonProperty(PUBLISHED_DATE) Instant publishedDate,
         @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
 
         this.identifier = identifier;
@@ -134,6 +139,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         this.embargoDate = embargoDate;
         this.rightsRetentionStrategy = assignDefaultStrategyIfNull(rightsRetentionStrategy);
         this.legalNote = legalNote;
+        this.publishedDate = publishedDate;
         this.uploadDetails = uploadDetails;
     }
 
@@ -152,6 +158,10 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
 
     public UploadDetails getUploadDetails() {
         return uploadDetails;
+    }
+
+    public Optional<Instant> getPublishedDate() {
+        return Optional.ofNullable(publishedDate);
     }
 
     public UUID getIdentifier() {
@@ -241,13 +251,7 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
 
     public abstract boolean isVisibleForNonOwner();
 
-    @Override
-    @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(getIdentifier(), getName(), getMimeType(), getSize(), getLicense(),
-                            isAdministrativeAgreement(), getUploadDetails(),
-                            getPublisherVersion(), getEmbargoDate(), getRightsRetentionStrategy());
-    }
+    public abstract Builder copy();
 
     @Override
     @JacocoGenerated
@@ -255,19 +259,31 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof File file)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        File file = (File) o;
         return isAdministrativeAgreement() == file.isAdministrativeAgreement()
-               && getPublisherVersion() == file.getPublisherVersion()
                && Objects.equals(getIdentifier(), file.getIdentifier())
                && Objects.equals(getName(), file.getName())
                && Objects.equals(getMimeType(), file.getMimeType())
                && Objects.equals(getSize(), file.getSize())
                && Objects.equals(getLicense(), file.getLicense())
+               && getPublisherVersion() == file.getPublisherVersion()
                && Objects.equals(getEmbargoDate(), file.getEmbargoDate())
-               && Objects.equals(getUploadDetails(), file.getUploadDetails())
-               && Objects.equals(getRightsRetentionStrategy(), file.getRightsRetentionStrategy());
+               && Objects.equals(getRightsRetentionStrategy(), file.getRightsRetentionStrategy())
+               && Objects.equals(getLegalNote(), file.getLegalNote())
+               && Objects.equals(getPublishedDate(), file.getPublishedDate())
+               && Objects.equals(getUploadDetails(), file.getUploadDetails());
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(getIdentifier(), getName(), getMimeType(), getSize(), getLicense(),
+                            isAdministrativeAgreement(),
+                            getPublisherVersion(), getEmbargoDate(), getRightsRetentionStrategy(), getLegalNote(),
+                            getPublishedDate(), getUploadDetails());
     }
 
     @Override
@@ -421,14 +437,13 @@ public abstract class File implements JsonSerializable, AssociatedArtifact {
 
         public File buildUnpublishedFile() {
             return new UnpublishedFile(identifier, name, mimeType, size, license, administrativeAgreement,
-                                       publisherVersion,
-                                       embargoDate, rightsRetentionStrategy, legalNote, uploadDetails);
+                                       publisherVersion, embargoDate, rightsRetentionStrategy, legalNote,
+                                       uploadDetails);
         }
 
         public File buildUnpublishableFile() {
             return new AdministrativeAgreement(identifier, name, mimeType, size, license, administrativeAgreement,
-                                               publisherVersion,
-                                               embargoDate, uploadDetails);
+                                               publisherVersion, embargoDate, uploadDetails);
         }
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
@@ -45,10 +45,10 @@ public class PublishedFile extends File {
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
         @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
-        @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
+        @JsonProperty(RIGHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
-        @JsonProperty(PUBLISHED_DATE) Instant publishedDate,
-        @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
+        @JsonProperty(PUBLISHED_DATE_FIELD) Instant publishedDate,
+        @JsonProperty(UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
               embargoDate, rightsRetentionStrategy, legalNote, publishedDate, uploadDetails);
         if (administrativeAgreement) {

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/PublishedFile.java
@@ -16,9 +16,6 @@ import no.unit.nva.model.associatedartifacts.RightsRetentionStrategy;
 public class PublishedFile extends File {
 
     public static final String TYPE = "PublishedFile";
-    public static final String PUBLISHED_DATE = "publishedDate";
-    @JsonProperty(PUBLISHED_DATE)
-    private final Instant publishedDate;
 
     /**
      * Constructor for no.unit.nva.file.model.File objects. A file object is valid if it has a license or is explicitly
@@ -53,15 +50,10 @@ public class PublishedFile extends File {
         @JsonProperty(PUBLISHED_DATE) Instant publishedDate,
         @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
-              embargoDate, rightsRetentionStrategy, legalNote, uploadDetails);
-        this.publishedDate = publishedDate;
+              embargoDate, rightsRetentionStrategy, legalNote, publishedDate, uploadDetails);
         if (administrativeAgreement) {
             throw new IllegalStateException("An administrative agreement is not publishable");
         }
-    }
-
-    public Instant getPublishedDate() {
-        return publishedDate;
     }
 
     @Override
@@ -72,5 +64,21 @@ public class PublishedFile extends File {
     @Override
     public boolean isVisibleForNonOwner() {
         return !isAdministrativeAgreement() && fileDoesNotHaveActiveEmbargo();
+    }
+
+    @Override
+    public Builder copy() {
+        return builder()
+                   .withIdentifier(this.getIdentifier())
+                   .withName(this.getName())
+                   .withMimeType(this.getMimeType())
+                   .withSize(this.getSize())
+                   .withLicense(this.getLicense())
+                   .withAdministrativeAgreement(this.isAdministrativeAgreement())
+                   .withPublisherVersion(this.getPublisherVersion())
+                   .withEmbargoDate(this.getEmbargoDate().orElse(null))
+                   .withRightsRetentionStrategy(this.getRightsRetentionStrategy())
+                   .withLegalNote(this.getLegalNote())
+                   .withUploadDetails(this.getUploadDetails());
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
@@ -42,9 +42,9 @@ public class UnpublishedFile extends File {
         @JsonProperty(ADMINISTRATIVE_AGREEMENT_FIELD) boolean administrativeAgreement,
         @JsonProperty(PUBLISHER_VERSION_FIELD) @JsonAlias(PUBLISHER_AUTHORITY_FIELD) Object publishedVersion,
         @JsonProperty(EMBARGO_DATE_FIELD) Instant embargoDate,
-        @JsonProperty(RIGTHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
+        @JsonProperty(RIGHTS_RETENTION_STRATEGY) RightsRetentionStrategy rightsRetentionStrategy,
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
-        @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
+        @JsonProperty(UPLOAD_DETAILS_FIELD) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
               embargoDate, rightsRetentionStrategy, legalNote, null, uploadDetails);
         if (administrativeAgreement) {

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UnpublishedFile.java
@@ -46,7 +46,7 @@ public class UnpublishedFile extends File {
         @JsonProperty(LEGAL_NOTE_FIELD) String legalNote,
         @JsonProperty(UPLOAD_DETAILS) UploadDetails uploadDetails) {
         super(identifier, name, mimeType, size, license, administrativeAgreement, publishedVersion,
-              embargoDate, rightsRetentionStrategy, legalNote, uploadDetails);
+              embargoDate, rightsRetentionStrategy, legalNote, null, uploadDetails);
         if (administrativeAgreement) {
             throw new IllegalStateException("An administrative agreement is not publishable");
         }
@@ -60,5 +60,21 @@ public class UnpublishedFile extends File {
     @Override
     public UnpublishedFile toUnpublishedFile() {
         return this;
+    }
+
+    @Override
+    public Builder copy() {
+        return builder()
+                   .withIdentifier(this.getIdentifier())
+                   .withName(this.getName())
+                   .withMimeType(this.getMimeType())
+                   .withSize(this.getSize())
+                   .withLicense(this.getLicense())
+                   .withAdministrativeAgreement(this.isAdministrativeAgreement())
+                   .withPublisherVersion(this.getPublisherVersion())
+                   .withEmbargoDate(this.getEmbargoDate().orElse(null))
+                   .withRightsRetentionStrategy(this.getRightsRetentionStrategy())
+                   .withLegalNote(this.getLegalNote())
+                   .withUploadDetails(this.getUploadDetails());
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadDetails.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/associatedartifacts/file/UploadDetails.java
@@ -43,6 +43,11 @@ public class UploadDetails {
     }
 
     @JacocoGenerated
+    public Instant getUploadedDate() {
+        return uploadedDate;
+    }
+
+    @JacocoGenerated
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
Add copy-method to files. Had to move `publishedDate` out of `PublishedFile` and into `File` to reuse `Builder`-class. `publishedDate` is only set in `PublishedFile` constructor.

Sneakily added `getUploadedDate()` to `UploadDetails`.