### PR TITLE
np-46885-degree-thesis-fixes

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.24'
+version '0.21.25'
 
 repositories {
     mavenCentral()

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Ji11EClBgIPr3K",
-    "ownerAffiliation" : "https://www.example.org/b46df8b9-a3e6-4a0c-85ac-41fb41cdb702"
+    "owner" : "4bqNVZgZpJHcpZTTCMK",
+    "ownerAffiliation" : "https://www.example.org/e64c8427-590d-4810-9b1d-2f133b7bc316"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9657006a-c40c-4147-9448-d8915506e1e6"
+    "id" : "https://www.example.org/6c381f47-3f91-4bbb-ba80-b92f7cb3afd2"
   },
-  "createdDate" : "1973-11-12T15:06:58.716Z",
-  "modifiedDate" : "2010-01-20T22:58:28.486Z",
-  "publishedDate" : "2016-01-24T20:22:39.747Z",
-  "indexedDate" : "2015-04-17T16:20:50.382Z",
-  "handle" : "https://www.example.org/6fe5ef23-eb1c-4d7d-9817-a135304956d2",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/48c9b74f-8c10-47cf-940d-bb5e18afd168",
+  "createdDate" : "2010-09-11T10:01:12.493Z",
+  "modifiedDate" : "1973-01-14T22:11:11.188Z",
+  "publishedDate" : "2008-12-30T18:33:03.618Z",
+  "indexedDate" : "2016-08-14T20:35:09.972Z",
+  "handle" : "https://www.example.org/0cff2be1-44c9-416c-83fc-a32a3d8fdc14",
+  "doi" : "https://doi.org/10.1234/quibusdam",
+  "link" : "https://www.example.org/10ccf03a-437f-4fb7-80fc-1bd0218e892a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Kz0CESMwDe7G",
+    "mainTitle" : "EU8dRG7e9RabubrWn8X",
     "alternativeTitles" : {
-      "nn" : "thIEn8GoOilD1eg5AH"
+      "pl" : "vZfL2XGZLGN4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "v07CpUSAY93fZ",
-      "month" : "dAuE3h9TPcZNiaXre8",
-      "day" : "CndWon2ZmcZicS"
+      "year" : "QGMHgYdgNe93g",
+      "month" : "pWJUGSx6awuB",
+      "day" : "o08Rv3DKi2ACp3H3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6f0f0cd7-e738-4624-9047-32fc69d66b61",
-        "name" : "q8MoqTU1mMTQj",
+        "id" : "https://www.example.org/dee49cac-f088-42a2-90e7-de0dad9c18c1",
+        "name" : "yB4qNn7Kw2GJFmPEN1A",
         "nameType" : "Personal",
-        "orcId" : "yVKOb3qHiytiGvxsew",
+        "orcId" : "J3ZfFNa6uvbkxP0",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kWewEf57z4yXk7aoux",
-          "value" : "NeDj04p9Mc8Z4XrmvZs"
+          "sourceName" : "hRDO1ZdcUTuQ4kRtx",
+          "value" : "2Xu17leUEZzP4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GktQKQirPm",
-          "value" : "BCLPpP45fI"
+          "sourceName" : "DT7Kj34vMEVYQ9Y",
+          "value" : "4K2KXS2rSnec6W"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5ca3dde7-7b91-4887-8902-846c5c646500"
+        "id" : "https://www.example.org/a93da829-ba96-4295-a8ea-28e2142a02ce"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/25d3138a-0068-4d58-963c-9ee86d6e80e6",
-        "name" : "okWiMOJ9gRiPRggjYc",
+        "id" : "https://www.example.org/6a36cf85-0d74-45a2-a3a7-f2d164514f74",
+        "name" : "AAdJV3A9e8CKkYBJS",
         "nameType" : "Organizational",
-        "orcId" : "MoArVuP0JQ7UN",
-        "verificationStatus" : "Verified",
+        "orcId" : "AjqEFIhtx14iEPJ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "exFh0wetLnh0jFwLYBq",
-          "value" : "334yyz6mon4"
+          "sourceName" : "BF2pml5B5hags",
+          "value" : "xmH1oX0HnYscFzeqYX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V01eE2rSUSWXXlanBxH",
-          "value" : "QjE4y9d5TGTTTgL"
+          "sourceName" : "WJ2rALXTInBb7HSL",
+          "value" : "iogbUG82vPDRgthBSA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fd631e5e-fa0a-45f5-869a-5f26b9b2f36b"
+        "id" : "https://www.example.org/549d9a7e-751c-489c-b480-0eba0d5c8359"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "hjqAb98MqU"
+      "fr" : "TgOvZfliAZO"
     },
-    "npiSubjectHeading" : "wCwyhYHNkQjxJ08S2r",
-    "tags" : [ "LjokiV23ixpCqhjMBy" ],
-    "description" : "8zT8RyAe7UmEfg",
+    "npiSubjectHeading" : "x8sEALabnA2",
+    "tags" : [ "zDqdhBl8821gU6" ],
+    "description" : "P1SDg30CP2N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e02fd472-860d-4846-9b9f-225cb9a0b38c"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af99cbe9-112a-4dea-9b95-8aa7cf1e9690"
       },
-      "doi" : "https://www.example.org/9f923255-c15b-4bc5-975c-487b80973549",
+      "doi" : "https://www.example.org/c61fbba3-64e0-4c74-8744-8736bfd21059",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "VXbQhBE97T1",
-          "end" : "AckEzKevIKR84hyjl"
+          "begin" : "vPPEKH9SscAA",
+          "end" : "8dsv7UMU5bE9"
         },
-        "volume" : "78JBYKVaBxmvI41M0S",
-        "issue" : "oGUO05nn5v6BN",
-        "articleNumber" : "umxFvVmzDOuFD9Dmdw"
+        "volume" : "mVaw2ibyudaBPj",
+        "issue" : "ujRnoyDAP4Cg",
+        "articleNumber" : "G0G9wMhBkM"
       }
     },
-    "metadataSource" : "https://www.example.org/cbe33ee8-bce5-4221-a3ae-5c92c3be114d",
-    "abstract" : "i0nYVdG4nBwQaBsw"
+    "metadataSource" : "https://www.example.org/4000dbb1-4ec4-4cfa-abeb-86387f8cdeb0",
+    "abstract" : "6GAjxXvF1Bgbk9E32SH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e360f1d3-b291-43b4-9250-026c1f02c0da",
-    "name" : "AR4BCiRVjGxMoS",
+    "id" : "https://www.example.org/106a2fa1-5349-4a3f-a158-1e984537f7a5",
+    "name" : "KWJLWFDP1nHrIyR6ih",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-06-02T14:35:25.411Z",
+      "approvalDate" : "1996-04-05T20:26:46.162Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "rIMfYwaHMZDpJz"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "eBrykdllCaaWPRy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6902f609-8e4c-4be0-a45a-b8b6a423da5c",
-    "identifier" : "58v7vdwgirpa3ld5Xz",
+    "source" : "https://www.example.org/d768f6eb-3017-4e2b-8f42-27d9a1b439a5",
+    "identifier" : "hobsqlzpE0",
     "labels" : {
-      "af" : "w1qvKqUxtRtr9fJhmO"
+      "is" : "i8W6cBIKtUskDAC8Tt"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 936105507
+      "currency" : "NOK",
+      "amount" : 202900667
     },
-    "activeFrom" : "1986-12-06T16:50:46.830Z",
-    "activeTo" : "2005-02-17T10:16:18.699Z"
+    "activeFrom" : "2014-12-23T18:32:37.033Z",
+    "activeTo" : "2022-07-31T02:20:40.715Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/af169a34-f712-45bb-8e2d-7946aaeba3a2",
-    "id" : "https://www.example.org/768ba5f6-56d3-4c09-bc01-c0422fbf1231",
-    "identifier" : "o8t5euLuSenL5EHvFF",
+    "source" : "https://www.example.org/970e2137-d863-4bce-8c81-4d5456dab597",
+    "id" : "https://www.example.org/836b1e36-2c3a-4a2b-bab2-23bf0f59a390",
+    "identifier" : "3zIKOZbTWa",
     "labels" : {
-      "cs" : "RXLBclv45vBAcJvQFI"
+      "nl" : "Qsl6jA72Ueo9oH"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 6402658
+      "currency" : "GBP",
+      "amount" : 647965764
     },
-    "activeFrom" : "1985-11-01T22:52:45.297Z",
-    "activeTo" : "2013-03-23T21:25:34.279Z"
+    "activeFrom" : "1979-10-17T03:38:02.961Z",
+    "activeTo" : "2004-11-09T08:55:17.568Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bc17a78c-9a15-48a2-8b65-a26951913422" ],
+  "subjects" : [ "https://www.example.org/3de0cd35-c279-4e49-9d45-2097906aadcd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "16022f23-62f2-409b-8e01-daa5779d2420",
-    "name" : "sHt1WHUvuZJcf",
-    "mimeType" : "qJgDZD0O1THi",
-    "size" : 41468541,
-    "license" : "https://www.example.com/qhjqut8ksj",
+    "identifier" : "285fd893-cb18-457e-892d-1e0d189461b3",
+    "name" : "YHxr6jiVXeXPQ",
+    "mimeType" : "TZPNfTgwC1sjjiWF",
+    "size" : 1872194794,
+    "license" : "https://www.example.com/fbsv7ganctqlb4ai",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "dIQ1xyDXoArOd0TBQ",
-    "publishedDate" : "1985-05-17T17:53:47.182Z",
+    "legalNote" : "DbKHthKMFz7dQkQ7nB",
+    "publishedDate" : "1997-10-29T14:29:24.253Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "7s1EKOulT85",
-      "uploadedDate" : "1985-02-10T01:47:55.206Z"
+      "uploadedBy" : "UQhoHb4qn9ReTHfd2AY",
+      "uploadedDate" : "1985-06-15T05:27:04Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ebfqWg5bWnRNhZ",
-    "name" : "QozGFOcLiBbDmAC",
-    "description" : "DyIj1ELWE1phM"
+    "id" : "https://www.example.com/rsVRZ5sme49n9BmwOYC",
+    "name" : "fLY9HdwzXT1kSFpvh",
+    "description" : "B60QzelwvhX53OdUdV"
   } ],
-  "rightsHolder" : "w2l2GfpW5XGi",
-  "duplicateOf" : "https://www.example.org/c5676907-5a1b-4981-8c78-1ffae87e04f0",
+  "rightsHolder" : "w4JpIR6LGKi6hx",
+  "duplicateOf" : "https://www.example.org/ec6c51d3-3482-4836-b269-59ef332792c4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "el3wGSaa4dmZtgV0bpo"
+    "note" : "MRjQZ6xaxnmAQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "AGezRski6I6SRBxNc0B",
-    "createdBy" : "YZUlZ1SVsSuGUnl0S",
-    "createdDate" : "2021-06-16T20:44:18.329Z"
+    "note" : "qFd6LbxdxF",
+    "createdBy" : "wiPKWVAAUo",
+    "createdDate" : "1984-03-21T08:02:15.407Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1f4a2638-0bee-4d8b-90bc-c044c8408000" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/24baa19e-29a4-40d4-8513-54a5bc0d0505" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "iI5WCZfCubV5yEg6y",
-    "ownerAffiliation" : "https://www.example.org/21909ae1-5e2a-42cf-aaeb-9cf1c57e492a"
+    "owner" : "XeLbiAHncspIJ9",
+    "ownerAffiliation" : "https://www.example.org/7955703d-3cb9-4e50-98df-2d5315d94821"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/81ff3a76-5d28-4834-9297-314ca0f565b3"
+    "id" : "https://www.example.org/e37a8b98-b8f5-40c2-89ab-66adc7da278b"
   },
-  "createdDate" : "2006-07-20T17:36:15.163Z",
-  "modifiedDate" : "2008-10-21T02:03:53.384Z",
-  "publishedDate" : "1987-08-22T02:04:31.657Z",
-  "indexedDate" : "1998-04-17T02:13:22.377Z",
-  "handle" : "https://www.example.org/45138537-fb1b-4954-94e7-9acedd22df78",
-  "doi" : "https://doi.org/10.1234/hic",
-  "link" : "https://www.example.org/1331a41d-42aa-4bba-bd6e-662daa5e8cb7",
+  "createdDate" : "1983-10-07T16:41:56.924Z",
+  "modifiedDate" : "2004-12-22T19:27:11.998Z",
+  "publishedDate" : "1972-05-26T00:58:31.362Z",
+  "indexedDate" : "1990-08-01T04:26:50.260Z",
+  "handle" : "https://www.example.org/e2064af7-30a1-49a7-9a3f-1c6c96973ad7",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/5b01b0ab-3abe-4a4c-a352-a8cb4323ca6f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4v2rXZjNDK9roBGC",
+    "mainTitle" : "ZwyTUjte5ol6NSKaDy",
     "alternativeTitles" : {
-      "se" : "mWoAaNElGK3"
+      "fi" : "fhFaRQs0RTUdybMO2"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "u3jFbXj7GL1OW",
-      "month" : "ai1HBCkPd8tIT",
-      "day" : "zGtaKqRfkS"
+      "year" : "4oCnmi252ySLe2",
+      "month" : "bnQgguyJdq1ZJb",
+      "day" : "Z2OC02E4qLj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ae6dd3fa-21f1-4abc-9d39-b617f18bf320",
-        "name" : "LOdL7eueKfe033lDZ1P",
+        "id" : "https://www.example.org/73f25e38-00e7-4d00-b19e-630d7a006382",
+        "name" : "y2fd7TnM8Ib",
         "nameType" : "Organizational",
-        "orcId" : "6o5iNCbOc4KeC11JXS",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CKyWG8fo82Ihwegz",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5vfBmmL9pZZY",
-          "value" : "I5Kf54ngtHKX94jBs"
+          "sourceName" : "1O9BPdAQ06k8dovBR9f",
+          "value" : "KCiaQfOsikPk53kW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OSlV5FB4dw",
-          "value" : "RJ3TvrIhSGJsgrwi"
+          "sourceName" : "rzTx2oH87m",
+          "value" : "ArsN69KfGUhhxT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/36e9d2d0-2361-43de-a5e2-ce5129d4e909"
+        "id" : "https://www.example.org/a2da5fb8-f1c6-46ef-b5c7-a3e240e5766f"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a8be4665-e74a-4100-996c-a5d27219e405",
-        "name" : "LpEnY8acBsQtnR",
-        "nameType" : "Personal",
-        "orcId" : "8Mp0TFhQdEmWPu",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d24d3334-2058-41f3-abdb-b7121dd1c81a",
+        "name" : "KGQWSF3etADb",
+        "nameType" : "Organizational",
+        "orcId" : "usC7DH93dmpKw0",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "E2c9i09lDK9hWcs",
-          "value" : "j22IZGYejHP2LHN67v"
+          "sourceName" : "0JQenEFKJESImAi0eKu",
+          "value" : "nRKrLBtRSt5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5hKWMf4BjHsGu5fu",
-          "value" : "m5wkanVDFe"
+          "sourceName" : "3UWMfZR4J1",
+          "value" : "V0f60Wi1W3edO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e0c7f574-bcad-44c1-8a91-11881d5a80a6"
+        "id" : "https://www.example.org/bc284877-2d33-4f13-8a56-8eba6621af3a"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "ghkL0Iv3T5M9"
+      "ca" : "ZRcploKUa4Dv8NhzNz"
     },
-    "npiSubjectHeading" : "5FyolAQvPw7gdNmZ",
-    "tags" : [ "wMYuKsB1Xa1c" ],
-    "description" : "DHQV8i2qi3gO2",
+    "npiSubjectHeading" : "RXRbfqGxW2p",
+    "tags" : [ "QkZSvxQWnRVizgvVWVL" ],
+    "description" : "Ymwq91gu4Er8N",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/R12GD1cIVAMdbD2Uv"
+        "id" : "https://www.example.com/YpkHyFdhpfGi582Y"
       },
-      "doi" : "https://www.example.org/7f8291ef-3d4f-4a29-970b-0f71efd35e03",
+      "doi" : "https://www.example.org/cb6254d7-687a-4328-b142-50d601b30752",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "Vfdav6KGtIoP",
-          "end" : "y7BU0v2w257zEtFVDg"
+          "begin" : "A0MH7xNV7bqpm",
+          "end" : "Mblq3xcTIhzmfLeZ2"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ce602947-b39b-4679-8692-1766ab1d45e4",
-    "abstract" : "eYvTmUxivhl"
+    "metadataSource" : "https://www.example.org/1d0bcb03-16e7-4c13-b594-4d4d5068bc7c",
+    "abstract" : "EQmTzkYIX9pI5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/19ad0eb3-2ab7-4294-8a45-7db4947910f7",
-    "name" : "dtdnnuMpSwZkmH4",
+    "id" : "https://www.example.org/d4dfb953-ceb6-4881-9470-212e0efcab2a",
+    "name" : "d9pI2nRTBZu",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-03-27T17:45:12.329Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Hli0BxqpCf"
+      "approvalDate" : "1994-11-19T05:22:26.024Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "gUQ8fCDsFwXcXp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/de932aa7-9dcf-431a-82f0-785677c58e88",
-    "identifier" : "LllBiYdate2",
+    "source" : "https://www.example.org/7eb4c492-ed23-4c7f-9ed4-6abc4111e43b",
+    "identifier" : "wfFoGAiA1cb8hpNSXzm",
     "labels" : {
-      "ru" : "lKjwytEP9l"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 853839769
-    },
-    "activeFrom" : "1980-08-10T09:17:09.808Z",
-    "activeTo" : "1997-02-15T15:32:39.931Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/bd41d94b-613e-4e36-825d-83c92f3abf87",
-    "id" : "https://www.example.org/acbe53c6-5daa-49ce-889d-133bd0060e03",
-    "identifier" : "WEG8naQDezNm7A",
-    "labels" : {
-      "es" : "cJ8HFc7fz1xH"
+      "nn" : "KUst8T9oPXjNoj"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1482208645
+      "amount" : 38909483
     },
-    "activeFrom" : "1999-06-23T06:49:13.622Z",
-    "activeTo" : "2021-08-27T01:32:17.741Z"
+    "activeFrom" : "2012-12-25T21:09:03.830Z",
+    "activeTo" : "2024-04-21T20:24:05.211Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/15fab030-f2ba-478c-aa6d-24903ab4de57",
+    "id" : "https://www.example.org/1abe8dbe-c7e0-4b41-a3e8-571ea237fd8d",
+    "identifier" : "LpxHeEOb8ILsAoWnC",
+    "labels" : {
+      "af" : "lwAyA9Syid"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1465163778
+    },
+    "activeFrom" : "2014-05-01T20:31:25.310Z",
+    "activeTo" : "2021-02-06T12:37:02.593Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/944ed099-79c7-4802-8c2f-64e7c628d66a" ],
+  "subjects" : [ "https://www.example.org/5042f132-e0f5-4986-b9c5-8c7d62668f5c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "340e50a5-8919-41df-a3a1-c3517f3b5d2b",
-    "name" : "IPvjRT1NnopNLYqTQMH",
-    "mimeType" : "33d9L38HGR6",
-    "size" : 17477284,
-    "license" : "https://www.example.com/jowabcjpdni",
+    "identifier" : "fd13c75d-fbdf-4133-aa21-d3cb9db496cb",
+    "name" : "Wlba65bUMt",
+    "mimeType" : "KoJkAL4FWfUZXuxLP",
+    "size" : 299882476,
+    "license" : "https://www.example.com/nev7h24f2r0a",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "FcageVrL68JBWdvG"
+      "overriddenBy" : "AcpTwCHrnxoBrU"
     },
-    "legalNote" : "gotPgDwrTz",
-    "publishedDate" : "2003-06-25T07:11:01.133Z",
+    "legalNote" : "kmszk73XhehKMXjkoG",
+    "publishedDate" : "2005-05-17T13:42:40.474Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "PvjpDDQncjhFt5bAPA",
-      "uploadedDate" : "2022-12-18T22:50:33.799Z"
+      "uploadedBy" : "JK7wUAPBqhJ1tvpOOUK",
+      "uploadedDate" : "1986-08-31T18:20:41.710Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FRM4MJYWvjyhK",
-    "name" : "XWvRNkdufvIBqY",
-    "description" : "uT22KfMGDyFGV2TzTW"
+    "id" : "https://www.example.com/cATTxLC9C4p4TKI3a",
+    "name" : "O238LkfbPI",
+    "description" : "rg1hVDxUcXGQ5T"
   } ],
-  "rightsHolder" : "xRiKTcEFMCGpDQ7TVf",
-  "duplicateOf" : "https://www.example.org/e1e41edf-c11a-4526-90a3-7e9475518ccf",
+  "rightsHolder" : "I1u4XQSVKnnAyV3iu9J",
+  "duplicateOf" : "https://www.example.org/3bb90c49-8420-4ebc-ae50-802cc6f4b225",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "eksqIcGRyLM"
+    "note" : "S7IC9FJViYAxI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1IhjRm8RwqdqMOM53wx",
-    "createdBy" : "YJRVasE4jZs",
-    "createdDate" : "1984-10-15T21:28:37.586Z"
+    "note" : "x676O8UZ9jDQWztMa",
+    "createdBy" : "Y8Lz19qWj3JAl",
+    "createdDate" : "1989-02-20T05:24:57.174Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6688bcf0-fc33-4eff-92f0-5d62feda2355" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/32c82cda-bacf-4b4d-95f8-e9128cdcdf09" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "AlZ8IsMWgAqaGqG4",
-    "ownerAffiliation" : "https://www.example.org/393a6279-a840-46fa-807b-c82be6d656bf"
+    "owner" : "kza3uXxGw2",
+    "ownerAffiliation" : "https://www.example.org/932395bb-1353-4bd4-8fcd-63909477fd46"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f14d74a7-c007-43e2-80ab-91ff24e90e0a"
+    "id" : "https://www.example.org/cee46398-1459-4b56-b40f-a4d4a68732b0"
   },
-  "createdDate" : "1971-02-26T14:36:06.084Z",
-  "modifiedDate" : "2005-04-07T04:21:48.328Z",
-  "publishedDate" : "2004-12-13T04:01:42.440Z",
-  "indexedDate" : "1972-02-17T18:06:34.547Z",
-  "handle" : "https://www.example.org/80f9c3cf-2c6c-46e0-bcf5-d997a066ff3d",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/03e0deec-b956-4bfa-bb46-833c15417bd3",
+  "createdDate" : "1972-07-21T04:29:47.525Z",
+  "modifiedDate" : "1985-07-08T23:07:11.406Z",
+  "publishedDate" : "1973-02-13T15:26:49.759Z",
+  "indexedDate" : "2020-06-16T06:07:30.661Z",
+  "handle" : "https://www.example.org/b1e0ea4b-b0db-4837-9e11-dc6d1f8069d8",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/fe96478d-9594-419b-aabc-101f58e49b71",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "j1E4VGzqZwLXy",
+    "mainTitle" : "k5ceb0tQ3SMdyYuzVxY",
     "alternativeTitles" : {
-      "en" : "WPPerqbS8PQ1l"
+      "es" : "IXKgMI8n2nCXhXX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Nop0AfeNbZSZ0",
-      "month" : "DcbdnvBTIelLCM",
-      "day" : "8yKBvhvXCGInNIQKpu"
+      "year" : "UHzDjlnhzEqHj",
+      "month" : "TF0BRwJ3QIacSaQ92HV",
+      "day" : "NMeBRPfYNW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/716e1593-7da9-4c55-82ac-6293f60f980a",
-        "name" : "Vj5uCoPUEodGUGe",
+        "id" : "https://www.example.org/9ae460c4-68cf-467a-bac1-29271ab92414",
+        "name" : "IS5xNVTYjz9gxJN",
         "nameType" : "Organizational",
-        "orcId" : "969Z68lgAPFSrOvdJIb",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "s6fRQlQCqSPKehxb",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GJSuS8lnG5qk9SzbVa",
-          "value" : "zahJBOvutk7QwoPq"
+          "sourceName" : "tAi65KUfIK6S8iCDo",
+          "value" : "qWyoZrgvGK5cAVV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RzNjyiyopc74",
-          "value" : "KoeYmoxmUbwAhZwH4tZ"
+          "sourceName" : "l2GumugT8eovb",
+          "value" : "GbYcxYPG7BPNoVL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/17ea1b78-71b1-472f-9714-e2c9be82b74c"
+        "id" : "https://www.example.org/4d3f7ea9-d160-496c-b149-2a036ccb5048"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/977ccd9d-32b9-4647-afd7-3d6388994a14",
-        "name" : "JnTkGvtktp9nTx5S",
-        "nameType" : "Organizational",
-        "orcId" : "UoO2TKI4lTfzNNeG7",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/6962207c-3e0c-4e6a-a620-372fabd36b7c",
+        "name" : "jDUpxgJEilOljTDHI",
+        "nameType" : "Personal",
+        "orcId" : "y0K1WjzDCmBUPf",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "y3xqdE6hTsYP6i",
-          "value" : "ioPIXNaxtIC9Oa9jo"
+          "sourceName" : "TFwjWmmQxEavO",
+          "value" : "E8ESHQ7Lc2Iy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZCAjrq5NqGD",
-          "value" : "QtveLtf3xbo9R4Qygf1"
+          "sourceName" : "Uuqmei2YinN3FYBCB",
+          "value" : "uHD37XKgIRovk1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f7f99e10-7628-4411-a741-a6478e369adf"
+        "id" : "https://www.example.org/d3a7a206-42fb-4896-9193-caede194a053"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "PmGB1BeSQ9Irtw8h"
+      "ru" : "dkaKFJSf372"
     },
-    "npiSubjectHeading" : "U0ZHnQw87box",
-    "tags" : [ "K9NNcjBVpf" ],
-    "description" : "PJhjrBOpc6yXd9TjD0O",
+    "npiSubjectHeading" : "5chKBfcrVPK",
+    "tags" : [ "dppbvq6kJcV" ],
+    "description" : "EXKnFMhLcLf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2fc3a765-8854-4a98-8530-b1557711b6f8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a7b78a7c-ac95-400f-872e-ceefefab448e"
       },
-      "doi" : "https://www.example.org/d53ad3d3-e58c-40ad-ab5e-2ea7ccdac929",
+      "doi" : "https://www.example.org/b2b9d8b9-d498-4829-a4f7-580663270ebb",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "vP4Mif5eNi06VpMwWD",
-          "end" : "4P3ZJMC7npiE"
+          "begin" : "Q4Irj3zDSd",
+          "end" : "yuNMk1Rn9rqwpHme"
         },
-        "volume" : "PJX6jRKEpu1napEk7",
-        "issue" : "59AnEmfbGB",
-        "articleNumber" : "3kxrNydmSKTox"
+        "volume" : "lzFZfPJGRWK5arVZV",
+        "issue" : "i0ulWEfVx4M1gf",
+        "articleNumber" : "WyhctfxDN23iUg"
       }
     },
-    "metadataSource" : "https://www.example.org/f3fff1ae-5cc0-46ee-9951-db932ae50739",
-    "abstract" : "5UrvMXr4wyYVoQzke"
+    "metadataSource" : "https://www.example.org/2294003b-c4de-4bce-bd3f-bea9f6ce4992",
+    "abstract" : "hTK72yAJLqmR9m85"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/242c740f-7921-4fe8-8fd7-04581cac7f2f",
-    "name" : "dGWmkMykIpR0i",
+    "id" : "https://www.example.org/149ce485-c320-4bf3-97b4-e54b46642e88",
+    "name" : "91baHsGTC1wE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-01-27T10:36:27.066Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "xYlNjdpDwP"
+      "approvalDate" : "2011-06-12T23:58:28.635Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "mmaNz5fZXFZZqIdFaW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e7f984f5-d146-485f-814b-678a9ae0f0b6",
-    "identifier" : "M8bzP3tHM83FGVXOs",
+    "source" : "https://www.example.org/7bd53990-d794-4d3a-8d2d-2a5b1664b178",
+    "identifier" : "IzVGlN8MZeqrUSdHR",
     "labels" : {
-      "el" : "mN69o7FxhXEennXv"
+      "hu" : "l39Jc0X4TDDIg4XFkhQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1717373780
+      "currency" : "EUR",
+      "amount" : 1048900941
     },
-    "activeFrom" : "1996-01-11T18:07:13.596Z",
-    "activeTo" : "2009-03-13T12:04:43.928Z"
+    "activeFrom" : "1984-11-24T12:43:25.618Z",
+    "activeTo" : "2024-05-30T02:33:32.341Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0bd4a54c-0580-4b0f-9cb0-1a64aa373b43",
-    "id" : "https://www.example.org/28364c13-0cd1-408d-a327-f25ec38877b8",
-    "identifier" : "T4612MzioVHniij",
+    "source" : "https://www.example.org/f553fc7d-7ee4-43fa-afbb-f2802615ddd7",
+    "id" : "https://www.example.org/eb70d274-e126-49a4-b9af-18ed055a362c",
+    "identifier" : "Vn0HgkKxmuSU72HvByZ",
     "labels" : {
-      "zh" : "oA8SedUBrTgl"
+      "pt" : "4ft1D6yfKbuOK"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1114811885
+      "currency" : "EUR",
+      "amount" : 1164908956
     },
-    "activeFrom" : "2013-10-16T02:53:56.101Z",
-    "activeTo" : "2014-05-10T18:55:10.886Z"
+    "activeFrom" : "1987-07-15T23:03:20.199Z",
+    "activeTo" : "2007-03-10T22:19:05.232Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1d0b189a-42fe-4146-8bce-87f71bd38f7f" ],
+  "subjects" : [ "https://www.example.org/6a90bee7-f702-40ce-8894-c3e86eb98c5b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f6a5f1fe-97b8-4e6c-a3d3-44e27c04dcc1",
-    "name" : "fbeFtg3RWQsHQ5CIk",
-    "mimeType" : "1KBVSiQKlzzP",
-    "size" : 244179444,
-    "license" : "https://www.example.com/gugykhjzbsmu2cbu01",
+    "identifier" : "511a2364-0f13-4990-996c-25f293a1be07",
+    "name" : "Ikbtke9x9XPKDdmbo9",
+    "mimeType" : "thhwYzB70qH3EeP3MI",
+    "size" : 879527520,
+    "license" : "https://www.example.com/jz47uxnxzfnojvieor",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "SFF1amf8ypxO",
-    "publishedDate" : "1986-04-14T17:44:05.159Z",
+    "legalNote" : "5iUfqRbP7bdflhN",
+    "publishedDate" : "1995-05-01T23:31:43.616Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "N0Uo6D37dl",
-      "uploadedDate" : "2018-05-14T05:47:46.191Z"
+      "uploadedBy" : "YHJ53CzzvQvMjW",
+      "uploadedDate" : "1973-09-01T15:06:40.662Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tgByLtEolO1KLg",
-    "name" : "29xzC1wdmP1C9W2hlC",
-    "description" : "iRODkW4C19jJEmxhx5"
+    "id" : "https://www.example.com/zQ0wlCJ6dqQHXtWmcX",
+    "name" : "iGbCP5DQl2QDxphDZP",
+    "description" : "4x6V1Su2QcHxsodPfb"
   } ],
-  "rightsHolder" : "qdoYa6SoP49WIW",
-  "duplicateOf" : "https://www.example.org/69df1e3b-f925-4642-80cd-c6042c7e98b3",
+  "rightsHolder" : "T81F1EO77zDT4dx4g",
+  "duplicateOf" : "https://www.example.org/0297d2d2-4170-4652-9afe-3480320a2d5f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "j9wjebaDoeRNCA"
+    "note" : "Z7dg0WpI0wsiejoHlaF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "74WEmoqGkvZv",
-    "createdBy" : "sBi3PrCqISZlW4S",
-    "createdDate" : "2018-02-06T17:18:47.598Z"
+    "note" : "sjbbR8U53FCr4t",
+    "createdBy" : "9jfsr5GEqtHAX3O6",
+    "createdDate" : "1996-02-07T07:23:32.195Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/aa1154d1-57f3-4147-abc6-87cea802056f" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/4d500c89-f0f9-4b57-854c-b1fa566c283c" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -3,58 +3,59 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "xkcXa5fHrp6c",
-    "ownerAffiliation" : "https://www.example.org/9e4f0b74-921e-477c-bf6d-cc49ebee162f"
+    "owner" : "Or08GQfO2GqBptCXpo",
+    "ownerAffiliation" : "https://www.example.org/3f3f47a2-8b00-4080-b953-6873f8535066"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/254186c4-792f-4702-884a-158c36abc960"
+    "id" : "https://www.example.org/3237d533-3484-4321-9f07-48914bd1b9d5"
   },
-  "createdDate" : "1987-09-01T01:27:56.955Z",
-  "modifiedDate" : "2014-09-01T05:14:38.264Z",
-  "publishedDate" : "2016-01-15T03:46:23.602Z",
-  "indexedDate" : "2018-01-28T05:42:23.893Z",
-  "handle" : "https://www.example.org/92e6066f-210c-459b-a83a-d7c38a2660c2",
-  "doi" : "https://doi.org/10.1234/quisquam",
-  "link" : "https://www.example.org/9da425de-8d9c-4876-95f0-15c69890b182",
+  "createdDate" : "2008-04-02T03:04:39.302Z",
+  "modifiedDate" : "1990-09-11T13:19:39.688Z",
+  "publishedDate" : "1990-05-19T03:55:03.263Z",
+  "indexedDate" : "2002-11-14T02:05:18.336Z",
+  "handle" : "https://www.example.org/e7e73034-c961-449a-b8a3-0622687f839f",
+  "doi" : "https://doi.org/10.1234/consequuntur",
+  "link" : "https://www.example.org/8c988e6c-92c0-4d7b-b811-342ee6024f5f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fRdoN2x7l9hA7Umj",
+    "mainTitle" : "e3i37zcdbsmtAyrJp",
     "alternativeTitles" : {
-      "it" : "evBejGKj4OQN"
+      "af" : "4FP563rmS2peBSc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "fbEzEJnLjsTx23q",
-      "month" : "CHf1EQMLrUa3KO2sw",
-      "day" : "EyA31qnb7dxZYFoa"
+      "year" : "pOumXgjE4no",
+      "month" : "9Diz6xmdarxDfdxDBo",
+      "day" : "e7CIkuGcq924gU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2ed90e49-1ce5-4a8c-bf1c-71d7111691c6",
-        "name" : "TGiXIbcelcX",
+        "id" : "https://www.example.org/a33e28ce-276c-42e6-8daf-595df44e7ccd",
+        "name" : "yqh4ipqaVnm3U5g",
         "nameType" : "Personal",
-        "orcId" : "RJlHLWOSG1wKwdVsxt7",
+        "orcId" : "dZ4N0dyaJj",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iCtB0Nyfm2yRy7Ar3",
-          "value" : "kfe8ZfOU9o2sno9V"
+          "sourceName" : "9FeaXI8ax3NRQ",
+          "value" : "EsgKsyYImoSms"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uWsSqYJF4FXWtyGy",
-          "value" : "CwJsKOeqlSPMe"
+          "sourceName" : "n005ptO1jVNLYl7pA",
+          "value" : "MvRYhPsWoTD4PG9U3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1bbf75f1-2d03-4874-b648-37d54af59c78"
+        "id" : "https://www.example.org/22fddd59-e9db-49f3-a44e-9d5f8425844f"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "RoleOther",
+        "description" : "sjLRYAmTV2ETF5TjDhX"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +63,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/11bf8f6f-2937-4dfe-b47e-f3a69ada4c50",
-        "name" : "ToJAv0cAgQm6ViLJN",
+        "id" : "https://www.example.org/d72f401e-138b-4a72-9144-fb7082097027",
+        "name" : "pNhAQwR1wD",
         "nameType" : "Personal",
-        "orcId" : "9FFQsFkA5AOWzkN",
+        "orcId" : "i8wXFj20cNFM6KnsaUm",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3eVTG8XNlJJ0",
-          "value" : "nBJ0uuTFxEq9"
+          "sourceName" : "YIFz1RgTzDrH",
+          "value" : "Qa2dAJn9D8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Q84apKzBLQQefNwEZn",
-          "value" : "XagrNq02ezXLaH"
+          "sourceName" : "Zl1fgn14Y8h",
+          "value" : "BO3sTYRhAi7W"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/72620051-f4b4-434c-bae6-8aced778cac9"
+        "id" : "https://www.example.org/ec93d3f4-b520-4e4d-937f-0ac90d34a04e"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "R5gMQemIFDm8E"
+      "cs" : "u3i3MEIToxEft3WU"
     },
-    "npiSubjectHeading" : "fyKA3VTFa4sv6pBOtGs",
-    "tags" : [ "JGBpPBOaoV9qlr0p9Y" ],
-    "description" : "AbiW86RS5iDB",
+    "npiSubjectHeading" : "aoyJC3bPCOzH",
+    "tags" : [ "d2lC4mB6bLzkAhh7" ],
+    "description" : "qgcMCEvzRs4uBrpzyy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/85a546f6-1855-4cfa-9b33-aeb397694a7b"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5451abda-83df-4dd3-a91c-9d9a51078ade"
         },
-        "seriesNumber" : "2QmTB2gtia2JqLqO",
+        "seriesNumber" : "kkBQNrK2sOcZxtMZ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bd712a5d-7c48-48f9-b94d-bd8405d0855a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/11d88a93-6839-49a2-9d03-74292e0b25c8",
           "valid" : true
         },
-        "isbnList" : [ "9781853629907", "9781546163954" ],
+        "isbnList" : [ "9781946434883", "9780903223010" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1546163956"
+          "value" : "0903223015"
         } ]
       },
-      "doi" : "https://www.example.org/cc163be0-e79e-4ccc-8717-24134351f43e",
+      "doi" : "https://www.example.org/278c98b3-ee96-4ecc-9d5a-a04f71891e37",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ZvaCiQiJlLVerMcX",
-            "end" : "1OehgvhBTDOFh8"
+            "begin" : "ngbE6Gdfnt7D",
+            "end" : "2N5Eh5on5yplCETfxQ"
           },
-          "pages" : "tSzGfmPfjM9rqOnjxRQ",
-          "illustrated" : false
+          "pages" : "ZiLjafP9wugbV",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a59146c1-d73b-4de1-94bd-93d3dc74b571",
-    "abstract" : "M2HveM7qqcpfdQCDwnH"
+    "metadataSource" : "https://www.example.org/7fec9e16-8138-43e0-a9b4-041a1d9ecc17",
+    "abstract" : "UbgpDzoBsamJ6NAiZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0e85466b-a520-49f1-9891-721df263478e",
-    "name" : "QPFxJV3BbfeEuE3nl",
+    "id" : "https://www.example.org/a89e9a54-63ec-4f32-94c9-bb9ac8653a95",
+    "name" : "vzis8exAMubjaN",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-12-01T04:28:11.807Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1971-02-19T22:32:12.740Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "XqyXjkMItHZXtBl"
+      "applicationCode" : "k3BQcLwKL15MO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/bce3ff7d-2f83-4430-8f52-d6a2a24ea4ae",
-    "identifier" : "ZRHel7vs5f",
+    "source" : "https://www.example.org/8db4baea-e304-44e5-bebb-88a338f9d718",
+    "identifier" : "i4AXe0eWaB",
     "labels" : {
-      "el" : "s7lfwRnCT2bmZe"
+      "fr" : "jRpYYOYPht"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 733761100
+      "amount" : 2140250080
     },
-    "activeFrom" : "2001-11-02T06:04:41.069Z",
-    "activeTo" : "2007-10-11T16:16:15.748Z"
+    "activeFrom" : "1998-12-05T21:06:08.531Z",
+    "activeTo" : "2015-03-10T14:43:25.394Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8cb9018c-d243-4ae7-8d97-5a790505ad78",
-    "id" : "https://www.example.org/761c1120-0c36-4f13-916c-6d9615b860a9",
-    "identifier" : "HlwJwhE0HyWqQmrE",
+    "source" : "https://www.example.org/191d3ccf-1fd0-43af-8fbc-cb1088ceaa36",
+    "id" : "https://www.example.org/3e735e89-2fb0-4516-bab2-9decfa054303",
+    "identifier" : "7kc1m81LqGyotD",
     "labels" : {
-      "en" : "sq0qKFzGypnh"
+      "af" : "f1EFJxqj0Z2tWu"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1088866321
+      "amount" : 694948595
     },
-    "activeFrom" : "2020-11-24T03:39:58.766Z",
-    "activeTo" : "2022-04-12T16:31:50.729Z"
+    "activeFrom" : "1977-02-06T20:21:25.249Z",
+    "activeTo" : "2012-06-01T12:58:44.292Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/75a881ad-17d5-4ea3-823a-bee800fa4532" ],
+  "subjects" : [ "https://www.example.org/7925065e-ff6c-4eb8-a0a0-42a68bfb9044" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0bcb3b89-da95-44f5-a464-8e1d2748d7c9",
-    "name" : "Dxp0FZxfDgceGakCXSP",
-    "mimeType" : "mGDOu2caXPQBFkr23G",
-    "size" : 195176323,
-    "license" : "https://www.example.com/wrv1vgo0kenkajxd",
+    "identifier" : "ca0c514e-2967-4873-a16b-0e4e05426a0b",
+    "name" : "q1pehP7eghvWzC",
+    "mimeType" : "rWOfY25rn2IgMBPDU",
+    "size" : 712790526,
+    "license" : "https://www.example.com/zwrdzvotmio",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "E764za0jQGOZrN",
-    "publishedDate" : "1975-01-25T12:36:44.756Z",
+    "legalNote" : "LKJwMtOYwD0yQ",
+    "publishedDate" : "1986-09-24T03:55:09.004Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "NvHqQys2jvagoST9dOi",
-      "uploadedDate" : "1990-02-03T16:16:54.737Z"
+      "uploadedBy" : "Bae2McD6B62ob",
+      "uploadedDate" : "1986-09-28T06:27:44.207Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KK0Qc52tM8mFHX",
-    "name" : "Y8fvxgU71TLzQL",
-    "description" : "mXj2NuURwK35xON"
+    "id" : "https://www.example.com/Tg2Ow6jeUvRr",
+    "name" : "YqtCj2NW3al",
+    "description" : "YlDoZ57tP3MqM7X"
   } ],
-  "rightsHolder" : "TDUa89b9p2Ba34cFZ",
-  "duplicateOf" : "https://www.example.org/b8400027-7570-4da1-975a-ccbe9dd78b19",
+  "rightsHolder" : "jfUm4lk01o13j",
+  "duplicateOf" : "https://www.example.org/5c27b9e1-1b94-4a85-b97b-30f6e8a0157e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "j96M0ZGY0Y"
+    "note" : "o9VzKgiDvZN5o"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QAZ2kzWhmJGctSw",
-    "createdBy" : "MKCvFr23fcLcUMV",
-    "createdDate" : "2021-01-16T21:46:44.742Z"
+    "note" : "oS1aiJmRZgUJbmcUlgC",
+    "createdBy" : "3MOizPOVbTh",
+    "createdDate" : "2018-12-31T11:48:17.514Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/63410316-314e-4182-b7a1-9dec075db6f2" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/b2794af6-faa4-4235-b83e-872e876bcd50" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "AkxKkr99BadxhFcao",
-    "ownerAffiliation" : "https://www.example.org/f1d36c0b-659b-464e-af7b-cb442ca0382a"
+    "owner" : "IsdUyCAYZAVbeAWi",
+    "ownerAffiliation" : "https://www.example.org/7e37144b-c34a-49ec-83d7-26d9875a2b34"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/61004ea8-eebb-4a9a-8218-d0465ef7b61c"
+    "id" : "https://www.example.org/fcd01ba9-cdd8-4ff2-96b7-dd32bc6bb658"
   },
-  "createdDate" : "2005-06-10T13:23:14.902Z",
-  "modifiedDate" : "1991-02-23T08:00:59.035Z",
-  "publishedDate" : "1988-11-26T00:51:49.437Z",
-  "indexedDate" : "1986-12-28T08:47:25.548Z",
-  "handle" : "https://www.example.org/7f670c13-6f57-423c-a233-8db8592759b9",
-  "doi" : "https://doi.org/10.1234/doloribus",
-  "link" : "https://www.example.org/974e821d-2e02-4d59-82b4-380e527880d9",
+  "createdDate" : "1973-08-09T19:16:10.643Z",
+  "modifiedDate" : "1987-12-25T00:56:42.809Z",
+  "publishedDate" : "2019-09-30T03:31:09.671Z",
+  "indexedDate" : "2009-09-13T10:47:13.209Z",
+  "handle" : "https://www.example.org/ef7c23c7-0db4-4fe0-809b-3e16c4bc531f",
+  "doi" : "https://doi.org/10.1234/iusto",
+  "link" : "https://www.example.org/55c5f610-5b39-4302-b164-1e58bc570cf5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "aMiTPLvjc4j6FepjIv",
+    "mainTitle" : "SHdVhUS6tR",
     "alternativeTitles" : {
-      "de" : "eQlcrJZK9yok6DAJFz"
+      "el" : "F523MYxcp1Clkzy9Yv"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wyJbYa5yxG7Os1Z",
-      "month" : "rESefyFHSWB1cAHJz",
-      "day" : "tnxUJuHLJR"
+      "year" : "xqgdy0QhkGUdkgq",
+      "month" : "RgJpPe6cPRsfY4CC",
+      "day" : "exglU14dujpJa8gQG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6b63747b-eaa7-4f9a-94fa-781741a4214e",
-        "name" : "PRL4klczgjVvaZSYH",
+        "id" : "https://www.example.org/9b00f732-f863-44f1-8df5-9da19cfe2405",
+        "name" : "ctcFFMSyYbDi",
         "nameType" : "Organizational",
-        "orcId" : "grtlfeCfgCHB76Ckt",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "X6hg4v2z2jQlZKH",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cfxdzWbeQXz09JWPyfx",
-          "value" : "PRnWtaDvFUoRj"
+          "sourceName" : "sXQ88kWnzwZ64Vizc",
+          "value" : "N0cb6DQ2UMF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZzLTXUALhrcWKyT",
-          "value" : "MC3T5VXCqSyO0NuAH"
+          "sourceName" : "YJ658DD8giM5E7",
+          "value" : "ibElxRV5JOX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6d6d768d-614f-40da-b9c0-a1418cbc25dd"
+        "id" : "https://www.example.org/94fcb377-35e5-4b7a-961c-0cbb32a5be6c"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Composer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,188 +62,188 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e0bd7375-7e5b-47da-ab9e-9fcf24b69603",
-        "name" : "cTl8DnUGBXvxW",
-        "nameType" : "Organizational",
-        "orcId" : "zEaZ9tobli",
+        "id" : "https://www.example.org/e8e021d8-3d37-4918-9516-bf2eecf6ed39",
+        "name" : "ibRlhK9GDzsOY0Jc8M",
+        "nameType" : "Personal",
+        "orcId" : "g0v0qyb2s6iana",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JTXjlwNmylCkhmHFhCQ",
-          "value" : "feI6rCWOm73FUS"
+          "sourceName" : "92pT8dFrEvca",
+          "value" : "4mcBFzgSqMp4vtndde4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DnK5nMR2pViNH910C",
-          "value" : "UZUfmWDLcCND"
+          "sourceName" : "x9HcSsDcaFmxZh3",
+          "value" : "NlQpTvObKeg6Ob9qc9U"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/22450b5d-c95a-4c66-9c86-d8a7d25f22c0"
+        "id" : "https://www.example.org/fb106b03-a9d7-445e-9425-7f4a17fadae3"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "Screenwriter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "FORtAx4QOGRS2P5"
+      "pl" : "VUGNt7Lu5BLOZ6ePA1o"
     },
-    "npiSubjectHeading" : "ONdpX6zbyu",
-    "tags" : [ "9kvLYA06nJ" ],
-    "description" : "fQg388Bl9tNqaw",
+    "npiSubjectHeading" : "KQ2QDh4gpDoCi",
+    "tags" : [ "WbHF1OrYRdUzx5J" ],
+    "description" : "r1SPBoCLNE1zhnmPc6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/0075bd9d-dd20-4456-aa7f-e717cbeed38c",
+      "doi" : "https://www.example.org/d9abef30-b8cb-462c-8074-58ee3c1ab55a",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "Interior"
+          "type" : "PlanningProposal"
         },
-        "description" : "Qap5Iaqswtz3P",
+        "description" : "toVPqJC6qcdBtbmH",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "p8lKvd3saN",
-          "description" : "letX78AkvBNVUi6O",
+          "name" : "KhzXE0i7dD7fFBAR",
+          "description" : "J9IcGIvBEn",
           "date" : {
             "type" : "Instant",
-            "value" : "1980-05-09T21:28:51.453Z"
+            "value" : "2020-05-10T09:55:57.971Z"
           },
-          "sequence" : 1696168129
+          "sequence" : 1783022421
         }, {
           "type" : "MentionInPublication",
-          "title" : "tsVmVfey6fXjgY",
-          "issue" : "XHGNeTK4QHO7lmXtgR3",
+          "title" : "gQsiMb8sBpme4WM",
+          "issue" : "cq6Exscn8NZnKUxl3I",
           "date" : {
             "type" : "Instant",
-            "value" : "2020-03-28T06:46:14.876Z"
+            "value" : "2021-11-18T22:30:51.120Z"
           },
-          "otherInformation" : "UgtTMpNqyslDV",
-          "sequence" : 372359726
+          "otherInformation" : "iEB6ZEtmbk41h",
+          "sequence" : 946104417
         }, {
           "type" : "Award",
-          "name" : "cMngzHoLD80z",
-          "organizer" : "AsAWHZJS0zeZf1Q60",
+          "name" : "s5QQHfewJhkc",
+          "organizer" : "iZJciCwBftatxnGy71",
           "date" : {
             "type" : "Instant",
-            "value" : "2023-11-06T08:43:42.560Z"
+            "value" : "1985-08-14T02:20:17.623Z"
           },
-          "ranking" : 427122989,
-          "otherInformation" : "rYcsYrnw4Lugry4DOoB",
-          "sequence" : 236144498
+          "ranking" : 467845713,
+          "otherInformation" : "6hoWrzlxoQ1aW1if",
+          "sequence" : 1501625571
         }, {
           "type" : "Exhibition",
-          "name" : "xNczlAvUG2LUB",
+          "name" : "H6F8l3L1FZ6tbyY1MT",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "L2qwBgTvdxy",
-            "country" : "84h30SpGLgGnUWmtXS"
+            "label" : "4Y9FgMYfOBXqLAx5",
+            "country" : "zE5EAmG058"
           },
-          "organizer" : "YBb0Mqc0nXZr",
+          "organizer" : "MbLLZYzzErkEmf9",
           "date" : {
             "type" : "Period",
-            "from" : "1994-05-20T09:03:59.726Z",
-            "to" : "1995-07-09T15:10:48.455Z"
+            "from" : "2019-09-01T21:51:32.353Z",
+            "to" : "2020-10-13T10:19:10.363Z"
           },
-          "otherInformation" : "lj0G4eNycoQro8lC",
-          "sequence" : 304477169
+          "otherInformation" : "ErMj6CL4gd0G6hqTaR",
+          "sequence" : 640074375
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/310f012e-d0aa-4002-8c5c-d5cbc0e996fd",
-    "abstract" : "3XefUqI0HNRtCUJXM1F"
+    "metadataSource" : "https://www.example.org/2594fa7a-4abc-4088-8ab9-47551ca0b096",
+    "abstract" : "X3pSJhlkrI83NZS"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6b42cb92-96b0-4f77-905d-58049d95a223",
-    "name" : "4uYZaxxu5yJ7jR",
+    "id" : "https://www.example.org/2522f042-af0c-4153-a473-58fd6525af19",
+    "name" : "yhsU4KZgt9THU8",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-09-10T21:29:35.521Z",
+      "approvalDate" : "1991-09-15T20:32:43.625Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "vRwpcY3EcaXlkq0h"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "yz44MaKGbSuBijE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c12f19b8-06cc-4b0d-ba1c-0d8472f91663",
-    "identifier" : "fKAsqChIDx",
+    "source" : "https://www.example.org/854f07d8-b5e6-4512-a009-c04e9eaa5ab7",
+    "identifier" : "yTIEAHx5x2JAY08nuGc",
     "labels" : {
-      "af" : "7zHZMFzvOT"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1056527060
-    },
-    "activeFrom" : "1980-09-02T12:03:20.112Z",
-    "activeTo" : "2012-05-22T02:01:16.142Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ce0fbaca-351f-42e8-bd2b-3e371242b775",
-    "id" : "https://www.example.org/446721d0-512e-4c07-9aca-ef766c7de1b3",
-    "identifier" : "lg4pZsYnYV",
-    "labels" : {
-      "nl" : "M5XVx609AF58ejmRy"
+      "ca" : "hPFE5WWf6ROAoyJos"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1881365234
+      "amount" : 669448167
     },
-    "activeFrom" : "2016-11-18T07:20:16.414Z",
-    "activeTo" : "2020-08-12T10:53:03.196Z"
+    "activeFrom" : "1993-03-15T07:59:40.545Z",
+    "activeTo" : "2010-09-15T20:09:39.017Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/88c10a4c-3270-4180-b9a5-4fc8fdcd8946",
+    "id" : "https://www.example.org/200dcbde-08d4-4f1f-a2a1-ee27076b8d2e",
+    "identifier" : "AAxynqzFO3YgkX",
+    "labels" : {
+      "da" : "9OzOc5ms1EdC"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 508533003
+    },
+    "activeFrom" : "2001-01-30T14:32:10.066Z",
+    "activeTo" : "2014-08-02T15:05:44.456Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2b1d6113-0aa1-44f5-a92b-8005c5770994" ],
+  "subjects" : [ "https://www.example.org/f40b20c5-64a0-409b-b2ad-14457ef2f257" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9c97c30a-80ef-4617-a2bb-6a5dd289203f",
-    "name" : "Cd6ljKWQ4QSYo5",
-    "mimeType" : "totrZBEN67Q54",
-    "size" : 2054538297,
-    "license" : "https://www.example.com/4arofl6vq6",
+    "identifier" : "a1be118b-6711-4144-b0f8-3dac1213a088",
+    "name" : "u3PQ73xIWB",
+    "mimeType" : "Q7viFaxaIEoBYgZMe",
+    "size" : 1526953335,
+    "license" : "https://www.example.com/vj2uo4az9bpbk3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "LKML9Wy6gL0",
-    "publishedDate" : "1992-10-31T22:39:49.099Z",
+    "legalNote" : "ns9IlA0yBq",
+    "publishedDate" : "2010-03-09T23:01:43.487Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TqRaI9PtYn",
-      "uploadedDate" : "2016-02-02T15:29:14.557Z"
+      "uploadedBy" : "MEMCRieIOXSB0zRd3L",
+      "uploadedDate" : "2019-08-22T22:29:53.778Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zDPGCLkRxC1ZGYHE",
-    "name" : "oFTrGzAb35Kpnce",
-    "description" : "zlsAqYHc6QN"
+    "id" : "https://www.example.com/QObRvTCebNMlT",
+    "name" : "y0VfH21X9oIYMbhKO8v",
+    "description" : "TzqWt5XiQXtNwFsoF6"
   } ],
-  "rightsHolder" : "r2v7tr3IWMu",
-  "duplicateOf" : "https://www.example.org/de26c6bd-5790-4f3d-b275-7fd03e865f58",
+  "rightsHolder" : "DpHte5AqpYCR",
+  "duplicateOf" : "https://www.example.org/d0bcb07f-107c-4fb5-91c3-002ba96c179f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "THplNfXQha"
+    "note" : "3HOZOVZ1TAI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QhMVRUNuWBI7hTrFv",
-    "createdBy" : "VN0ECp7kLl8RU1N",
-    "createdDate" : "2004-10-05T21:48:29.917Z"
+    "note" : "kTqMGWFockB2Fub",
+    "createdBy" : "PmxJXO99L28",
+    "createdDate" : "2008-06-01T18:15:32.682Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/efa7d3a3-17e4-4fca-88de-f9c93b2eb314" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/9ee6c78f-ab8d-43dc-9596-bbd57267964c" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "Zp4qQjTGmJ0iKBhwpaD",
-    "ownerAffiliation" : "https://www.example.org/ca183108-2ade-4562-8be8-4de8d0abd148"
+    "owner" : "RsgLmxjSQKtp49i03c",
+    "ownerAffiliation" : "https://www.example.org/4e3c17c7-aadd-4044-943d-6fec576b19f2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b47f395d-8125-4911-a2ef-ea17a0a37bf4"
+    "id" : "https://www.example.org/d377369f-4af8-4da5-a4e3-c190aa8348bb"
   },
-  "createdDate" : "1976-03-31T11:20:15.915Z",
-  "modifiedDate" : "1997-09-05T12:24:55.019Z",
-  "publishedDate" : "1989-11-03T20:41:21.170Z",
-  "indexedDate" : "1997-08-10T12:44:07.961Z",
-  "handle" : "https://www.example.org/7658b2a6-ac05-4571-b6d5-ecc94c7b433c",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/bcb19fb8-5f09-436c-ab4e-ebd2a07a4f89",
+  "createdDate" : "2022-12-10T14:44:57.904Z",
+  "modifiedDate" : "2011-01-19T21:43:22.399Z",
+  "publishedDate" : "2018-06-03T23:57:27.739Z",
+  "indexedDate" : "2007-04-19T09:04:44.853Z",
+  "handle" : "https://www.example.org/c762b4a1-3c51-4e4e-912c-930790fa5418",
+  "doi" : "https://doi.org/10.1234/sequi",
+  "link" : "https://www.example.org/a931dcb8-1b8e-46f4-941b-14eca9a2a29a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "G2LVvzPSG3i",
+    "mainTitle" : "QkP9oUEwdoVTRvzrAj",
     "alternativeTitles" : {
-      "pl" : "7hmqsARD43382uz"
+      "pt" : "JSb3eMWrCsxk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OEKM9UXvJMMNdACj",
-      "month" : "LkSj1riaLgIL4BBQ",
-      "day" : "825N0WfffMeB0AG"
+      "year" : "u8tPxqPraQ",
+      "month" : "9sOiEAT5S67C0qI",
+      "day" : "xYwoqp4DQNiZwX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9ae29a89-b898-4e4f-b49d-7b3eeff67e71",
-        "name" : "1zlbOxhlGyV",
-        "nameType" : "Organizational",
-        "orcId" : "t3Jc9u9miM7vw8OFm",
+        "id" : "https://www.example.org/7694e8a8-8fa0-47e5-aead-0915f878373c",
+        "name" : "6qRbUQXzaKipMPKw",
+        "nameType" : "Personal",
+        "orcId" : "UuTZR73hMVM",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DnycPQ9LjeN4",
-          "value" : "nrx2w9hvkby8"
+          "sourceName" : "s54CE3TYUFdGmS27Ck",
+          "value" : "l4KuSZQQrXjE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8YdOidzdKMMG",
-          "value" : "KFCtjSsYa2GPQPHrUZ4"
+          "sourceName" : "s4YzRJ1bBZ30H",
+          "value" : "i7s6xXUUDcr9iPfMXpT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b03a4546-dcee-455e-bff9-16080a52b05d"
+        "id" : "https://www.example.org/5e3ba91a-f634-4e40-a21a-4e02e8fe21c4"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bb311cc1-d491-4b67-8310-fed5ab778ad5",
-        "name" : "D7ifflpbQvi",
+        "id" : "https://www.example.org/06123a2c-5306-4528-adbd-88242668f3be",
+        "name" : "DBtsgUwceJSLFMVTjb",
         "nameType" : "Organizational",
-        "orcId" : "dNcqMCohBGPC0mY9Za",
+        "orcId" : "6MIUT6jIXhdBW",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rUjIyOoIRAKEZ8cHk",
-          "value" : "sNtZMefjsyzpEfLX0E"
+          "sourceName" : "QnsmXC8LwFUxj",
+          "value" : "YvAIK56Tee1wb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "C5ndPm5cvsdJEDAxq",
-          "value" : "OQmuY1AzuN1X"
+          "sourceName" : "hbIcp1f6Zd1r4fODK",
+          "value" : "EovZLB29qhL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/684f6ccf-67f3-4c10-a175-4643d4c273d5"
+        "id" : "https://www.example.org/3b3d1bef-77b8-4b58-847e-a2d751b4b49c"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "RQKLmUToVP0vqR"
+      "hu" : "WloLTzSIX21Edn"
     },
-    "npiSubjectHeading" : "IukbuAcVnOMuGC48",
-    "tags" : [ "x8vaUN8V9ILlAS" ],
-    "description" : "U4NdLECs6dH4",
+    "npiSubjectHeading" : "zmgOpmgwtA",
+    "tags" : [ "aEpGmDsL4l4r" ],
+    "description" : "HneOKcvJskQzf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/5867a499-8d59-4329-9d32-ab3ddac7dfe4",
+      "doi" : "https://www.example.org/f1f79599-3abc-4af2-b82e-ae5de9b09efd",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "LightDesign"
+          "type" : "ServiceDesign"
         },
-        "description" : "UJC9w8Jg3Ez",
+        "description" : "UgOtLxvb994xp10tU",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "ptvXcKd1ImYFBF",
-            "country" : "QlOzbku9pvpN6apO"
+            "label" : "bAXVbPFRQW",
+            "country" : "oh5qDckhqovHKy0"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2012-02-22T00:05:42.068Z",
-            "to" : "2018-11-01T14:40:00.884Z"
+            "from" : "2022-02-01T17:43:50.112Z",
+            "to" : "2022-07-26T16:10:49.856Z"
           },
-          "sequence" : 111491349
+          "sequence" : 499865660
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "GAanUTNiUtHK4",
-            "country" : "41ptHURLGTX"
+            "label" : "kM47clUqJtu97Iry8",
+            "country" : "tVFPqrHhTRjUv"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2006-04-24T21:21:28.366Z",
-            "to" : "2008-01-23T04:23:19.333Z"
+            "from" : "2020-06-27T11:20:19.537Z",
+            "to" : "2021-07-06T15:29:04.988Z"
           },
-          "sequence" : 1591683442
+          "sequence" : 21074936
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2c1abb39-3314-4d11-9d3b-32d6a11a5b73",
-    "abstract" : "Ssjmnu3bKXJqmCbt7"
+    "metadataSource" : "https://www.example.org/fd02cbcd-6f14-4c70-8eae-14786b3f0ab8",
+    "abstract" : "JcR1h8Ubhb7KJ5crCA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2411f1ab-cb9a-487f-8552-c0fd97cd0244",
-    "name" : "eVi7NKPxm1sv2OMpXX4",
+    "id" : "https://www.example.org/29261383-400d-49c9-a0c9-37fe8bdff6ef",
+    "name" : "Hlb0qX54xylHpdA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-01-15T08:29:17.321Z",
+      "approvalDate" : "2020-09-22T00:11:46.747Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "nrYm2ElXm7KG"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "zDhciu5xLPxyUhKz"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1515bbf7-bbea-4acb-857d-266bd00b571f",
-    "identifier" : "pmA71zsQ05mwNj6V",
+    "source" : "https://www.example.org/0cb94fc6-b48a-4da4-a1ef-b616cd518715",
+    "identifier" : "36UIYanekh93o",
     "labels" : {
-      "pt" : "9WfBscUEw2"
+      "af" : "PC6H2qAalMJE3T"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2060519928
+      "currency" : "EUR",
+      "amount" : 1353594748
     },
-    "activeFrom" : "2004-08-23T15:12:21.413Z",
-    "activeTo" : "2023-10-08T21:08:24.633Z"
+    "activeFrom" : "2005-01-20T19:00:40.817Z",
+    "activeTo" : "2019-02-24T15:37:05.761Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/11fc6ab5-e8dd-47a9-972e-ed6dca0f4118",
-    "id" : "https://www.example.org/44b5c4ee-3e55-4dd3-bdc9-420560725f68",
-    "identifier" : "fuvCWdD6piJx6tFqdkE",
+    "source" : "https://www.example.org/8b41c1aa-b540-4650-8810-f3c797a4fc8e",
+    "id" : "https://www.example.org/5b88f0ed-9397-41ad-9d5a-e8e5a9feee05",
+    "identifier" : "5qUVhowZrfbK",
     "labels" : {
-      "af" : "dGSwe6gPwjWr"
+      "zh" : "sSae0kJhcYL"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1417551574
+      "currency" : "NOK",
+      "amount" : 1193526637
     },
-    "activeFrom" : "1982-12-14T21:24:33.588Z",
-    "activeTo" : "1996-04-14T14:15:59.785Z"
+    "activeFrom" : "1973-12-07T15:46:27.580Z",
+    "activeTo" : "2004-11-08T07:39:25.430Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/37a53e80-f4bb-4a23-aa82-2d96da19bd9d" ],
+  "subjects" : [ "https://www.example.org/8916298a-6aec-40d4-85bd-711293228059" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "51f81581-0555-4a66-817a-e937ab26d007",
-    "name" : "QRxnU8cFL7d9L",
-    "mimeType" : "VBM7u5kTptCqsanb",
-    "size" : 2128463945,
-    "license" : "https://www.example.com/r4cfshhwrnnpae1y",
+    "identifier" : "39a8f031-ca64-4293-8d6f-96ac2f3092c3",
+    "name" : "q2nJDAkevw",
+    "mimeType" : "7PHVB37xwCMN15",
+    "size" : 1961866549,
+    "license" : "https://www.example.com/mtde28pnoim",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "RRfJqcniuM",
-    "publishedDate" : "1975-12-18T19:46:58.872Z",
+    "legalNote" : "Vmvf68zHbU3oLEwb",
+    "publishedDate" : "1977-03-05T10:31:19.841Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ERRtN30uHbBOJN",
-      "uploadedDate" : "1994-03-10T17:07:47.634Z"
+      "uploadedBy" : "N72VzjBTtB2oAuFUDA",
+      "uploadedDate" : "2022-11-02T21:06:02.351Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SdwAPnZdDiMBhY",
-    "name" : "g9EK5q7c12mab1z",
-    "description" : "Xh1fXE0UMnUvj"
+    "id" : "https://www.example.com/1zLi58X2lEvkU2EV1j",
+    "name" : "hW1MWyXa4dmgos115rt",
+    "description" : "K92yMSzYtwfrFZ"
   } ],
-  "rightsHolder" : "U5IEnE4NUB5I28",
-  "duplicateOf" : "https://www.example.org/c59d3c1b-f4cb-48b1-9c64-f96b1bf36986",
+  "rightsHolder" : "illhXpWgjnj",
+  "duplicateOf" : "https://www.example.org/0a8742d0-269f-4029-90e7-8d5bec1e2965",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "AAfx3OdD90mNBDgg"
+    "note" : "LgxkfLbJQue"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "5m5ObrFAz3iUcpxS",
-    "createdBy" : "lUNwkPAsFT",
-    "createdDate" : "2014-04-15T23:33:31.870Z"
+    "note" : "CbzioNl1MslfY",
+    "createdBy" : "wEMzZCPXuOB71Qw7R",
+    "createdDate" : "1990-12-24T15:05:59.241Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/876e328a-dfc8-4ffe-afec-d2c817d08643" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/2062607d-462d-41e2-9ed7-4463f837f120" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "5hjQksEh2CiyM8Yri",
-    "ownerAffiliation" : "https://www.example.org/fc08304d-4920-4727-8e0d-778a78762d6e"
+    "owner" : "eITPypBo2XKIipP1",
+    "ownerAffiliation" : "https://www.example.org/7ffa35a8-d21d-4cdc-b7e4-ece79ca0c762"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ec04deed-eb80-489f-8f06-433c589ecb81"
+    "id" : "https://www.example.org/764a7368-162d-4736-b8f7-bd508c026b00"
   },
-  "createdDate" : "1974-12-01T03:46:17.425Z",
-  "modifiedDate" : "2019-02-14T23:29:22.027Z",
-  "publishedDate" : "2016-03-20T07:07:06.098Z",
-  "indexedDate" : "1989-10-31T20:37:59.109Z",
-  "handle" : "https://www.example.org/d9dec5f1-407d-46d0-a918-c01acac30faf",
-  "doi" : "https://doi.org/10.1234/consectetur",
-  "link" : "https://www.example.org/bc084d01-94fe-4c8f-ae00-d6ebf5d4aa0b",
+  "createdDate" : "2016-11-09T00:56:16.405Z",
+  "modifiedDate" : "1993-09-10T18:26:27.305Z",
+  "publishedDate" : "1981-01-25T09:39:50.400Z",
+  "indexedDate" : "2011-09-29T21:24:32.787Z",
+  "handle" : "https://www.example.org/dbbec1eb-d605-48ee-9efa-f122c64c87e5",
+  "doi" : "https://doi.org/10.1234/repudiandae",
+  "link" : "https://www.example.org/69be6fd8-9790-48a6-afc0-5d3570641bea",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "XGrwR75Ca504Vp0cCP",
+    "mainTitle" : "sJxjjeQoisNf7pk5",
     "alternativeTitles" : {
-      "pl" : "eRcOaqcz7s2NF"
+      "zh" : "8817Tn7nynErQbhMyq4"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "jYof5ZSNhM4o4wTN2",
-      "month" : "4w2hT9uMQpVjmzMMgNy",
-      "day" : "HXlOSFdFmIZUml2ffL"
+      "year" : "sEb0AKlNZM3fygL",
+      "month" : "VaZElufL05HiJ",
+      "day" : "cQwbO3TQQd5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/40786f49-2bc7-4520-83f1-5e9b209f9cae",
-        "name" : "PgkEwJI9Y3tycHzMPw",
+        "id" : "https://www.example.org/8aa259cc-716a-4c2e-aecf-c3624d37991e",
+        "name" : "KpCKaiiKrUjfVa",
         "nameType" : "Personal",
-        "orcId" : "j0hX0F6tj5n7",
-        "verificationStatus" : "Verified",
+        "orcId" : "ZIfzBKMdfRvnzdyh1Cx",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6X1w3cZWgtYaEGB0jDF",
-          "value" : "tLGcs0K74QZMjvkIP6"
+          "sourceName" : "UX1JhstKe0QezT7F",
+          "value" : "FPJ4GBLb1rY270zo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9LyonuHPc7Q8s7Zd",
-          "value" : "PyrNxj2B3v"
+          "sourceName" : "02DLHn8SkRaZ",
+          "value" : "YcduuuDjwpLiyz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9eb2643f-7b5c-4459-a394-c929cfd9a78e"
+        "id" : "https://www.example.org/2fb66a4d-8cc3-43ae-be49-6f93be825c4d"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/82534960-541f-4755-9c94-f29c110d5df7",
-        "name" : "KwhXXwwS33oA7DBM4Z",
-        "nameType" : "Personal",
-        "orcId" : "Wy263KLVn02eW6s",
+        "id" : "https://www.example.org/c516e489-edc7-45d0-8ec3-a5a342d45f26",
+        "name" : "Mm6Ue6XtA5Rph",
+        "nameType" : "Organizational",
+        "orcId" : "lyBNf8GIqG",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mQTDObimxQN",
-          "value" : "0aMrz9NRn3"
+          "sourceName" : "jjIAplcX9fKKf1",
+          "value" : "s9iGsGYriUFAkYc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CacOMlPDnk3waPY",
-          "value" : "MfdiaUttcO"
+          "sourceName" : "1JLVNX6EbYsJZh",
+          "value" : "wf20nPzxMLwY3S"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/56d62dc9-dcac-4600-a40a-448017259a5d"
+        "id" : "https://www.example.org/a3ac0340-cb13-40aa-9f8b-03e78bd88ef3"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "vWc9wGoK18o0sRW1MlS"
+      "it" : "aV7s3oxavHcY"
     },
-    "npiSubjectHeading" : "NJZhlaaou2EqN9AJZ",
-    "tags" : [ "FjfdlXOrFjCd" ],
-    "description" : "V04dbiBBXt4",
+    "npiSubjectHeading" : "WRkBobbGRlwQNbo3WW",
+    "tags" : [ "v5fXnXg1hizx" ],
+    "description" : "hm0hc9JweKEzjQIW59",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f7278bb2-d28e-4257-affc-50fc92d0e6ee"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3c86559a-13c6-4085-817e-6cfda33033c5"
         },
-        "seriesNumber" : "B00KixR0KiFUxhswPa",
+        "seriesNumber" : "E402zMJJYwbzLNy",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4a1ec95a-ce8e-4e0c-8843-63be8b60ae24",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/79943973-200c-4a40-906d-53e4413a82f8",
           "valid" : true
         },
-        "isbnList" : [ "9790229345075", "9781852312664" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9791018131053", "9780912024189" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1852312661"
+          "value" : "0912024186"
         } ]
       },
-      "doi" : "https://www.example.org/5094905f-e885-4456-9015-51cc31fe3eb5",
+      "doi" : "https://www.example.org/642fc1a9-3ca0-4eab-b077-6f29c120422e",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ixoSatFe9e",
-            "end" : "oj2ZcBh28lWSHT"
+            "begin" : "HweB7h0yDBH",
+            "end" : "UumC19aiw3br1gJqOya"
           },
-          "pages" : "KhsSnndt8OiLht",
-          "illustrated" : false
+          "pages" : "cvquHFAYcB0",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/04fdeaaa-e287-42e3-9716-5ef2d31f6c28",
-    "abstract" : "yPxZl3qjDyUn"
+    "metadataSource" : "https://www.example.org/00ceed5b-5b56-4376-8f08-1a82f6fee5d6",
+    "abstract" : "ts2O8obA1NXW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d59c3302-d9d0-4f66-ade8-1c5d8d04fdb5",
-    "name" : "uZw8EbtBsGGjSlCMD",
+    "id" : "https://www.example.org/44eeb039-10d0-4c2d-87f6-c7a23781e79c",
+    "name" : "eNdoigVbsJukuRd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-03-26T22:47:14.083Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "YfJbkayh66gT"
+      "approvalDate" : "1997-10-01T10:42:33.559Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "YaRhaETaUYZlOKMJ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dc971a6d-f565-4b86-854a-3e6cc5dcd7cf",
-    "identifier" : "OlCcGnW1t6QhZJraW",
+    "source" : "https://www.example.org/781ac947-bdc7-464e-b8f4-28268aa711c6",
+    "identifier" : "MWS9rSOyOlT7",
     "labels" : {
-      "pt" : "1QQoHQneBQGgKpSEOf"
+      "es" : "rbftZjPiVE1gU9"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1831556662
+      "currency" : "NOK",
+      "amount" : 11729507
     },
-    "activeFrom" : "2002-04-10T10:00:39.523Z",
-    "activeTo" : "2004-06-02T13:26:46.853Z"
+    "activeFrom" : "1974-07-30T05:45:27.608Z",
+    "activeTo" : "2018-12-27T21:10:10.723Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b398dd77-042c-4dd4-90ef-c749fb5c68c5",
-    "id" : "https://www.example.org/0706fa10-baa6-49f3-804f-e6c837c9ac4a",
-    "identifier" : "RjKL8EON2a",
+    "source" : "https://www.example.org/4cd78f74-54d0-4a96-972f-2b66af85bd7b",
+    "id" : "https://www.example.org/29f897ff-4612-4dfd-a815-6550b57200ae",
+    "identifier" : "loWa4PkDjsaVWr6",
     "labels" : {
-      "af" : "Er6PfR0HQPHffrmq"
+      "fi" : "Pe844quAr4r7a"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1927959720
+      "currency" : "GBP",
+      "amount" : 115882357
     },
-    "activeFrom" : "1994-01-07T20:28:52.029Z",
-    "activeTo" : "2004-08-22T05:47:01.130Z"
+    "activeFrom" : "1988-09-20T19:12:28.083Z",
+    "activeTo" : "2007-08-19T22:41:36.435Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/505bb9e4-5e13-4710-8689-7bb957938951" ],
+  "subjects" : [ "https://www.example.org/89e9d2f1-3201-4aac-bc00-f2f8e1536156" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fb012995-1453-4858-acb0-d4c98e06afe4",
-    "name" : "yA5uSw2fkcQ7Wzd",
-    "mimeType" : "MBMRLXwxYace9ZxqsQI",
-    "size" : 2095384135,
-    "license" : "https://www.example.com/y4xxkwrasnpxbilxwj",
+    "identifier" : "6e716983-584c-4f44-8704-750f01b8a656",
+    "name" : "Vtx9x0VT9t",
+    "mimeType" : "8Tsu2I4dtNzJ5jp1M",
+    "size" : 2081054980,
+    "license" : "https://www.example.com/quyxdainrgwwt4y",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "lmEQhEd3Eb3uKFNlAm"
     },
-    "legalNote" : "yJErVZz2sV43H",
-    "publishedDate" : "1991-05-27T07:32:36.794Z",
+    "legalNote" : "BuUshXjaidty4",
+    "publishedDate" : "1972-03-12T08:33:08.751Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "iPHM6RGElow6oj",
-      "uploadedDate" : "1972-08-01T16:45:20.379Z"
+      "uploadedBy" : "xzOEvRb12Rt",
+      "uploadedDate" : "1998-01-17T19:41:33.836Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VIDlIa0K8HjD",
-    "name" : "Zg93NdIu7Wdolug8",
-    "description" : "bxeBv0bkVi6gykzjC"
+    "id" : "https://www.example.com/Rl106BmehAp",
+    "name" : "o0Hgx3A25DE",
+    "description" : "CR9XcMxQwFoNfy7L"
   } ],
-  "rightsHolder" : "YEq0u6BGdM78YZ",
-  "duplicateOf" : "https://www.example.org/6c2f3be8-fbd7-4884-9c2b-2d410eb617b8",
+  "rightsHolder" : "Dx2crhJFrtzIP",
+  "duplicateOf" : "https://www.example.org/9ffde13f-4db0-4ec5-8a75-7cfe447a89ea",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "poI5eBLL88IPvUrKi3Y"
+    "note" : "TyKtpnXGEzy03V"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "uRLIFgJL3Gyf",
-    "createdBy" : "sceufxTq8N4Z6kc7",
-    "createdDate" : "1974-09-11T08:23:04.278Z"
+    "note" : "ss2TYlUBnuT165wOtO",
+    "createdBy" : "uiJqwtx2gVyV",
+    "createdDate" : "2012-06-20T09:03:00.948Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2940872b-a124-4c66-858f-5bcb0e2af7fa" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/0016a5ca-dded-4369-8c00-b44a0f907bc1" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "8A2GznpTixc",
-    "ownerAffiliation" : "https://www.example.org/1adfe92d-9ed2-4680-9680-94e6fe5605b7"
+    "owner" : "o0gUnK4PyZ773O6S6l",
+    "ownerAffiliation" : "https://www.example.org/615f702f-c7d3-4bd3-a9e0-6e4a4a5e9d80"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/254e7350-a07b-4d6f-a227-a7e3c1d10aad"
+    "id" : "https://www.example.org/df1f712c-262a-451c-8947-877f7a89edc4"
   },
-  "createdDate" : "1975-09-21T04:18:47.779Z",
-  "modifiedDate" : "2008-05-07T23:34:28.516Z",
-  "publishedDate" : "1998-10-18T16:35:13.304Z",
-  "indexedDate" : "2020-03-31T16:48:28.240Z",
-  "handle" : "https://www.example.org/8cfdd4f5-3ebe-4db1-8792-d27f1de9a3b8",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/6ed5b64e-cd94-48f2-94ff-9b84e2206d46",
+  "createdDate" : "1998-10-01T06:57:16.624Z",
+  "modifiedDate" : "1972-02-09T22:51:43.466Z",
+  "publishedDate" : "2015-04-15T02:26:42.375Z",
+  "indexedDate" : "2000-12-22T12:40:12.325Z",
+  "handle" : "https://www.example.org/b684390b-2ecf-476a-bfcc-0b3542637696",
+  "doi" : "https://doi.org/10.1234/ea",
+  "link" : "https://www.example.org/3556de01-69cb-46dc-b66d-21fbdcb973a4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "I0QOu9Tv2Qf",
+    "mainTitle" : "fV2Fzh1nHKyrl",
     "alternativeTitles" : {
-      "ru" : "hGDgwxCXrcHgA0O"
+      "sv" : "ReudSZ5tkHQS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Hr48KawNhQEp2T",
-      "month" : "ChBVMXntb5qfmM",
-      "day" : "FfKk9T6QyO9gmrtkXW"
+      "year" : "dOafqxdow3oXovSgL",
+      "month" : "6EAMXv1cyYffFmmFBvz",
+      "day" : "OKZ4B7OgGoPRGGtkqd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9f5793ec-0c24-4cf8-989c-15888b1c48eb",
-        "name" : "FosEKrL9QhFzY1RAfW",
+        "id" : "https://www.example.org/2d4f1860-6c16-4646-9062-2f01dab08157",
+        "name" : "QolNkrTay8",
         "nameType" : "Organizational",
-        "orcId" : "XcvNJILOUEBsi1ks",
+        "orcId" : "G6S6eskL2UyEY8xp",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kop4VKHRnSQzUtBaqMR",
-          "value" : "sfqYTjgkAx4fBefR"
+          "sourceName" : "kAZuY5PsmKcLqLY8",
+          "value" : "7mF6MJzMmn3md5wqPL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6AbI8iAtLLhHf",
-          "value" : "U3xXz1GNyfigM"
+          "sourceName" : "924IrJoopueLKZPsruo",
+          "value" : "lnWYs8BQi8em"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/63088097-da02-42a4-b3c8-5e96b2cecaa3"
+        "id" : "https://www.example.org/9b49a8fe-87fd-4663-a383-becb7190a734"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Dramaturge"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d6ca2553-ce4d-4078-8e3b-fc999e1742e2",
-        "name" : "lNvDGr2MTY2VC",
+        "id" : "https://www.example.org/43ad1bae-ad54-4b15-b8a0-8e93b7cd2b43",
+        "name" : "g3uc8yO6SQcctgWwF6",
         "nameType" : "Personal",
-        "orcId" : "mJhhzSORY1wuYs3",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "1vfQWNEQJ87rx2uWU2",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8mYWv7XrQQaavGF",
-          "value" : "sQrOpn5ueyeQYxtGCR"
+          "sourceName" : "q5rzF1qfXOA",
+          "value" : "bLv0POEM7DYJC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oxxtJyHla8E",
-          "value" : "a9SeK8VTpQ9Wk3"
+          "sourceName" : "1s0nO2HAGyQDYRDWI",
+          "value" : "yelCtvSbiPWQSHYG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5e966cc8-79db-4a59-a76d-488dcabcaf62"
+        "id" : "https://www.example.org/76f103e4-5720-40ae-9d77-abe5d09df7ee"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "fmbz8OAYZvVNGZKp"
+      "se" : "kOANPTTURejC"
     },
-    "npiSubjectHeading" : "o2KTQ6FchZntT67tqr",
-    "tags" : [ "TeqJl9uzdGaXgkf" ],
-    "description" : "m7a3eUNbmGg",
+    "npiSubjectHeading" : "AKJCk2guyZwn3o",
+    "tags" : [ "Jd6YcSqUbna5" ],
+    "description" : "xTSyTOta8gs1gIzLV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f35a50fb-77a1-49ff-b7e7-9ceddbba1831"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/300f8c48-1d8b-4c4d-b6c1-0082cf476347"
       },
-      "doi" : "https://www.example.org/6d4265f8-cd58-4c27-9a6d-f71ee9ebd560",
+      "doi" : "https://www.example.org/e10726ec-5274-458d-bf6b-a4d19986a4f8",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "XKixsILcDC9BhYtz",
-          "end" : "Bh3KB6T30syYSIDE"
+          "begin" : "mkj84B5HQeA",
+          "end" : "6exyMKxrEplCm2UiXTu"
         },
-        "volume" : "RNC16nHhTDooEPH",
-        "issue" : "Dhx81poo9p00eUjg",
-        "articleNumber" : "vRXmYz1t76"
+        "volume" : "IootngSGgkCWd",
+        "issue" : "knxKDbhg7JosHd",
+        "articleNumber" : "u5UdViwBsbA"
       }
     },
-    "metadataSource" : "https://www.example.org/0c450a16-2350-4762-9fe4-83e8342a1e14",
-    "abstract" : "WUULUHlYY53c1b"
+    "metadataSource" : "https://www.example.org/cfcf0cda-6a57-4e9a-a311-199b7eeb9a4c",
+    "abstract" : "XlQ87wLSWPAUSRgN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3abd5f51-7311-4196-93db-f9f25f7d0895",
-    "name" : "AP6R35kfxhmGPrnT",
+    "id" : "https://www.example.org/dc6c4f2a-b86b-4a68-b3dc-4597eb21ad2b",
+    "name" : "OsJGVFXX6RHrKwW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-04-30T01:47:46.662Z",
+      "approvalDate" : "2008-11-05T22:09:21.014Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "bmYMow3GHiM9oY0"
+      "applicationCode" : "jYc1Lxefb6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4149e277-ba34-4ea8-8e65-05f4d6e3251b",
-    "identifier" : "UoHzkoflWdc",
+    "source" : "https://www.example.org/24b29a92-e630-4708-a93c-22ce9e923b8f",
+    "identifier" : "Vm7gAVuo1aANk2",
     "labels" : {
-      "se" : "aaQkqG2bG4OmFSs"
+      "nn" : "akJG5SL6HkOzZUa"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1293668117
+      "currency" : "NOK",
+      "amount" : 1512336652
     },
-    "activeFrom" : "1992-01-16T20:42:43.543Z",
-    "activeTo" : "2023-11-09T17:06:25.489Z"
+    "activeFrom" : "1995-06-25T02:46:43.831Z",
+    "activeTo" : "2000-11-23T16:35:05.605Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dc705f7a-18d9-4b4d-8137-f7a8fa4165cb",
-    "id" : "https://www.example.org/7a611e64-3b59-42f2-ada4-371d43886ea1",
-    "identifier" : "bedeslUCfVloAGYT",
+    "source" : "https://www.example.org/cbaea040-5cba-485b-8627-da17ac587920",
+    "id" : "https://www.example.org/8443befe-ccf3-40da-862d-c85e147df0aa",
+    "identifier" : "q6wnO65y0mAwpul4B19",
     "labels" : {
-      "ca" : "OfOdHY93YDUH"
+      "es" : "Zuy2VZazexEV"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 982000515
+      "currency" : "GBP",
+      "amount" : 1821411894
     },
-    "activeFrom" : "2007-09-09T22:46:05.333Z",
-    "activeTo" : "2013-09-01T06:00:42.794Z"
+    "activeFrom" : "2006-01-19T02:12:06Z",
+    "activeTo" : "2013-12-13T20:20:56.865Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8f7fd697-bde9-4e60-ab32-66d7991555a5" ],
+  "subjects" : [ "https://www.example.org/0ccf9af1-2660-4c55-97af-18fa1491104d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9e6d2e31-22a6-4abb-8fd0-b94b7922f7fe",
-    "name" : "oeBIPnJON4eifPq5",
-    "mimeType" : "OIffGAqwd83eKbb2iw",
-    "size" : 121654671,
-    "license" : "https://www.example.com/c1pbjjp2vdoqbvh4w6",
+    "identifier" : "ff18bbd3-3369-4de7-8735-7d183f16c0e2",
+    "name" : "WsMu02OCk2",
+    "mimeType" : "khH2Qv3YaJ1",
+    "size" : 2093439475,
+    "license" : "https://www.example.com/68v6bcpywjatu",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "bota7yZSakET",
-    "publishedDate" : "1990-02-19T01:25:27.910Z",
+    "legalNote" : "Qdqgn8PpdAo7JWa",
+    "publishedDate" : "2006-12-15T22:45:05.574Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GuBL03FaV0RS",
-      "uploadedDate" : "2014-06-27T09:09:58.534Z"
+      "uploadedBy" : "hWaNzyzEv3JtD31Y2b",
+      "uploadedDate" : "1985-10-30T13:47:11.036Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VlrFUGEuPhA1Tgc3D",
-    "name" : "ixsbBUvPkX4Ad",
-    "description" : "T7YZPHI1yO4Kmq"
+    "id" : "https://www.example.com/z4c2OrIAC4bEJ",
+    "name" : "kFmyrJnulWHPJTeg3f",
+    "description" : "rfcUMEf25u"
   } ],
-  "rightsHolder" : "moMzX0OFLPe6tvoM",
-  "duplicateOf" : "https://www.example.org/c2cd32d8-129f-4a28-8f95-975ea5977d47",
+  "rightsHolder" : "zQvbMDXIQjPlVuad",
+  "duplicateOf" : "https://www.example.org/73cd1038-d317-48a8-8431-d2b49de6d3d3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "A3o4IOUdaXMFon"
+    "note" : "GT7G0Dr2w9Lp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GZ5cV2xdb7LxRKhk5",
-    "createdBy" : "DIKhMsL1J5n",
-    "createdDate" : "2021-11-19T17:29:03.726Z"
+    "note" : "pYxuagIBtG7UhNL8",
+    "createdBy" : "SRxARcTHLBZoFT",
+    "createdDate" : "1984-03-07T12:15:49.790Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0ad55b08-8a78-44eb-b3c6-7e1be5d008bf" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/4a2db6c1-0fd4-4bd1-aec1-034cfac06428" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "3e0Pn9pL3j9u9W",
-    "ownerAffiliation" : "https://www.example.org/b27a68ba-68ba-46f8-b62c-144674ed79b7"
+    "owner" : "1X2uC0pixxT4TjgsXWu",
+    "ownerAffiliation" : "https://www.example.org/8b7c8644-89e2-4c0b-9b83-e30352a87ec2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/588b5439-ef0b-42db-95d2-ee9b86a79ad7"
+    "id" : "https://www.example.org/6a7c5602-0f48-4242-99e1-2482056cab5b"
   },
-  "createdDate" : "1976-11-10T09:25:06.036Z",
-  "modifiedDate" : "2000-03-07T06:18:50.736Z",
-  "publishedDate" : "1976-10-18T23:39:15.011Z",
-  "indexedDate" : "1975-08-29T16:43:45.562Z",
-  "handle" : "https://www.example.org/f5727fa5-e1fd-4aea-8aed-d5600bac9049",
-  "doi" : "https://doi.org/10.1234/rerum",
-  "link" : "https://www.example.org/9599adc0-5d87-4196-971e-ba67c4a0ae0d",
+  "createdDate" : "1981-09-03T01:07:56.631Z",
+  "modifiedDate" : "1995-04-20T13:45:00.366Z",
+  "publishedDate" : "1971-12-22T14:28:26.398Z",
+  "indexedDate" : "2020-09-08T11:51:02.277Z",
+  "handle" : "https://www.example.org/8ce15f54-041d-465c-8603-34640a06962e",
+  "doi" : "https://doi.org/10.1234/similique",
+  "link" : "https://www.example.org/f3b12fc2-9031-4757-9f7d-0901b6cebefb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VRY20ixhzPKtpKvreF",
+    "mainTitle" : "ormtasu86I",
     "alternativeTitles" : {
-      "hu" : "CODDl1sPw6SgmbbPBWl"
+      "it" : "XTr8oNaQYi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "84teyReQ2Qpoj",
-      "month" : "MfSn33Xr4U5Mm73",
-      "day" : "nyVRo7aLU5bHFf1FLz"
+      "year" : "81TwW031ANoVbkzFyPD",
+      "month" : "U7oeCrXnjiB",
+      "day" : "NhLWOma8DkwPnxs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/11e6a4a6-8cb8-47e4-a303-b83f2d498590",
-        "name" : "I0BPeW0HLhlEv",
-        "nameType" : "Personal",
-        "orcId" : "yyPAzSk7M5eaEYook0K",
+        "id" : "https://www.example.org/7158923d-7dbf-44f6-9473-e075e26c542d",
+        "name" : "YHFcBoK0z7QgAGVbD",
+        "nameType" : "Organizational",
+        "orcId" : "uKkJA4TcYOBcyw7my",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KC5PKbj6bWiY8",
-          "value" : "8jlg8cxKXlTUH6rwy"
+          "sourceName" : "2RqGiEUVemtTENvO",
+          "value" : "S22mH2g9tMQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7vB24wWKNFd1ldpvD",
-          "value" : "nHrqigZ1EU"
+          "sourceName" : "f3I2inM9WcX",
+          "value" : "ZU2AP0dWIZe2RBFWtbT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/88c08532-63fe-48c7-99f7-4879b9ace8c4"
+        "id" : "https://www.example.org/7692e508-0e2e-45e7-948f-8fcf9f5aac2c"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ca05ed67-c84a-419c-8c74-3dcb2bee12aa",
-        "name" : "rRsYqtjphZ",
+        "id" : "https://www.example.org/ff38f884-200a-4e75-b4cb-34aba47e2694",
+        "name" : "cuIIsOc3phEcJ8",
         "nameType" : "Personal",
-        "orcId" : "K0ZNh8nfi1mh9",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "yajk9lAoMG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wxFtic3R2TrbgMH5",
-          "value" : "W90SZg2nPi1A"
+          "sourceName" : "DYwoOnmex2OG",
+          "value" : "h2osfSlk1nOKCFY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dbjCiWCxeMqV48FrNb9",
-          "value" : "LCxKdjsXEzEGi2sjh"
+          "sourceName" : "Sy6wKFpNuCVnj",
+          "value" : "zfa3Y8iKJU97E5omb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a99ea3fd-3d1f-4b25-8cf5-00c1540d5777"
+        "id" : "https://www.example.org/13d06490-0c5b-42bf-850b-eb683c9dcdf3"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "dPJ1Q0XVnzdADG"
+      "en" : "dIEhpBlz6aq"
     },
-    "npiSubjectHeading" : "rrwdGGlJkxH",
-    "tags" : [ "rWzhLZygK3v6Wieuk62" ],
-    "description" : "EU40wq5jol6Md",
+    "npiSubjectHeading" : "foT0Fgra6Z7",
+    "tags" : [ "NX1skNb3HG2UV" ],
+    "description" : "A1cY1L6WBCp3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/en54EQaWFd"
+        "id" : "https://www.example.com/usRgX23IFZx"
       },
-      "doi" : "https://www.example.org/0de4f134-9fc5-4f34-a717-5943a90f014c",
+      "doi" : "https://www.example.org/d79c6e5c-04ee-4cd7-bea2-d70b1a12943a",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "hXmlFAz5etm",
-          "end" : "JilCi7u4SRkiT"
+          "begin" : "p2HUcjSNmw3AJH",
+          "end" : "Roon86Bqcis"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4bf0fc7c-b67e-4cf1-bb08-aeef0feeb852",
-    "abstract" : "cKNtVqS23t"
+    "metadataSource" : "https://www.example.org/900a1a27-0487-426e-83ed-3cbed2f5850e",
+    "abstract" : "2ubg6nJ1rH3AcYRDARs"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0850af38-4dee-4707-9590-5e2b99ce76ac",
-    "name" : "m3nci67SpOCI6pj",
+    "id" : "https://www.example.org/00322650-979b-42b0-bd0e-ed262b5069a8",
+    "name" : "We8B2YAzc9cUgQrH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-11-04T19:07:35.515Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "j7wySbS0YUKuHr9sege"
+      "approvalDate" : "1990-11-22T17:38:41.685Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "SJZPWVK7e6tr2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8a4e5a36-85e1-487f-b225-56381e6d02b7",
-    "identifier" : "O3epuBATe99BPw04",
+    "source" : "https://www.example.org/94238dd0-923f-4b88-b75e-926ae312ee94",
+    "identifier" : "qOYehCjkmiXzKY7mh",
     "labels" : {
-      "pl" : "pveZFPrmpbzLDnIZA"
+      "fi" : "A0yl1fcRgb2"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 665652226
+      "currency" : "USD",
+      "amount" : 1970677975
     },
-    "activeFrom" : "2020-08-18T19:22:59.439Z",
-    "activeTo" : "2022-06-26T10:54:16.851Z"
+    "activeFrom" : "1999-01-09T11:09:03.895Z",
+    "activeTo" : "2001-11-18T08:04:52.039Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5f5e561f-183e-449a-9583-8341d7dd08ba",
-    "id" : "https://www.example.org/175a1520-d684-40dd-8d8d-94c77015833f",
-    "identifier" : "11bq3FqANXv9T56Lh",
+    "source" : "https://www.example.org/49a0c06f-44a9-4b67-b0db-518a1eb6c9bc",
+    "id" : "https://www.example.org/c32fe4d4-a4ef-4e37-b53d-a0772338b11b",
+    "identifier" : "KTDecG8FrHgc",
     "labels" : {
-      "el" : "UqzSXDmc6yy6"
+      "da" : "6Elf3wZAooEhxKNW5D"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1245761860
+      "currency" : "GBP",
+      "amount" : 1161506762
     },
-    "activeFrom" : "1991-06-16T14:08:03.478Z",
-    "activeTo" : "2021-09-01T05:05:17.959Z"
+    "activeFrom" : "1994-09-03T21:05:46.808Z",
+    "activeTo" : "2012-08-06T21:44:01.586Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ad70bfe7-bbc3-46f4-9101-e7d54998a576" ],
+  "subjects" : [ "https://www.example.org/0e5c5841-8c69-4a67-b650-55cdaca5e786" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fc202264-cc93-4d58-befa-577dac63f81d",
-    "name" : "Cbn1t9ecbGyEaGAjCc",
-    "mimeType" : "n4bcdhXsyV",
-    "size" : 490611639,
-    "license" : "https://www.example.com/jgxmicjjgh",
+    "identifier" : "47e3ef49-cbc0-447d-8c85-c7a2147a6164",
+    "name" : "za9JQA2Lodmt",
+    "mimeType" : "QK6wRwRjSuLETHN2",
+    "size" : 1411160868,
+    "license" : "https://www.example.com/pctb5lpocp24t8kpjx",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "gceE4t2lhWAe1phQEO",
-    "publishedDate" : "1973-06-08T16:33:42.326Z",
+    "legalNote" : "XXCRF2qBW5NRBpn",
+    "publishedDate" : "2023-05-12T22:52:45.920Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "HHGSU3hyVJIMu6Y9v5",
-      "uploadedDate" : "2014-01-03T12:45:47.343Z"
+      "uploadedBy" : "zsOhOC3oayUzDpDZc",
+      "uploadedDate" : "2020-09-27T19:09:27.904Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/y0XcKs46PRWgev",
-    "name" : "JeQepQbJnDMAehIzZ",
-    "description" : "3ai3PSn6AUfCETIp"
+    "id" : "https://www.example.com/BffR3WsEpGijM5v3Cm",
+    "name" : "qbFST66NY4WHinS1b",
+    "description" : "7AihGxsCVuKodSVpE6"
   } ],
-  "rightsHolder" : "1Bd95OU9GdMU0J4",
-  "duplicateOf" : "https://www.example.org/57b1a093-0076-4f99-a78d-1a3e6f03092b",
+  "rightsHolder" : "BcOzbsDLGzYTLI",
+  "duplicateOf" : "https://www.example.org/0509459e-14a5-4e9a-a351-bf1868c076d5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "SGJDDS7tolWjpN015B"
+    "note" : "iyKWEn7BWi6"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "cU2qZqnNDyLT",
-    "createdBy" : "TGWtIEx4cYZr1Qa",
-    "createdDate" : "2001-07-09T14:00:58.555Z"
+    "note" : "uhJHWK2mQSYkBmu72JX",
+    "createdBy" : "faXqSYGcTCphMYXg",
+    "createdDate" : "2021-12-31T13:24:04.981Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f20fe570-7a8f-483a-9f80-078fbfbc92cf" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/1c5b1ebd-b5b6-43ba-8daa-01a71e979c30" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "5Ns7oMGwFJAbmZleO",
-    "ownerAffiliation" : "https://www.example.org/96b41724-3c83-460a-8942-1aa5a12cfb79"
+    "owner" : "WYkCqryNeT",
+    "ownerAffiliation" : "https://www.example.org/500e4cbb-dd22-4cfe-b632-534766715bfe"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e540aff5-4aaa-4424-aa84-882d90ab6b08"
+    "id" : "https://www.example.org/b291832d-13dc-4b69-b9fd-b77b45b7945d"
   },
-  "createdDate" : "1992-01-12T23:17:02.498Z",
-  "modifiedDate" : "1972-03-26T15:07:36.463Z",
-  "publishedDate" : "1996-12-16T23:11:17.634Z",
-  "indexedDate" : "1992-06-29T03:25:43.592Z",
-  "handle" : "https://www.example.org/e19cae78-4fe9-450a-8429-941f6eb4f15d",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/2a30dea3-a6e2-4bc1-a59d-69742d52771f",
+  "createdDate" : "1996-12-07T06:34:35.834Z",
+  "modifiedDate" : "2016-12-23T10:02:42.683Z",
+  "publishedDate" : "1983-06-22T17:06:30.184Z",
+  "indexedDate" : "2001-10-22T04:22:48.443Z",
+  "handle" : "https://www.example.org/c6ff156b-0f22-4a5c-88b7-ae814514f5fe",
+  "doi" : "https://doi.org/10.1234/animi",
+  "link" : "https://www.example.org/2ba892cc-ae99-4933-8258-a94c2b3fbc9d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cC7AfWdJ50Mc",
+    "mainTitle" : "9kEhA3ZkHJmkYQzP",
     "alternativeTitles" : {
-      "pt" : "25kkjWbNVUbsJyWbTfW"
+      "nb" : "eEK04rbWcI9ShtI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "sTVzbhScoS2eRP4PO",
-      "month" : "JnvAl6r7Ah4KJmtKgR",
-      "day" : "nxOivAI4ViG"
+      "year" : "T7GtVHeq7jGhMncv1tF",
+      "month" : "Fvt9GB2DydkzFfKwBa",
+      "day" : "d5qP79c8mY83VHEQ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c05a6283-e210-4460-8926-410096275dd9",
-        "name" : "SUcrNMq5sUPPMYGhtc",
+        "id" : "https://www.example.org/1ca88ead-134d-471a-bec7-3d07d35274a0",
+        "name" : "gImIwYHw2p8Ljsszj",
         "nameType" : "Personal",
-        "orcId" : "rneHBWoDAaDgww9",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "I8bBDNWUIBVYyoSO",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "np13Ar17FBEh",
-          "value" : "4F2KC06H0sg14bHYi"
+          "sourceName" : "j3bvLTpbR3",
+          "value" : "P7g5tqocbkDWVLsX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "94PoWNufBKs4XbNf",
-          "value" : "8hwQmLRlJKEdQjvKm"
+          "sourceName" : "WcZEvB4dY8org7wxy0S",
+          "value" : "Xr7vQoG9aqsb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/32a79e42-7084-4c39-a5c9-cfef88dabf83"
+        "id" : "https://www.example.org/9e1fa545-7891-431d-b068-938ba744fdb7"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/972051b0-25d4-46d7-b401-0c8149493938",
-        "name" : "AUFox0iya66Ls",
+        "id" : "https://www.example.org/8f6826e7-b954-40d0-a3a2-c0db385bd442",
+        "name" : "OKPcgkdiEFq",
         "nameType" : "Organizational",
-        "orcId" : "PBTSJSAxaSi6I3",
+        "orcId" : "hKRGUorO3J2J9d2",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gSz9yPMEFDQ",
-          "value" : "vbEXUImoxF"
+          "sourceName" : "aawcCkUdGnRAC",
+          "value" : "CThXru7heR8jiKVPjwy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Fu9ta5d1SP9As",
-          "value" : "mQXEVJJ7e5688k"
+          "sourceName" : "gSDGHZhf70XeADgrO",
+          "value" : "08DEJ7gDzn24"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7895cbca-d07a-40b1-a1e6-dcc4f96e448b"
+        "id" : "https://www.example.org/298fd418-13f9-4e77-b22d-588ca4388c59"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "XoRP1M2xV4ItqXjG"
+      "sv" : "SRfVCfOcIflmAssse"
     },
-    "npiSubjectHeading" : "oMSsVpQNY3z",
-    "tags" : [ "iOGtOUk2a9J1h" ],
-    "description" : "mayV9PllMQTm",
+    "npiSubjectHeading" : "vPcVb0KfEtbNiE",
+    "tags" : [ "lA5oyeAnuFIM302HLn" ],
+    "description" : "OQiFH88rFw8RjGH",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/suzW7sIdkHueBJ"
+        "id" : "https://www.example.com/ngh1wgO3gO7xtnf"
       },
-      "doi" : "https://www.example.org/f75ab576-5506-40fd-a86e-770671b1797c",
+      "doi" : "https://www.example.org/8e4d7f22-046c-4553-ab5e-c07d10967cc2",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "S0yocUQypNBTBR",
-          "end" : "LscFZql6Pp"
+          "begin" : "dpqwo9R88uMq",
+          "end" : "2sI2vmNWq5GwItw"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2e918685-c1ab-4e8e-8f10-25020b441a77",
-    "abstract" : "7BJfqXumPX5d0q8zKH"
+    "metadataSource" : "https://www.example.org/b6003e00-9630-4030-bd44-2297bcbf292a",
+    "abstract" : "skQ4ENMM1Tl"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3af4bb2d-55d3-49f7-b22f-c558d0f17a14",
-    "name" : "jjpkQivSgkol",
+    "id" : "https://www.example.org/ecc32669-fae9-4a62-92be-eccf896eb4d6",
+    "name" : "zDSbHZLWszLs",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-10-26T01:56:59.012Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "0PnQ4QVOU7HG37CuDS3"
+      "approvalDate" : "1996-11-30T12:21:02.458Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "lCGTGeYRYzvcIV9ahH"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/51361bb4-f7e2-4adf-9c67-cdd365a498c7",
-    "identifier" : "r5HQZFq427Rj7PPJikj",
+    "source" : "https://www.example.org/e02178f3-be1e-46e6-ab21-e5eb6ec380c2",
+    "identifier" : "q0FEvbgRcQX1rb",
     "labels" : {
-      "el" : "LvZ0M4GcYySBYbEp6O"
+      "hu" : "1zdBifo8o8Jg73X9Qt"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1729441784
+      "currency" : "GBP",
+      "amount" : 1257638867
     },
-    "activeFrom" : "2012-09-12T19:37:53.170Z",
-    "activeTo" : "2016-12-20T19:21:45.498Z"
+    "activeFrom" : "2004-02-22T11:37:23.734Z",
+    "activeTo" : "2021-11-16T04:28:19.684Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cfc59839-be2c-48e0-bd46-0f75eb38e6dc",
-    "id" : "https://www.example.org/18dc4f15-2289-4dd3-8e7a-2cd1e767b5ad",
-    "identifier" : "0A3VkqKBWpoSC9",
+    "source" : "https://www.example.org/1d7bb09f-47be-433c-85b8-c5f2198d3b9d",
+    "id" : "https://www.example.org/70df0314-195a-420e-8fd7-2ee8eed892f1",
+    "identifier" : "NcBCqAY7Kai",
     "labels" : {
-      "nn" : "4cbXDtlyJI2"
+      "fi" : "SSOmGCoqAbP"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1539609689
+      "currency" : "GBP",
+      "amount" : 220539414
     },
-    "activeFrom" : "1990-04-11T22:52:43.393Z",
-    "activeTo" : "2015-07-05T19:18:37.838Z"
+    "activeFrom" : "1984-01-09T01:35:38.495Z",
+    "activeTo" : "1989-04-14T10:27:00.670Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/112e4c54-fc44-4ff1-ac42-ad7bd747c00b" ],
+  "subjects" : [ "https://www.example.org/5c9ccc0b-a838-478a-800c-fb7a7edb2308" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3d82c0c7-cabc-4436-b86e-a0834a36c588",
-    "name" : "wK2HHjoNWDaP",
-    "mimeType" : "u99LkBamrM",
-    "size" : 1311084437,
-    "license" : "https://www.example.com/sn6vqyx4ftzt0o9qel",
+    "identifier" : "98e76efa-6883-49ef-b000-a9e8cf8f25da",
+    "name" : "dPrpZy8pm4F6Sk",
+    "mimeType" : "YGImCDun3XWvg",
+    "size" : 163761635,
+    "license" : "https://www.example.com/b1u5qyvpa8",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "b9mU3vnAZQgLI",
-    "publishedDate" : "1999-03-15T21:06:50.298Z",
+    "legalNote" : "Rq3L7QDkDPf",
+    "publishedDate" : "2001-04-02T11:11:26.048Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Jtd7bnqza9M54",
-      "uploadedDate" : "2002-09-26T05:30:22.650Z"
+      "uploadedBy" : "VWRRZvmi4qufa",
+      "uploadedDate" : "1986-02-07T04:31:31.310Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JDAcSX8Q9TsSynU",
-    "name" : "4ymp9CYFVXmvvArlM",
-    "description" : "2j2anHgE4jIhrkiIi"
+    "id" : "https://www.example.com/K0DgQAISiyS5HViRlUD",
+    "name" : "WsjUvzF1RfOJb6v9V",
+    "description" : "wMb4jjZvtUIu"
   } ],
-  "rightsHolder" : "2rnxfC7lzL",
-  "duplicateOf" : "https://www.example.org/2f3fa637-0aec-4797-a890-fae010bd1e2f",
+  "rightsHolder" : "esngzffRWTy6MDQ",
+  "duplicateOf" : "https://www.example.org/d68b851b-1aa0-4694-aa58-b53053758fe2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FCw96l9JFGv6"
+    "note" : "J9dV7XB1JLRN0dFyF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2QXAOdI8LidI8XMb4V8",
-    "createdBy" : "7ijQu51kYvXKds",
-    "createdDate" : "2000-05-28T04:52:47.211Z"
+    "note" : "PGpEu6OsqtYBHrQR70X",
+    "createdBy" : "bCGPfD0Pa5aeGV4",
+    "createdDate" : "1976-10-14T21:01:03.984Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/cac2335e-dd24-4f71-9ddb-e63b49ca18d2" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/49eaaf47-15ec-4dc0-8b95-3a0c0b9fcf29" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "E3BgR1UnJscnU8GCXCM",
-    "ownerAffiliation" : "https://www.example.org/ab402958-9aa7-4350-b5ac-9bab6ebcce15"
+    "owner" : "LoH70Ncuh4Q807R8n1",
+    "ownerAffiliation" : "https://www.example.org/1b15a891-c402-4c32-9937-b9a950bda4c0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/31d34d69-54bf-45a4-a7df-7932811d051f"
+    "id" : "https://www.example.org/43436de2-6766-485e-a41a-de24a0e94bf5"
   },
-  "createdDate" : "2020-09-01T01:14:43.220Z",
-  "modifiedDate" : "1986-01-14T00:20:29.670Z",
-  "publishedDate" : "1995-05-09T11:41:58.188Z",
-  "indexedDate" : "2014-09-16T19:22:39.696Z",
-  "handle" : "https://www.example.org/529dd0aa-3e7f-45ca-a164-92e0334f05c5",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/bed20503-e045-4e58-9c59-5c814b0d5656",
+  "createdDate" : "2018-02-12T10:34:01.490Z",
+  "modifiedDate" : "1991-12-28T07:41:48.789Z",
+  "publishedDate" : "2017-05-04T14:20:26.527Z",
+  "indexedDate" : "1978-01-02T16:24:16.884Z",
+  "handle" : "https://www.example.org/9c92fc96-fb4d-4042-a6af-4eda8c3f2eef",
+  "doi" : "https://doi.org/10.1234/fuga",
+  "link" : "https://www.example.org/8dfcf780-4dfa-43a3-babe-a3db9fc7e980",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mUOEUjIhdidah",
+    "mainTitle" : "bCvnPULUyYj15hTV9XB",
     "alternativeTitles" : {
-      "en" : "n4yh7HvNJRSqg9"
+      "nb" : "rszPFdR4VDPPZESJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xShxNyvSWHa4U",
-      "month" : "SHUVgGO8dx6t43K1",
-      "day" : "8DHn1ScnQRLyIpu6"
+      "year" : "X2qsbRI3zxb",
+      "month" : "0XP0gCcVaNQKfxo9Jq",
+      "day" : "RvLBoccN0iDN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3ebe0d4a-a89a-453d-9ed3-9626452eead6",
-        "name" : "7sG9QRGecwB1ze9ruMi",
+        "id" : "https://www.example.org/c2ad308a-f4b8-4a05-998a-c2c4c585d19b",
+        "name" : "5yngXcR4E9I",
         "nameType" : "Organizational",
-        "orcId" : "JGdD0g1ywOCSi",
+        "orcId" : "xDTEOGfhzaRbB7vadx",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wCTlYscYL2OdHHWWcu",
-          "value" : "JkHb6oP1xyuFO"
+          "sourceName" : "suqTrnNZqKfL6",
+          "value" : "E4QbBAkKH1Jb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xaNAct48pNMrkksIY",
-          "value" : "FmUpdvxnOhVsXrnL"
+          "sourceName" : "gWJChGQouGCWJ",
+          "value" : "ad9Jve4M79g"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c59ff3ec-8b0d-475b-ac12-ac948f44657e"
+        "id" : "https://www.example.org/cbdffb8a-337a-40b7-ba9a-5896e717a3b8"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b92eadfb-504e-454f-9ba8-8a5dfd866169",
-        "name" : "kkAq3vSKS111gexS8",
-        "nameType" : "Personal",
-        "orcId" : "fUFruVPqH1zwZM08d",
+        "id" : "https://www.example.org/1ba4fea2-9ae3-4f0c-adbc-3d9996dc64d3",
+        "name" : "VlprtbXdEbo3",
+        "nameType" : "Organizational",
+        "orcId" : "QvlipPXRRusltdd",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xhwGd5dApLX",
-          "value" : "9UXvSjSrQCVW2LF"
+          "sourceName" : "C7D2UUzm2NgfOXsR",
+          "value" : "wVCWUh4xnP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sqkeZRHOWTxmRY7Cp0",
-          "value" : "NdsavPwL6R1lsOJ"
+          "sourceName" : "1anEpnqAExPG",
+          "value" : "K2URYC1hVa57usyg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/86b0f484-0ca1-44c5-a6bb-a80b6b559869"
+        "id" : "https://www.example.org/945dfcb1-c76e-41a1-b6d5-515b8fbbc57e"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Advisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "PeXnLB24l4zsP"
+      "sv" : "vCWHrsX8ChFRv7eOPA5"
     },
-    "npiSubjectHeading" : "rvlH5qtdN6Kbw4MeE",
-    "tags" : [ "tapts92TllTM4UczD" ],
-    "description" : "ETPVjFHKBhEKhzoJ",
+    "npiSubjectHeading" : "mFTtcQ93dEqAHR",
+    "tags" : [ "kdqVlbC8AYfo80GQAfo" ],
+    "description" : "ixj7yzgaFGH2llLf",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e2b568d6-10ac-4849-9113-9d5348b046d1"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3b3f7f2b-9600-48ec-aa15-c8193f145b07"
       },
-      "doi" : "https://www.example.org/3356c4b5-1789-490f-9b9e-dd51b3e51f01",
+      "doi" : "https://www.example.org/76382284-2c3c-4bab-bbd1-015fe373d82a",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "yeMdzZOufkV7POgt",
-        "issue" : "fkhb9IPdo2Ny",
-        "articleNumber" : "LczXYeGGcHR",
+        "volume" : "RqxONsUHVGoHt",
+        "issue" : "pWp1VbdZvrLsldTV",
+        "articleNumber" : "ddbYpscY3NG0PPN84d1",
         "pages" : {
           "type" : "Range",
-          "begin" : "xJemgU13czetH1wM",
-          "end" : "9KNDtslnnn7MOH"
+          "begin" : "YXbHQP01UhVXsx4",
+          "end" : "vlHjz8OEMeeluMp"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4bc0aba5-6c44-4d9b-9d3b-17f1043776b5",
-    "abstract" : "4uJGlFap0n9x3GoyJ"
+    "metadataSource" : "https://www.example.org/1385dee1-cf2b-430f-b6d2-61a93c7275f5",
+    "abstract" : "tl1BylSziCzbn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/55f3103c-cfb9-441b-9df6-839381dc3c78",
-    "name" : "IqRKw8QDqWoGr",
+    "id" : "https://www.example.org/feee70a9-755d-414a-b86c-80037163b3f6",
+    "name" : "qNIbseFnPeh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-08-07T13:33:51.088Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2015-07-07T16:00:45.909Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "WAcuNh0wsFVmHRAF5tu"
+      "applicationCode" : "U74TYcfGrTL9iW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9a25ed03-84f0-451f-833b-c2ab65c056f0",
-    "identifier" : "sWIJLTAyCLcEtjOY",
+    "source" : "https://www.example.org/f9c894d4-6e2f-4e41-90dd-40737779dba0",
+    "identifier" : "S3tqXY0k5Tk6vt",
     "labels" : {
-      "cs" : "BbcOhIw1cNsctJO0rN"
+      "nn" : "GSW0h2vKzk24Y44S"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1576323839
+      "amount" : 495004006
     },
-    "activeFrom" : "2023-02-21T00:30:02.892Z",
-    "activeTo" : "2023-03-19T14:12:47.263Z"
+    "activeFrom" : "1996-05-01T01:04:05.518Z",
+    "activeTo" : "1999-07-25T20:28:34.022Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/12975970-1428-48e7-b942-6138d475d9d2",
-    "id" : "https://www.example.org/55fca614-e4f9-4771-a1c7-7a5a2808ae5f",
-    "identifier" : "kLSpED4srHG9TEE9t",
+    "source" : "https://www.example.org/ed5a9c1f-e6f8-45c5-b978-63a65e48fa5f",
+    "id" : "https://www.example.org/1f05f490-fa5c-49d1-808c-01f064ccc4d6",
+    "identifier" : "K2qaf5TruJ5de",
     "labels" : {
-      "fi" : "F3igVdBZIHwhcMh"
+      "pt" : "aGtLHOWj90G6BL"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 518040300
+      "currency" : "GBP",
+      "amount" : 1901222815
     },
-    "activeFrom" : "2005-11-14T23:58:50.745Z",
-    "activeTo" : "2017-08-18T18:49:27.324Z"
+    "activeFrom" : "1994-07-31T13:34:14.439Z",
+    "activeTo" : "1995-02-11T02:57:30.761Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/895e77cd-501a-4ce9-be71-1929034678f4" ],
+  "subjects" : [ "https://www.example.org/18f05a26-3d69-47ce-87b5-ac7ebaa53c60" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "316a6942-30f1-4e42-977a-2e5c935c0d79",
-    "name" : "KkXeqE9CytmDfpeD2M",
-    "mimeType" : "zoAPScV0hqV3NZozUM",
-    "size" : 694496220,
-    "license" : "https://www.example.com/ixc9nkfs4crs",
+    "identifier" : "a42ea1eb-4d15-4f8f-9e8b-6f9bcfb65f38",
+    "name" : "Cd3GGkO7FsI",
+    "mimeType" : "q6VGJYGsGrWP",
+    "size" : 1731520787,
+    "license" : "https://www.example.com/5zwle8vbgna1djqg2w",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "jySoswikiwiiKockNI"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Ir8ui2LjRCxMqwgWrd",
-    "publishedDate" : "2004-01-04T23:49:01.044Z",
+    "legalNote" : "dqvwOBIl0PZXr",
+    "publishedDate" : "1985-10-23T15:08:22.820Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ptodMrz0tooBk",
-      "uploadedDate" : "1974-03-03T01:04:31.511Z"
+      "uploadedBy" : "W5GcBAYbgrK4B",
+      "uploadedDate" : "1996-08-15T07:29:15.673Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/z1Q6k6xB4FSXB6",
-    "name" : "fG92YRnf7jJ7jUWyX",
-    "description" : "JcsoL7GCmAVt"
+    "id" : "https://www.example.com/1eYZMmljMbmUC",
+    "name" : "npSjR0OS292f2NW0R",
+    "description" : "1b7KFCOECxLTSE7sF"
   } ],
-  "rightsHolder" : "7fubVzFFHKD5GCY",
-  "duplicateOf" : "https://www.example.org/f2d62e9d-cf2c-46af-83c3-c8ac66e48590",
+  "rightsHolder" : "86qeL32O2A",
+  "duplicateOf" : "https://www.example.org/97350f18-9a50-4d93-9a03-e7986444e829",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "GFXoFc2AwwXodkPur"
+    "note" : "fW99kpB7EJEQrJD64bC"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "aJFgzVoIfQ9Tyxpc",
-    "createdBy" : "zEiIvnu2PN86n3",
-    "createdDate" : "1989-12-06T15:55:06.405Z"
+    "note" : "mhFfROpAWfT",
+    "createdBy" : "4yxs2nsNnVFU7e",
+    "createdDate" : "1971-07-13T00:06:19.318Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/23b273cb-f983-4442-855f-fddae057201d" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/303b11d1-8a60-43fa-a59a-3c2cebc5de79" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "v2GTS0GLoZ4kLWwIm",
-    "ownerAffiliation" : "https://www.example.org/82a502b4-5937-4384-89a7-19f534da17b2"
+    "owner" : "IWjmmNjjxWrm",
+    "ownerAffiliation" : "https://www.example.org/9bc5eb27-b9e7-4d5b-b6ba-0b4b50c50357"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c929d0b3-7efa-4a91-a3aa-61dc09d6ed23"
+    "id" : "https://www.example.org/23ce872c-63ec-4650-b92a-5748e4089c02"
   },
-  "createdDate" : "2003-11-08T22:27:25.625Z",
-  "modifiedDate" : "1981-04-12T17:03:43.718Z",
-  "publishedDate" : "2016-11-24T01:54:26.189Z",
-  "indexedDate" : "1998-09-14T02:17:46.787Z",
-  "handle" : "https://www.example.org/d5edf980-cdbc-4d5e-95da-54d05197d3c9",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/ddd34d29-2bcc-4bc7-b1a9-93bea66710de",
+  "createdDate" : "1996-07-29T21:24:57.103Z",
+  "modifiedDate" : "2014-11-07T05:27:35.190Z",
+  "publishedDate" : "1983-12-10T12:39:11.963Z",
+  "indexedDate" : "2004-07-26T06:57:25.896Z",
+  "handle" : "https://www.example.org/da5c1a48-9af6-4da3-ac4c-19063c86e397",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/2a0f73bd-caff-4910-b59b-4a2dc1d4ebeb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xVC8SqY7HUHRWOu",
+    "mainTitle" : "LdMiNEfXA3Hx",
     "alternativeTitles" : {
-      "ca" : "Jm20EfvuMD"
+      "en" : "VJJcbmWCaaCmEOSa7"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "4JPClLvQu45Jx17O",
-      "month" : "LOWXXc7bPsjEV",
-      "day" : "h4u1amlBH9Gc4RiuGa"
+      "year" : "ZO5mYtGMTEGIGvPNeS",
+      "month" : "61zGTjIPs4vXD52tqzB",
+      "day" : "qBihjUK1eKw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4730f23b-772c-48d3-9c43-f8d11d29b593",
-        "name" : "VW02jBLaJEkiQV",
+        "id" : "https://www.example.org/2a301335-ef18-43be-9fbf-5c504262ad90",
+        "name" : "Nbponi1vGRSkwkX",
         "nameType" : "Organizational",
-        "orcId" : "MOShdi5ug9r",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "NNzdZtdZX6fgVJY17",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7N6MNrhH57eRbwO8MaU",
-          "value" : "SL7PyLALYO"
+          "sourceName" : "A8DB13ppQx9zN",
+          "value" : "fCnvPwcKyS6IIlY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ffdeWBvwWd3rGNJdnu4",
-          "value" : "lgvZCSLQ7zl"
+          "sourceName" : "b4rCOPrOApQVAo3sH",
+          "value" : "z4sdQc6vtnHlGc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3f8d1b05-9a92-42c8-9408-bf01ad8ba819"
+        "id" : "https://www.example.org/82127402-5918-42e1-b1ab-d1b3337a7094"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "RoleOther",
+        "description" : "wVJhQUuo8Gg8gn"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +63,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c560626f-d965-4d3b-bd79-6e0a4c1b48f9",
-        "name" : "w0enbMjo3J",
+        "id" : "https://www.example.org/cab18970-eb7a-4e28-a6d5-0199c1946f87",
+        "name" : "Whc7dyYBE0D7Q",
         "nameType" : "Personal",
-        "orcId" : "wYXFDcG8zrge4bMk",
+        "orcId" : "JlieckAmwcXSvr",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XFAtmCklsciqKpM",
-          "value" : "bHLV2JeQHc3vxGTg"
+          "sourceName" : "QNPLN2WzYNs6ZHnXKJ6",
+          "value" : "c3DnGXyt1DmPVjRhAQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IGwDsdMM6c",
-          "value" : "MIy3TLm3svKVT0RX2"
+          "sourceName" : "RFbqG7JiIrmfmPCkjmH",
+          "value" : "agmeIjOHly"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/60f87eff-b600-4ab3-b131-be056e4c1f06"
+        "id" : "https://www.example.org/0ae9ed73-ab58-4ca6-b5f9-3e1a10b9fcd8"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "Choreographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "Bwry9nQwNNSbj5clj1f"
+      "da" : "qIDbiEyfI5hhgvms"
     },
-    "npiSubjectHeading" : "Hm8u6jNzevC",
-    "tags" : [ "TvNAitAB9uL" ],
-    "description" : "FY7ulecuot3CmPx2L",
+    "npiSubjectHeading" : "7EkdIsHXWSk",
+    "tags" : [ "ZPJfvSdk9GbDkhIc" ],
+    "description" : "CMC0C4wG2zWGExzjXzL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "dnrpxprn0vf6h",
+        "label" : "7z17SXdAcBSN",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "8s9tqcXCKr",
-          "country" : "M3fIzOWV20J4AVWUo"
+          "label" : "eK7iXkgnlcXe1p",
+          "country" : "VDEGsNG85W"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2007-02-25T03:29:51.530Z"
+          "type" : "Period",
+          "from" : "2002-11-14T03:02:19.513Z",
+          "to" : "2013-11-12T21:12:23.735Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/RVsbwFMOxeGeuU6"
+          "id" : "https://www.example.com/uqxd7NzlFkc"
         },
-        "product" : "https://www.example.com/eOfc4bCMvqtY6cu7X"
+        "product" : "https://www.example.com/oohjpgBEKq5"
       },
-      "doi" : "https://www.example.org/ff8722b9-f5b5-47d4-93d9-9a95a52c217d",
+      "doi" : "https://www.example.org/05fc6d48-0a67-4cc8-b7a6-2d779d7e6620",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -121,93 +123,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/34e4a64c-a0a8-4275-bdca-945c0b8a9504",
-    "abstract" : "AjwDxc1IvvtmIQm2r"
+    "metadataSource" : "https://www.example.org/f00008d4-7707-4ba2-99bc-1d7684dd02fb",
+    "abstract" : "bZOQAvzP3Qe2r6SM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/77f62574-32cf-4f9b-a8ff-4303ea297272",
-    "name" : "00jkp8kfvaRSg7",
+    "id" : "https://www.example.org/849684a6-91cb-444a-b86c-60fe890ff901",
+    "name" : "cYqEBUUtGuBKu1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-10-26T00:59:18.424Z",
+      "approvalDate" : "2022-07-01T15:25:34.517Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "wICbuweX4kyl"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Gt1b5ohepXugeK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/aeda50e8-8127-4d67-9f24-926b0641f4b6",
-    "identifier" : "DepzYifENi4kZTt",
+    "source" : "https://www.example.org/ab6ab1a6-af21-45a7-b6ff-a0052e647167",
+    "identifier" : "72CjzcQKJl7VBUUvqB",
     "labels" : {
-      "is" : "7h3ETV6vgOwQSn5"
+      "el" : "bNjppUjZjZdUBM"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 658030883
+      "amount" : 115812739
     },
-    "activeFrom" : "2007-02-28T05:14:40.806Z",
-    "activeTo" : "2021-01-11T23:13:37.772Z"
+    "activeFrom" : "1994-06-22T06:42:19.731Z",
+    "activeTo" : "2000-04-21T07:44:54.024Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6d802b5a-45c7-4991-bd3e-1e5a75520c6c",
-    "id" : "https://www.example.org/41c1a0d0-4ee4-48ce-b90c-235e861a07c9",
-    "identifier" : "Yy7aJzectP6Ccnl",
+    "source" : "https://www.example.org/7390a7ab-e7fd-427f-b890-51eb950d2191",
+    "id" : "https://www.example.org/51d6e66e-83af-4555-9504-244502ea1c3f",
+    "identifier" : "n5Zu6hcZ0X2JyNZy5F",
     "labels" : {
-      "is" : "a79Nrw0Uex9"
+      "bg" : "TxNhXXIdfEt1"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1170242019
+      "currency" : "USD",
+      "amount" : 1586700550
     },
-    "activeFrom" : "1998-09-19T17:17:27.356Z",
-    "activeTo" : "1998-11-01T00:56:00.535Z"
+    "activeFrom" : "2012-02-10T04:49:18.627Z",
+    "activeTo" : "2016-09-02T08:52:25.489Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/494a1c0d-a2b6-42ad-917d-3a4c032e8c0b" ],
+  "subjects" : [ "https://www.example.org/e79ac595-368a-4e39-ba83-cb6f19fb4d79" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bedf5eb7-d238-4e7d-b151-ab5085787e70",
-    "name" : "VTRik535BUbS",
-    "mimeType" : "Qrf4xaPaoia8mW9",
-    "size" : 1458952549,
-    "license" : "https://www.example.com/zoborf3lukzc",
+    "identifier" : "e6373838-40e8-429e-b19b-9aa5245e6375",
+    "name" : "7BZoTP4tR9AhPE5nw",
+    "mimeType" : "y6eCBdREgEWxj7JmPV",
+    "size" : 317599921,
+    "license" : "https://www.example.com/nwcgyuxc8hag",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vQzhLk4VMssSCE8n",
-    "publishedDate" : "1988-11-15T22:59:37.453Z",
+    "legalNote" : "QEOwaEL1aQ",
+    "publishedDate" : "1974-08-18T11:50:57.117Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "dkBYstO3j3H",
-      "uploadedDate" : "2020-08-12T02:45:41.170Z"
+      "uploadedBy" : "B7kzbIyL9bydINR",
+      "uploadedDate" : "1992-01-01T18:38:38.587Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/yG6Cs1SP3JIu",
-    "name" : "Vl3NY88DRB",
-    "description" : "zGCrbH4zfL"
+    "id" : "https://www.example.com/wwVl5LAFAz",
+    "name" : "RjsBwiaSS6dvidFaN",
+    "description" : "EAuN3ky2TAOnh6x"
   } ],
-  "rightsHolder" : "n6oExSlZ8GJq4HRfQ0",
-  "duplicateOf" : "https://www.example.org/1e16f6d9-b3e2-4a68-8c75-65cf502ee462",
+  "rightsHolder" : "7ipZIAWkSy",
+  "duplicateOf" : "https://www.example.org/6a737b5d-1afb-4833-b6ea-1129c566f152",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Cs0lVGhz8tN"
+    "note" : "HM5FGxH6ww8w2c"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Z9XtV8VXZMJoBzo4x",
-    "createdBy" : "K7F4ao4NlAyXRqalt",
-    "createdDate" : "1976-07-10T20:32:14.520Z"
+    "note" : "rDs4AwAVtkRmnj4CX",
+    "createdBy" : "0pL2YB6e02dsAD",
+    "createdDate" : "1992-04-28T22:57:33.874Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f9bfec9d-18a3-4b2f-9805-928bc3f82f01" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/c2cfb96f-715b-4e5e-8e6f-6fd887931d8d" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "eeNlMiUEWNIyEfZAu8w",
-    "ownerAffiliation" : "https://www.example.org/e49569f1-f9fe-4996-9e65-fa745e683375"
+    "owner" : "wPYPsbNaTwYB",
+    "ownerAffiliation" : "https://www.example.org/ab771287-4ca8-4590-a2ec-5ed33c4da9a2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/cb45c4b3-f69c-4046-a34d-e882ef6d84fb"
+    "id" : "https://www.example.org/dbc0af44-e60d-41f4-89d9-6160f8fa0684"
   },
-  "createdDate" : "1994-01-16T17:02:48.523Z",
-  "modifiedDate" : "1984-11-12T09:12:15.715Z",
-  "publishedDate" : "2000-12-02T12:02:38.768Z",
-  "indexedDate" : "2013-08-25T12:15:02.729Z",
-  "handle" : "https://www.example.org/8f052040-d158-446e-a687-b0feae882728",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/c3a30462-5f8d-46a9-8175-25992ba3024c",
+  "createdDate" : "1978-10-29T09:19:21.702Z",
+  "modifiedDate" : "1977-05-22T08:31:04.225Z",
+  "publishedDate" : "2013-02-28T03:13:43.072Z",
+  "indexedDate" : "2022-10-19T08:07:52.239Z",
+  "handle" : "https://www.example.org/96338e6d-58fb-46ad-b638-06be5d8a4d47",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/e7ba76c1-ccdc-4ebd-adc0-173aeba2dbf7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "WlQacF93llczJvIEIR3",
+    "mainTitle" : "Ba5aYMDfHSn",
     "alternativeTitles" : {
-      "nl" : "FCWMTl86K4"
+      "pl" : "RHfwxGdCvq"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Ierv4tauvmut",
-      "month" : "EuJCiELSMbdkwIA",
-      "day" : "LERRvTPK0a3UhF"
+      "year" : "tPFGnIxH8jP",
+      "month" : "5D7OMH8QMz9eoCKLNz",
+      "day" : "Mt66DrilwSv39z0g"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/931c935e-cd8c-408f-b100-09da558ab92a",
-        "name" : "olH4qvSxbbv6",
-        "nameType" : "Organizational",
-        "orcId" : "7eL0R8Vgd0JjPOuKjPY",
+        "id" : "https://www.example.org/4ac6b140-4217-48a5-8d11-52d746c148a1",
+        "name" : "NrNlpwnOx0KBK8KfVr",
+        "nameType" : "Personal",
+        "orcId" : "7AcG29dtGJQ2bqa6qH4",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5B8lcvgGUziHDaTUb0k",
-          "value" : "FOsBbMiie2EF"
+          "sourceName" : "xVmCJSLhlb",
+          "value" : "PAmlAi6Eh3Uqj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "d5GwG13nFNog",
-          "value" : "TN21DrEn7F3OrR"
+          "sourceName" : "dogb16ZPiCvDU",
+          "value" : "hbxYPNHtCD1J2wopdP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a57f0c8a-a232-479d-87e7-86af0884be82"
+        "id" : "https://www.example.org/368c3380-c193-4fbf-8a7f-289dc8667466"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c849a6e8-c465-446d-91db-38cdb1cb5a48",
-        "name" : "zfDoHsG0hDgnX5pg",
-        "nameType" : "Personal",
-        "orcId" : "xNbR63rpfCpaaXBNUf",
+        "id" : "https://www.example.org/e2e97b85-0587-41c4-972c-0141999f845a",
+        "name" : "KDe7vUKEKO8LW2o",
+        "nameType" : "Organizational",
+        "orcId" : "bybxBuNQEASXZEf4Bc8",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8FczoLLyQy",
-          "value" : "RHIl1uq0GfUiy8EZ"
+          "sourceName" : "9XQuzOEgJLJKTLakK",
+          "value" : "6BL4UyHzZoR9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l1l9WLfaWlbw11",
-          "value" : "Vh20g8oidfZd4"
+          "sourceName" : "S7fMT4A0sxGFZsoa",
+          "value" : "rOLwKtBmFViw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9ecd69b9-284a-4783-9f30-9536c173c050"
+        "id" : "https://www.example.org/01481f02-55ab-4a00-8d4a-a0ad5f87bb9f"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "DataManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "v08gOARgIiG0m"
+      "is" : "bS8Xy4qt8xA"
     },
-    "npiSubjectHeading" : "0B8a31Yh2BBFPyUigMQ",
-    "tags" : [ "SAwevjXXxq7LsUI" ],
-    "description" : "5h9Uvi9iqtU0",
+    "npiSubjectHeading" : "qvLHRlbHq6tRZl",
+    "tags" : [ "90DivSrbXF" ],
+    "description" : "HcqeoCxeklM4Dy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "xo06ulaBaIt",
+        "label" : "6d0oScAGj1ARGPghCe",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "VdqFFry4gHXVPLniSl",
-          "country" : "ocB1nYfJIF88e2A"
+          "label" : "WxOw6Z0tZX",
+          "country" : "aFPaFuHdbXfP"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "1983-09-30T19:55:26.267Z",
-          "to" : "2000-01-04T08:19:36.262Z"
+          "type" : "Instant",
+          "value" : "1991-12-18T14:23:46.255Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/0FOPcRn8d1"
+          "id" : "https://www.example.com/cX3gKmQZ0z1DJqRd53"
         },
-        "product" : "https://www.example.com/iGJGt8n6jTD"
+        "product" : "https://www.example.com/YfgwBEIBWP01hSqhD"
       },
-      "doi" : "https://www.example.org/02a35eb6-380a-4e67-b656-bfc812575a63",
+      "doi" : "https://www.example.org/2890eb44-23b3-438e-bf9d-e8310e2d7168",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -122,94 +121,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a71f65a1-9f39-474c-bac7-f0b8d841a77f",
-    "abstract" : "nt9Tp92NBrudIxWj"
+    "metadataSource" : "https://www.example.org/fa7aef15-4d55-4d35-a680-236b6fe8ec19",
+    "abstract" : "EGXnZhstus02NQY0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/54bbcf78-f702-4fbd-a485-a6f8068fb832",
-    "name" : "L5bveH5R3c46V8sHz",
+    "id" : "https://www.example.org/897df5ed-cd8d-4fd3-86c4-70f34b632fbb",
+    "name" : "CapzFIxZdd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-12-24T18:52:47.891Z",
+      "approvalDate" : "2019-11-25T21:12:58.214Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "eP6KHRkP7Zma9xv"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "MvJZflZRwpRRgm"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c1a9d436-52c8-4b81-a67b-afed3ff6fce4",
-    "identifier" : "ba61hgYwQUpcrspv",
+    "source" : "https://www.example.org/f208709b-edc8-4fa4-8940-889f63be3080",
+    "identifier" : "9UhoOv3iuhS4",
     "labels" : {
-      "da" : "01r3qvMXa5jG3oiTYXl"
+      "es" : "dc1PkEMmrUV7FyMUo3W"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 592034850
+      "currency" : "GBP",
+      "amount" : 1440353577
     },
-    "activeFrom" : "1986-10-22T10:39:06.697Z",
-    "activeTo" : "2012-05-10T16:35:47.331Z"
+    "activeFrom" : "1983-12-13T20:58:47.843Z",
+    "activeTo" : "1989-01-18T12:57:26.720Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/43c3de01-3427-4161-8172-0869f3f8863d",
-    "id" : "https://www.example.org/1a79b073-0c1c-4f7d-987d-755c7b999665",
-    "identifier" : "1qQtPto1i7DoNlsH8x",
+    "source" : "https://www.example.org/ffa75127-2455-42c8-9fbe-1828902ef640",
+    "id" : "https://www.example.org/ee6e5977-45c3-4814-a1e0-8e0afba9cf4d",
+    "identifier" : "DhmPor8FrsnWVMu714",
     "labels" : {
-      "zh" : "tOhF7l4sVrnf3XB3D3"
+      "ru" : "LCdjRy0A3Anj"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 559516260
+      "amount" : 150621137
     },
-    "activeFrom" : "1980-05-06T23:17:16.396Z",
-    "activeTo" : "2005-03-10T18:04:17.904Z"
+    "activeFrom" : "2007-02-21T23:31:48.566Z",
+    "activeTo" : "2024-03-21T04:13:28.650Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/508f6916-a574-452b-83f5-b264fce2f260" ],
+  "subjects" : [ "https://www.example.org/89b7f7f2-229e-4cc9-80e0-5d8c091938b8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b1837a49-a18b-404a-94b8-3c5e1c3f239a",
-    "name" : "cgosR0LgWz2OAHSK",
-    "mimeType" : "tMQiKDBY6JlXbnF8p2",
-    "size" : 449613181,
-    "license" : "https://www.example.com/knasy0jw8v",
+    "identifier" : "40eec941-1cf8-46db-9d3c-a4b7cfddb165",
+    "name" : "BlgHORRhNJ",
+    "mimeType" : "Nyw1yuZQ7qamd1cu3W",
+    "size" : 1060653471,
+    "license" : "https://www.example.com/dl2afuvnwg6iuuszpgo",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "cEcXGJA05GUxN"
+      "overriddenBy" : "PI2knsuFBTuhsF"
     },
-    "legalNote" : "3nDuMR6ht8hx6",
-    "publishedDate" : "1971-07-27T08:05:44.416Z",
+    "legalNote" : "YJyyFBRpN7sA",
+    "publishedDate" : "1995-12-18T23:32:18.169Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "MNWFOoxYfo3D3",
-      "uploadedDate" : "1994-09-26T22:36:29.812Z"
+      "uploadedBy" : "PtJihFvaO1xAvgUHM",
+      "uploadedDate" : "1978-10-23T22:07:54.632Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SnN5ARbNFpGlFOQ1hD",
-    "name" : "q6e1h9XyaqGZVti2GG",
-    "description" : "5FHlD9TjK41GsDBlo"
+    "id" : "https://www.example.com/8RppZerJCykG",
+    "name" : "1t46uLXROFxS87DN",
+    "description" : "PBm0VMScwGjZWiD"
   } ],
-  "rightsHolder" : "BFf2IjtR5P2qeP5DVKm",
-  "duplicateOf" : "https://www.example.org/835365f3-3de6-45d5-a6f3-f6e8fcd30e94",
+  "rightsHolder" : "jaE8lnZvugFP",
+  "duplicateOf" : "https://www.example.org/823c3c8f-3690-4f27-9605-dd98dc855e3f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "IAVGRuNopa1bBTtwv"
+    "note" : "y0UVQ4m6eFF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "y2D2VbjBZmdaI5vJjB0",
-    "createdBy" : "HYws0vPdvRrH5h95y",
-    "createdDate" : "2024-01-15T03:54:42.025Z"
+    "note" : "iVbTPPspKaho",
+    "createdBy" : "7ce5Rd2LWpXbQn",
+    "createdDate" : "2013-05-03T17:33:49.517Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/59ea2e25-c5a4-4e79-93fe-519ecd7aa269" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/546349f4-c164-458b-a9a8-f276663caba0" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "kS5jRblLFI",
-    "ownerAffiliation" : "https://www.example.org/3350bf7d-8761-449c-97d2-9bc17382a800"
+    "owner" : "sL2TWCDk18I7gSQS",
+    "ownerAffiliation" : "https://www.example.org/2f29a7c1-51ab-4e22-99c0-7ad99ba897c1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/adee41f8-00ae-4ba6-b8ef-835a7c273909"
+    "id" : "https://www.example.org/1769c033-d10c-431b-a20a-38a92c366772"
   },
-  "createdDate" : "2004-08-17T23:05:40.835Z",
-  "modifiedDate" : "1979-05-09T18:58:47.884Z",
-  "publishedDate" : "2003-05-14T12:56:24.796Z",
-  "indexedDate" : "2006-01-19T07:26:06.841Z",
-  "handle" : "https://www.example.org/b8bb0abe-4c3c-41d8-8525-b5fe3a177817",
-  "doi" : "https://doi.org/10.1234/dolores",
-  "link" : "https://www.example.org/964faa94-d202-47e5-9ce5-08a0e59c02c0",
+  "createdDate" : "2003-12-11T11:51:13.130Z",
+  "modifiedDate" : "2013-07-28T11:18:46.149Z",
+  "publishedDate" : "1974-10-28T06:26:46.708Z",
+  "indexedDate" : "2011-12-09T07:15:09.289Z",
+  "handle" : "https://www.example.org/49ff781f-c271-42f7-b798-f6376bfa4b87",
+  "doi" : "https://doi.org/10.1234/natus",
+  "link" : "https://www.example.org/6fc90cb6-edaa-4944-a615-70a842261f81",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "88KkyH9yrD",
+    "mainTitle" : "jq2YiMdkRJNZro5LlQi",
     "alternativeTitles" : {
-      "fr" : "OrEjZtgxof974kF0Wm"
+      "se" : "VNm5J1CHDd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tVAJIlAOaojN1QV",
-      "month" : "0oNcvI4GTWECnHT6w3",
-      "day" : "ynENOvHyH7gc"
+      "year" : "6AUh0KjtezsLH",
+      "month" : "uBLFh6CDmx",
+      "day" : "A4SoCrYxdZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4d49c8fe-0c19-4698-b1b0-5b8503edf067",
-        "name" : "LzGc1VpNZLfKx",
-        "nameType" : "Personal",
-        "orcId" : "x124um4Fpvte8kiP",
+        "id" : "https://www.example.org/58be0cc6-4df2-4a1a-aeba-82bc34296432",
+        "name" : "zH8GkWbAMJ6QFYKhjZg",
+        "nameType" : "Organizational",
+        "orcId" : "fxxCPIMMEFu1d",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w5FvjGLGHT",
-          "value" : "viSmJJq3D9XuRCSiqwS"
+          "sourceName" : "LHlpASdKGPj7i",
+          "value" : "lhq8UPSC4zW0B3b"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YRFYcD4Vy2wm65t6aC",
-          "value" : "GX9dsYbSI10KFBvmm"
+          "sourceName" : "GKwbaZbJi8LjY",
+          "value" : "E5yqGt9hK0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/61d00880-b9f0-4e83-9c45-37a471d62bef"
+        "id" : "https://www.example.org/c8f77865-e977-4dfe-8914-c00166b16f7a"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7fc29c57-8095-4177-abaf-3753b10af853",
-        "name" : "A4yQ7BHl9Qsc0yXHLzN",
+        "id" : "https://www.example.org/08f98a33-5a0f-4ad9-becc-88b2271ebb05",
+        "name" : "NbTGWSzb4DqF6",
         "nameType" : "Personal",
-        "orcId" : "ADU3bkFb47Kd",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "T31tnoiQ4IL",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U7nbjagFAFjp7K8L9a",
-          "value" : "vstYS2tgqIH6Wm1oql8"
+          "sourceName" : "MrOzpsEAliaT8IiNrh",
+          "value" : "yqU61R6YJQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7x2uI572E4",
-          "value" : "fdwSAnfJQo8pIqS"
+          "sourceName" : "sD94F8YQLQnCrY",
+          "value" : "9v8HBg3nEFNSg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7adbb231-082c-4cea-9ed5-71dc7f4a9807"
+        "id" : "https://www.example.org/e88c1aa5-bc58-44c4-af58-51032e376a98"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "lIlznV1p63vh"
+      "es" : "F0MQOZaY5e"
     },
-    "npiSubjectHeading" : "elJOxjHb5Sbq6oM",
-    "tags" : [ "tjAkZsCeLzcY8JWz" ],
-    "description" : "TV7QlSXFABAHUAXpHa",
+    "npiSubjectHeading" : "pnzpLmetAaAhVgCS",
+    "tags" : [ "wDTEpUO2m47KGabaOww" ],
+    "description" : "7QJ8lRLVpOocEPFT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cf12abb7-6eaa-410c-a33f-fe75fa24802f"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/458e4327-2cf3-4753-960b-7a121ca89815"
         },
-        "seriesNumber" : "GqBU1aNijg",
+        "seriesNumber" : "rQ02ZS9lurIjlPobn",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5d4d6fdb-6bb9-47a6-a16b-3f18ba67ea35",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d9109688-2c5e-4ab4-b036-9e300061529a",
           "valid" : true
         },
-        "isbnList" : [ "9780963602770", "9781852138349" ],
+        "isbnList" : [ "9791943062200", "9780004042244" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1852138343"
+          "value" : "0004042247"
         } ]
       },
-      "doi" : "https://www.example.org/d94416fd-5534-4143-8137-441033aba1df",
+      "doi" : "https://www.example.org/e146626d-490d-4b3c-b4ed-f347a56de2b7",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "0cxHlEWqwMzcJPdo0",
-            "end" : "bGO7rNIIgTthZOwO"
+            "begin" : "4zR10d42jT9H",
+            "end" : "cFNAD4MjCA"
           },
-          "pages" : "9fX8ESlGVMdxksQZ",
+          "pages" : "2GGGCg1HpC",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/924f9bba-cb05-4303-87b9-25003bfd571e",
-    "abstract" : "hoekzpRROK5xc99qzD"
+    "metadataSource" : "https://www.example.org/c4233728-85cd-470d-963a-db6204779a79",
+    "abstract" : "bxQmpVVxTdce"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/04e00021-8f1f-43fb-9e95-0c343aecadf6",
-    "name" : "K6ZpwPmormB",
+    "id" : "https://www.example.org/1baa93a4-a76a-4d5f-90e4-9b8b17844a1e",
+    "name" : "N2dv3b1pGsozPUM2",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-04-09T19:42:40.886Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1971-11-03T18:37:28.121Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "1RAdkrznxRhOsYNNm"
+      "applicationCode" : "Nkb3SbY1fFLbwWiACY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/70ae450c-a3ad-4f98-b8b4-ac0ebffbb39e",
-    "identifier" : "xSivANEnbZ0VgutMbA",
+    "source" : "https://www.example.org/f298a82d-d8a2-46ac-9e3d-afbaeb1bb788",
+    "identifier" : "d2fFg3ypzqz",
     "labels" : {
-      "is" : "LxQQ9ucqnt7RB"
+      "en" : "eWQ2YZBEkGXUmSpQHdz"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1781041153
+      "amount" : 1271813906
     },
-    "activeFrom" : "1985-11-04T13:47:53.115Z",
-    "activeTo" : "2001-01-27T09:43:00.863Z"
+    "activeFrom" : "1985-11-22T21:57:26.670Z",
+    "activeTo" : "2010-05-30T15:42:18.119Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/074c1280-b96d-4d1e-8113-0149d869753f",
-    "id" : "https://www.example.org/8620a62b-4973-4e29-a84d-f7b86a04da90",
-    "identifier" : "XV2wVZ7PDj7bBDjp",
+    "source" : "https://www.example.org/259f0558-cc6e-4e44-a9ed-58865642283c",
+    "id" : "https://www.example.org/ecd366dd-cda7-42bb-921a-1188eddfe28c",
+    "identifier" : "Zx21qeJLdPk8JOWA",
     "labels" : {
-      "nb" : "fdqJePHhts64Qx"
+      "el" : "zRHJSNCF4G0HH"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 239786609
+      "currency" : "GBP",
+      "amount" : 1444134516
     },
-    "activeFrom" : "2013-08-16T08:18:50.543Z",
-    "activeTo" : "2020-01-01T17:45:29.501Z"
+    "activeFrom" : "2019-03-24T22:25:46.675Z",
+    "activeTo" : "2019-11-28T01:52:52.040Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4d72c9c2-37d9-4f97-bf2e-91db13ef6344" ],
+  "subjects" : [ "https://www.example.org/5d08ae45-3c6b-437d-86e0-3c7f3a0349d3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "80483807-6449-4986-aa43-791161175dc3",
-    "name" : "hD26uYkQwWx8hBnFd",
-    "mimeType" : "KBuUiAtch6D8Z",
-    "size" : 38604323,
-    "license" : "https://www.example.com/pxr1nvpbkz6xtygc",
+    "identifier" : "ab8df49d-7548-4ac4-ad27-f1086bfa6942",
+    "name" : "RXiMpbeq64",
+    "mimeType" : "mIUdQ7DHQN4UBHIRdV",
+    "size" : 904826918,
+    "license" : "https://www.example.com/g4kca7azo0amglxfrb",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Olyv64ILheR1"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "3tINLVFGn4OsMEy0tRE",
-    "publishedDate" : "1997-09-12T22:40:36.299Z",
+    "legalNote" : "Az3L0jS1x5E",
+    "publishedDate" : "1986-06-25T05:44:45.662Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "l5qjY6f17HCRTZBD",
-      "uploadedDate" : "1979-03-23T03:22:50.608Z"
+      "uploadedBy" : "h60Q4ir4tXDOiBq5a",
+      "uploadedDate" : "2008-07-29T00:38:42.772Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Qar1ZxEYBfS0F0xL",
-    "name" : "12HwYHolU58O",
-    "description" : "ZyRqP9s9p7pBt9"
+    "id" : "https://www.example.com/wuYYHmOI2opirsd6rc",
+    "name" : "7liCUUZFXo6",
+    "description" : "bad762T38cHOKt"
   } ],
-  "rightsHolder" : "SzZCIWY9fBeMFV0q",
-  "duplicateOf" : "https://www.example.org/da418347-3d7d-40ba-bffd-f00abc57179b",
+  "rightsHolder" : "29LjRJ7dgyiWm",
+  "duplicateOf" : "https://www.example.org/d5fe49d9-51ee-4c10-8c37-8cd8314b9e4a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "MVb8L5jz2lEN"
+    "note" : "xtUYIbsy6om"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2usuF7JwYEsg",
-    "createdBy" : "z8ST2ViO6eYSONTdmwS",
-    "createdDate" : "2024-04-30T23:39:54.864Z"
+    "note" : "F3KRaJkZImTRZ",
+    "createdBy" : "B0FEnYpyBL5",
+    "createdDate" : "1983-10-28T04:22:34.993Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/cc23f341-ea42-45f6-8a1e-0029cfa3cf2a" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/5700ad51-deed-44e4-a12f-4595da2e548b" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "uSmL2g2gqgsWAuNdz",
-    "ownerAffiliation" : "https://www.example.org/b3c1047d-c904-451b-915b-dc00d859fdcd"
+    "owner" : "C53FdzuqsThFfZkvM9G",
+    "ownerAffiliation" : "https://www.example.org/3c870415-2523-4157-9e2e-9714f1a764b8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f67494ed-d4a4-4f75-b306-ec2df542b01c"
+    "id" : "https://www.example.org/d1ccb187-eeb2-4c89-92af-021c35a6e00f"
   },
-  "createdDate" : "1978-10-23T16:14:43.550Z",
-  "modifiedDate" : "2004-10-26T15:13:39.830Z",
-  "publishedDate" : "1971-09-19T05:45:25.868Z",
-  "indexedDate" : "1998-12-10T20:18:12.539Z",
-  "handle" : "https://www.example.org/a8016e27-81e6-4fbc-95ba-e44b3b7491f5",
-  "doi" : "https://doi.org/10.1234/delectus",
-  "link" : "https://www.example.org/6302d47d-d9c5-49e6-b191-329c0fab0896",
+  "createdDate" : "1978-10-18T12:06:12.702Z",
+  "modifiedDate" : "1998-11-20T22:30:29.376Z",
+  "publishedDate" : "1974-01-11T01:17:55.414Z",
+  "indexedDate" : "2005-09-21T10:22:09.114Z",
+  "handle" : "https://www.example.org/58a54b92-0cbb-4813-a3de-c13932484108",
+  "doi" : "https://doi.org/10.1234/accusantium",
+  "link" : "https://www.example.org/4e9ff06d-3aa9-47d0-8bbb-b543679afd1e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tUTM3zsEZohlpkjG",
+    "mainTitle" : "fF471eIqjeyoME",
     "alternativeTitles" : {
-      "fr" : "xi63CiIJQ2W"
+      "it" : "p3Djt9nOPMYbaHC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "WqZ3cHVs4MRFFWlt",
-      "month" : "s9rQpf1SkdI3",
-      "day" : "XPaFCiYfxLFvWNRlYy"
+      "year" : "cBwzFrOfOtxP7",
+      "month" : "10iDek2oOfjo",
+      "day" : "VFQdVfwOLU7jD6RnL9"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/77882950-92cd-4f0c-9ab5-25d56340e93a",
-        "name" : "LGmMLw4lsSzT00n",
+        "id" : "https://www.example.org/4d1af502-4a14-4e3b-a02e-6395b71ada36",
+        "name" : "1ImNneoMadHoyM",
         "nameType" : "Personal",
-        "orcId" : "mICubpAkL3kBEFmIR",
+        "orcId" : "8frmylSGWHHUAMB0iAx",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FEUjsFhPaeHavJv7",
-          "value" : "OHOF313s9y"
+          "sourceName" : "Xfht1MLn9XPAeBcp",
+          "value" : "9hNqOKORh6Ze"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "s1RQiMdZRbFaHVXP",
-          "value" : "wKDVuZ9Qe5xPQYMGFk"
+          "sourceName" : "Qwqc2tTSqdalblu0d",
+          "value" : "QzK7C8dEicWNjFmyHh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7de2cc7d-3d05-4d99-acd7-4f9b46a81a7d"
+        "id" : "https://www.example.org/62b5ea64-0d10-456b-a0f9-9da96e2f9f70"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/19894d7e-6c60-4f9f-a71a-68b21d935f2a",
-        "name" : "ZijCYFVDMbeFTJ",
-        "nameType" : "Organizational",
-        "orcId" : "H7nCkBlPJRAVmo",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2615601c-3b62-4e27-b5aa-eef9f2a80bf4",
+        "name" : "lp1pYIZeQARXwLE",
+        "nameType" : "Personal",
+        "orcId" : "WWSa4KxRHeWd6uPpn",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "L00UKnRhUXr8hcPjGbD",
-          "value" : "c9JWa7U2iMykSC"
+          "sourceName" : "AZe6iEbfkyC8SRX2cJ",
+          "value" : "Ef0WJnEPx9gz1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t9EDDAlbNCADCacXGC",
-          "value" : "nGAFmizlqiJto"
+          "sourceName" : "ggVTjrQvtgF",
+          "value" : "cFHqO9IqQyYC"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a8856c19-5b1a-4690-8717-03e78b131024"
+        "id" : "https://www.example.org/c43b44f9-ffec-4f5e-bbeb-59b7b962c22c"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "LightDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "j8zzI5Rdau0faBjfM5"
+      "pt" : "DQntZpNtcMl"
     },
-    "npiSubjectHeading" : "naZBhtBklRp",
-    "tags" : [ "o0Ea9WzyZ1pX0KjkKYQ" ],
-    "description" : "bzMPHtwo55JF3Bd",
+    "npiSubjectHeading" : "efNHTFbVGRbFqTLZi",
+    "tags" : [ "t1HhQrgdOBbLgMXv93Y" ],
+    "description" : "jrlZAQACcoSx86Z1v04",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e3529e64-5995-4af0-9289-0e607efa8d73",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fbd2af8c-7045-429f-b28e-6fc7716bb9ad",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/f5638ed0-a10a-4777-864f-2e8525fd33e8",
+      "doi" : "https://www.example.org/8280ea9d-5f27-4c8d-adfe-4dae879da55f",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "chtjAhOHt48bnK3o"
+          "text" : "PBBupkdkMb"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "a62Mbp41lB5BfBVSr",
-            "end" : "yoOlrfYD4Ppa"
+            "begin" : "qgaAaTNmQrMrE",
+            "end" : "OnlxVbLce2v7hx"
           },
-          "pages" : "6z1o5sEQf0",
+          "pages" : "X4xkNEYhHVaKQEv1LY",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5784e27e-501a-4064-a5d6-29cc76722bf7",
-    "abstract" : "SuUEdK5qNb"
+    "metadataSource" : "https://www.example.org/08852ab5-4b13-4934-bf8b-b9e94917dfe5",
+    "abstract" : "NWeromlu9LC5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/bc9b06b9-cda1-4266-bc43-237fe5438ad7",
-    "name" : "pCCttQ1wSfwSpKK",
+    "id" : "https://www.example.org/b5b0036c-ac67-4afb-a57c-dd5a67145570",
+    "name" : "GUr1KsCXWgJk",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-07-16T12:40:08.224Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "LUdmCTVLSqUrMHidE"
+      "approvalDate" : "2004-03-22T22:15:04.243Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "fD7yZgemyzdbGljW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f806f33e-075e-4ffb-87a6-ee7d513b9a06",
-    "identifier" : "xNFfyyJSrWzTiYA",
+    "source" : "https://www.example.org/9318558f-5da0-452a-b28a-3b8d0eb4c1c1",
+    "identifier" : "7n3D9l69pXs0obJqYJ",
     "labels" : {
-      "bg" : "QCMRRaQ3f4bUciAbz"
+      "da" : "jBTNrqMXETfv3kEc0"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 964414681
+    },
+    "activeFrom" : "2002-06-23T18:32:14.092Z",
+    "activeTo" : "2009-05-11T13:26:54.611Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/188dc564-c6f0-4729-8ad5-745954fa875d",
+    "id" : "https://www.example.org/5512cf38-56f7-444f-99e8-d9630ebc2ea6",
+    "identifier" : "aBi6mUC6hM0mD7nj",
+    "labels" : {
+      "af" : "HutPSa0WqDoH"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 618843217
+      "amount" : 2147397461
     },
-    "activeFrom" : "1972-09-16T10:47:08.673Z",
-    "activeTo" : "1972-10-29T18:46:13.377Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/166c1cdd-8556-46a4-9499-94a726446cf7",
-    "id" : "https://www.example.org/36f1d036-27b9-4d5b-ab44-7a1a39187ae2",
-    "identifier" : "hLaSl45ehVMN78",
-    "labels" : {
-      "se" : "WoTYJQ2DKGm2z7lj"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1146691610
-    },
-    "activeFrom" : "1984-07-30T15:52:20.264Z",
-    "activeTo" : "1999-02-04T19:56:56.346Z"
+    "activeFrom" : "2003-12-23T04:24:26.050Z",
+    "activeTo" : "2007-08-14T00:51:03.571Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ac5f2b69-69f8-422d-88c6-0ce39adf8297" ],
+  "subjects" : [ "https://www.example.org/af503001-c95b-453e-81c9-82d4319f9b76" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0dc06f7d-843e-44ad-8299-d39044037bf7",
-    "name" : "HoTtZPwEwxQf4cY3",
-    "mimeType" : "Y8OFHnAoc81",
-    "size" : 66314825,
-    "license" : "https://www.example.com/g8cu0upliaqmun",
+    "identifier" : "a83b76eb-b9be-48fc-a551-21b406cd359c",
+    "name" : "wAvvdJIBwlkf1bCJS",
+    "mimeType" : "hxcLNRBa2cHyaBK",
+    "size" : 2006706400,
+    "license" : "https://www.example.com/nwiyrcxy7hpnj",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "1rznGODp0J4G77"
     },
-    "legalNote" : "cDJF5QwABX6Ji",
-    "publishedDate" : "1977-04-29T01:54:12.471Z",
+    "legalNote" : "eBZ3depPI7IcPoron",
+    "publishedDate" : "2005-06-01T14:43:38.166Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "D8tnfPLXtRmkCI",
-      "uploadedDate" : "1986-03-31T23:11:04.620Z"
+      "uploadedBy" : "9OtHH4q31ueXkVAkdzT",
+      "uploadedDate" : "2011-07-25T11:53:12.237Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/95WA2gSXzvV1",
-    "name" : "miG54mEfFy6ZNOMtiBF",
-    "description" : "8TGH4Bpmhqmg6M"
+    "id" : "https://www.example.com/pQ6q59QltieRvq1",
+    "name" : "30WXz1b04ZFc",
+    "description" : "c8Oee6sQnKUCQU"
   } ],
-  "rightsHolder" : "ngk3jsAkvMcoYQZaiS",
-  "duplicateOf" : "https://www.example.org/eb8f3360-071d-4009-aea7-7b4f7c27dc04",
+  "rightsHolder" : "DaR2qaSnGjUjBjy",
+  "duplicateOf" : "https://www.example.org/fb510efb-d43b-4cb8-ae05-79124600618f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "aBdvkIfmDHp9Wp"
+    "note" : "qpTnRSdfL1u"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "clZbCywKGzAQwvzyNL",
-    "createdBy" : "Ms6Wlc8uxLFe4Ri6d",
-    "createdDate" : "2016-07-06T02:08:29.575Z"
+    "note" : "6Q1XtMpSR1Tgqyy",
+    "createdBy" : "iWXweug3LvBkH7sa",
+    "createdDate" : "1976-05-20T04:14:03.525Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1e1c2300-f5cd-4f60-b9e5-403ed3a2bcd8" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/ff2ab300-d337-47f4-b7e0-bb873e5623f1" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "klkgneoPbllcM",
-    "ownerAffiliation" : "https://www.example.org/74f31904-34e2-40e5-b9c4-d53466fe4398"
+    "owner" : "BbfRfvWoOnl2",
+    "ownerAffiliation" : "https://www.example.org/7f29c290-07c6-49ac-8982-600e528c253d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dc464ccb-f947-4170-a790-fb33a9f41d69"
+    "id" : "https://www.example.org/ec7f778f-cb2d-4117-a468-469affd402dd"
   },
-  "createdDate" : "1972-09-16T21:36:49.321Z",
-  "modifiedDate" : "2008-11-16T22:04:25.013Z",
-  "publishedDate" : "2007-07-10T11:58:41.964Z",
-  "indexedDate" : "2014-02-02T14:21:11.780Z",
-  "handle" : "https://www.example.org/c8427cbc-5b4c-4fed-a534-4ddf3df01f24",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/a3b64796-e740-4316-b993-a9f15fc6fa3c",
+  "createdDate" : "1973-12-16T10:10:46.522Z",
+  "modifiedDate" : "2013-12-05T23:46:57.262Z",
+  "publishedDate" : "2014-03-12T22:59:21.337Z",
+  "indexedDate" : "1985-05-23T18:49:21.232Z",
+  "handle" : "https://www.example.org/ff9f381d-282e-4048-89ff-453ba759bff9",
+  "doi" : "https://doi.org/10.1234/quas",
+  "link" : "https://www.example.org/1e895db3-d11f-46b2-bc3f-ab0dd2fb7e21",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ARUR6UV2lIrV4",
+    "mainTitle" : "12Y3JsgYBEQ9",
     "alternativeTitles" : {
-      "ru" : "piJs9nu8P1faQW8t6J"
+      "ru" : "jIMoCIcwDnVOCxOf"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bmLVJJw9ajysHi4le",
-      "month" : "6o34JtbQmUwPCw2XL",
-      "day" : "gz351p0hYyzTQoawl"
+      "year" : "YLUQ0yxAz0xisxW8U",
+      "month" : "4t1dQHdqKl4BnPWU",
+      "day" : "3CDWCi7sHB5uOH85v5C"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/15db0df3-be86-4fe9-9fcc-c889471a1d9e",
-        "name" : "U8uBK27L2fE6Y",
-        "nameType" : "Personal",
-        "orcId" : "DAFLSpnY9MexE5R",
+        "id" : "https://www.example.org/ffe96170-74ea-4a28-a0b2-0ae4d6d0ca64",
+        "name" : "CCeihy8KuEE",
+        "nameType" : "Organizational",
+        "orcId" : "wFowljVsap3",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mPXFnRU9jLoP",
-          "value" : "x0erHogr1OTCHx"
+          "sourceName" : "E7hRVU14AivBr1",
+          "value" : "BrNKvgVQnO4382"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cclezSOjXhzbKmW",
-          "value" : "sukbE1TYTbC9Xs9M"
+          "sourceName" : "KRUXk7q4Ik",
+          "value" : "uAtFO2IGLm31brYiOF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0c868778-f12d-45f1-a8c9-5f51e6a70261"
+        "id" : "https://www.example.org/1d9a72bd-7016-4f3c-b976-53f1eae2fd20"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,153 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/71c17e72-680a-44df-9ecf-c1cf18c22627",
-        "name" : "LXkQjxWsA9hDjaf",
+        "id" : "https://www.example.org/df691e1f-b27e-4d17-ba9d-2d0d519f698c",
+        "name" : "U47Sa35F14MJNXpCZB",
         "nameType" : "Personal",
-        "orcId" : "ZtZeHj2ZphPAk",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "kEsLI02NXhGk1XM1ud9",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GffO2zRZ7kiMBb",
-          "value" : "EnrpzFYvjaoK"
+          "sourceName" : "NUbPdPzpdjw",
+          "value" : "FtOAv9BnEYXtRgtp8pn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TY1Rlakbdepek5",
-          "value" : "AHxpJtDNpfd1n"
+          "sourceName" : "vI6sVtPwmAl6",
+          "value" : "GsV8NTRnVazPvR219"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/af4a3ada-06fb-4c1d-9a8b-90550c752ae6"
+        "id" : "https://www.example.org/0e24d207-8109-4f51-93a3-03c6650f75e1"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "5Pgdl9ShysgkW9nvX"
+      "el" : "UC5VYozBrpuRE4z5"
     },
-    "npiSubjectHeading" : "k3kOxhTbdjrac9JC3",
-    "tags" : [ "lUvHFskMi9LYLR87NQW" ],
-    "description" : "ByeCyfHlsNquNXG4Q",
+    "npiSubjectHeading" : "Cce0Q311lZ",
+    "tags" : [ "uMlNw9eXgk8" ],
+    "description" : "ezbsoEgs7XHy4M",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/639f9e6d-ae24-4fdc-890e-506e2c0e8440",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c2d4b516-1288-467d-8414-f75b4724ffde",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/8f337819-36b4-474e-bd50-cc1939752792",
+      "doi" : "https://www.example.org/32ddfd58-698b-47e1-b4e8-fb336ca1ac0d",
       "publicationInstance" : {
         "type" : "DataSet",
-        "userAgreesToTermsAndConditions" : true,
+        "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "kipqlxX03n"
+          "description" : "fuESXo7Ulm"
         },
-        "referencedBy" : [ "https://www.example.com/y9zzHAsWBQo16t" ],
+        "referencedBy" : [ "https://www.example.com/GCnnyLKI3q" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "a5TdZw9yDKV"
+          "text" : "WaiESVK1moIP"
         } ],
-        "compliesWith" : [ "https://www.example.com/tMtNJnOSP3Q8lceTjBg" ],
+        "compliesWith" : [ "https://www.example.com/8PUB25Prpu3QD" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5292b97b-692d-487a-96bf-2cbbb5fbff9a",
-    "abstract" : "6eBLNkQIOsF2nD"
+    "metadataSource" : "https://www.example.org/63f01a83-11ab-475c-861d-25f46f24478d",
+    "abstract" : "1Nn1pXy3Ba"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/41be4997-e0a8-4682-985a-1e09fe48b835",
-    "name" : "lCUe3N58ksY",
+    "id" : "https://www.example.org/41f110ab-b736-44cc-b838-5ef611a22dd1",
+    "name" : "MMN0SqRjOz5BMZ8z0K",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-06-20T09:25:41.280Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "sPwvnx3kvsxrCYRsyfc"
+      "approvalDate" : "2002-04-10T15:03:58.053Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Y3o47aKJE5Gn4Uh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ccb486ce-5233-4c19-bd8f-55a9b8950f04",
-    "identifier" : "Zcvf8tRw8fZdL",
+    "source" : "https://www.example.org/52fe8925-ff48-4aab-804c-cd267e90a552",
+    "identifier" : "Kv8HS0XwSCemR",
     "labels" : {
-      "nl" : "p0A65fuTnMmahYtBP8P"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 626934539
-    },
-    "activeFrom" : "2019-01-15T10:14:48.824Z",
-    "activeTo" : "2022-05-26T10:29:05.097Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/7e8741f3-50ae-4456-a0df-d8e16e138e9d",
-    "id" : "https://www.example.org/05d94dde-270e-420c-bf4d-9c46df9d32a2",
-    "identifier" : "YVHD0YJ9dha3Hi",
-    "labels" : {
-      "cs" : "cRbhEQcYuOrZx4HzZ7"
+      "es" : "fawOVzCbzoua"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 841163341
+      "amount" : 1172497572
     },
-    "activeFrom" : "1975-06-28T09:53:34.465Z",
-    "activeTo" : "2002-07-25T20:08:55.117Z"
+    "activeFrom" : "1990-02-10T14:40:50.765Z",
+    "activeTo" : "2015-05-15T01:44:06.029Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/2a94da5b-657b-42f7-9f1b-3bf6b76e0b1a",
+    "id" : "https://www.example.org/cdd7d25f-f14c-4e87-b791-a062ea2d04fe",
+    "identifier" : "N76v7hJ6Xb",
+    "labels" : {
+      "fr" : "Ais5r1vJZZk"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 2032447958
+    },
+    "activeFrom" : "2019-04-21T16:05:22.323Z",
+    "activeTo" : "2022-02-09T18:22:00.616Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4df63f43-3df8-4bbc-878d-feef4a82087e" ],
+  "subjects" : [ "https://www.example.org/b1d0b7b9-1629-4914-8b38-de2f58f0355b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "eb8fd367-cab5-426c-8b12-bbda306e18f0",
-    "name" : "SuYg4LSpAEBmJEQR",
-    "mimeType" : "99oYwWfFkAaufNOsq",
-    "size" : 1004745832,
-    "license" : "https://www.example.com/bwfiadtq91dfvzj",
+    "identifier" : "5a2371d3-23bf-4aef-b8a0-c558ece9e161",
+    "name" : "yTJqts3UYvK",
+    "mimeType" : "R5Ck1RPKZ4",
+    "size" : 2135754195,
+    "license" : "https://www.example.com/xgrhh6vyp5czi95sf4",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "XtWgoLYh6nfUc5Vvsa"
     },
-    "legalNote" : "sITafWgV2cf7B",
-    "publishedDate" : "1990-03-25T15:33:29.669Z",
+    "legalNote" : "D9MdlM4EfEE13yT8ky",
+    "publishedDate" : "1979-01-02T06:29:37.818Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "hxNrCh5B0KqQ93",
-      "uploadedDate" : "1977-08-08T21:44:32.347Z"
+      "uploadedBy" : "fNWliBWwQ2hC79Eh",
+      "uploadedDate" : "1975-04-26T02:32:51.834Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/G0fvWiQeEkKeknc",
-    "name" : "uuxNic8b3CU",
-    "description" : "pphEePQCnclWhqcGC"
+    "id" : "https://www.example.com/jLOVtqIokB8v0SutC",
+    "name" : "rvhjuZ2d72zk2Gdu6g",
+    "description" : "VKtIB0EaWdu8k"
   } ],
-  "rightsHolder" : "lsoYlUP32MQZHVe",
-  "duplicateOf" : "https://www.example.org/41e6bd1d-69da-4838-accf-f483044872ee",
+  "rightsHolder" : "u6XPhR5pfy",
+  "duplicateOf" : "https://www.example.org/5ee554e1-cfa7-4ccf-8763-ce8034e10bd4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZHw1NBiBMFSC1D"
+    "note" : "xFyYpUn4F0xdNdosM6Y"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "wM13bfVJPst2Og3HS",
-    "createdBy" : "wftaEA7mtO97enHAhzh",
-    "createdDate" : "1986-11-28T01:44:23.828Z"
+    "note" : "ZYSO274Co0cVEraT",
+    "createdBy" : "pz93igcD5a08FuObAt",
+    "createdDate" : "2002-10-27T09:48:24.010Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3195098c-1e6a-4b81-b187-2d55f9963af4" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/2a498807-1e9d-48ee-a43d-104a3a0b44ae" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "nLzNaqn0WaR",
-    "ownerAffiliation" : "https://www.example.org/0580636c-f04c-48a5-9e85-513ba397e384"
+    "owner" : "g1fXFHdzbg9C5s",
+    "ownerAffiliation" : "https://www.example.org/c43eaf44-fe97-433b-a85f-dc34d11591d1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/84d1bc9b-5be2-4270-9fb0-d7503d983bca"
+    "id" : "https://www.example.org/1d4af195-d89b-4ef1-984f-51cba2325cd1"
   },
-  "createdDate" : "1990-01-23T04:42:03.481Z",
-  "modifiedDate" : "1991-09-30T02:17:42.890Z",
-  "publishedDate" : "1995-07-22T13:09:42.205Z",
-  "indexedDate" : "2014-07-26T16:09:15.625Z",
-  "handle" : "https://www.example.org/3c9137e7-929c-4f9d-bae0-860dde5eb540",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/08a64f67-6f47-4bda-965d-9c661e91f28c",
+  "createdDate" : "1991-02-10T20:21:47.427Z",
+  "modifiedDate" : "2021-05-25T19:30:04.308Z",
+  "publishedDate" : "1986-11-10T02:04:59.505Z",
+  "indexedDate" : "2005-11-17T15:32:29.295Z",
+  "handle" : "https://www.example.org/5462a166-d07d-473d-9f1f-81bf357ce528",
+  "doi" : "https://doi.org/10.1234/animi",
+  "link" : "https://www.example.org/2a8c96bc-1b3a-4e64-be56-36b62ea8debf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mLBrdNKHdzwn",
+    "mainTitle" : "QUZ8vxyDUel9X",
     "alternativeTitles" : {
-      "fi" : "fwdxTyOkVNF0I"
+      "af" : "QdhQuluhC9XNM5q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "volVZ5czsyVY",
-      "month" : "cxejDJgPTz",
-      "day" : "wEYkr4kpjAJ4"
+      "year" : "oYZvEvMbFSmGMKymzEI",
+      "month" : "Z2EI6LFf0as0",
+      "day" : "2HZaz6bRSelDOQqOx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/84c73dea-9dd2-4014-97c9-0c43a72f0df9",
-        "name" : "zI1zcNEMzQ0osqrURm",
+        "id" : "https://www.example.org/b79684e7-9211-47a4-8266-4d8f42a08eac",
+        "name" : "iwFdcZm1o6BLBaeh",
         "nameType" : "Organizational",
-        "orcId" : "Sl0gVibV22tse4z",
+        "orcId" : "2x0d6tCfa83QGMe",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Oi0iptFEgi",
-          "value" : "XXIwdrHjIUNewYvwoZT"
+          "sourceName" : "Gb5kFd8tPsf0zUw",
+          "value" : "Lc4B5aXWHeb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MSjgz5DGjSGGleWKF",
-          "value" : "5ssV1lhk7rKzcivqY"
+          "sourceName" : "fTsS2p22YGSpVq0P",
+          "value" : "vHLeryiTY4BdP0JRbob"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/afbbe050-a0de-4335-bcbb-c8691fad7b81"
+        "id" : "https://www.example.org/f6e70d1a-8dae-4c8b-a955-46169397b643"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e841c3d0-12da-4b26-aaa5-dd83d4bd17fd",
-        "name" : "9ktVPICVgvTFMFdjO",
-        "nameType" : "Organizational",
-        "orcId" : "q7lRAT4srrLIHESONtr",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d9d7124f-481d-4b7e-9164-1a9960333129",
+        "name" : "TqaIY54BzB1",
+        "nameType" : "Personal",
+        "orcId" : "vkTF1fCljfOVEtVy",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6MtgRRNSzVOzLrEz",
-          "value" : "6sPl8daXg3"
+          "sourceName" : "CEbs7ryA8efl",
+          "value" : "Apmb49kzuU7C8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ke7zN9eVJrwa",
-          "value" : "bo5o6Db9A1rfSL"
+          "sourceName" : "xwcMd5f0nk5d",
+          "value" : "SwRPjnaBw5Ai"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/982e8e7d-bdea-4903-955c-3256c36dc377"
+        "id" : "https://www.example.org/c134d20c-5054-4afc-93d4-fbe380ddcfb5"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "HostingInstitution"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "BXYiR5BKwaJYm1R"
+      "bg" : "0HDmTKIrpw"
     },
-    "npiSubjectHeading" : "gQ8BnQE67hGy0Ya2",
-    "tags" : [ "C0JWaMuJh9" ],
-    "description" : "pevaDBVclCzwVa7jYxX",
+    "npiSubjectHeading" : "WHYBR7d4Rg8Fb5",
+    "tags" : [ "Fys7oAV4JGo" ],
+    "description" : "rolvSQcFxT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5a3b75e3-2aca-475b-b66f-8c6e39dd47fc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9d06a7f9-6383-4c0f-a8f1-ee674dff4fce"
         },
-        "seriesNumber" : "8N3FEDRMLtXVMAu5Es",
+        "seriesNumber" : "pRazghhuvvCHXRc",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d7df9fe7-af52-4d7e-a3bd-e65eac17239d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1d8c2f5a-2a15-44ed-8a09-1718647b6fba",
           "valid" : true
         },
-        "isbnList" : [ "9780909260774", "9781966261421" ],
+        "isbnList" : [ "9790902261739", "9780967934211" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "cIbL9ZJ3B50Upo"
+          "code" : "YP9KSSVgCQwG8zaCl"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "196626142X"
+          "value" : "0967934214"
         } ]
       },
-      "doi" : "https://www.example.org/760bee5d-322f-4736-a7ca-2158e42cbb53",
+      "doi" : "https://www.example.org/f711aadf-34d9-4a36-b7a9-0fee333d4806",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "nEfMtPGIsP83wLEb",
-            "end" : "WjuukrktVrn1jOiqSBh"
+            "begin" : "zhVD0hYUHL5rR03",
+            "end" : "7H807pqoF9U7mugVC2"
           },
-          "pages" : "txbDHYdFiyJ",
+          "pages" : "H8h7HUBATkHXo",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "GpsZi09Au0GFEG8H",
-          "month" : "KSY76N8ghjCnt",
-          "day" : "Wp3zkjrKhTOLNYlmx3h"
+          "year" : "XdBUWKRgUdw",
+          "month" : "RyMxeDLtcb5R2pA7mb7",
+          "day" : "223jQDCJXjjIpcB5Vo7"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/13a7411d-0d67-4ba9-9ad0-7f5dcbf8d45f",
-    "abstract" : "hUcIRwLn4OExP"
+    "metadataSource" : "https://www.example.org/c72f6ec0-400f-432d-b744-ee23a0214a34",
+    "abstract" : "aQmIIKaUCI0ku"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/153713be-9f6d-4686-a2a5-a8894c114f46",
-    "name" : "1tVUOqq8gJ6x0jEk0",
+    "id" : "https://www.example.org/6b1bc015-04ca-49e2-a9bc-69155feafa21",
+    "name" : "gpSgYS3wn5c35ZMQI",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-12-10T08:07:18.291Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1985-10-01T19:15:22.348Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "zN36PKuWCrosguL0n"
+      "applicationCode" : "b6CxfblHIsYTKDWNhk"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7762af37-5981-46b2-b9f4-9b7c086f4e74",
-    "identifier" : "L1F5xayDs0",
+    "source" : "https://www.example.org/07ce03cc-306d-47c4-a6bf-14b1079c70f1",
+    "identifier" : "3k9JFVOGrS1f65U",
     "labels" : {
-      "ru" : "knmLhS6GPW"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 761937020
-    },
-    "activeFrom" : "1994-02-19T19:50:14.782Z",
-    "activeTo" : "2002-11-11T01:32:19.408Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4d00343b-956d-4368-b9e6-18c8e6060a25",
-    "id" : "https://www.example.org/95bd0ea5-3a70-4c6e-83d4-3127369a9677",
-    "identifier" : "AMrJ2vXW80ioW4vbJ",
-    "labels" : {
-      "da" : "ukaVXVpurbYnC2"
+      "de" : "Ym5D3x6lAfDKyE2UUo"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 626205851
+      "amount" : 111710158
     },
-    "activeFrom" : "1983-07-29T22:53:13.636Z",
-    "activeTo" : "2016-10-25T08:57:05.599Z"
+    "activeFrom" : "2010-09-17T20:13:10.460Z",
+    "activeTo" : "2018-06-14T00:01:41.472Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/605e3933-7204-4a70-9af6-255bdd6d2cf0",
+    "id" : "https://www.example.org/60f74d62-cc04-4bb5-ac2e-35b61d2f187e",
+    "identifier" : "L8jp2Ilvk3gPyBB",
+    "labels" : {
+      "fr" : "9cZKzVk9GKS"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1205373352
+    },
+    "activeFrom" : "2010-06-25T07:38:37.643Z",
+    "activeTo" : "2023-01-15T09:48:18.902Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4f5ef221-ebac-4207-9a33-3a73c853a972" ],
+  "subjects" : [ "https://www.example.org/322d03b0-33cf-479e-a73b-d450ba41b684" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dbd1df1c-a0ae-4d57-828d-b57383dbc552",
-    "name" : "jErGKBcJnx6av62u2x",
-    "mimeType" : "u0DtT1uHVS8u5KyA1WU",
-    "size" : 1397859555,
-    "license" : "https://www.example.com/hq56jtq8fzbbmo",
+    "identifier" : "81c6687e-105c-482f-83f6-fc40a9bb16b0",
+    "name" : "Id7bl80iZAefbMK7Bp",
+    "mimeType" : "gaoxz2KT6UYhmmC",
+    "size" : 1703855445,
+    "license" : "https://www.example.com/yqfdscmtnj6y",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "MdekmwwdCxM",
-    "publishedDate" : "2021-11-30T14:11:05.461Z",
+    "legalNote" : "sf8gtKa8coj",
+    "publishedDate" : "2019-05-03T00:54:47.105Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "FiJDsrXl7m",
-      "uploadedDate" : "1983-07-10T07:00:42.828Z"
+      "uploadedBy" : "361wFeyTE2Rou",
+      "uploadedDate" : "1991-07-14T19:09:36.853Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/GDlY3eI7b3N1F3Z",
-    "name" : "EcAOaKdRqVS",
-    "description" : "MYZf0OZih44dCMejVa"
+    "id" : "https://www.example.com/uY85QbXKyzBBaU",
+    "name" : "ks4YokXFvEq8Sz3r",
+    "description" : "ziNIrTCV2X76I6SXDy"
   } ],
-  "rightsHolder" : "Z8BUZJ2JN047V",
-  "duplicateOf" : "https://www.example.org/43df4526-3557-4711-a13c-f4e21938ee0a",
+  "rightsHolder" : "JkMFABGGk8WJclFBkX6",
+  "duplicateOf" : "https://www.example.org/e5eb75ee-cb33-46e9-8bd9-88de9db3ae3a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bnNDDP6uB36X89"
+    "note" : "84LVtJEomXkH5BINFdz"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8YEVl0l6c0wqC",
-    "createdBy" : "1l10nOqjR6PTAb",
-    "createdDate" : "2004-09-14T19:29:46.364Z"
+    "note" : "6K0jQsrZTRip",
+    "createdBy" : "h0uzgcCJVEfGMch2ZyZ",
+    "createdDate" : "1978-07-10T19:49:02.132Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f918b99e-2cc0-4077-aa05-e27b92ca2973" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/f8492b5d-d2a5-4a85-9bc8-1acec2c51be0" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "SKAhXdDnImpSQnG1ihB",
-    "ownerAffiliation" : "https://www.example.org/a2182b81-45b7-462f-b26c-d677dab65d8d"
+    "owner" : "GbRAaLtoShYnAlFbV",
+    "ownerAffiliation" : "https://www.example.org/e06d7574-19ef-422a-bcdb-ec0a8c67f5aa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c723fb21-e345-4c34-a802-acc562e0d895"
+    "id" : "https://www.example.org/dd0c4298-027c-4337-85e2-ebc57a425636"
   },
-  "createdDate" : "1998-10-14T20:22:55.980Z",
-  "modifiedDate" : "1976-04-22T07:01:21.301Z",
-  "publishedDate" : "1995-12-14T15:33:40.733Z",
-  "indexedDate" : "1978-07-27T21:34:46.101Z",
-  "handle" : "https://www.example.org/9ca39474-1eca-43e1-8bf7-1413940a33cf",
-  "doi" : "https://doi.org/10.1234/culpa",
-  "link" : "https://www.example.org/42d5960a-cc02-4285-b3d6-e8328d179155",
+  "createdDate" : "2016-10-04T21:41:48.049Z",
+  "modifiedDate" : "2004-03-27T09:25:39.982Z",
+  "publishedDate" : "1992-08-05T04:29:19.913Z",
+  "indexedDate" : "2012-03-20T15:33:27.187Z",
+  "handle" : "https://www.example.org/59dfb4cd-f640-40a4-a1ba-6e054cc8d4b9",
+  "doi" : "https://doi.org/10.1234/perferendis",
+  "link" : "https://www.example.org/4c9ccea9-32df-4fdf-bc7d-3ee183aba613",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "gQJlh3IeOKBGS1pu",
+    "mainTitle" : "zAu1iSkbUMcylpC3npQ",
     "alternativeTitles" : {
-      "nn" : "XXaGDFR4c02"
+      "nn" : "hKUm1N8R9rO3tpdF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "f5s8WSNXrYv3yz",
-      "month" : "Dup45zNTvdB0oD",
-      "day" : "bmGHlxzHrwAt8"
+      "year" : "ZaKcWHb1OO",
+      "month" : "aD1I8hKN7AC",
+      "day" : "Z4BIiGu9tIq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd9f8146-e118-4900-a34e-c4c0b0a128a7",
-        "name" : "sk9eVkUW6Lh0tsOxH9",
+        "id" : "https://www.example.org/35e0fc57-682e-4c41-91af-64bcc6117c5e",
+        "name" : "tQlzCjvDOi9uE",
         "nameType" : "Personal",
-        "orcId" : "RNZiSRIKpo",
+        "orcId" : "1PzH3fsJVq",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m3dWnqTbN1i61K",
-          "value" : "Q0nUZqD2Mb0oRh"
+          "sourceName" : "CyF49dU1IXN0jbX80C",
+          "value" : "1qT1Co8xbjhICtD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5Z7AzM6z7liLNw",
-          "value" : "OvTAPbOIMohD41bKDLW"
+          "sourceName" : "xFGTakP8sbccKGNCY6F",
+          "value" : "LzFvqMOsi9t"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/70faced7-6412-4c5d-91df-cdd1c1c670e9"
+        "id" : "https://www.example.org/24b21431-b0b6-4715-a6ac-fee4b8c98c33"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "Producer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c8285c67-3224-4cb9-a0a0-8cd1c10cb75c",
-        "name" : "TIx54nIHzSqr",
-        "nameType" : "Organizational",
-        "orcId" : "mn5Xx700jKTqIhFqhH",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/916af9fe-4bf8-4a9a-ac74-9136d1de1c2b",
+        "name" : "eOWcsnoQ2OHAttKz",
+        "nameType" : "Personal",
+        "orcId" : "oPJeacJRGKsrz",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bqZ44LpBAEXOHGQha1R",
-          "value" : "lzsl1hGAsQGmtnfoP1"
+          "sourceName" : "y7vgMfXtbL",
+          "value" : "LeKCczoxKTFR2YbWV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0NknvgcelhLO6U6",
-          "value" : "88dF8XSnqoEwUuwKr"
+          "sourceName" : "pbEfdn9V8ODTT",
+          "value" : "WUk2B95xYqWqfFU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7ec07861-2ddc-423d-b27b-7e45e25a7309"
+        "id" : "https://www.example.org/a8137adf-59be-4ac1-9dea-b754847854b4"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "DvhxOYaBRoNpD"
+      "ru" : "SeAeC8psk0Q74tLFu"
     },
-    "npiSubjectHeading" : "AewgTl9y2d8SzINIGd",
-    "tags" : [ "TltvJUOs7NcC" ],
-    "description" : "e9AZstii1NgqGCfxzEo",
+    "npiSubjectHeading" : "L5wGl0hTLWbiXwINT",
+    "tags" : [ "NkvjMNkDC3g6K2" ],
+    "description" : "rLkIjjnO4mI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/18e8b584-10ce-47b9-8ab2-cbda4fb71259"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eb8074ba-56b5-4dc2-ae85-d36f26a7b3fe"
         },
-        "seriesNumber" : "mwcuL4JsVYx",
+        "seriesNumber" : "kzqajOYtOrO",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/431a621d-4e71-44f2-8d6e-b440cc2ec007",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/adb18718-e67e-4733-96a1-86b84e70b4d6",
           "valid" : true
         },
-        "isbnList" : [ "9791886156042", "9780749072834" ],
+        "isbnList" : [ "9790727182882", "9780666675972" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "XgYJHxB3eI3M"
+          "code" : "KyWNUa8sEyiENJ"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0749072830"
+          "value" : "066667597X"
         } ]
       },
-      "doi" : "https://www.example.org/04677a15-1958-465c-bbe6-70685d81dd16",
+      "doi" : "https://www.example.org/bc26013d-3401-422c-ac1e-33c17030a52d",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "8nT5j6WdyRjG",
-            "end" : "vBu5FoRm8b2K0SN83R"
+            "begin" : "z74JMqokiz9i",
+            "end" : "668dBSH4F4m0"
           },
-          "pages" : "Skz7Bdt6KM1eOWAII6",
-          "illustrated" : true
+          "pages" : "PgNDYeu2keu5gm1Q",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "YUNAySEDK0e9C",
-          "month" : "1kLkvtdtDioO90sikTo",
-          "day" : "LcE5cm6ZcWPVN"
+          "year" : "DX8O5KKcB8lTCqYy",
+          "month" : "c4ADjzKI7vKNBbmZ",
+          "day" : "VeA8DCEKzeUIXTW9Q"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1e147c67-4323-4256-9d80-e6550792e2e4",
-    "abstract" : "V5tD3bpFSqKgsfWOa"
+    "metadataSource" : "https://www.example.org/891e19ca-c53c-4efa-83b8-2e5a79fd3b16",
+    "abstract" : "sSwxb3l7MU4coobb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1993574f-9b0c-42c3-abe8-e965f90ade3c",
-    "name" : "bcgeSHeCYaIHB36oXp",
+    "id" : "https://www.example.org/3062794e-6607-4607-b9f7-a3934cb804d0",
+    "name" : "TA3s4wnAf1Qr1qaTIPq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-02-28T18:40:45.930Z",
+      "approvalDate" : "1983-09-29T16:52:34.373Z",
       "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "1leKkc4yVwsHSYEc"
+      "applicationCode" : "GWwp12HSxluWM4XKTK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/33c08fd3-b669-4e2b-8459-38e156772406",
-    "identifier" : "Gd0EX32VFMO",
+    "source" : "https://www.example.org/f79dc462-c5ce-490a-a933-b67cc7642e75",
+    "identifier" : "wDRy3bgWcoWcis",
     "labels" : {
-      "nn" : "27vWzhkjmjwDDDLe"
+      "bg" : "OOQYgDOQEZCiEI"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1655520240
+      "currency" : "EUR",
+      "amount" : 807044144
     },
-    "activeFrom" : "2013-07-20T21:04:48.175Z",
-    "activeTo" : "2017-09-27T09:23:13.092Z"
+    "activeFrom" : "2016-04-28T21:35:25.990Z",
+    "activeTo" : "2017-10-12T14:01:53.041Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/247cfe9a-794c-4e28-9997-384d84bcba03",
-    "id" : "https://www.example.org/744ad879-aa86-4f67-8264-f20fac5b4e9d",
-    "identifier" : "TTL0XvnTfZ2MQtAhtNy",
+    "source" : "https://www.example.org/7fd2ba8b-6014-4813-a3a4-258d4ee44535",
+    "id" : "https://www.example.org/37ddf6a5-1572-4df4-86d3-c3245f944e84",
+    "identifier" : "NHXevzbi6g8fjliDkO",
     "labels" : {
-      "fr" : "od4nhOznmPyC7F1w"
+      "ca" : "U55v4wCKJXJ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 989598512
+      "currency" : "USD",
+      "amount" : 1236252836
     },
-    "activeFrom" : "1973-11-30T16:00:48.296Z",
-    "activeTo" : "1996-09-03T19:35:59.707Z"
+    "activeFrom" : "2010-09-09T09:18:39.742Z",
+    "activeTo" : "2022-12-21T22:19:02.808Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/096ba351-5241-4ac1-80e4-dbeaabe76203" ],
+  "subjects" : [ "https://www.example.org/12d223e1-d920-4108-9036-b858f17b07f8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "08776fbd-7035-4d0a-922a-b3adb67cb179",
-    "name" : "dLF8umYwprYt",
-    "mimeType" : "NG6zfsgnyqZ",
-    "size" : 767125691,
-    "license" : "https://www.example.com/sh90gfbgsde9",
+    "identifier" : "eb43427c-fadf-4e4d-a865-b5929d3e24d2",
+    "name" : "j5IQruW13ZAcUsE",
+    "mimeType" : "ix8AvvcFpLQf3",
+    "size" : 1931118796,
+    "license" : "https://www.example.com/kkrcf5qon8t52hszjs",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "HDCBB5PY9zDyus",
-    "publishedDate" : "2009-08-08T21:12:03.445Z",
+    "legalNote" : "q7ykp27vqfmjeVhzVVL",
+    "publishedDate" : "1988-07-16T23:12:26.994Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "alL8FxIvml0w7Ytkor",
-      "uploadedDate" : "2003-06-03T11:33:05.215Z"
+      "uploadedBy" : "iH5HhKTN3SijX",
+      "uploadedDate" : "1998-10-28T11:31:20.667Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/IKGAkzj7f4",
-    "name" : "VBvpGoHzACrf6mBiSS",
-    "description" : "GgtevFbTgcxIxc"
+    "id" : "https://www.example.com/oHFCATAY3srpjh8",
+    "name" : "YaBsGdD05NXbFwf",
+    "description" : "9AsrOhcxlwSq"
   } ],
-  "rightsHolder" : "65NmnaiSP6Nv",
-  "duplicateOf" : "https://www.example.org/16097561-0708-4e10-9d8b-33e67b720e58",
+  "rightsHolder" : "3SzOM2lB5Ham",
+  "duplicateOf" : "https://www.example.org/9ccea124-baa2-454f-b35f-508ff7472668",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Nhf0RX2gLu10"
+    "note" : "tHByrnb3JFHb6O8"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "PBgbjakr3I",
-    "createdBy" : "yNiB3JE1Ujq7wY",
-    "createdDate" : "2021-06-21T09:01:55.543Z"
+    "note" : "VbMHOwsWplZsLbE",
+    "createdBy" : "QyYyHae8UbIZQ3Y",
+    "createdDate" : "2020-03-25T19:05:57.499Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9cd224ce-2f2c-4a7b-a6a5-087e2bb8cc5c" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/b8b1ab8c-ff38-4b72-a2d5-b182f3806b3f" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "unAQfjdA0eKZuGi",
-    "ownerAffiliation" : "https://www.example.org/961309b7-268e-45f4-a056-a24d6ed49b72"
+    "owner" : "RjTX4Qcc5NkAdQwvapG",
+    "ownerAffiliation" : "https://www.example.org/2fdf5c8e-d848-422c-b48b-04fffd73be8f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2e56781f-c12a-4b94-a1b1-53e7981a8966"
+    "id" : "https://www.example.org/e9130040-39ec-43ee-b895-cad8448185a3"
   },
-  "createdDate" : "2022-03-17T12:49:10.367Z",
-  "modifiedDate" : "2020-04-11T10:59:34.938Z",
-  "publishedDate" : "2022-07-08T17:14:15.350Z",
-  "indexedDate" : "2002-09-01T15:00:08.536Z",
-  "handle" : "https://www.example.org/61eeff34-970a-452f-bce6-66e16c6c5bcd",
-  "doi" : "https://doi.org/10.1234/ea",
-  "link" : "https://www.example.org/93ab95a4-5e82-47ec-afc3-3bbaf84b0e7f",
+  "createdDate" : "2020-10-31T01:27:30.951Z",
+  "modifiedDate" : "2007-06-11T06:23:57.912Z",
+  "publishedDate" : "2001-02-20T01:55:02.489Z",
+  "indexedDate" : "2013-10-04T18:23:55.578Z",
+  "handle" : "https://www.example.org/515f1ddf-c0c1-4646-893c-9e73d8c6efb4",
+  "doi" : "https://doi.org/10.1234/soluta",
+  "link" : "https://www.example.org/89ff5ca6-34ab-4089-a558-6b33088f18a9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YzUXD6nz7eD4LJ",
+    "mainTitle" : "pLHmrJlYYnI3Lo",
     "alternativeTitles" : {
-      "pl" : "JK6Bo5NO85d7"
+      "bg" : "LXnLI4BfNCC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "pPo0Bvrp6IR6D6ENerx",
-      "month" : "ori52VDOP9pjPsPLWe",
-      "day" : "xCLNzSylLUKVY"
+      "year" : "zx45lLJzAY",
+      "month" : "LbGI3EoHJquR3OZLMN",
+      "day" : "91VLzuS7u5xr2hjnBA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/391c3560-c78d-4da1-9ef5-3720637442b0",
-        "name" : "s2fHHeietfH",
+        "id" : "https://www.example.org/efe55d3f-caa8-46ff-a2ef-0dc2abed6a55",
+        "name" : "m2i5tgfHM2LDFbE",
         "nameType" : "Organizational",
-        "orcId" : "zFhp3nrrgy7",
-        "verificationStatus" : "Verified",
+        "orcId" : "Zaaaf5DShb1NIfoY",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EMpclPa7xFVlHdgc6",
-          "value" : "1gNwRTt5PeMGzQ"
+          "sourceName" : "wQdpdSnWlIBcs9PWJ7z",
+          "value" : "eIIYzgUvJI0sE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sf4SwEzUMLZ",
-          "value" : "7og2ynyhDvmlhR"
+          "sourceName" : "dx4SShovtgfluxxo",
+          "value" : "WAZ3rpze12Ge0nl8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b2b2522e-5d13-479e-9703-0fed43be66f5"
+        "id" : "https://www.example.org/ec4f93ed-e10b-4100-be6e-ef0184017e5c"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,170 +62,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c8e0f055-4478-46d4-bbbd-b707d4cde052",
-        "name" : "bNbVd0ZutUm7",
+        "id" : "https://www.example.org/19cdfe97-1786-4cad-b968-2a343ec7f792",
+        "name" : "nNFn3aygpA",
         "nameType" : "Organizational",
-        "orcId" : "yjIyDUCi1TfB",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "POLgb9zwbqd",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m7QrpoU46zUg",
-          "value" : "SXazk1DCTGLOepjb7"
+          "sourceName" : "uBP93Cx7KLmiY",
+          "value" : "qVpbSuhooW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VcqfBoXneAq9r",
-          "value" : "VlG0j9TBOLXvA"
+          "sourceName" : "wwKYFMwc7JUbD",
+          "value" : "2CK9LLKrQcMgUqcjk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/39ab9947-00d2-40b0-899a-ca6bcf0eabbc"
+        "id" : "https://www.example.org/179fc947-4121-4cef-b6d1-aaadf858fcde"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "rEziBqePZYLCo0ZfvEJ"
+      "pl" : "ZxPrrjxhjLD"
     },
-    "npiSubjectHeading" : "UFNdaEfKQcQA8",
-    "tags" : [ "U42FQ5d70emY1i" ],
-    "description" : "F3xVprgtkrTf",
+    "npiSubjectHeading" : "NMasBk1tyZS1aDj2",
+    "tags" : [ "OaerG9PqA1fwEFlCT99" ],
+    "description" : "QsGMUEbmg7hCA",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7eda0d6f-543e-4d79-a366-04c1349c1229"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/da366067-f19b-4284-bb9d-330b8938e6a2"
         },
-        "seriesNumber" : "o5mVTW4jz5i1VcZvw",
+        "seriesNumber" : "y0kBXSb5Gr",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d0b03803-182f-458b-8c1c-e19aec5dec4e",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e248676d-de7f-471a-b86e-5cc2cb6804ff",
           "valid" : true
         },
-        "isbnList" : [ "9780474158964", "9781911128267" ],
+        "isbnList" : [ "9780736895569", "9781213107779" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "uXPXXlbXI4"
+          "code" : "iD49QwGNFd6aSpnG"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1911128264"
+          "value" : "1213107776"
         } ]
       },
-      "doi" : "https://www.example.org/588d22d7-9e6f-404f-8e94-1556da9c762f",
+      "doi" : "https://www.example.org/3b8eef2d-7230-4165-ac0b-b1ba7c31556c",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "dLXO7v9SI34ZHHRb",
-            "end" : "IRMXoojtTzIezW3vM"
+            "begin" : "g2Xv6zJZdD4sqaDVR7g",
+            "end" : "rgPTs9tabgg"
           },
-          "pages" : "ZhUY4MqrcvtumH4T",
-          "illustrated" : true
+          "pages" : "o0AhzBwatxkOQXwqv",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "U9tAVqhkMnjvFktk",
-          "month" : "l1aoTYs6oWLoBvBSnz",
-          "day" : "0inBbf6oNSlJqD8b4"
+          "year" : "gGBNSrRTYYGvL2DmJ",
+          "month" : "ltNjGiswyU0eRA7",
+          "day" : "rPdQL3co1xt"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/872498ed-e1a8-4959-8489-1c9ea2ed0561",
-    "abstract" : "0WqCEr5vRhJx"
+    "metadataSource" : "https://www.example.org/bf93452d-87ae-48d2-90c0-61126aae0c92",
+    "abstract" : "lAoAjJ9kz96"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5913e214-c1f1-4eb4-aa84-c6ec3123a85b",
-    "name" : "SVfM4tAwss6CR1Ll",
+    "id" : "https://www.example.org/8bb91a47-159f-4bdb-9b2c-50a910096dad",
+    "name" : "Y1FxYsaB3r85LJFm",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1977-07-09T07:07:38.485Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "abiUfZqYz8rXE"
+      "approvalDate" : "2022-03-11T22:18:53.034Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "lQ6ujqJMS0J0joW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/95289097-39e9-45e7-af75-4c85d244caeb",
-    "identifier" : "hwHFKz2Urk3yFuRJEfe",
+    "source" : "https://www.example.org/2ee52649-ee61-4c79-92de-04f466639f9f",
+    "identifier" : "UAafneGT15CepLhGzo",
     "labels" : {
-      "it" : "2D6eNEfLjjs"
+      "ru" : "2AtdiPBOBckmOyKqdj"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1009064268
+      "currency" : "USD",
+      "amount" : 862865590
     },
-    "activeFrom" : "1999-06-07T21:10:08.242Z",
-    "activeTo" : "2005-01-30T04:49:02.713Z"
+    "activeFrom" : "1993-01-24T21:06:51.986Z",
+    "activeTo" : "2018-11-21T20:48:05.924Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4e753e6d-e447-4df6-be4f-6a60b6c6e7cf",
-    "id" : "https://www.example.org/6ddfd94c-ff25-4966-ad0b-601b51013672",
-    "identifier" : "Ec7FxCaUjTaJ8vhL",
+    "source" : "https://www.example.org/154706ea-715d-455e-bea4-b32aa428ac05",
+    "id" : "https://www.example.org/4b56e994-09a1-40be-b22d-bb9fcaa5d4e4",
+    "identifier" : "GTiDDHUeVO4JOtOH1",
     "labels" : {
-      "sv" : "vDt7NPEBkGw"
+      "nn" : "8YGxG3dkLmhilXmlP"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 242391972
+      "currency" : "NOK",
+      "amount" : 1593544597
     },
-    "activeFrom" : "2007-01-27T06:30:53.911Z",
-    "activeTo" : "2016-04-06T22:29:08.077Z"
+    "activeFrom" : "1982-06-23T08:12:43.591Z",
+    "activeTo" : "2019-10-17T07:32:31.794Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f0f4ef76-d2cc-4292-9054-2b42ee3dde72" ],
+  "subjects" : [ "https://www.example.org/73bc8e6c-2041-445c-bd79-1166695e1505" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "79acc64c-385c-44fb-ab7a-2a18cdbc32c2",
-    "name" : "s5LzpenE3CeQFh4jH",
-    "mimeType" : "tSiswwxa8Ae737Ns",
-    "size" : 947203558,
-    "license" : "https://www.example.com/xr07qf5szd",
+    "identifier" : "674b4f86-f955-4eaf-9d22-8061b2fff0f7",
+    "name" : "RLgplIjvGD",
+    "mimeType" : "hFcMhK1TtdFqSC",
+    "size" : 1810417125,
+    "license" : "https://www.example.com/rp0vxvm0ymdc7p",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "WBRxogLIlQTtL",
-    "publishedDate" : "1978-09-18T00:33:40.161Z",
+    "legalNote" : "Rbs73mSuh5JE",
+    "publishedDate" : "2002-01-14T09:00:09.348Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "lSMysnknYFEDthSDXKJ",
-      "uploadedDate" : "2006-07-30T15:32:58.291Z"
+      "uploadedBy" : "mNBeVv3vVDPSca6Tj",
+      "uploadedDate" : "2020-09-05T20:51:18.554Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HkTJ75hR7ag",
-    "name" : "Y1E4gAEpGQCA",
-    "description" : "8CO9x6mGsjyqG"
+    "id" : "https://www.example.com/4iEer9MEBxYP1Fdt2",
+    "name" : "zEEVQRzMU2oE",
+    "description" : "pfbpbsxS4y"
   } ],
-  "rightsHolder" : "2JE9pK5skN4AQ",
-  "duplicateOf" : "https://www.example.org/453c09cf-5b5c-4154-9c3b-6f74d23619e6",
+  "rightsHolder" : "c9pGD9p1a4XrqSwe8",
+  "duplicateOf" : "https://www.example.org/3b1c4fd7-c753-43c8-b9d1-0fd3a2119d9c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Qu5RAcVajgUeN56"
+    "note" : "JmwuxCMvEFW3D4"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "4otBjLTKNA1kI4iUQ",
-    "createdBy" : "SAQNqkvPBDIlhCvU9l",
-    "createdDate" : "2010-03-31T21:13:26.402Z"
+    "note" : "P5LXptusFTU",
+    "createdBy" : "UrY0qLBvkmrkK0y",
+    "createdDate" : "2000-07-01T14:03:07.986Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/90e4fd5d-9a43-4e2d-9c4d-e9057812dc9f" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/f0e9791b-d763-4ba8-94f3-7ca39b701dee" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "SWFevAIsWb",
-    "ownerAffiliation" : "https://www.example.org/7db39185-5dab-436c-8dab-0790e9d1452d"
+    "owner" : "UdHyHtqMzX1m64BSWd",
+    "ownerAffiliation" : "https://www.example.org/81bba121-797d-44aa-98c3-6f7cde7461fa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4805f83e-6b2d-4bf1-a0a9-944e55f2ac41"
+    "id" : "https://www.example.org/bf587987-d576-440f-9179-09092a6ade8a"
   },
-  "createdDate" : "2021-08-04T09:17:33.612Z",
-  "modifiedDate" : "2023-09-04T23:39:20.199Z",
-  "publishedDate" : "1975-05-03T17:28:35.963Z",
-  "indexedDate" : "1997-07-13T09:22:16.437Z",
-  "handle" : "https://www.example.org/a29f2580-bf5c-4340-abad-b365b2e7d011",
-  "doi" : "https://doi.org/10.1234/quis",
-  "link" : "https://www.example.org/73c21559-d28b-43bd-aba2-bc8fa22e3d5a",
+  "createdDate" : "1998-06-12T23:32:26.899Z",
+  "modifiedDate" : "1975-08-03T21:59:50.676Z",
+  "publishedDate" : "2023-01-09T22:18:50.060Z",
+  "indexedDate" : "1983-10-04T01:20:44.968Z",
+  "handle" : "https://www.example.org/27d9c384-b671-424f-bcbf-d1a477ab985d",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/6990e516-78fb-407c-a507-2a059fa13764",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7OZnlivj4RNf",
+    "mainTitle" : "R6n3Zhrcv02",
     "alternativeTitles" : {
-      "cs" : "NgiflUPheOX6Pd9Xogf"
+      "ca" : "fk3OjdAW9r6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AOF5VrmOi6",
-      "month" : "QZpKPtdoqFX",
-      "day" : "zFBGVldK5yP"
+      "year" : "gTKhnp8H6vvYj",
+      "month" : "VFpUP7I6wJQ9Lw",
+      "day" : "wRjZmAIzLiXBHTEgA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0d92db24-769c-49b7-8c1b-6167956082a1",
-        "name" : "FtZvVkTk0GPPlpSvV",
-        "nameType" : "Organizational",
-        "orcId" : "jmSARgO00n469u",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/0e3eaa13-646a-4019-ab45-19086b6dc7de",
+        "name" : "Iq9lO5UQU9OlHVk",
+        "nameType" : "Personal",
+        "orcId" : "O97HgwhE4DoAJdf86",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IgVtu0Guoy1DmkTLz",
-          "value" : "nMWATh5hoSgtKdRofd"
+          "sourceName" : "FUMIpkJqJCbYMA",
+          "value" : "IAjWIrKOL3dfU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mFDg6oyXvn1e",
-          "value" : "MDrxQhTusgcxcs"
+          "sourceName" : "eSBfMJyynDXE9ow",
+          "value" : "KPkdyQaZKGmkR5GOcm"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7014f7a6-5dd5-4f0b-9cfc-6b33645116d6"
+        "id" : "https://www.example.org/a36d5876-fdf8-485e-9c2d-9696b740a149"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,178 +62,177 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/23d96a6a-5f6c-4dbc-a0c3-0f18e96c98d9",
-        "name" : "deCJMfKOxQTKTj05",
+        "id" : "https://www.example.org/efb1e02b-b43a-4a9d-9bb1-bf8fe2f0ce83",
+        "name" : "4QBIwh8tYDdFbOh",
         "nameType" : "Personal",
-        "orcId" : "k9bsu1ygIcECT6",
+        "orcId" : "vMFU9reGxm9KoNnXE",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "evv2H743FshuAY",
-          "value" : "DX3gG1gqorBS4aybh"
+          "sourceName" : "D4SyXp1m7HgJT4Boy",
+          "value" : "jYcTTPab4b"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ppStsmpWjZdq6HWI9XH",
-          "value" : "VQiOSsfAEKLGdKo"
+          "sourceName" : "aEtWb3ol2QjKsjQ",
+          "value" : "6FYOOlhaDs8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/efb49c4b-94af-45dc-b818-ed55417d3214"
+        "id" : "https://www.example.org/327135f0-97b4-4897-bf66-2c9a51cbf135"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "cVUrMoQgFXpKfS3yBBd"
+      "sv" : "wsfwYv85Ne7x7WDgHj"
     },
-    "npiSubjectHeading" : "YTPPU3b6hrlRaj6",
-    "tags" : [ "Pe2BadxVlwSryMGH" ],
-    "description" : "K0xlTOmmS1R",
+    "npiSubjectHeading" : "5ekA9JPzyiDM",
+    "tags" : [ "qgT6jxV4L8qh9Ej" ],
+    "description" : "zw6xxPtIjAEP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a06655bd-c8b5-438a-a89e-da5d84140b2a"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/18e75a4c-ec0a-4a1b-8ad4-3bd9fa3c64f0"
         },
-        "seriesNumber" : "iTsT1GmedxpYhM",
+        "seriesNumber" : "foWp3uiBlobJN",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7e125ec6-e33b-4899-b833-5eb061902be3",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ddc55273-c340-49fb-9af1-8688f6e0a3a6",
           "valid" : true
         },
-        "isbnList" : [ "9780613335911", "9781065934158" ],
+        "isbnList" : [ "9790857085701", "9781888006216" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "HVAmxpKWGgj8Tg"
+          "code" : "eOXVCOOzbBowTHYB"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1065934157"
+          "value" : "1888006218"
         } ]
       },
-      "doi" : "https://www.example.org/cf4a5bc9-a52f-4c37-9b93-d1a367679635",
+      "doi" : "https://www.example.org/f7980de5-6883-4b45-8ba6-6265bc9a2fe1",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "i8IMyYWfXe0vKjebw7n",
-            "end" : "oLaEf7d35u8"
+            "begin" : "H6j2PvyibkCkB",
+            "end" : "74wBI0uSnmY3"
           },
-          "pages" : "bK4tdPJVKKd89x",
-          "illustrated" : true
+          "pages" : "aUFdGYW8GM5Wd",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "hlNrkyKJRlmau5WY2Q",
-          "month" : "24xDj20emNj8M8Gia5",
-          "day" : "qA1DqzHpZqePMHX4"
+          "year" : "S14gi5tMmSw9o4bn1h",
+          "month" : "jQDtbMFlRdcjOjNn",
+          "day" : "JDeV4H9d7sJV2nJjoL"
         },
         "related" : [ {
           "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/0MTBnu4z53"
+          "identifier" : "https://www.example.com/3Um71A2XMgOnVcheP"
         }, {
           "type" : "UnconfirmedDocument",
-          "text" : "4briKtNIbqN5IPwNoN"
+          "text" : "BjQISZtCPgi9"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/b9d782d6-4763-45cb-bc7d-1d0cc14dac8e",
-    "abstract" : "3vxvOGR2djHZ55X"
+    "metadataSource" : "https://www.example.org/5fcf8524-889b-4c9d-9f4c-9bbdbeffa8dd",
+    "abstract" : "WHZNJxdBJTFFAIenUy0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8117edd1-64e6-44e6-b456-0be2b6df122f",
-    "name" : "eVXMzNUOhx0r3Nm",
+    "id" : "https://www.example.org/cc097b12-1c42-4519-a512-b69300532c83",
+    "name" : "5N5COaTDW2O",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-02-17T14:48:48.973Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "pgzPiX034IeGS4Y"
+      "approvalDate" : "1975-04-06T18:30:09.495Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "y7bhD6aoorKEh2d"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/00b3d99a-55c2-44c5-97ab-79c2ffb2b5fd",
-    "identifier" : "Mi5pVd4251aHQF0sgZP",
+    "source" : "https://www.example.org/d47847a5-e6a0-46a7-a443-85f4809d66df",
+    "identifier" : "2NqsJsEgRyftNa1y",
     "labels" : {
-      "af" : "p4WUX0iSWpzSsV8RX"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1520534494
-    },
-    "activeFrom" : "2018-06-23T05:11:50.448Z",
-    "activeTo" : "2021-01-27T20:07:23.722Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3f5bef10-a309-4d72-bfea-10384413292f",
-    "id" : "https://www.example.org/72da492c-be53-4cff-b445-6148a996719c",
-    "identifier" : "W9UTLKSlou62n5Vek6n",
-    "labels" : {
-      "de" : "F8T9wuocCBtG9"
+      "cs" : "rMkzoxOl0x"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 665392154
+      "amount" : 252862048
     },
-    "activeFrom" : "1993-02-22T19:47:48.301Z",
-    "activeTo" : "2002-04-02T01:09:16.379Z"
+    "activeFrom" : "1995-08-04T20:51:45.373Z",
+    "activeTo" : "1996-04-09T17:31:38.624Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/f1bcdfa3-94e0-43ce-8b3a-fe99f556d073",
+    "id" : "https://www.example.org/ce325a08-bf48-41a1-9950-1a0a3cf6b241",
+    "identifier" : "OJnME8vI4t",
+    "labels" : {
+      "fr" : "ZR8GmqOcH2W7Z9ulG"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 846440801
+    },
+    "activeFrom" : "1987-01-23T20:37:25.745Z",
+    "activeTo" : "2022-01-31T09:02:39.215Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ab52632f-8c05-457c-81b4-5a0b1ca3cb2a" ],
+  "subjects" : [ "https://www.example.org/6d5f4c89-fb5c-455d-b3d5-cde39b6d7627" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2797bab1-3cd4-47a1-b4b8-0410164bbd80",
-    "name" : "i5RsAvf6P2BPwNi",
-    "mimeType" : "KX1fWpl1RczzcNMdC",
-    "size" : 260122287,
-    "license" : "https://www.example.com/asrnvltf5u3z6xg1h",
+    "identifier" : "754dfe83-308c-4576-bfe4-7e968aaf1fb5",
+    "name" : "cYBRTeCWCnusg",
+    "mimeType" : "1YgIRdoLCQh",
+    "size" : 1065043851,
+    "license" : "https://www.example.com/vm9bxhqy1qudx",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "y4c49pKpdVMk0"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Imgriq1cTopadgGB",
-    "publishedDate" : "1978-04-12T16:39:31.067Z",
+    "legalNote" : "PB9cXJWzbxwrB",
+    "publishedDate" : "2024-02-08T10:51:40.153Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "jzxGzKqcDHSySae4q",
-      "uploadedDate" : "1989-04-08T12:03:58.051Z"
+      "uploadedBy" : "TCTNDNraEEN4Mf",
+      "uploadedDate" : "1975-05-21T01:49:12.390Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5nLu5Fv2dAp",
-    "name" : "5abspyk5q0bHp",
-    "description" : "C2ggwT1z7jkoJ3"
+    "id" : "https://www.example.com/E5YUIqVvfuXwBnfI",
+    "name" : "ptRwLqiwVP0oUM",
+    "description" : "Bzy97L9BJfj"
   } ],
-  "rightsHolder" : "1V111XCubRdAE",
-  "duplicateOf" : "https://www.example.org/1b1f3141-be79-42ce-aea9-2f043bda9b39",
+  "rightsHolder" : "blbJu9dtxVMA5xj",
+  "duplicateOf" : "https://www.example.org/e6c3127b-9739-4459-80be-2ff3b690cb3f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7I9lQg0z3wx2o3"
+    "note" : "FoMWEuXW76HgP9c"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2LYfmG1UERcPJ",
-    "createdBy" : "rhruRkVDhD",
-    "createdDate" : "1989-10-23T23:11:28.056Z"
+    "note" : "zTcJwxHHxZ",
+    "createdBy" : "AKkDqckfgcl6",
+    "createdDate" : "2012-02-09T16:30:29.858Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f8eac183-dd91-4425-8b31-16fdfe1b9e44" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/4577748f-5d1f-4444-aa40-5654326a711d" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "xhFsuXqmoPYKnQQi2eI",
-    "ownerAffiliation" : "https://www.example.org/df2822c7-d9b9-4432-8dbe-1ff922c31179"
+    "owner" : "asANYdJkKk",
+    "ownerAffiliation" : "https://www.example.org/f25e2ce7-9a46-4aef-b2f5-7f3f28d92f97"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5be59e04-49de-4ae8-8533-15dd3ee818f8"
+    "id" : "https://www.example.org/3ac25d11-2b26-4609-b406-eefb5703130a"
   },
-  "createdDate" : "2010-08-15T08:45:24.651Z",
-  "modifiedDate" : "1977-12-24T17:00:43.936Z",
-  "publishedDate" : "2003-04-02T00:10:06.037Z",
-  "indexedDate" : "2019-03-20T22:22:48.143Z",
-  "handle" : "https://www.example.org/3996b198-0d6d-4014-9ae7-fb8eed3ab9a9",
-  "doi" : "https://doi.org/10.1234/earum",
-  "link" : "https://www.example.org/d0e3b211-7a1a-4ab4-b310-203fd6fd6008",
+  "createdDate" : "2013-10-04T10:47:23.938Z",
+  "modifiedDate" : "2021-02-20T03:09:45.544Z",
+  "publishedDate" : "1992-07-26T18:51:00.757Z",
+  "indexedDate" : "2003-02-21T12:14:50.722Z",
+  "handle" : "https://www.example.org/686f187b-232f-476e-ae54-a70ae0b0532e",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/d2bffd09-2f4e-41fe-b931-574b7255363d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ft3mexhlTSHAuepk",
+    "mainTitle" : "7eXt2I71xYGLJ01vk",
     "alternativeTitles" : {
-      "se" : "gQ6fgY6H9o0y95cre"
+      "es" : "msHiarkoVn0JcEcEeG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AIBe9P2Z7fL6uH2M4",
-      "month" : "ofanBevVmvNvSG6HS",
-      "day" : "s6lSCvZASxRx"
+      "year" : "jXDv5BaD3vSOEsa",
+      "month" : "DEeb0DzOFHs6SlE8S",
+      "day" : "gF8AcL6yhlhTke"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5dd03c27-8fc4-42ec-9251-d2831af24336",
-        "name" : "oNLrFA9AznDoi7af",
+        "id" : "https://www.example.org/a6fde1e9-df1c-47c2-8750-57e8a7be9e8d",
+        "name" : "7YC6HtJWyWX3fs9",
         "nameType" : "Personal",
-        "orcId" : "P0Ij3hfYuE",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "nFC61Cq07NxUnI",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "btZHpSU2G8AehZYjjQ",
-          "value" : "4fbMckKBkg"
+          "sourceName" : "ULnwc1pPTNboLVrxgU",
+          "value" : "pQtHRALFbACKh9avuz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1Bsqs3Ui1dFoVxESFwK",
-          "value" : "x2RZjuZuZaYF2Gw"
+          "sourceName" : "3T8BCszfCvV1bTwCNn",
+          "value" : "A7g4w6SHEaWKTO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/33d74fda-e244-4f1a-9299-55591974b5d0"
+        "id" : "https://www.example.org/16303c7a-55ba-4a9c-8cf0-25174f4edc6b"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0ee8d873-ae34-4a73-8075-106e1e2731b8",
-        "name" : "Ob3GLytM3Riu847n",
+        "id" : "https://www.example.org/68f5a8fd-1802-4817-939e-a1fca82f6e57",
+        "name" : "c5ntH4g7hOd8z",
         "nameType" : "Personal",
-        "orcId" : "VEo0Rj7Pcy",
-        "verificationStatus" : "Verified",
+        "orcId" : "1S005uIesB",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NBeAH6NHcbSeZlaIbeO",
-          "value" : "4EHGDCymvm"
+          "sourceName" : "ewr7pL453dPniTXr5p",
+          "value" : "IKfhhOXQkr3U"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VGswl3SiDj4xya3BWkF",
-          "value" : "rzmXgagU7V"
+          "sourceName" : "qZkwcrtE5i7H",
+          "value" : "qQorUNx2T344Q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8e96dbb2-63c5-4dbd-98cf-5ba078032ca9"
+        "id" : "https://www.example.org/340d94d4-21d2-4813-8c0a-492c0c8d6861"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "Creator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "S3Gv3IzKYkFTOgcO"
+      "de" : "Tj28tKH7tkH"
     },
-    "npiSubjectHeading" : "lLa0B1eGB2NPxNBlNg",
-    "tags" : [ "0r4SiSbD7qc" ],
-    "description" : "mwwxsiL2iUxPIRXJv",
+    "npiSubjectHeading" : "aReg99DhF7KAqdH46I",
+    "tags" : [ "9BkQu76lAjHnL" ],
+    "description" : "uzG5CFiVIWNnW7rJjd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3dc79254-ebd3-481c-ada4-a68759676da0"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ff96eb3-6a63-4589-b60d-db2b2ab784b8"
         },
-        "seriesNumber" : "Ud1gXZvdJlin",
+        "seriesNumber" : "ASACaYsHvRL2dH4LcV",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7ca647e3-6278-43f3-9e3a-6d5af0671f8c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/217f856c-a2a7-49b2-b996-30eb7acaaa80",
           "valid" : true
         },
-        "isbnList" : [ "9781907402074", "9781935445494" ],
+        "isbnList" : [ "9780054140723", "9781019604830" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1935445499"
+          "value" : "1019604832"
         } ]
       },
-      "doi" : "https://www.example.org/ea115c98-1339-4ac8-bfb9-3d8e2f568049",
+      "doi" : "https://www.example.org/e951b434-9e21-4d57-9451-ad3af1622a65",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "OyAkOQ8c8q",
-            "end" : "xU8k4etBeOVCQrcP"
+            "begin" : "pNbVoFNND1qh",
+            "end" : "GWP56tzLVcMX9eULwW"
           },
-          "pages" : "BDXRTgDACBP0U1EGd",
+          "pages" : "YQHmblnrYKO7z9DlnSV",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9fe10238-00b8-4b22-99a4-16d15adb1da8",
-    "abstract" : "x8LAaF2yYd0"
+    "metadataSource" : "https://www.example.org/81ac9377-e1ab-4bd0-94b3-b930d5b6103c",
+    "abstract" : "ERXqVmnToSnd5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ea8f129b-d036-4708-99bf-bd1b05a20edd",
-    "name" : "5aYACVvjgtp7LrFQUF",
+    "id" : "https://www.example.org/ae92eeab-e3d6-4d2f-b119-2658e07c3388",
+    "name" : "7kTAKWLzquxEj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-10-12T19:50:49.848Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "2024-02-22T10:38:50.736Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "LeuVYP6wD6KBh6"
+      "applicationCode" : "1dqoVu7HtEQUP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/14a0d5eb-466c-4028-82d8-72af46ebbc1a",
-    "identifier" : "WZ1fWR0bBELpBonvH",
+    "source" : "https://www.example.org/1ebb164c-5eaf-4e49-80fe-d051af3621f0",
+    "identifier" : "qX2zlpBdmB1k",
     "labels" : {
-      "hu" : "T8J9EQJM6vX"
+      "de" : "pkaILfbE2gUZ3sC3o"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 902206549
+      "amount" : 1186941402
     },
-    "activeFrom" : "2001-01-15T03:57:29.811Z",
-    "activeTo" : "2020-06-05T17:08:57.461Z"
+    "activeFrom" : "1999-01-02T12:06:56.308Z",
+    "activeTo" : "2008-02-28T13:31:58.820Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/52dcb4c7-25ee-4916-b621-b090d25d90a4",
-    "id" : "https://www.example.org/f37d916d-4d4e-4029-b499-f57e75292eae",
-    "identifier" : "WiaguJuUMFS6",
+    "source" : "https://www.example.org/2988aff0-002a-403c-a627-dfaefae3fb57",
+    "id" : "https://www.example.org/614e376c-8180-475a-9faa-efaf7a65c133",
+    "identifier" : "NsR65E6cQwp",
     "labels" : {
-      "se" : "i3yDX7sa4pnJOREj5"
+      "nn" : "snriTbPwSEQCMQy18eq"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 775628079
+      "currency" : "GBP",
+      "amount" : 440213750
     },
-    "activeFrom" : "1988-07-09T08:27:17.085Z",
-    "activeTo" : "2008-01-28T15:21:45.529Z"
+    "activeFrom" : "2009-03-18T09:46:54.330Z",
+    "activeTo" : "2010-11-19T18:06:37.870Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/97a37c1d-d133-4381-b71e-d9ccec421753" ],
+  "subjects" : [ "https://www.example.org/9dac00b3-ee48-4ae6-8150-3ef4b5755eb6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "86627af7-3605-4611-b3cf-de772bee7374",
-    "name" : "QAAGbosYmGllpgoTUli",
-    "mimeType" : "YV7b56mSL9H6iKYsLo",
-    "size" : 1377183452,
-    "license" : "https://www.example.com/glqodpvnccmebn",
+    "identifier" : "59aca24b-9fc8-4476-8a4a-5ef17d692fdd",
+    "name" : "ngDeJWFzWfO",
+    "mimeType" : "DaaPV8Z2LIji9RHqc",
+    "size" : 1055969465,
+    "license" : "https://www.example.com/rhniuhix91",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mh6AyYTcV06FcF",
-    "publishedDate" : "2004-11-30T08:25:52.645Z",
+    "legalNote" : "5zoA2eZ3TDkW2Sthm",
+    "publishedDate" : "1990-10-19T19:25:06.531Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DeWn1Md6AzjSGMx4u",
-      "uploadedDate" : "1981-12-06T06:22:58.744Z"
+      "uploadedBy" : "n9B65vghuXXpq",
+      "uploadedDate" : "1974-11-05T02:16:16.063Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5EpeHe3VuFSBbQF",
-    "name" : "BV9yBpYpdJXQ",
-    "description" : "Z34z6gceqPGQ4D76"
+    "id" : "https://www.example.com/PFtJOfw0M6tMXNm9P",
+    "name" : "QptnFwXC3lixpC2xas",
+    "description" : "DyO4orDbyiJ"
   } ],
-  "rightsHolder" : "43XLXJoeYuvSMZQ",
-  "duplicateOf" : "https://www.example.org/dcabab3a-5e9b-44a5-8477-3e62a0900b8b",
+  "rightsHolder" : "wurLhGjILD3x",
+  "duplicateOf" : "https://www.example.org/73da9622-6fc7-402e-8378-caaf42f28233",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FqxRKSJocK"
+    "note" : "OtwROCxidya1E0W0gh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "6ZUrwzCYN96BV",
-    "createdBy" : "j9DaPx9sEODt65QlLwy",
-    "createdDate" : "2021-09-21T08:50:26.802Z"
+    "note" : "fN58IjA7MTlnJv0",
+    "createdBy" : "TmcHdwO8l15TWViA87",
+    "createdDate" : "2005-05-14T23:57:52.223Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/617cf2c5-04e4-4a67-8c96-d8e4b31e67f8" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/11acff87-6d39-4ed0-bee5-0692fd8bbfd6" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "NQbKY4tt45I5dX4maZa",
-    "ownerAffiliation" : "https://www.example.org/c13d0f13-8c99-47fe-be5b-3284dbf29a94"
+    "owner" : "PxAsxzeujPz1qoxe3",
+    "ownerAffiliation" : "https://www.example.org/2723b8e9-3314-4632-9143-dfd87d765290"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9e37a2e0-075d-484d-b2d5-2b52a36604fc"
+    "id" : "https://www.example.org/3f8a9900-6ab6-497e-a0f6-4a47cd4aa13b"
   },
-  "createdDate" : "1996-07-28T13:34:22.742Z",
-  "modifiedDate" : "2021-07-26T20:57:14.848Z",
-  "publishedDate" : "2008-01-14T12:14:05.321Z",
-  "indexedDate" : "2012-08-10T21:44:30.915Z",
-  "handle" : "https://www.example.org/0bc2f1ff-b85e-41a6-9f1d-3ddbd99b579e",
-  "doi" : "https://doi.org/10.1234/deserunt",
-  "link" : "https://www.example.org/cf3a4033-3683-4378-90da-0a092e14fe85",
+  "createdDate" : "2014-06-13T22:05:01.981Z",
+  "modifiedDate" : "2004-07-17T09:48:44.466Z",
+  "publishedDate" : "2006-10-29T21:29:00.352Z",
+  "indexedDate" : "1993-08-30T21:12:38.372Z",
+  "handle" : "https://www.example.org/f27f2305-3d36-45f3-a9e8-bc0029180ef5",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/db54a990-8ae9-41a0-9912-371b4060dec5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5VhDZuzbnI0DejZHRG",
+    "mainTitle" : "ZhzmBFXTV87QJx",
     "alternativeTitles" : {
-      "hu" : "Bwxl05WFg56AWLKQGt"
+      "fr" : "VsD61PRGivEX8iSzO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JTOpy2ir8J8Ki1o",
-      "month" : "HymAoUrIribW",
-      "day" : "OPUqFz9S3SJp"
+      "year" : "HGKEHQ1wEgmcY4V",
+      "month" : "crxeLH1wvjcAbPEavzH",
+      "day" : "8BgG2Hhuu1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e2c3557c-dc1b-4c66-936c-925beff4e5a8",
-        "name" : "tAM62w2O3IieWNRoYW",
+        "id" : "https://www.example.org/da461000-2fe5-40e5-8607-2d223dc1aa20",
+        "name" : "r4k3qM2Ea0OLlL",
         "nameType" : "Organizational",
-        "orcId" : "FUCAVPCmvD651Y",
+        "orcId" : "ISDiUeMNNUDdSwVkq2v",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kmmZ2osZ63yKE4yL2S",
-          "value" : "yqWNQeOl4uKhDfTWh"
+          "sourceName" : "1uj3CwOmbh",
+          "value" : "NsJ54tT3gTUMrY02"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5sdPSOzj8pdtucw",
-          "value" : "CmW0TZUEdwqM"
+          "sourceName" : "RWJnERj3pP",
+          "value" : "t7rscEuB2h"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/89e5a0e5-629b-454a-a5b0-2ade4e45b563"
+        "id" : "https://www.example.org/cfa665ec-8675-4f0d-9ca6-0067eb50bd38"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/49be9530-4ed0-4709-bacb-3f74da8c00aa",
-        "name" : "uKNHw6AgD0WPa2I4",
-        "nameType" : "Personal",
-        "orcId" : "BKPoiYNxikPYD",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/a6c71181-3f2a-4ed6-a45a-a5eb33718210",
+        "name" : "OAeYhXvAftLK",
+        "nameType" : "Organizational",
+        "orcId" : "mVVRP0gbHk",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "91JegpX7eDhyT",
-          "value" : "ck0zeP3xxF6V3ksr"
+          "sourceName" : "BQQoNrejSnX0",
+          "value" : "8F9t1sbs0xkj2AAjNFc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qEnpr0Vtu8L1Mj",
-          "value" : "B81fbFjs6shz"
+          "sourceName" : "8ZBvQq9OEeH2DklhJ",
+          "value" : "lo0MNvDAvq4C9098"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/039b2350-dabd-4cf7-a9b2-75391ebb0f1b"
+        "id" : "https://www.example.org/7b0398c6-bbf5-41e3-975d-104d1216048c"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "txqnnA3iSz521S"
+      "hu" : "uEHjUItxpDX334b1D"
     },
-    "npiSubjectHeading" : "UGW4EqVSPzH0m0v",
-    "tags" : [ "vXSp9OM9YPjXOkPIG6" ],
-    "description" : "G9zqoiZvZGstoB",
+    "npiSubjectHeading" : "m2cApKmVCReLB",
+    "tags" : [ "ZvHtGG3tvI6dk" ],
+    "description" : "HCQbFt8F5EFxmqN",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/TsANerevUPRhKOe"
+        "id" : "https://www.example.com/0lWndPIXcNZHBvfy"
       },
-      "doi" : "https://www.example.org/333246d8-2f39-4287-962a-5a863aa02208",
+      "doi" : "https://www.example.org/7814da48-d426-45bf-8fc1-eb089438c074",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "DndMOkK20Kw4z5S",
-          "end" : "nJgMF7bzz31cSvH8h"
+          "begin" : "fMgqXYSxWQoczGU",
+          "end" : "AXtW4bCxbS4ATotVl"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1930af2f-fab6-47be-85f0-cecb55f7a54b",
-    "abstract" : "V4toHRuX4VntXjZMCIs"
+    "metadataSource" : "https://www.example.org/d2672362-6ba9-4990-950f-90485baab598",
+    "abstract" : "rprJJt4XvMh9d"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/381b69e5-662a-44c5-b7e8-aabb79e6cf2c",
-    "name" : "vdDIyVZtuJGv9Lh1X9",
+    "id" : "https://www.example.org/7e09e3df-bc39-4a9c-aff6-4af7fb3ea176",
+    "name" : "AIUbdfs9rewd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-12-10T16:26:33.857Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "H4lI4sUGSmll"
+      "approvalDate" : "2006-03-25T17:16:34.331Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "LgLsNGK6QxqNnKXx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/21cb6fff-6d06-4929-b178-0bbc8c932d51",
-    "identifier" : "9G13HXJsTxpoX",
+    "source" : "https://www.example.org/c0240df6-2418-4292-9674-09aee44c5730",
+    "identifier" : "F9FeC85y1Y7wP3rPP",
     "labels" : {
-      "bg" : "H1Lm4r3EfhFwqlRqYIc"
+      "fi" : "G6v7qCqFck"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 41135104
+      "currency" : "NOK",
+      "amount" : 1246691143
     },
-    "activeFrom" : "1977-07-08T02:43:56.526Z",
-    "activeTo" : "2012-04-08T08:10:09.686Z"
+    "activeFrom" : "2015-12-25T11:05:02.976Z",
+    "activeTo" : "2021-08-28T12:01:08.629Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/724f2574-e5a6-4ac1-8f99-0340be9ac681",
-    "id" : "https://www.example.org/4000b31c-71b0-42de-8556-07a583fd08d3",
-    "identifier" : "dHI6bUD4HnR",
+    "source" : "https://www.example.org/99673e31-6ba4-4aa2-8496-396be0cefe02",
+    "id" : "https://www.example.org/43b8cec5-60b5-44fc-9df0-0da0e37f8d87",
+    "identifier" : "3KHGgwrZm9rkK1qZ",
     "labels" : {
-      "nn" : "HO973Ibq0zH3XudKq"
+      "fi" : "L7r1EVIQ53wJsGSKG"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 999591623
+      "currency" : "NOK",
+      "amount" : 968554025
     },
-    "activeFrom" : "2013-01-14T16:33:40.238Z",
-    "activeTo" : "2016-06-18T12:16:06.467Z"
+    "activeFrom" : "1990-03-16T02:37:14.809Z",
+    "activeTo" : "2008-03-31T20:32:19.842Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8acb78c5-94eb-4d4d-bf92-7a740cc61e36" ],
+  "subjects" : [ "https://www.example.org/f40cfd72-5d72-4102-8d3f-95877e8c52d1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d3048497-f7d4-404e-a523-c2ca5fa961e5",
-    "name" : "4sNkzl0cS9ja",
-    "mimeType" : "zXFFxM8X8QXAU",
-    "size" : 367051077,
-    "license" : "https://www.example.com/ancpny4iceb9zo",
+    "identifier" : "55339047-76e5-4b6a-936a-f3f3e17cacb9",
+    "name" : "Hyhg1xHhoyWd",
+    "mimeType" : "DHdCNpr9H56gtUax8",
+    "size" : 1622371935,
+    "license" : "https://www.example.com/gfbxytsi9vfpyujgr",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vFJsh7uokAabd0oa",
-    "publishedDate" : "1974-05-24T12:43:15.818Z",
+    "legalNote" : "Iu4qOluVxov15gplw",
+    "publishedDate" : "1988-12-07T04:37:48.238Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "43slGjBGnMJznFvSy3",
-      "uploadedDate" : "2010-03-14T14:53:12.204Z"
+      "uploadedBy" : "rbPnkjQq1o49mN",
+      "uploadedDate" : "2010-10-19T20:38:25.267Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XsJUWPBWf8MUEtz",
-    "name" : "5miUdDcdeA3",
-    "description" : "jYCoN52VM1H"
+    "id" : "https://www.example.com/xHOXIRadPwc",
+    "name" : "ia399wFb3dFCZr",
+    "description" : "4gdT9VArfaJQZz9g4"
   } ],
-  "rightsHolder" : "U2dIlvnlAzJF9",
-  "duplicateOf" : "https://www.example.org/846fcb50-19ea-4007-ba6d-d1110cb932d2",
+  "rightsHolder" : "LTwoGVscglqTf",
+  "duplicateOf" : "https://www.example.org/c2881ec7-fb89-463d-a306-2a8f88547970",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "BJrq1dfL0TAB2ZZeXD"
+    "note" : "o4YD7wF86hd7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "7msRRunRUgCNt1NwtKH",
-    "createdBy" : "o2aesq3DSHBOBy",
-    "createdDate" : "1984-12-27T00:22:49.033Z"
+    "note" : "qbdemqL6vmJRTCYTF",
+    "createdBy" : "4PByFHvBdJc",
+    "createdDate" : "2003-07-09T03:09:33.374Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6fd0a28a-cf76-473c-8537-227b103ff5fa" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/d20f37aa-f678-4dfc-92fb-af72eb72033b" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "WWNKbOTNf3A07EhySy",
-    "ownerAffiliation" : "https://www.example.org/d7310969-5a56-4d22-942d-b608b4de37bf"
+    "owner" : "dQZupOUSjyIRj2MEsce",
+    "ownerAffiliation" : "https://www.example.org/244c31c9-e82f-44bd-94b0-e213f1b84a4e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4221bc6a-801e-42c1-825f-aa3b8f53d4b4"
+    "id" : "https://www.example.org/fa232ed7-af31-4417-929f-c2ddf50e1dc7"
   },
-  "createdDate" : "1987-09-13T22:20:45.199Z",
-  "modifiedDate" : "1981-05-01T18:21:10.648Z",
-  "publishedDate" : "1979-09-08T11:35:00.046Z",
-  "indexedDate" : "1993-07-09T15:11:24.712Z",
-  "handle" : "https://www.example.org/419c7c2c-adf0-462a-899d-5f2af979e2b3",
-  "doi" : "https://doi.org/10.1234/optio",
-  "link" : "https://www.example.org/2cdf381d-9698-410e-807e-747090e3ec5d",
+  "createdDate" : "1975-04-30T13:17:15.201Z",
+  "modifiedDate" : "2006-04-06T01:46:27.341Z",
+  "publishedDate" : "1977-04-17T07:23:23.485Z",
+  "indexedDate" : "1973-04-03T18:09:20.571Z",
+  "handle" : "https://www.example.org/f4476cbd-3ec9-4220-9bc0-c91a6303a17d",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/836b2a43-2ae0-4918-af0a-8a22931d8131",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ulN41IMkh5z1",
+    "mainTitle" : "GPr43CjD5htP3Aj9o",
     "alternativeTitles" : {
-      "zh" : "P0OPjNvIeNyHulXrT8r"
+      "ca" : "QGuC9xlG5hAv2yvh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wPGPkkX4hKmXHdGPy",
-      "month" : "p0I1taoi1XHdSoyMGc",
-      "day" : "wDbtUBorixspDUN4Kp"
+      "year" : "fQUIeuM8Mo",
+      "month" : "LSoLbAPyySV6ISE6XTA",
+      "day" : "boNpjYjcyhGLs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/618b3c83-81bc-48d6-a7d9-ad401fbe63f1",
-        "name" : "t1lvIW39iR6ijxVDNbI",
+        "id" : "https://www.example.org/9ce16383-cddd-4ed9-adc4-86a8297151c8",
+        "name" : "6Nxx6XI2OyZdOQywG",
         "nameType" : "Personal",
-        "orcId" : "49iwWVk0A4UhKMlkFT6",
-        "verificationStatus" : "Verified",
+        "orcId" : "wnMsQrz8vQmO",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "J02heogIy4vQA8KOQ",
-          "value" : "H4oc4vdT6lzM1"
+          "sourceName" : "yaVXzaf3FTM",
+          "value" : "lZrbIme22j5Oq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XtE7TO3Gdeyqg2",
-          "value" : "7ApYkq1vi8DxbdjDT"
+          "sourceName" : "nyWdq8qqxB",
+          "value" : "YOuVinFMqHj2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ab082b34-b83f-40fa-9ca6-5aba72ec88b2"
+        "id" : "https://www.example.org/2175a016-96b8-444d-b046-07072b56f244"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/efb7a04d-ec5d-4c50-83bb-7277bbb51ea4",
-        "name" : "OcNRroVEPfPRWqIKTB",
+        "id" : "https://www.example.org/aa7016a2-bde4-4a49-8fab-ceeb36934ab0",
+        "name" : "rcsBiMJVhFJCJmvU3E",
         "nameType" : "Personal",
-        "orcId" : "Aj68avECxHVKk0klgMb",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "EwmdVGgskZoNAza",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2lWGGUCuRtE",
-          "value" : "MygioSO8eGM4OBCWO"
+          "sourceName" : "1mwT0Eb3zn8m",
+          "value" : "GJFhQdaERc4XHNrn3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Vk2oLLd4HlNIKm",
-          "value" : "JGBVC8ai82zuuvx"
+          "sourceName" : "yNpGu2v4MU9oAi5",
+          "value" : "VysSUd7nL21tgtoJ9a"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/68ea27b0-6cc4-4c02-9589-3e7d1ab03cc6"
+        "id" : "https://www.example.org/721346ee-c42f-4887-a044-9b92d0eea179"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Librettist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "oOPqIo6b2uJP"
+      "bg" : "xnravADiw8"
     },
-    "npiSubjectHeading" : "o3iBLmIqUn3k1q",
-    "tags" : [ "n9HC0mmg8G" ],
-    "description" : "NtCkScxcCqOMxiI41f",
+    "npiSubjectHeading" : "u4d261raNXGJnlVot",
+    "tags" : [ "5Kvrvi2pnuq" ],
+    "description" : "L95dn4vs70Y",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5011c743-e16e-4279-8e66-b704b84cc24c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b4fd5708-b0c9-41e8-8bc3-be1507cd686d"
         },
-        "seriesNumber" : "PopxAzYrRm",
+        "seriesNumber" : "0zPPtYDUaxumY4WZ",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/40b9999d-5e46-4ba2-ba9a-38e5280bfefe",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9fb0e1c8-f119-4c3c-b08e-4e18aa595c33",
           "valid" : true
         },
-        "isbnList" : [ "9781988019352", "9781832139823" ],
+        "isbnList" : [ "9791936664664", "9780925619686" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1832139824"
+          "value" : "092561968X"
         } ]
       },
-      "doi" : "https://www.example.org/6dfc4718-0333-4807-af8d-babe901966dd",
+      "doi" : "https://www.example.org/1fcb2c19-95da-4710-8a8e-1ac9c6289811",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "seNyQH9ZTfRfNt",
-            "end" : "sgGjAW0vbeDmJL0qM"
+            "begin" : "znCNsdGD5XLXA4m",
+            "end" : "EOD7pk2DfGv"
           },
-          "pages" : "xi45yvAYkSZnSerHM",
-          "illustrated" : true
+          "pages" : "BoM97ltn1HY",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f6685a28-8352-43f4-b87d-ee753cbce23e",
-    "abstract" : "8xIUp9dwvifa0"
+    "metadataSource" : "https://www.example.org/6df7d8b2-80ca-4fc0-9ee6-789ea270391c",
+    "abstract" : "2zoADtipzhbMwsecy3M"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/051ea28b-cd2a-49f0-8a45-7ce5b136bec0",
-    "name" : "Yk0fYZQj14",
+    "id" : "https://www.example.org/54451612-2c46-4e70-9755-d3df682af253",
+    "name" : "SzuxFgczOSc6yvU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-06-15T22:51:31.254Z",
+      "approvalDate" : "1992-02-06T14:57:14.761Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "xl24okClWY5"
+      "applicationCode" : "PeWOWBT41CBzK2Bw6P"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3f68fecc-84fd-4578-8262-5c0a7051c8a4",
-    "identifier" : "g35JjjfQCAmCg2l5",
+    "source" : "https://www.example.org/ba2a67d0-c049-4741-b8a9-9db8d1359537",
+    "identifier" : "HDZt3HyirmreW",
     "labels" : {
-      "af" : "YpG3Hy53YBEcR0Wlm8w"
+      "pl" : "KL0rfgeRfI8r3kpCn"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 694486834
+      "currency" : "USD",
+      "amount" : 496485336
     },
-    "activeFrom" : "1980-12-27T10:54:02.943Z",
-    "activeTo" : "1997-06-15T16:34:37.574Z"
+    "activeFrom" : "1991-11-07T19:12:59.128Z",
+    "activeTo" : "2021-09-21T19:52:58.093Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/adbb7fae-4f50-44ed-a02d-575d56c88419",
-    "id" : "https://www.example.org/e123cc32-bbdd-4a29-8e62-91961395f253",
-    "identifier" : "2y8SyrjGOLguv0snl",
+    "source" : "https://www.example.org/1a2dd30a-129c-465a-9ec1-4fc25f36a9cc",
+    "id" : "https://www.example.org/643fb045-d18b-4b4e-ac0e-cd60b1d09b25",
+    "identifier" : "NVvBAmELPwFBw1GgU",
     "labels" : {
-      "es" : "Phshy5heO7w"
+      "fr" : "KSOD3AYPjCkzSk"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2014053904
+      "amount" : 1067943227
     },
-    "activeFrom" : "2004-12-13T07:59:38.285Z",
-    "activeTo" : "2012-03-24T18:09:26.629Z"
+    "activeFrom" : "2003-10-16T00:15:31.576Z",
+    "activeTo" : "2005-03-23T01:40:58.464Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cb2b0cdd-7827-4749-94d5-5d1a21ee5be4" ],
+  "subjects" : [ "https://www.example.org/18349b1a-ae82-4ec0-8b90-6847c78decfe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "449cde8e-905a-44c2-ab71-3e753d00a31a",
-    "name" : "8ooNnclRxQMw",
-    "mimeType" : "CfQ3R7Osz1aTpov6Z",
-    "size" : 718427778,
-    "license" : "https://www.example.com/kczbvothpzh",
+    "identifier" : "363e853c-8d0b-4c40-ae89-e7f2321ee3e6",
+    "name" : "6q4cnRf1I4qEXGHgvx",
+    "mimeType" : "CBSY4zczAVl2ehc2Hm",
+    "size" : 2057844656,
+    "license" : "https://www.example.com/bx9elz7z3oumnqsm7",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "hnjCShfcAQ4n"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "HFVsttBsKp9Mj",
-    "publishedDate" : "2002-01-01T20:37:50.025Z",
+    "legalNote" : "XoxXtDM7eqF",
+    "publishedDate" : "1993-09-20T20:55:44.253Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "uYyJJPn3FRT",
-      "uploadedDate" : "2008-06-29T05:07:44.638Z"
+      "uploadedBy" : "PDXl5up05D6fvy2",
+      "uploadedDate" : "1985-07-22T22:17:54.736Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5n9EpGEFPD2smO4pz",
-    "name" : "FsrF4hSyhVEf0ADqOHV",
-    "description" : "dWCEKTQ7oWc7wQHgKsd"
+    "id" : "https://www.example.com/BG4onqI6hWQW",
+    "name" : "7DK379MotyuvYbhVJo",
+    "description" : "WjAASgvwJp8"
   } ],
-  "rightsHolder" : "nWBohMB4MsGKsWFe7w",
-  "duplicateOf" : "https://www.example.org/4a0ac19a-0ee6-4353-b50c-57dce5061e4e",
+  "rightsHolder" : "elFgjiscXo6BQtS8",
+  "duplicateOf" : "https://www.example.org/ae43b0d5-4fd4-45a1-8a3c-75c30e23514f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "70NaI4exxwbO3UK"
+    "note" : "8MoQXtzmVa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "YkiRVoZvCa4y19uMle",
-    "createdBy" : "wwTCzHlKJgz1",
-    "createdDate" : "2023-07-31T12:13:29.935Z"
+    "note" : "piUK6AL77OjHemEZFO",
+    "createdBy" : "bTK9ceuzYm90bjleV1",
+    "createdDate" : "2005-12-17T09:53:21.305Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5f0fbc1b-9628-4adf-8291-80d60ce9db99" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/40395be2-9411-48a7-97be-deb508c0273c" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "U2osjcYsG97H5ac",
-    "ownerAffiliation" : "https://www.example.org/7e54fe2e-08f6-4431-9643-29ea096a3c8f"
+    "owner" : "2vxwqkMpGBXb",
+    "ownerAffiliation" : "https://www.example.org/74dfbe86-1d69-4149-b7d8-fbd8dfb2eb7c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5d881976-d26a-45dd-aa65-57a9a169f8fc"
+    "id" : "https://www.example.org/cae20421-3087-4f7e-ac95-5fefdf80ccad"
   },
-  "createdDate" : "1979-10-28T11:58:39.062Z",
-  "modifiedDate" : "1985-06-07T11:01:47.256Z",
-  "publishedDate" : "2016-04-28T07:10:57.162Z",
-  "indexedDate" : "1977-11-06T06:59:02.257Z",
-  "handle" : "https://www.example.org/206ad655-958a-4d17-9755-fe808bab3849",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/a62a3d53-93a5-4251-925b-3cfa45f4282a",
+  "createdDate" : "2009-09-27T02:19:07.105Z",
+  "modifiedDate" : "1974-11-09T00:42:22Z",
+  "publishedDate" : "2004-02-04T14:52:21.186Z",
+  "indexedDate" : "1975-09-13T09:05:32.506Z",
+  "handle" : "https://www.example.org/b497c861-46b3-471c-b4b5-1bd1b89e3118",
+  "doi" : "https://doi.org/10.1234/totam",
+  "link" : "https://www.example.org/23af8118-1332-4469-af49-cd3f53eac7c1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "y38aUTQwAqWXgf",
+    "mainTitle" : "LbdmzGmC0lv",
     "alternativeTitles" : {
-      "ca" : "oNbPTITJHkOILgDTe"
+      "pl" : "hN7C8lJe4KWO"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6ISwICJkqaDe2v3VV",
-      "month" : "GX0vZxtKh9pdwDMEJm",
-      "day" : "nILvi0y8CVVYE01oDO0"
+      "year" : "lm4YQbYzWP9wHfTqWq",
+      "month" : "pH8BXgZvke2A",
+      "day" : "XmuhE9RNVRIXhkCu4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cf490f1c-311c-4761-8f8c-3d988cdc14a6",
-        "name" : "xyHLqvieaye",
-        "nameType" : "Personal",
-        "orcId" : "APqxcIgRoyzCWl",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/ebbff849-2e3f-4dc2-87c6-49bda4592f27",
+        "name" : "0Esz6ev7hzECmsKnY",
+        "nameType" : "Organizational",
+        "orcId" : "oUgGJYlBq8B4QTMkWw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rZE9fh9l9cLHO",
-          "value" : "oTQTVs4T1jj0"
+          "sourceName" : "Rhnhi2KUo7daaKQ",
+          "value" : "zIM1yurl6jghuR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AMUBdDllfnq",
-          "value" : "mmImjHKMews"
+          "sourceName" : "imoOl1pvxSYbGxGBkbI",
+          "value" : "ttwx1S0JJwNYD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/95d1a768-aab6-4b74-8b70-5d466e3646de"
+        "id" : "https://www.example.org/6bdbe650-e9e7-47c5-8de4-9e6301d9c530"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4c284e4a-7e1c-4bd0-8608-749ff27df426",
-        "name" : "v9Zw6HRUGVD",
-        "nameType" : "Personal",
-        "orcId" : "jidaODw228CpDL",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/80371039-ab3c-4faf-bcb3-d63a20863f90",
+        "name" : "ZJNC58mcmPO1o8KjQne",
+        "nameType" : "Organizational",
+        "orcId" : "fT2W52BYA3Aln",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p55aBhfAZP7KKvqd",
-          "value" : "VYTMHznR0KUW"
+          "sourceName" : "ck1nXRzQuHoXu0N1",
+          "value" : "DWGEjXBfcjhK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xHb0Mrmgwbvkb0",
-          "value" : "qgkdp5SZU4S8MzLht9s"
+          "sourceName" : "P9CKRoD0DyB",
+          "value" : "Og6eayVCY7OJhQCwB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3b92ddef-4d34-4f1d-a8b8-532c23fe6540"
+        "id" : "https://www.example.org/c4c09c60-8abe-4464-97e8-3c43800dc887"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "UdzZ8CBSTywzz45o9"
+      "ca" : "vn8654bZAjkWzArgk"
     },
-    "npiSubjectHeading" : "Br43ifja5iWsGng",
-    "tags" : [ "CwNcujRX4Z5lZV7" ],
-    "description" : "1QgSJ2qa2tfg4Ja2N",
+    "npiSubjectHeading" : "pc0MPmF1Qd1H2Fjcfo7",
+    "tags" : [ "aY3hkfGZkfwiOsI" ],
+    "description" : "5mZnjdGk9jIeXmjPW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/ay70GeDShyv9ySamX5"
+        "id" : "https://www.example.com/1y2QaNzGSW"
       },
-      "doi" : "https://www.example.org/22b5c45a-5a53-42ac-9d96-d6fefe4b734d",
+      "doi" : "https://www.example.org/bf607ba8-afee-487d-9a42-9ca0692d7010",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "nWuHYon7W6MVajtDTI3",
-          "end" : "SAa9jjnL5dTseYdHGv"
+          "begin" : "MCQhDqSaE1el",
+          "end" : "tiZ5qip5tiMP66"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b24de99f-a002-4c5f-91c9-fd7454642604",
-    "abstract" : "QkPKnfgMcgPNegoPf"
+    "metadataSource" : "https://www.example.org/fabe735a-b7ee-4703-86a6-545e5dcb498d",
+    "abstract" : "xKsRGbQ8tN"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2c021c0c-10eb-4955-9bf7-d35c5cc356ad",
-    "name" : "A1WF3ARaoUeAP5",
+    "id" : "https://www.example.org/42bee900-e438-432c-8a41-cc6e58ce4290",
+    "name" : "0BSLWjouxxTmsya",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-04-01T21:48:16.820Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2022-10-25T10:13:54.894Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "mt6vTjmXKyuM"
+      "applicationCode" : "cISzkN9j7Ktx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a81611ad-6a2c-40c4-9896-678dabe87a3d",
-    "identifier" : "pa0AC9A3C8N9W",
+    "source" : "https://www.example.org/480c24d7-e0ec-470c-91c8-b0179f3ca7ba",
+    "identifier" : "upVTyMZROHcU",
     "labels" : {
-      "fi" : "LEKmuTU2DmJJZZ"
+      "cs" : "W0mOckvzbOEmvhH"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 711019345
+      "currency" : "EUR",
+      "amount" : 3500766
     },
-    "activeFrom" : "1994-12-15T00:39:16.019Z",
-    "activeTo" : "2003-04-22T08:45:54.682Z"
+    "activeFrom" : "2002-05-07T14:42:11.420Z",
+    "activeTo" : "2007-09-22T21:51:45.840Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5d8e5c51-424b-48a5-af7b-3af9e9571e2e",
-    "id" : "https://www.example.org/c7072f33-ad6d-470e-9e6c-326aa5649024",
-    "identifier" : "08ubALcWYoW4L1U6WH",
+    "source" : "https://www.example.org/4e5079a1-44df-44db-9fec-7c72cb267dea",
+    "id" : "https://www.example.org/8aab86ae-9f7c-457f-b1cf-849b91e556df",
+    "identifier" : "x9DuGWeB0uCf94",
     "labels" : {
-      "cs" : "WhH0rXvv8XO3NFyux"
+      "pl" : "6wf3kaiZULlG8OV"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 230894098
+      "currency" : "GBP",
+      "amount" : 1287391245
     },
-    "activeFrom" : "1984-08-21T04:45:41.577Z",
-    "activeTo" : "2013-02-24T18:20:21.973Z"
+    "activeFrom" : "1990-02-09T07:53:57.294Z",
+    "activeTo" : "1991-05-24T04:51:06.490Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5bfdc608-bd93-4c14-9b51-b7d887d3d333" ],
+  "subjects" : [ "https://www.example.org/193ac233-5ecc-43fe-af3e-d0c14b17ed2f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "031eaef5-645f-4677-b9fa-6afa4ac66a86",
-    "name" : "WTs9DvEoAm",
-    "mimeType" : "D0QzYzFrZLN8c",
-    "size" : 646138980,
-    "license" : "https://www.example.com/qpyhmvjfbssue18e",
+    "identifier" : "a2fbe0d2-9a4c-47d2-80a8-b3c7821e3a01",
+    "name" : "NBvTOmA87dnMifLX",
+    "mimeType" : "QeM8DH9OrSFMzR5DxgG",
+    "size" : 354056963,
+    "license" : "https://www.example.com/jyuyhlsxia3elpuu",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "oRMyKwO6NTJ",
-    "publishedDate" : "2023-01-29T22:59:55.733Z",
+    "legalNote" : "mVG4BGmo8berFZchUB",
+    "publishedDate" : "2006-07-29T07:02:32.853Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "8YpZXTexNzBlvSKs9FG",
-      "uploadedDate" : "2006-04-13T21:26:20.261Z"
+      "uploadedBy" : "qSlY6AFFbG",
+      "uploadedDate" : "1985-12-22T20:18:49.050Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/4EtODzZ6T4M",
-    "name" : "77l8NtlFT9",
-    "description" : "TU7nPJopx7leUkEv"
+    "id" : "https://www.example.com/hoXWesLe0fGBoPGDfoA",
+    "name" : "Ju4lBhnI21da2lbw7C",
+    "description" : "h3t3MJ2dgbm0W"
   } ],
-  "rightsHolder" : "ZZrqruZKVbhKyuCKl",
-  "duplicateOf" : "https://www.example.org/9c22dcd4-2fd7-40ee-a06e-bf1ff3e0d6bb",
+  "rightsHolder" : "BCEJcjId2t",
+  "duplicateOf" : "https://www.example.org/0d4245b8-80dc-4754-989a-952a214dd951",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0a5aL5FWiveZT2bd"
+    "note" : "ETg8aOCEwOKDjilaFw"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dpjgTPi9S34",
-    "createdBy" : "CH5YVHONhavL8MgsGJ",
-    "createdDate" : "1971-08-23T03:26:40.712Z"
+    "note" : "4Yuud4ZtcT",
+    "createdBy" : "7dKk6iwnEQ2Gx",
+    "createdDate" : "1991-05-22T06:28:20.877Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d81a6ac6-5cce-455f-a2ac-16209b377aac" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/5f169994-51c2-41da-b0bb-ad6f0a8f9ccf" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "RuFBSKiM3SiUIlpRLe",
-    "ownerAffiliation" : "https://www.example.org/4a40a84c-d534-4f6e-be8f-da3875954fcb"
+    "owner" : "67gWlZdRHcEqrcBLqF",
+    "ownerAffiliation" : "https://www.example.org/2abe9695-af2c-4f16-a6e2-f129a002b716"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/94c303cb-ae1b-4a57-b389-965093045619"
+    "id" : "https://www.example.org/c7a47bc4-bc54-4ac5-9e3c-4878867cf59c"
   },
-  "createdDate" : "2010-02-12T17:53:07.302Z",
-  "modifiedDate" : "1992-02-22T22:29:58.131Z",
-  "publishedDate" : "1983-11-29T16:14:08.740Z",
-  "indexedDate" : "1985-07-24T07:06:50.663Z",
-  "handle" : "https://www.example.org/c0fd55a6-0dba-4db3-9dc1-7cb6f27b4759",
+  "createdDate" : "1998-11-10T01:45:16.010Z",
+  "modifiedDate" : "2013-08-04T03:34:13.459Z",
+  "publishedDate" : "2006-04-08T10:00:01.247Z",
+  "indexedDate" : "2011-03-11T22:31:35.847Z",
+  "handle" : "https://www.example.org/7a95ea8f-40f7-4cb0-a48e-4bbca190b80e",
   "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/6e414ffe-1719-4e2a-bf73-ff537f506404",
+  "link" : "https://www.example.org/6204d703-e15f-4545-a72b-f649997908cf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FKIVj2PVYM",
+    "mainTitle" : "nh1BQvclvqNJTrr",
     "alternativeTitles" : {
-      "cs" : "cRKm8gBDYKZDg"
+      "sv" : "t8GjBhBXfOH6rTb"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "mNYEplqjvCJ8NoA",
-      "month" : "zXoorzty4ei7Yvc",
-      "day" : "FD2eOwxdGrlsJ565d8"
+      "year" : "dcGQc45CIm",
+      "month" : "cGiTApBCj5mJ7",
+      "day" : "yHw31nViyAdPsfqAib"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ac91bdc6-ad0b-46d9-8671-ad4049759e03",
-        "name" : "Q1tilYFBL8Bj0",
+        "id" : "https://www.example.org/04005cb2-8856-41a6-a43d-f8e59f030d93",
+        "name" : "Z3zQlXJThO",
         "nameType" : "Organizational",
-        "orcId" : "Z0BLIMeeccgosGO",
+        "orcId" : "qSiNBRr7MWibwkt4Qx",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nAOxXvpeJ2NzLl",
-          "value" : "giF2g8qKfTUxgVX7VV"
+          "sourceName" : "jVl3ywT7dhon20Kg",
+          "value" : "Cc6V8i3VP6Q"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eqgTGOmeJ5",
-          "value" : "5rqPgSsYM2w0Y"
+          "sourceName" : "vTipLeIO1JNy4YaN6jo",
+          "value" : "btd1YEXvuv2z"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/087b62f8-97bd-4b93-84ae-bf0b96695264"
+        "id" : "https://www.example.org/f1653568-02c9-4ea8-9279-4ad1c0cd1a13"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "PQko8pmTDbF"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,94 +62,95 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4dfbf279-0797-4d37-ae03-91c442c9813e",
-        "name" : "tRO3IK92GvW",
+        "id" : "https://www.example.org/41eabc80-95ca-49bb-bf97-2d1a0b9d92ae",
+        "name" : "PbacL5IuhL",
         "nameType" : "Organizational",
-        "orcId" : "3l7Q81nalKiw223fZ",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "IgplTZ3jPqWJDp",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SzF2xsUWVF5MDeeKDI",
-          "value" : "sbFCNDL3irLejf5"
+          "sourceName" : "kscfATHQNL",
+          "value" : "RZStRg9OMLj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ju4zhEhKNMFsy2T2T",
-          "value" : "twCj0arEM0"
+          "sourceName" : "CsBEc4L9VK",
+          "value" : "9LXs5yN5jep7H"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7fdb0803-8766-4335-9fca-439776846fba"
+        "id" : "https://www.example.org/792ed559-8b33-4292-b229-e40549f4f874"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "FONjsgz9Bkq08w09Agp"
+      "nl" : "IxIeNe4Z4BY"
     },
-    "npiSubjectHeading" : "hJpviZ2v3a41",
-    "tags" : [ "egftmh06GVyHllOjyc" ],
-    "description" : "w52GVI3MMcYcXey",
+    "npiSubjectHeading" : "tkUuytbopSjY2icC",
+    "tags" : [ "xseg22s0zVrYMc2x" ],
+    "description" : "RDpK2sylqRAhaNZzlIK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/140d3caa-e83f-494d-88f7-87ec707de871",
+      "doi" : "https://www.example.org/f7269ad3-b0bb-4a23-9d3f-83ede5542aaa",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "PopupExhibition"
+          "type" : "ExhibitionProductionOther",
+          "description" : "Zu34F3aFEEAdcM"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/UHyNcyaxDNiS5VC"
+          "id" : "https://www.example.com/BMQH3suz36bK8v"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "i05zTNVfYJws8"
+            "name" : "tMmBaEsse70GbmwoJmq"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "4iHza0LQEru8bBQwn",
-            "country" : "lBW6HVybvBZEb2FUrWY"
+            "label" : "3BYtdR97GqX",
+            "country" : "llHeDFz0wIXDwM5"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1986-08-22T22:34:02.685Z",
-            "to" : "2020-09-30T19:14:44.303Z"
+            "from" : "2007-10-30T10:13:17.012Z",
+            "to" : "2017-04-10T12:27:05.028Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "V66IHziWSxEwlLU7",
-          "issue" : "a3pwfUORxFd",
-          "pages" : "7dNVpcJxOIyqVs",
+          "title" : "6LPeK1sYyT",
+          "issue" : "fnV9jfsbOygjDaqd",
+          "pages" : "z7kurE23MIfF95",
           "date" : {
             "type" : "Instant",
-            "value" : "2004-12-09T12:55:25.532Z"
+            "value" : "1986-07-05T12:29:52.878Z"
           },
-          "otherInformation" : "DsWyNQisRFYC"
+          "otherInformation" : "V1xuDShYgXcVCxORT"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "op7Ssd825vZzHz",
-          "description" : "S1xlfQDsiLKPmzG",
+          "typeDescription" : "Ru7j7OevUoSMTtez",
+          "description" : "6rNecImD7p",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "xUJB59VaFPY",
-            "country" : "aDRvOkmC0OZHTk1rf"
+            "label" : "YxmkvYsx4DUBGcE",
+            "country" : "uCUGw2i7dkvQoS7sH"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Vc6JsGQ4wCYOZZ",
+            "name" : "6XJbGdBkeMVONuk",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1980-12-10T08:17:42.346Z"
+            "value" : "1985-04-09T11:49:39.753Z"
           }
         } ],
         "pages" : {
@@ -158,94 +158,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/bb0b1e8b-5e37-4949-a06d-ad1b4c868f10",
-    "abstract" : "7X1FoNZCY9db3"
+    "metadataSource" : "https://www.example.org/fe1f0228-a5df-4ad1-9b8c-319068f743cc",
+    "abstract" : "SZghRbz4Z6MHJm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dcdc3f37-fcc7-4ccc-ac44-700ab78b0444",
-    "name" : "FolsVF9bH09Y5Vy7Uz8",
+    "id" : "https://www.example.org/d38c5592-9c9a-4ca6-a2fa-91b327def229",
+    "name" : "QzliTEp2bWtKD",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-11-23T05:47:52.226Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "lCqVcEYn0aV"
+      "approvalDate" : "1987-08-09T12:40:52.208Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "LN6yB6zXqtoQ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5fd7a284-40bc-46a5-a663-44c69abaf308",
-    "identifier" : "XXIEMIVq0R04bD",
+    "source" : "https://www.example.org/5bad115e-5b0e-4b38-8d70-42ae7a9ac877",
+    "identifier" : "oGpSqVEJO5",
     "labels" : {
-      "pt" : "nf4ZG13mgWnC"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 229147677
-    },
-    "activeFrom" : "1974-05-15T22:06:40.437Z",
-    "activeTo" : "1988-05-16T05:06:44.481Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/90cc4692-ce3f-4904-8581-0d85969656ac",
-    "id" : "https://www.example.org/23108efc-064d-408a-ab2b-a30bec6135b9",
-    "identifier" : "JKGdN0uw15",
-    "labels" : {
-      "it" : "aNULNrA8Xctbg0AqzVC"
+      "pl" : "lbVSKFytn2uNw7LHAl6"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1587324278
+      "amount" : 2113669296
     },
-    "activeFrom" : "1971-01-22T14:09:49.470Z",
-    "activeTo" : "1974-01-13T03:40:36.174Z"
+    "activeFrom" : "1999-12-02T14:23:25.702Z",
+    "activeTo" : "2008-07-07T09:24:02.491Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/88db71ed-29d2-4a69-92dc-52f309969d86",
+    "id" : "https://www.example.org/81c7fdf1-f517-4e24-9d69-b223c9b19594",
+    "identifier" : "Bw7Px9GEnA",
+    "labels" : {
+      "fr" : "vezO3Ad5ZnaqcRnuz"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 394241971
+    },
+    "activeFrom" : "1975-08-08T13:51:34.952Z",
+    "activeTo" : "2021-08-08T00:18:03.271Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bc9e2453-904b-478c-9b90-f028bab7ad96" ],
+  "subjects" : [ "https://www.example.org/7e113d42-b311-42e0-9c5a-cf480e33fcb1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "760db02e-b365-40f9-9b8a-9a8072f00a31",
-    "name" : "Fv345EzV9fB39",
-    "mimeType" : "awz44eS2F7yhmsjf",
-    "size" : 950027056,
-    "license" : "https://www.example.com/e81yqbr667t0",
+    "identifier" : "3e4fb056-17bf-4905-ad20-9221ba8007fe",
+    "name" : "LwCPT6mpeIRv8Zwfh",
+    "mimeType" : "Z7oFoiCJuyo7",
+    "size" : 994080981,
+    "license" : "https://www.example.com/b6rpvvpzibpp7jkb",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Zym8UC4HBuWGoidEN"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "TcVZbI8xvtkI6SFM",
-    "publishedDate" : "1989-12-20T05:47:55.643Z",
+    "legalNote" : "PC6df5lDGC",
+    "publishedDate" : "2021-02-14T22:35:18.331Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "IP72slcmYUdTnC",
-      "uploadedDate" : "2018-07-15T02:29:28.328Z"
+      "uploadedBy" : "DskbltVrhJWovw2MJRA",
+      "uploadedDate" : "2006-04-28T14:19:14.619Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/OK3m1itV4ZAsd",
-    "name" : "9oYXoXgQDf26tUl",
-    "description" : "UeTYUdky89By1Y7xiz"
+    "id" : "https://www.example.com/drs9V2w55K",
+    "name" : "B015zykGLI3YoQ",
+    "description" : "B6PbWylUYAb8EwsekcP"
   } ],
-  "rightsHolder" : "S2QGnyZzkQX5QdX8GOZ",
-  "duplicateOf" : "https://www.example.org/2633a83b-f74e-4256-a15a-b0055ba628af",
+  "rightsHolder" : "NnQogINCayB0",
+  "duplicateOf" : "https://www.example.org/23e86d7d-d6ef-4dcf-a074-723923d1453c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lIhUJJ3CtYKY"
+    "note" : "gHG2x1Il1Yp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "YxuB1KlTb7zJ1iI",
-    "createdBy" : "nSTK6uBXJe8B",
-    "createdDate" : "2000-01-09T06:48:00.401Z"
+    "note" : "nlUWPSXRTycTDP",
+    "createdBy" : "xCheAMz8tdWq8nPS",
+    "createdDate" : "1987-06-15T12:27:24.813Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9d0b5367-659e-4abe-9edb-facfd7bdacc1" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/89243502-adad-4a0e-afd9-4045ce2c956e" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "0xJVA0d8rfkYicwN6bs",
-    "ownerAffiliation" : "https://www.example.org/007bc92c-cde2-41bc-94c6-04311c2698b3"
+    "owner" : "U3gulrgIYYCh0eI",
+    "ownerAffiliation" : "https://www.example.org/c49a0454-c746-4e77-9806-aa9dcc16f8bf"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a51c69e9-ce4e-41f8-8dfb-4b7591ca3234"
+    "id" : "https://www.example.org/8400b184-a37c-41bb-b8ed-0b0e4bbc2d63"
   },
-  "createdDate" : "1996-04-13T19:53:38.740Z",
-  "modifiedDate" : "2006-08-21T22:14:44.389Z",
-  "publishedDate" : "2002-04-29T18:39:35.894Z",
-  "indexedDate" : "1986-12-12T15:42:44.048Z",
-  "handle" : "https://www.example.org/98e49875-04f5-42fe-b78f-e9b5f81cf866",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/0fabb7af-4d0c-47e1-866a-062f70590344",
+  "createdDate" : "2021-06-11T09:31:50.226Z",
+  "modifiedDate" : "2018-06-04T05:26:36.148Z",
+  "publishedDate" : "2005-04-28T18:33:56.448Z",
+  "indexedDate" : "2014-08-26T04:31:48.611Z",
+  "handle" : "https://www.example.org/a40116b5-a431-4574-be8f-ebbeba1e929e",
+  "doi" : "https://doi.org/10.1234/similique",
+  "link" : "https://www.example.org/2d9d2cfb-388d-4e02-8659-6c53328ec253",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bFhnXYCMN5QXb",
+    "mainTitle" : "tKgLz8eufm1F6",
     "alternativeTitles" : {
-      "se" : "esRDvYdi7CJ4kG"
+      "de" : "TFmRfVQbK1S7di3FB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "06jN2s70lWimVY",
-      "month" : "LlGFrRSc5VMWpR9",
-      "day" : "SJE8O5KT3TCuR"
+      "year" : "7M3eyQofgLM",
+      "month" : "0Y9FBUgqWV1lI0lGY8G",
+      "day" : "XIrgDZWCbxPz33Tz3cI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f2bad6df-2a29-4f49-8c5c-0af2f63d4300",
-        "name" : "zZCuGfVvXhjhh",
+        "id" : "https://www.example.org/642f4298-59cf-4757-b334-2280e9e319bb",
+        "name" : "JbmLgbzz2tn8zMqgCwt",
         "nameType" : "Personal",
-        "orcId" : "AUMMNsPSo8BngF",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "a8Aqsu9xztA",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "15069gVKSVMifIWvtBm",
-          "value" : "IltyXqvwyt"
+          "sourceName" : "x0ta9YPR0k",
+          "value" : "6jb5DtLix5Lr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uyiEBtTID1v",
-          "value" : "4SmVg6l9L4"
+          "sourceName" : "xfSz8xhC2XcYENjw6IB",
+          "value" : "0bbz0nAY4X"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5eb3170f-c176-42ab-b304-77fdcf528790"
+        "id" : "https://www.example.org/f5b252d6-c182-4360-a4ca-85a1e3663369"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/29b98949-8068-4f74-af27-8dc4989e810f",
-        "name" : "XnUiHz06RQ3",
-        "nameType" : "Organizational",
-        "orcId" : "8KsHBEKeT4LUhJy",
+        "id" : "https://www.example.org/9cc9cbdb-b57d-401d-a7c2-f98b202e4910",
+        "name" : "Jfz2EggRxgaPvz",
+        "nameType" : "Personal",
+        "orcId" : "mNF2krIMwAkgPI5Li",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wPAnDEAWZDdrAhcft",
-          "value" : "GIGVEw7MEtSt9cO3YZ"
+          "sourceName" : "wEINwrRwAY4h1EhkYE",
+          "value" : "BlZrVmqpJ6pi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6AJOP5Db8acy",
-          "value" : "5PNLDtetUwGT0KUzVEy"
+          "sourceName" : "g7kCMHvP3UOKyL",
+          "value" : "Qh5FoVaXgzI418q5fo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/175079e6-48d7-4271-944b-a4405a020e1b"
+        "id" : "https://www.example.org/82018cff-5b2b-42b3-a2db-9cdf742512f5"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "TrilVuji3emYDQETi"
+      "fi" : "WvJJTjMupyo"
     },
-    "npiSubjectHeading" : "h6vPLzRs5tSpH",
-    "tags" : [ "Dj37Hozv9O4" ],
-    "description" : "6qk41EbaLuSx3FaXMgt",
+    "npiSubjectHeading" : "QdTe7KDHk4wSqY",
+    "tags" : [ "3vGvaG5cTatr" ],
+    "description" : "zx3n4cmomPkh",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/k4Xdx5Jd0Z"
+        "id" : "https://www.example.com/xGArqPAszBIir6Emub"
       },
-      "doi" : "https://www.example.org/f67af919-c5da-4cb8-946a-7e2b2b907b1f",
+      "doi" : "https://www.example.org/49f652ba-da22-4038-b07f-db6f3345635a",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "CIvk2QlSwEDK9SkE4Nt",
-          "end" : "4CloVrnFumZtiDvep"
+          "begin" : "Il2RfwogVl3lIGDmt",
+          "end" : "PmcLP8sfXsMThFiRC"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/199df21c-4cae-43d6-ab55-db26a9c30e87",
-    "abstract" : "hOHJpQ0N8SLfqi7Sq"
+    "metadataSource" : "https://www.example.org/959df369-48b8-4e2d-b87d-99be3a959a11",
+    "abstract" : "7o5b9UXJSN317sBzn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/652ef6d5-a94f-479b-86d5-87747bd36366",
-    "name" : "RxMwRzs7FLGq195S",
+    "id" : "https://www.example.org/751de294-26e0-445c-b49b-80d444963340",
+    "name" : "hNGwJXFUuwco",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-11-25T19:37:57.116Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "iGXS1lwLwEhxFw"
+      "approvalDate" : "1994-07-18T22:46:43.722Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ZQKQQExdcaKTKsyZ7"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dfd6af41-16a9-416a-8004-bcffb73671d7",
-    "identifier" : "F5KErW4hMJ0lPq",
+    "source" : "https://www.example.org/ec6b058f-35cd-4bac-a88e-dd4149e0b54f",
+    "identifier" : "AhhL9wXXA9n",
     "labels" : {
-      "fr" : "I348oppVu9aK"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 812599210
-    },
-    "activeFrom" : "1972-08-25T04:04:17.292Z",
-    "activeTo" : "2015-05-02T20:39:01.962Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/45d88779-2adb-4691-9abe-0769aea2f3aa",
-    "id" : "https://www.example.org/99d0c4b4-5746-4011-89e4-d24b73a1e7b3",
-    "identifier" : "pGvdLASIG03gHiUHin",
-    "labels" : {
-      "pt" : "6Cwvm33xt5O6S"
+      "bg" : "NldV4f0cflBQC"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 499372920
+      "amount" : 261404903
     },
-    "activeFrom" : "1975-01-12T08:29:40.328Z",
-    "activeTo" : "1990-12-29T04:44:05.216Z"
+    "activeFrom" : "2019-04-07T02:24:28.792Z",
+    "activeTo" : "2020-01-29T18:55:52.770Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/7642d198-20df-4441-bd84-631818fd6c77",
+    "id" : "https://www.example.org/c7195e7a-a35e-4ae3-918e-e6ca29a99c3b",
+    "identifier" : "ILQJqHKXb94B",
+    "labels" : {
+      "fr" : "s6pBVQH5uROfX"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 693107124
+    },
+    "activeFrom" : "1978-12-10T05:44:20.488Z",
+    "activeTo" : "2011-10-24T01:15:33.617Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a09ef534-80d2-415e-9958-b02b7e2d33af" ],
+  "subjects" : [ "https://www.example.org/4d700aae-f776-4926-bf21-02a145ca4d1d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e8b4f925-5ec6-414c-b5e0-a8d9c6c7bd54",
-    "name" : "ryYbtiUblUO7WWEZvxu",
-    "mimeType" : "bmNC1DfnxN",
-    "size" : 85306755,
-    "license" : "https://www.example.com/xldhx18cwipuovmq",
+    "identifier" : "1bc64c9a-bc85-4f35-a1b5-f2aec59f2f25",
+    "name" : "M1mmVG8kiIyAxEAD",
+    "mimeType" : "k2gkFooeGiPq8tt",
+    "size" : 1389748264,
+    "license" : "https://www.example.com/9jnqee34mh7",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "v8EA0sQRiAlvl",
-    "publishedDate" : "1992-12-02T03:05:29.688Z",
+    "legalNote" : "sWij5QdcO1sn0",
+    "publishedDate" : "1997-07-16T18:57:50.162Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "bPPrtrNzFb",
-      "uploadedDate" : "1990-11-11T01:32:12.707Z"
+      "uploadedBy" : "jYEn3tFO4aw",
+      "uploadedDate" : "2004-08-07T23:51:00.548Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wG00mjPvr3CsXN",
-    "name" : "JYNjR8DDyK",
-    "description" : "c81Mn9s3YFBJM1NK"
+    "id" : "https://www.example.com/NuTLwSrONh3eGZJr6s",
+    "name" : "2FkofvcgzzGB5cjfgL3",
+    "description" : "baGcpNEtwNO8Wi"
   } ],
-  "rightsHolder" : "Mzdh8gCf0rwQBFj",
-  "duplicateOf" : "https://www.example.org/730124e2-4aea-48de-b6d0-8b00d610bb0d",
+  "rightsHolder" : "mITfuJUQjEddV",
+  "duplicateOf" : "https://www.example.org/379fad88-9eda-46ce-9378-9e2bc85119b9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "jTvcjM3ZJOeN0PW"
+    "note" : "vRQWwHKdFi1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "eNAbcaPo53rg",
-    "createdBy" : "PQj6KM2PgNHu9mCBU0",
-    "createdDate" : "2013-11-21T20:37:09.557Z"
+    "note" : "7QveH7wrPLETj",
+    "createdBy" : "STHreEPuad",
+    "createdDate" : "1988-02-09T07:56:59.739Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c1e9d988-67a4-407a-95a9-85fbbaf1bda6" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/2823e3de-c4d5-44bb-ba21-16c1e7edc517" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "bTKt0CL696Ff5QN",
-    "ownerAffiliation" : "https://www.example.org/755a3fbc-79de-403c-874b-416b201e642a"
+    "owner" : "8XyvxxyjGlzHZhum",
+    "ownerAffiliation" : "https://www.example.org/a888d37f-28dd-44ad-8946-04cde96ffb28"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d43746ed-065e-4797-a97f-a73bdcd56da1"
+    "id" : "https://www.example.org/5d17c021-c5a0-4b8f-9b27-3fc70dbd472e"
   },
-  "createdDate" : "2007-08-15T16:44:42.655Z",
-  "modifiedDate" : "1979-11-14T22:17:43.354Z",
-  "publishedDate" : "2013-11-09T01:46:15.642Z",
-  "indexedDate" : "1998-07-27T03:20:52.604Z",
-  "handle" : "https://www.example.org/6f8fd637-3bc0-4f0b-aa4b-5c0fa051e1cc",
-  "doi" : "https://doi.org/10.1234/quis",
-  "link" : "https://www.example.org/078493d4-fe63-4014-803c-6db1911fcc42",
+  "createdDate" : "1993-05-26T10:26:55.366Z",
+  "modifiedDate" : "2020-04-22T14:53:50.166Z",
+  "publishedDate" : "2015-11-12T15:15:25.650Z",
+  "indexedDate" : "1994-08-17T14:57:47.723Z",
+  "handle" : "https://www.example.org/be13088c-e2e4-4410-8aec-13a076afb647",
+  "doi" : "https://doi.org/10.1234/eveniet",
+  "link" : "https://www.example.org/1d7bef6d-c16d-41d1-9789-bdb127a0b78d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8MvQC9Se2z4ZUvYgQmD",
+    "mainTitle" : "bpMdLSNfO5xnn7eHr",
     "alternativeTitles" : {
-      "el" : "dtR2gOEGGVP"
+      "pl" : "54BqS2wIqedlXC8k"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "5LwD8xqDKRC",
-      "month" : "XHq5aZ1OwEHsK5HVCoR",
-      "day" : "gAknbxSMS7g"
+      "year" : "qQ3cLW5TsltljBDnUUd",
+      "month" : "6UNcvs7SUXcq",
+      "day" : "CJ8U4yzhBCVV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/262a161d-9f4e-4f0f-bc2a-9b2a7b984e15",
-        "name" : "K6UPpLaPMgBoft8",
-        "nameType" : "Organizational",
-        "orcId" : "Jyn6yByI3E3mtba",
+        "id" : "https://www.example.org/10bdce84-0cd9-4f39-a8c4-2cd1433fb945",
+        "name" : "Fp98LDf5BRTJS7r",
+        "nameType" : "Personal",
+        "orcId" : "tVzg5Ksyv7QyR5Kv24",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cEMIpf45M1",
-          "value" : "mWfAbqYOXtra"
+          "sourceName" : "WjHToFkZSKVSFv",
+          "value" : "MwXE0I9jHd5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xJbJwMsCmgWdQfaga",
-          "value" : "6YAZi4hw1qiPlsFY9"
+          "sourceName" : "1JsQ0agRMm5BOf",
+          "value" : "DaZwO4tNoKJfp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d31d4cf9-71a8-463a-a918-38cd1988881a"
+        "id" : "https://www.example.org/6d2e4340-bf12-4dc7-9fa4-1b197ec72c1e"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "ProjectManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,145 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0256ed1e-addc-44fb-92ef-9f6ffcc61276",
-        "name" : "4ncA4YCYYOtgsG",
+        "id" : "https://www.example.org/01353a98-14c5-4c95-9a1f-181e90b484eb",
+        "name" : "uhPLxX4fdZSlqBs8",
         "nameType" : "Organizational",
-        "orcId" : "0LBU9VKnETurTV",
-        "verificationStatus" : "Verified",
+        "orcId" : "m6JfmybaN87wk",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ByE8x7RqCmywp2SOfyV",
-          "value" : "gLnGn7wXYfcZI"
+          "sourceName" : "LeXJXsfgCpzt",
+          "value" : "l2DcSTfhElLtDOesJS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "deDrPk4UtVr1YXVnCm3",
-          "value" : "EDbSzxKFuBYrEOF2Lak"
+          "sourceName" : "MyWkAraBpDK55yOfeim",
+          "value" : "AZqTd3GtG540kKIBeU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/161fa070-d346-4278-97e1-d5b3231252a2"
+        "id" : "https://www.example.org/ae4e2ab7-5729-4167-9c9b-441db62c86ee"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "ij7uPSWPuLCxM"
+      "pt" : "DMFrMcdYfT9d2L2"
     },
-    "npiSubjectHeading" : "YnN2JGBGA8KyLwXgNP",
-    "tags" : [ "tRaYvF7coJtY9R1" ],
-    "description" : "LuE9YkKV6W",
+    "npiSubjectHeading" : "Mn245Y5Poq",
+    "tags" : [ "1tqkKeVagJA" ],
+    "description" : "pcXQgXP5CE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e68cf7e9-d547-4597-b930-1ec6d7012437"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8d9d4244-88ed-4fe7-a1ec-0820458fecac"
       },
-      "doi" : "https://www.example.org/5931e197-4288-4258-aef6-b40b5a998ea1",
+      "doi" : "https://www.example.org/be763815-d92b-4840-8906-2adfab805e0e",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "QlffyFhWd1xPg2zI",
-        "issue" : "VGKCyMVQKITcYtGU6S",
-        "articleNumber" : "Meek9NoelQos",
+        "volume" : "wt6WgpdDAdZ",
+        "issue" : "7TY0zi7FMzCG",
+        "articleNumber" : "xFEY3PVFYFCAtS8",
         "pages" : {
           "type" : "Range",
-          "begin" : "RSLq1Fb4RiPBpd",
-          "end" : "3ebfl9oEkdd60"
+          "begin" : "rqwpKBRByjJQ7GX0p5u",
+          "end" : "89nE4H5l2d"
         },
-        "corrigendumFor" : "https://www.example.com/ErO3hr4a3jVFeaPexya"
+        "corrigendumFor" : "https://www.example.com/vgcHhP81YPVZ"
       }
     },
-    "metadataSource" : "https://www.example.org/a2aeac2c-abc4-4fe2-bb5b-cf36035f0048",
-    "abstract" : "Yq5GKzAnOPfn"
+    "metadataSource" : "https://www.example.org/ad259cfe-9794-47bd-a26e-550ee2c717b9",
+    "abstract" : "sZDvudWz1DZFd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d3945ecd-7bdd-48c8-973b-37d0c622588a",
-    "name" : "1uMmUhJwejV8s",
+    "id" : "https://www.example.org/42e67849-845e-45b9-b698-7d566536b136",
+    "name" : "s0XZD3KF6byUZp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-09-06T20:11:58.251Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "pCElJsFF06Zyi4r1"
+      "approvalDate" : "1973-10-31T19:31:33.586Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "bamat3gVHdHiBwe"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ae51c4b0-fff7-4c87-a550-878a8285001b",
-    "identifier" : "tr9J8J5iUzNXAiZS",
+    "source" : "https://www.example.org/15b73add-3a12-4a71-ac3f-98bc275aa5ca",
+    "identifier" : "gY7zmrAl2yC",
     "labels" : {
-      "ru" : "QoRqguhyi5"
+      "nb" : "0dZz7nrLXf9GV"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1546443309
+      "amount" : 466522724
     },
-    "activeFrom" : "1972-11-19T03:31:23.673Z",
-    "activeTo" : "2007-04-28T20:21:37.602Z"
+    "activeFrom" : "2015-02-24T10:03:52.455Z",
+    "activeTo" : "2022-03-09T09:25:57.288Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8571652c-8225-44c3-b38e-196c5504bcf2",
-    "id" : "https://www.example.org/3760dde4-b40a-404c-95a5-0b109cfa1f35",
-    "identifier" : "oyFNdrqfoma38DZUrc",
+    "source" : "https://www.example.org/533df20b-6ab2-4de5-b946-46f6535da8d3",
+    "id" : "https://www.example.org/6f5f23bb-aeb3-4008-8d90-02a8be8f2eb3",
+    "identifier" : "mgd6IAbyEZn",
     "labels" : {
-      "nl" : "6uD8wtvk1n"
+      "el" : "pXQbNviFSENaZm"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 813029429
+      "amount" : 751913415
     },
-    "activeFrom" : "1983-12-24T18:54:24.646Z",
-    "activeTo" : "1994-04-11T00:13:17.224Z"
+    "activeFrom" : "2011-12-27T14:02:28.055Z",
+    "activeTo" : "2020-04-10T18:02:57.527Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/482c4aa8-4d3b-47fc-a83a-a3d9f3d872aa" ],
+  "subjects" : [ "https://www.example.org/c4539e1a-b432-4b1e-a73f-ad00e04de1e3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "944bde67-75b6-42f7-aba9-31b11b63446e",
-    "name" : "RH12UTa3wYI0F6Zdh8",
-    "mimeType" : "f1VD4FveOQVpBnvc",
-    "size" : 1505262666,
-    "license" : "https://www.example.com/lheucbj2d5lcakgz1o",
+    "identifier" : "5870eef5-a909-46f3-9cb7-4096bf8da907",
+    "name" : "iuMihTA3lGhTkM3N1nq",
+    "mimeType" : "HGoGEgUhjBzf0AS",
+    "size" : 1034666828,
+    "license" : "https://www.example.com/cvsax6nrlx4kqoq6",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "hQ4T8VQTKl1jzFe7D"
+      "overriddenBy" : "hMcXY7AJO63NrdqSLhd"
     },
-    "legalNote" : "wEMBFZuCv5LTQ",
-    "publishedDate" : "2002-11-14T21:24:35.496Z",
+    "legalNote" : "mI0cjcIes8",
+    "publishedDate" : "1980-04-11T17:21:21.102Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "cKiGoFeZ8ueJB",
-      "uploadedDate" : "1998-08-20T17:37:36.480Z"
+      "uploadedBy" : "gpGJDolGjc5kyld",
+      "uploadedDate" : "1971-10-15T15:02:47.975Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/uye5djhK7I",
-    "name" : "zaZL28IqmBOklUHW93d",
-    "description" : "GD1rdK6bUdirQ"
+    "id" : "https://www.example.com/Vj6jMDNeQjQ6D",
+    "name" : "ADSAS47kCiLK8",
+    "description" : "56cPLV9LH1"
   } ],
-  "rightsHolder" : "PdFP3wm7P76P7RArLlt",
-  "duplicateOf" : "https://www.example.org/e7119778-7783-4e72-8b05-1aff78df3103",
+  "rightsHolder" : "GSiASljEOUa67",
+  "duplicateOf" : "https://www.example.org/da48b4b1-f789-4157-bd7c-b93027cf66a0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "2w0vjkzObvP6tm0"
+    "note" : "q8QJ8Gy230jcRKBFW"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "iUeseBrb1cXShu9aEi",
-    "createdBy" : "znCIrqzeETk",
-    "createdDate" : "1982-03-25T20:42:48.430Z"
+    "note" : "4UIx7n6P3m",
+    "createdBy" : "hPvqgLGJ1ooT1p3DKOL",
+    "createdDate" : "1984-05-28T06:55:12.875Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/32874570-f76e-4a1f-9f42-35a6134039ef" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/76bfa724-5342-4010-bf85-b632add169e4" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "ErkQYtXkms7",
-    "ownerAffiliation" : "https://www.example.org/242f612b-048b-469a-9638-bc936c5f3e0a"
+    "owner" : "NL4G4QTmFNU0ti",
+    "ownerAffiliation" : "https://www.example.org/607b3c4b-3484-42dc-9e6f-04384f46f353"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b6d76fc0-fca7-40c8-835f-4e16d9c2d9e6"
+    "id" : "https://www.example.org/914c3469-13ac-42b2-998c-4af3f16080c2"
   },
-  "createdDate" : "1990-03-23T23:54:56.600Z",
-  "modifiedDate" : "1972-04-30T10:33:11.620Z",
-  "publishedDate" : "1984-11-27T17:09:29.031Z",
-  "indexedDate" : "1983-06-28T10:36:45.407Z",
-  "handle" : "https://www.example.org/1bf4bd12-e5af-4912-bb83-5ec6af4d28d6",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/25d46b10-f013-49f8-b6c7-7bd55daa99f1",
+  "createdDate" : "2021-09-26T18:47:49.936Z",
+  "modifiedDate" : "1984-08-15T20:24:54.461Z",
+  "publishedDate" : "1981-04-06T23:43:13.968Z",
+  "indexedDate" : "2017-05-03T07:04:51.541Z",
+  "handle" : "https://www.example.org/9ae80ad4-2890-4477-ac86-73b638015b15",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/97cdad0e-c24b-4631-a71d-029a8eef9831",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2xLXVg8djuT5",
+    "mainTitle" : "o97tblsRG8",
     "alternativeTitles" : {
-      "it" : "sY4hGDyErZnjdOgc6"
+      "pt" : "u8umn1Ke9TJsy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PZu9X89JzVIG7g4dQeq",
-      "month" : "gqROCyC0E1pT",
-      "day" : "YyQP4aDcJ6Y"
+      "year" : "twyQf1uPcqr4QoFz",
+      "month" : "zTwd9EQN33n82tZSWpj",
+      "day" : "TRTYZ6N2dp3APcq8gNk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dfeeed8c-5b6f-42bb-8fca-17beb5a75474",
-        "name" : "ohDNVCDK1dvIsP",
-        "nameType" : "Personal",
-        "orcId" : "eSvlRL1fEG7M",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c5d743fa-349d-414e-92fb-ae6f249f1b11",
+        "name" : "3MbWONvCGghES",
+        "nameType" : "Organizational",
+        "orcId" : "8XrwmILLphBApOjoub",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ut8HDmcGZ1YmaK3KDDe",
-          "value" : "7EnsFX4gTTIcrddK"
+          "sourceName" : "FEUN46O6lCcGfsUHWNw",
+          "value" : "SWWfFfIeGeZFM7atLB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "riiDPTuGXBspd0Lp3n",
-          "value" : "AnMO0p7sfbm"
+          "sourceName" : "QMxF1OKlkvFr7dG",
+          "value" : "WmtpziA5M9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7a355228-77fd-43f2-a59d-d9a6a1e4cc20"
+        "id" : "https://www.example.org/996e7f8e-1eee-4e54-8528-fd3c45f38002"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Editor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/59a154d8-2d54-4641-b539-668e532214ff",
-        "name" : "DJfwGWD7ODtQwoNC4AZ",
-        "nameType" : "Organizational",
-        "orcId" : "IL4sPk8TTskMi2",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/08f3ef0e-64b7-403f-aa89-813aa7d9fe64",
+        "name" : "pyz2fkkQALaamsZ",
+        "nameType" : "Personal",
+        "orcId" : "5g8FURwAHxLYUNHk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "h8Kt0m32lL",
-          "value" : "qwS6HxcC8ak"
+          "sourceName" : "ggdJOcP8YFEI1yn",
+          "value" : "WbCgHGPZofByuEe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pFmmGQtlhk5YF",
-          "value" : "iLLHHOTKAximfDffB"
+          "sourceName" : "AjbDuBfVW7AlxnRE",
+          "value" : "nseb8ycwKa5aY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5e834b0d-6149-4c1e-bf4b-5ce9622b1c96"
+        "id" : "https://www.example.org/5d787111-3b00-4b99-9e0a-d824a8437ade"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "tBGw40dlM0ngCwIo7e"
+      "it" : "fb6ThVvYG8KMxSgA"
     },
-    "npiSubjectHeading" : "ehn7ZTsXYcu",
-    "tags" : [ "Br6Kk0Dyl8Inaj" ],
-    "description" : "0YAv4EjugIk4p13DyV",
+    "npiSubjectHeading" : "E4l4nu2Y68qq",
+    "tags" : [ "amtOB56A2qLjKox" ],
+    "description" : "I2pmPDp7MZq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c2a63691-a9a5-4f1b-a004-31051af1d542"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7dcb6082-98e3-4ad6-80e4-f1eab239c982"
       },
-      "doi" : "https://www.example.org/4602365c-8f43-420a-85cd-da5e620df9ae",
+      "doi" : "https://www.example.org/81fa3a4b-4937-4a94-87e0-df1a9f5cf6f2",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "5n5ljuBk6reoIw3N9nK",
-        "issue" : "wUd2C3jFP0",
-        "articleNumber" : "0wQqSOzE1hDl",
+        "volume" : "qdC7X35Q40ayGAi",
+        "issue" : "02kyZylDF8VDkn",
+        "articleNumber" : "GfGFe059qvSGH",
         "pages" : {
           "type" : "Range",
-          "begin" : "7sIfmiYuTbll4H3Cgk",
-          "end" : "r5MvJVsworUXQ"
+          "begin" : "bjBYnS7GVILkyL",
+          "end" : "dzYxiCYqINHZe"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b6a84c6e-d954-4c04-a6ae-653ba35a1b06",
-    "abstract" : "KUqu1bfLTV1uEPXx1"
+    "metadataSource" : "https://www.example.org/08cf3103-01a1-41b9-8f23-201a484a8475",
+    "abstract" : "A2lYdNZ5VGY9gQKbTKR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/933c839f-84d4-432e-93b3-7c5f27db6d32",
-    "name" : "lE41tltpjeUwldm",
+    "id" : "https://www.example.org/766d94ac-b972-418c-881e-c098b6037b17",
+    "name" : "KUbhUsaeGYRrzxbLXv",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-06-17T23:24:13.718Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "LLnMWWvg65gnZrM"
+      "approvalDate" : "1973-07-13T23:43:33.411Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "k2GhUS3CQq"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/23c2115b-c671-44f0-addd-1948285e0251",
-    "identifier" : "Sa1oiej6AKnjX",
+    "source" : "https://www.example.org/78b3f7c6-1252-4d6e-9e5a-b0555c653bdd",
+    "identifier" : "5NiDKeVa0XNtsB",
     "labels" : {
-      "nl" : "gHAEvzP9rH"
+      "se" : "qQk3GrlzaPHVL"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1573258668
+    },
+    "activeFrom" : "1978-11-30T00:40:09.731Z",
+    "activeTo" : "2016-08-24T22:37:53.236Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/9488f82a-526a-4108-acff-df60383c37d2",
+    "id" : "https://www.example.org/6f13afeb-528c-4df8-85bd-2c425ec7406a",
+    "identifier" : "hL5NmK2dDkY",
+    "labels" : {
+      "it" : "QPW0IFydPgiOfhyTM"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1150553321
+      "amount" : 1015677320
     },
-    "activeFrom" : "2002-05-01T13:37:49.208Z",
-    "activeTo" : "2020-12-27T03:41:11.489Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/281789fe-3d34-4ab4-a80c-6b444e75e28c",
-    "id" : "https://www.example.org/30c756b0-5613-4bc0-8d2c-4d2bdfb0451e",
-    "identifier" : "YrZfuvbwmhDlvSv",
-    "labels" : {
-      "nb" : "66uPsteQ1kTyv6MR"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2003573044
-    },
-    "activeFrom" : "1971-02-26T16:42:52.421Z",
-    "activeTo" : "1980-12-29T04:58:13.259Z"
+    "activeFrom" : "2014-08-19T17:47:21.702Z",
+    "activeTo" : "2020-07-27T02:13:07.012Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/38b77561-af1d-4f9b-840a-40b7262dde3b" ],
+  "subjects" : [ "https://www.example.org/d1f3114c-f96d-4d98-9a2c-5c2061a767e8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9c4494ce-6f66-4420-aa64-ce9a55ada7cd",
-    "name" : "r670ASV1oZAv7H",
-    "mimeType" : "sPx7rxoHoq7j5hWcQ",
-    "size" : 355633453,
-    "license" : "https://www.example.com/3e69mwwtvjq",
+    "identifier" : "ad8a63c1-347b-41ad-bae7-411249ad6a91",
+    "name" : "TTwn9qtgFGmf",
+    "mimeType" : "EnVBy9r3w5eNnl",
+    "size" : 1448455480,
+    "license" : "https://www.example.com/ztqd7j43npww8l",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "QzB1WBTZDL",
-    "publishedDate" : "2020-12-20T17:10:47.469Z",
+    "legalNote" : "c7uRFGOAOmyMonQj",
+    "publishedDate" : "2023-10-02T15:57:13.555Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Mmv6lhonBI74Z5O",
-      "uploadedDate" : "2021-09-23T04:55:03.772Z"
+      "uploadedBy" : "wDw0nptmZR0k",
+      "uploadedDate" : "2008-05-07T20:39:13.886Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/mURWiosqL6Svr",
-    "name" : "DCYrdwDEoVqsjvbDIo",
-    "description" : "DaJtf6KSWLTq2S"
+    "id" : "https://www.example.com/vDXz9LcUHVvCHv3lJ",
+    "name" : "pYg0lvvvuC",
+    "description" : "XlkcbvjQ2R9D6lwmmK"
   } ],
-  "rightsHolder" : "TIWTEYKEm7t",
-  "duplicateOf" : "https://www.example.org/8ecf7cae-d92a-43d2-abf0-757b85038281",
+  "rightsHolder" : "PpvO7WygGtUCbUxiK",
+  "duplicateOf" : "https://www.example.org/1f52415f-ba77-42d8-b08a-fa4cae2339b7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "h31BSuSn2PMLPo"
+    "note" : "ZXS6DGCu4874wMCya"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "NojfAnwGfbcGim",
-    "createdBy" : "OGChHCIdTFViifT9Qb",
-    "createdDate" : "1989-07-20T18:30:23.407Z"
+    "note" : "T3aLRTnJa0gvDDd",
+    "createdBy" : "W9GrrEdDGheOKyrWwG",
+    "createdDate" : "1995-10-03T19:07:34.038Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/97e600ce-c279-472c-847c-e4d5b90d0e4c" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/acc75c44-aecd-41eb-991c-6b954459bc89" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "LTOBcpJqPmHU",
-    "ownerAffiliation" : "https://www.example.org/2dc54a71-3ce9-4188-8e99-13b3ad51b089"
+    "owner" : "R1l4rXOYEM6JEnH2a",
+    "ownerAffiliation" : "https://www.example.org/1cd1c26c-2579-4e0d-9362-f203e153387a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2acef340-48f1-4808-807e-cf32e97c0e71"
+    "id" : "https://www.example.org/b39c7c60-13cb-4826-a9fc-345078b49b8a"
   },
-  "createdDate" : "1994-03-22T16:47:53.186Z",
-  "modifiedDate" : "2005-12-15T12:24:27.623Z",
-  "publishedDate" : "1975-07-18T23:32:02.749Z",
-  "indexedDate" : "2005-02-26T10:05:59.578Z",
-  "handle" : "https://www.example.org/8192d65e-ff50-4eed-918c-dc8c6c90a5a4",
-  "doi" : "https://doi.org/10.1234/enim",
-  "link" : "https://www.example.org/3c6235d6-940c-46d0-8b37-57ff4bfe1e67",
+  "createdDate" : "2013-05-28T07:48:35.998Z",
+  "modifiedDate" : "2008-03-14T21:27:34.681Z",
+  "publishedDate" : "1982-06-27T23:41:36.245Z",
+  "indexedDate" : "2014-03-12T02:08:31.111Z",
+  "handle" : "https://www.example.org/d81d749b-8803-4442-b5d9-54daf960405a",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/b59d3bed-4463-4abb-be51-4e1d88d1b157",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7jxsmwyBCE",
+    "mainTitle" : "lM9TePQPZq",
     "alternativeTitles" : {
-      "da" : "fz4WmAM0poUu"
+      "el" : "qHK06TDRIxH0D6Fiz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "i6p3vvboNLoIqtv",
-      "month" : "nW6hJX7nI2MTxw91oie",
-      "day" : "LtvghGveGYFDc5j"
+      "year" : "ErukVqMrHDrcg",
+      "month" : "2Mw8bEoanYGlr",
+      "day" : "yNDF4lVhOm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d61a77d7-9166-47e8-b315-20f0dfc4229d",
-        "name" : "E3s0lwoFmH",
-        "nameType" : "Organizational",
-        "orcId" : "JMug4c6hguIq6EXrY",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/4996ea08-3180-4445-ad84-e6e077157081",
+        "name" : "V1y1CSAHoN",
+        "nameType" : "Personal",
+        "orcId" : "zmkRmvcoXGKuNPGFlRw",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vlvWUdLddnsUOxHr",
-          "value" : "jHzTojX3PGWJMDNZ0EM"
+          "sourceName" : "eVBJIzdQRqaqX0b",
+          "value" : "lOnttTHhdv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uAfkXFASdS1xh",
-          "value" : "mOFwjTNNWg1Tqu"
+          "sourceName" : "UCXq57WuZaOaGjWxH",
+          "value" : "Grrp3FUHE34o6NZQEWu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/025b0edf-bf12-4348-8617-d3bd5d075d08"
+        "id" : "https://www.example.org/0dd4196b-a1f5-40a9-b879-dc1083cc783d"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "MuseumEducator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/30c3eac0-9dd5-4dd8-a932-7ad0159f5097",
-        "name" : "Nu4R9NLwj5bl",
+        "id" : "https://www.example.org/20250660-e02c-48cc-9415-e443b6891197",
+        "name" : "7pKFasNYBCgl0HdT",
         "nameType" : "Organizational",
-        "orcId" : "0ZGgio74BFzJy9l",
+        "orcId" : "Xz18vt8G9Yy8kty",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "r9M46u67Dw",
-          "value" : "txZenJXfzs2TC"
+          "sourceName" : "yXMuEwjpV64bRR",
+          "value" : "IB71YqsEK49Qa0x"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lZLqW6GdHJ",
-          "value" : "zZHBO3HrvuoFlq2s"
+          "sourceName" : "F3iqISzDnG",
+          "value" : "0R9z6A7MFXz88zWWy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/df878bba-90ce-4aa5-b47f-96f106c29dbc"
+        "id" : "https://www.example.org/60321e38-cf50-4055-8a06-233526ae5369"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "Fby3xwO0MTvP3MnB"
+      "el" : "XO3Ri6IXUnx"
     },
-    "npiSubjectHeading" : "1iEEHlWULQEKy",
-    "tags" : [ "1GI5Iz6LCmfbgqQ1vCG" ],
-    "description" : "CAyMlorhpJsCLJvxA5",
+    "npiSubjectHeading" : "lQ6iGZ1wYR0LGYCKB",
+    "tags" : [ "MxeKqt03JsWxaf" ],
+    "description" : "GnG0LePfxpzX5C",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9f0d51cf-59be-44d7-b51b-7c4eb723ac44"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/58cfe91f-c504-417b-8530-8a9428e66bdc"
       },
-      "doi" : "https://www.example.org/dd2c938a-05f9-49c6-aa3e-97f50e26ae7f",
+      "doi" : "https://www.example.org/cca97aa9-8a4c-4315-810e-e9372f10cd4d",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "ElkDVPVxkn",
-        "issue" : "pqFTQsGADV8X3xsR",
-        "articleNumber" : "Et7RakA0sAr",
+        "volume" : "bLqBrnynvl",
+        "issue" : "VMQqWhEqRPM",
+        "articleNumber" : "PbnD2fmQhKW",
         "pages" : {
           "type" : "Range",
-          "begin" : "slKx8plcbgjSLf",
-          "end" : "LhtJJGELIi4K4FnPX"
+          "begin" : "xPS8KZRkPkKKj8jo",
+          "end" : "lDLmnUVts4Hb3Nuv2u"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e0c7d562-b523-4ca5-8508-7459f3da1ab0",
-    "abstract" : "iSPOfNMgKf"
+    "metadataSource" : "https://www.example.org/ea806a61-9547-41e6-b4df-bebbf1ff2d7e",
+    "abstract" : "JfKCxpUP31E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/497c7e0a-e545-4f5d-827e-342e17e739b8",
-    "name" : "Yoo9FG7CimunpMrS",
+    "id" : "https://www.example.org/e705242e-cc3a-4646-84ed-109a41556592",
+    "name" : "ndqcxhQwR4qeT",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-06-26T19:48:18.016Z",
+      "approvalDate" : "1980-07-30T16:30:18.781Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "DQf3JlWpq4QknA8im"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Pb2By1SOB7al1cL"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/13c87e72-d5a6-4b18-bb92-c4afdaca58f0",
-    "identifier" : "HfFiCIQsfHyrSz",
+    "source" : "https://www.example.org/9903d7d4-74f9-4593-a918-b365e2582a85",
+    "identifier" : "4bqXifRWdadoU3GebH",
     "labels" : {
-      "fi" : "bgaJL5yOCGP1nF4Qu"
+      "en" : "VHlf6B9cdsRybZPQ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1672307146
+      "currency" : "USD",
+      "amount" : 1960754355
     },
-    "activeFrom" : "1972-06-06T11:29:05.217Z",
-    "activeTo" : "1982-04-22T19:32:12.839Z"
+    "activeFrom" : "2013-03-21T00:47:17.168Z",
+    "activeTo" : "2021-07-10T10:35:01.752Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/34f8df54-aea7-45e5-b2a8-12cb7cc5c86d",
-    "id" : "https://www.example.org/419ba8c1-fde2-4f02-9d48-c623b99b7d78",
-    "identifier" : "Ws8iL5QVeJY",
+    "source" : "https://www.example.org/951e2900-55db-4f73-9f17-817ebcbf640c",
+    "id" : "https://www.example.org/f2662875-a17d-4cbd-bc11-7f277e509ead",
+    "identifier" : "EDJ0fg24GUfvrq5",
     "labels" : {
-      "nb" : "qHPCw2876Wiwe1Y9tkW"
+      "el" : "xP4ce3CPeRLFfu2k"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 113694923
+      "currency" : "GBP",
+      "amount" : 19163109
     },
-    "activeFrom" : "2023-01-06T04:35:27.230Z",
-    "activeTo" : "2023-08-26T13:13:38.248Z"
+    "activeFrom" : "1978-05-15T15:57:18.376Z",
+    "activeTo" : "1988-07-07T14:41:10.370Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/05f7fd61-1e1b-4b37-b8a2-d111bd5d2be4" ],
+  "subjects" : [ "https://www.example.org/e88a3b41-0b02-4df2-bc4d-d2866315c8c4" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b96a2d0e-b7d7-4882-992e-6aa47f637832",
-    "name" : "cwHpKV4SpZpUAPNx6W",
-    "mimeType" : "JpitjatRt4iJ",
-    "size" : 118060604,
-    "license" : "https://www.example.com/tq3sppdavspdnh4ar1x",
+    "identifier" : "7ef2f1e7-210d-4920-a662-21164a11c855",
+    "name" : "lxiwuLGUb8oPnsvu",
+    "mimeType" : "2pcAGEeUBi8nCwMtFg",
+    "size" : 1976223078,
+    "license" : "https://www.example.com/rg49vk1tvlc6wjwcl",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "xTzByrz5fwt5do"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "Css8hrdH6l",
-    "publishedDate" : "1977-11-28T02:39:28.699Z",
+    "legalNote" : "O3lw06T4HWLp",
+    "publishedDate" : "1973-10-24T06:30:11.316Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "tGQDYSw65xyQRy",
-      "uploadedDate" : "1987-09-06T17:38:49.036Z"
+      "uploadedBy" : "noqW1jNdg6rAuFN",
+      "uploadedDate" : "1985-06-26T06:48:23.309Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/GtY1YYVoz0N",
-    "name" : "c6pCuvS5FhbrMffUMc",
-    "description" : "QLbYkiezheEhJkL"
+    "id" : "https://www.example.com/ThizQ5uzNhoOqVpeQ",
+    "name" : "rBYP1kOVkVwDh",
+    "description" : "Fm3QTpY7gA"
   } ],
-  "rightsHolder" : "CFBuuSgfPe2",
-  "duplicateOf" : "https://www.example.org/91a24407-b8e9-4357-8c2e-34d8346c4dfa",
+  "rightsHolder" : "5oALYqwKSTF4dNS",
+  "duplicateOf" : "https://www.example.org/de997d5d-8f88-4fb2-9668-47d5c3bb1efa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Zx9a7A9Zs47"
+    "note" : "GkyoB5p9zcVlY27NXVU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QW9IGq1T67XrGDr1",
-    "createdBy" : "65SjjYb05KRof",
-    "createdDate" : "1992-12-07T09:06:14.043Z"
+    "note" : "q5ToFyEJqtb",
+    "createdBy" : "YtwOYGlj5IwsB0qYoX",
+    "createdDate" : "2012-11-22T13:25:27.559Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/08fb30db-c4b2-480f-98a6-903cf0b9d180" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/fe60a74b-ec00-48a8-91a5-3cc5a2a2e87d" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "9r9SDi4g5GZW",
-    "ownerAffiliation" : "https://www.example.org/d7b7ea39-6fce-41ca-8f98-adfe7bdb386b"
+    "owner" : "9XWNSsRaDFX",
+    "ownerAffiliation" : "https://www.example.org/70c07144-884f-47a2-8795-701ea78d5d51"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d0517b18-8561-4a6e-b9c2-3fe048d0f3db"
+    "id" : "https://www.example.org/c0d391aa-3599-4af9-bafa-2b49fd8a46cc"
   },
-  "createdDate" : "1988-12-06T06:45:21.351Z",
-  "modifiedDate" : "1992-03-11T22:51:35.756Z",
-  "publishedDate" : "2024-01-21T11:44:30.310Z",
-  "indexedDate" : "1977-06-09T08:46:17.232Z",
-  "handle" : "https://www.example.org/9acc5b05-a081-4a7c-9f21-50a5b39b76ae",
-  "doi" : "https://doi.org/10.1234/dolorum",
-  "link" : "https://www.example.org/5079d2f8-396d-4b92-8beb-4e9af415e9c7",
+  "createdDate" : "1971-10-11T21:22:47.131Z",
+  "modifiedDate" : "2018-02-02T13:10:43.780Z",
+  "publishedDate" : "1997-04-10T00:59:29.078Z",
+  "indexedDate" : "1974-04-13T04:20:09.840Z",
+  "handle" : "https://www.example.org/947b5884-ffc6-4385-980a-12113d29bc5e",
+  "doi" : "https://doi.org/10.1234/quisquam",
+  "link" : "https://www.example.org/a2fdb275-f988-4b58-a4c7-957719d84f8c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yA1AXROEZv0nWp7",
+    "mainTitle" : "wRgkl7kgYxFsNSuP",
     "alternativeTitles" : {
-      "fr" : "aBsMW94OTz2"
+      "pt" : "8OOJYOziAFMfxN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GoAXfTiQ3u36A",
-      "month" : "regMOh1gUoNR",
-      "day" : "vLgpgvxxri834RM3"
+      "year" : "2BnbwanALi",
+      "month" : "DhuBdOAnUWIhTD",
+      "day" : "5I5MbjIHXhl1eH5f9mq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/64cf7e41-47d3-42ba-ab79-bbd5375f271f",
-        "name" : "wKBnpHEQ3PExiB0",
-        "nameType" : "Organizational",
-        "orcId" : "uogGrT1Sk1TMJ5oH",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/55b77a48-9bc7-4a67-8b08-5e89d53325f8",
+        "name" : "m8OPVY0ilcyHSyPUQtE",
+        "nameType" : "Personal",
+        "orcId" : "AGm9rvA27Bwt08D",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YMlddfXRrTqYWwitZ",
-          "value" : "F3tnloqQC5EXf9"
+          "sourceName" : "6RBx1rzPbor6kSJvzPc",
+          "value" : "DalKWfcsHO4c"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7VJqKWC5AWrU5Rj",
-          "value" : "hJBnnrhwSuKypklSFH"
+          "sourceName" : "OkTsBC8mfPwJq6nn",
+          "value" : "vVJCIUo6addG4mZ3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fd804f0f-fcd0-487a-bb8a-98576e4e3135"
+        "id" : "https://www.example.org/1a5f73a4-a85a-450f-a1ee-a12c8dccb053"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7e805608-bf4b-415d-bfbd-c41851a9f0f4",
-        "name" : "76tt24FPfOzs",
-        "nameType" : "Personal",
-        "orcId" : "bOh5NcYzpa1SGN",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/4b82f478-63d2-483a-835b-978a8d136363",
+        "name" : "eSjE9xrJlu",
+        "nameType" : "Organizational",
+        "orcId" : "7z06vAGzOJ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "st9DepaF3PVCMzpN2oO",
-          "value" : "whvPzpfO2S"
+          "sourceName" : "vZ1DvtWIG12",
+          "value" : "dXs66DYAYewO80A"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oS8jLHCiAkAKERKtXS",
-          "value" : "neUKTSVWa5NBKe"
+          "sourceName" : "GU0EqflmcfAP",
+          "value" : "RdH6cRPrbabqT4yiev"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d0eadd97-0a24-4b70-9513-3086b62e7e77"
+        "id" : "https://www.example.org/ce29174f-6cd9-4089-afea-4f896bef4e90"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "eUQdcWzbl67YvTf0W"
+      "da" : "QAEl0kBdZmYg0pbe"
     },
-    "npiSubjectHeading" : "xda99Ko8mh",
-    "tags" : [ "hXjoiFl44W8Z" ],
-    "description" : "lQOMfiu7rBU",
+    "npiSubjectHeading" : "oh6zgWlUQGZ",
+    "tags" : [ "psFmVXAFpSiO1" ],
+    "description" : "46T51iVH29",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0c3242fa-eb4f-4c0f-abf3-b4d8d28a71c7"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3a7c0491-cd88-4872-85a6-6c92fd36a470"
       },
-      "doi" : "https://www.example.org/1aaf11e8-d773-4ce6-a670-8270e0bf3d03",
+      "doi" : "https://www.example.org/84581beb-8f7d-4584-8fb9-4c93fa4d2dbd",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "9MPO6vJ1JDIldsrAIcI",
-        "issue" : "nOprTxRoAXn",
-        "articleNumber" : "SUr2Qoy4N9HZ",
+        "volume" : "uHMJkmIXphjT",
+        "issue" : "PAKY3dyH2lb",
+        "articleNumber" : "ucPp9LdDc5gFva9jR2H",
         "pages" : {
           "type" : "Range",
-          "begin" : "f16E4xs8aeoz32oZL",
-          "end" : "xf0kS1BSPotOvg"
+          "begin" : "lGldCADd1CK",
+          "end" : "kcjMAfSRN0HmBa5g"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/dbbf5164-4e88-4e7c-95a6-74113f5bde45",
-    "abstract" : "eGuHx1HZAgCTb"
+    "metadataSource" : "https://www.example.org/3bec8982-13a2-4ead-b727-92e366cd8782",
+    "abstract" : "Kp4jGgwd1D"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c5604604-7c74-467e-ba3c-633c5d8529d4",
-    "name" : "4CcIa6DmVOlHyT7",
+    "id" : "https://www.example.org/8ee49387-e322-4f88-a3eb-95b9ade6f0b3",
+    "name" : "KW6zpAjpfsb",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-08-20T04:39:18.355Z",
+      "approvalDate" : "2008-05-06T19:42:23.728Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "o7qCyxnsIoDIxUqGu"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Cb6Ahibs6PRANj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1ad904b7-ee20-403f-bcb9-4f04dc567031",
-    "identifier" : "NXHB8KIvhRrXwkmN",
+    "source" : "https://www.example.org/74d71ccb-3749-4856-8a08-5551254a55e8",
+    "identifier" : "WnzRV0htpaJzIPtBjV",
     "labels" : {
-      "el" : "oUrBpL3qVpAzKW"
+      "nb" : "sYKW2qvRPFH"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1647828086
+      "currency" : "GBP",
+      "amount" : 1700127113
     },
-    "activeFrom" : "2009-11-30T19:34:41.112Z",
-    "activeTo" : "2010-01-12T23:47:34.426Z"
+    "activeFrom" : "1978-07-12T16:09:23.991Z",
+    "activeTo" : "2012-09-23T15:45:07.335Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6044ce88-9404-4a92-a270-1472e75a6efb",
-    "id" : "https://www.example.org/187ac660-0a34-46c5-83b1-27de4ef43f6c",
-    "identifier" : "neMLPcXPoioNV",
+    "source" : "https://www.example.org/93d719bb-b46d-46d6-b8d9-b614dc9b81d6",
+    "id" : "https://www.example.org/dbc349a0-8960-4e02-b0d9-4ca69d96e62e",
+    "identifier" : "asWG0zbhOQcGmA8iU",
     "labels" : {
-      "is" : "d9Zq4KcKcIAxuXQ"
+      "fr" : "rA2XjPSWSx"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 201457357
+      "currency" : "USD",
+      "amount" : 1578576775
     },
-    "activeFrom" : "1997-06-06T03:42:44.467Z",
-    "activeTo" : "2017-03-05T15:29:09.551Z"
+    "activeFrom" : "2023-06-26T01:01:45.225Z",
+    "activeTo" : "2023-08-11T08:03:44.595Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/12c16d9a-cd1e-4bd3-82e9-59386f3b719e" ],
+  "subjects" : [ "https://www.example.org/9b8af1b6-e026-43c6-92eb-dc8edc692822" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7e4f030b-aaa8-4173-908a-10a2d77aa259",
-    "name" : "r6p76jsKqZtVMB9eB5",
-    "mimeType" : "0RE1zEB8RRPO",
-    "size" : 345137304,
-    "license" : "https://www.example.com/okm2co40obtr",
+    "identifier" : "aa86c1be-e36d-4c3e-ac5c-dbb6cd170f4d",
+    "name" : "BjctddGQZuazkWw3lS",
+    "mimeType" : "IXKXkcwCbSk9lYoo",
+    "size" : 1143576785,
+    "license" : "https://www.example.com/mlyhhvjnxgwkjisy",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "jqMP6Gg1IaNB",
-    "publishedDate" : "2020-01-17T05:15:40.907Z",
+    "legalNote" : "kbtxFkTL2LA",
+    "publishedDate" : "1971-05-31T01:31:39.029Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TutTFQUv47v6gb",
-      "uploadedDate" : "1999-12-22T05:49:41.616Z"
+      "uploadedBy" : "0jOqCTgCbV0d55I5",
+      "uploadedDate" : "2004-02-04T09:43:52.966Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JIynj3Tx04UPNfd",
-    "name" : "JiswjHCW3I1Yr8LzgW8",
-    "description" : "pyOORSnNIP"
+    "id" : "https://www.example.com/nYOiXfezuAdFFasVp",
+    "name" : "kb5yWzOOqFUOs6IGL4",
+    "description" : "HAOcJcq4qft"
   } ],
-  "rightsHolder" : "5T1xxj4SBqYoBJOZC",
-  "duplicateOf" : "https://www.example.org/11855201-a39e-4252-8fea-a8a6da8d3317",
+  "rightsHolder" : "ZVqXgswRjWA95IApp1J",
+  "duplicateOf" : "https://www.example.org/f0a8a1a0-efea-4120-82d9-e33952123b5b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Wz5X0NvVVgr"
+    "note" : "cS8uDwB2JIpWBjvt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kINJOXWe8IaD",
-    "createdBy" : "JJNWGTIFGoBfzyGxNO",
-    "createdDate" : "2022-01-10T14:23:06.762Z"
+    "note" : "9kztcngabsNDJgHlRAJ",
+    "createdBy" : "k1wTjIwnrP5X8kRwtA",
+    "createdDate" : "1976-06-10T21:42:57.368Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e4fb46bd-9de8-4481-8c1a-103dc0e15e2c" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/4b63c1d8-1276-4582-86f6-9745e49e2147" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "5I3HskxpyIY2p",
-    "ownerAffiliation" : "https://www.example.org/11f9d613-0131-4f0d-be50-e9f8205556de"
+    "owner" : "FeoGZJMKS9xY3e",
+    "ownerAffiliation" : "https://www.example.org/a9149ee6-4eda-4cfd-b630-0cd4efd33462"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e9f321e0-3d6f-4f61-9d74-5c7907e077f1"
+    "id" : "https://www.example.org/0d30fb7c-f900-47f0-a0a9-20e775937222"
   },
-  "createdDate" : "1971-05-27T13:11:14.246Z",
-  "modifiedDate" : "1988-06-08T22:16:37.848Z",
-  "publishedDate" : "1993-03-17T04:28:14.895Z",
-  "indexedDate" : "2003-02-25T14:54:48.120Z",
-  "handle" : "https://www.example.org/69c5cf27-2887-4df1-96fa-47807cc7b0da",
-  "doi" : "https://doi.org/10.1234/in",
-  "link" : "https://www.example.org/16083279-f966-4540-a2d9-6ebc60cd4bdc",
+  "createdDate" : "2024-01-10T13:27:21.258Z",
+  "modifiedDate" : "1980-07-27T12:38:55.815Z",
+  "publishedDate" : "1983-03-20T19:28:02.900Z",
+  "indexedDate" : "1975-07-13T12:09:49.123Z",
+  "handle" : "https://www.example.org/34e4b6d2-3131-4567-908b-ddc71fbdb423",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/58cfa929-43da-43c7-91cf-6717f71e8616",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kyHCDcbkZPJQsE9PaF",
+    "mainTitle" : "9XcG5YPvVb6o5g",
     "alternativeTitles" : {
-      "pt" : "dfUrIQnmjU7Q"
+      "fi" : "3dvj6o3NeRghPrnyXa"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "CTZgpK5c2QTvi",
-      "month" : "jpPl4EgzkS7gMckv2",
-      "day" : "UDIxZDwRB7Hnoz0"
+      "year" : "EpsHqkToQtnZXI",
+      "month" : "YgHp4rNPXD94WNyWG",
+      "day" : "N8hKngS11B24"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fe5cd976-fff5-47b0-a667-e9c1392572ea",
-        "name" : "OTFduGIyYy",
+        "id" : "https://www.example.org/7fa1465d-b5d8-4400-b349-8392808814d5",
+        "name" : "ZxyYSkGpues8jxEUc",
         "nameType" : "Personal",
-        "orcId" : "uT9lTu9Siun",
+        "orcId" : "QFAWn7VJPlPrHwUJlYu",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ljYwLmZ57orz1",
-          "value" : "dydGK9akxYZn4i"
+          "sourceName" : "VJ8R0XvUQFgpZiyZ3",
+          "value" : "bML72SUhla"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9FKWx6DBI09HFPm1em",
-          "value" : "DBGKzIXocflb5P"
+          "sourceName" : "Z9pmtWchYmU",
+          "value" : "gQqkxkfJAfS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6049e528-bbf2-4dfc-bec3-f340efb0ba4f"
+        "id" : "https://www.example.org/182ebf03-a498-446b-99fe-e6b83de56de7"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/857cbf2e-1e3f-46ec-983c-f8d75da7dedc",
-        "name" : "blbKhmmxgrQqLvrvN",
-        "nameType" : "Personal",
-        "orcId" : "sfPCyjHILErm6e",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f2d6a62c-e2a5-44bb-9ad6-b8b0b7597092",
+        "name" : "67P2PLELFFjUh1RJ",
+        "nameType" : "Organizational",
+        "orcId" : "nO7fTdDPqeWhwDGZcn",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xcD1t3cOsDSYKVx7",
-          "value" : "xXlVe8IbV4lLKR"
+          "sourceName" : "JjvcgYWSUXTQD",
+          "value" : "dzwVIXxVaX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tKqAFvIDjk",
-          "value" : "559Ys1BfV1yY96cPL8"
+          "sourceName" : "v6HcDaHYf6MgMnnMR",
+          "value" : "LHreOZ5wTtI8RyHF8ew"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4f1c1b5b-5048-4732-aa05-b03b2830b9e6"
+        "id" : "https://www.example.org/3ca1bbe2-0199-43f5-9a2b-b9c58e0f5223"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "Choreographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "8z4uiFoGce8EEOQO35"
+      "cs" : "Wove3bxbVp7MF0UjXHW"
     },
-    "npiSubjectHeading" : "iwWxnYJPNn",
-    "tags" : [ "VTJlKVVrDNfNMcyt1g" ],
-    "description" : "ZenoQHHV6a",
+    "npiSubjectHeading" : "4YvnkVRMPJ8dm7yL",
+    "tags" : [ "Resgnqjr67dmAmMv78" ],
+    "description" : "h92OvQUSLOkd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7de10dd2-6cb9-4a84-b800-fc0944fe03f5"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/41c95bd9-fefc-4f1c-bf8c-a7d4cd3a335b"
       },
-      "doi" : "https://www.example.org/b59af595-cde4-421e-bd75-8bdf57f5a6a5",
+      "doi" : "https://www.example.org/e3b267b9-f361-49b9-a684-9eecaa51aaec",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "zlJo2EP9fK55igS3Zd1",
-        "issue" : "HIV7By34ybFh8ehSbx",
-        "articleNumber" : "3VCWlzrYn8uwctS37",
+        "volume" : "34bHeErIef2oUPYX3",
+        "issue" : "jMFfFYJ27SRm9n",
+        "articleNumber" : "eQ2NiZ85MXQU",
         "pages" : {
           "type" : "Range",
-          "begin" : "Og86sk0RMWDd",
-          "end" : "pzBYq13TEMdfykg9IQ"
+          "begin" : "Avukw8S0qb",
+          "end" : "I5djyl4mEeXdj8rF"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5310849d-a494-4c71-9c8a-5b2573cd3248",
-    "abstract" : "ss37gjqUMGV"
+    "metadataSource" : "https://www.example.org/e2c6193a-c3ce-4a02-8df8-bf66e8d23052",
+    "abstract" : "J41oSdP8xPU574m0Fnb"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7db0cdae-d7f0-4024-a4b1-98edcfee349f",
-    "name" : "wejy8AJbiw0zd9M",
+    "id" : "https://www.example.org/f02bb0bc-ad6b-47b8-8db0-7ad5035ff963",
+    "name" : "cIYTyXIcWn9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-09-14T01:58:28.376Z",
+      "approvalDate" : "1987-10-08T07:37:24.618Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "l4AejH8T0zcxGq5Tw"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ymPkoD6MAR5"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d33229c5-a264-48e6-b0a4-d54943b51bde",
-    "identifier" : "a0d5osAnjJva5GAh",
+    "source" : "https://www.example.org/e16e1cfb-fd0a-4db3-8a36-0b7946ba0649",
+    "identifier" : "wzFBhKPzgikPv3",
     "labels" : {
-      "fr" : "khdyaBEHtVmCzd4XjQ4"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1282461253
-    },
-    "activeFrom" : "2000-09-06T08:26:33.228Z",
-    "activeTo" : "2023-02-02T23:15:45.767Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c4ef7a0f-203b-49aa-a9a9-e77671537a2b",
-    "id" : "https://www.example.org/3a8a70e1-71a4-4e1a-adf6-bce469ac03ce",
-    "identifier" : "Mdug4mhS2nITE",
-    "labels" : {
-      "sv" : "rQLIOKrDP3LKK"
+      "pt" : "TvbwMJqolQKn"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 840417837
+      "amount" : 1012914809
     },
-    "activeFrom" : "1973-02-04T04:56:52.553Z",
-    "activeTo" : "2022-11-19T16:16:08.932Z"
+    "activeFrom" : "2017-01-18T07:19:47.688Z",
+    "activeTo" : "2020-03-02T10:00:02.584Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/a1bc0c52-acda-4732-99fa-08d8cee00ddd",
+    "id" : "https://www.example.org/290c4cd3-562a-4b87-a5e3-ad6c90b02eb6",
+    "identifier" : "baV6eeFUPPQhUUtth",
+    "labels" : {
+      "nn" : "MbygvyOeUGs"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 644538953
+    },
+    "activeFrom" : "1995-01-27T01:11:42.694Z",
+    "activeTo" : "2021-09-13T22:20:28.250Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/67d8413a-bfa3-44b4-96d5-96e8ad58ed47" ],
+  "subjects" : [ "https://www.example.org/1a93b026-de90-43df-82ff-045c8c1e753d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f17589bd-529b-440f-af55-75c40e4dc5cd",
-    "name" : "65XWLUuFJAL5WD",
-    "mimeType" : "qX6KwJHF1Ocz",
-    "size" : 1356285565,
-    "license" : "https://www.example.com/sc0n5qlwpfw7am5s",
+    "identifier" : "bcb28857-ce3c-41d8-818f-016d2f300a35",
+    "name" : "iB9th2gLbzAe7A7khC",
+    "mimeType" : "ukZ29jjbd5kvL9",
+    "size" : 1846434254,
+    "license" : "https://www.example.com/9kkqii8w7vyufa",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "umDPMRkWgp1QRZhcR",
-    "publishedDate" : "1994-12-20T18:33:34.580Z",
+    "legalNote" : "wi9dI08JJtl",
+    "publishedDate" : "2009-11-28T07:59:14.546Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "fD5yjvw52Mm3TIM1pJQ",
-      "uploadedDate" : "1971-04-12T20:01:30.765Z"
+      "uploadedBy" : "4KM5o8s2v6UebJFZujJ",
+      "uploadedDate" : "1971-09-05T01:29:16.224Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/takEBZRrgljc",
-    "name" : "9fjs2rGyu5DaszeTHT",
-    "description" : "Zg42DWuTwDc5UN"
+    "id" : "https://www.example.com/y5mo7Jujbpu",
+    "name" : "XaoODZFAFrF8CcPjAt",
+    "description" : "nzDPUlSlwWQN"
   } ],
-  "rightsHolder" : "Ds3hJ6vTHppweNUD",
-  "duplicateOf" : "https://www.example.org/65806135-9843-4c18-9238-dd6f6e83a4d1",
+  "rightsHolder" : "E1TMehvybi",
+  "duplicateOf" : "https://www.example.org/3069156b-53e6-409c-998a-7c489d4d22ba",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lEMwFYe2hJRg"
+    "note" : "Lo99txNaXBy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kTWYwAD4fhVP",
-    "createdBy" : "ym8vqc2rPvD",
-    "createdDate" : "1989-08-20T14:19:39.903Z"
+    "note" : "377PJYOoyErQQ5",
+    "createdBy" : "F0XRWKSCDHxJ",
+    "createdDate" : "2013-11-20T03:09:23.159Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6e74d77d-4040-4d7f-b831-70522998eddc" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/7e24cc59-ad74-4a7e-9753-89f3cf1543aa" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "8acffnACPaeVPq",
-    "ownerAffiliation" : "https://www.example.org/de7fa80d-cdf8-48fe-bdd5-9ba08d53aae9"
+    "owner" : "mNEr2DjWhpk",
+    "ownerAffiliation" : "https://www.example.org/84c8427d-8bc3-41d0-b58b-7991705a57f2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/746bade6-e89e-4ecd-b6a7-91f272ca9ae3"
+    "id" : "https://www.example.org/597bb89c-d2f8-4519-b8fb-1f7a45e65bca"
   },
-  "createdDate" : "1991-04-12T03:31:06.460Z",
-  "modifiedDate" : "2020-09-24T04:38:13.979Z",
-  "publishedDate" : "1982-11-17T04:47:58.841Z",
-  "indexedDate" : "1978-05-10T05:53:37.888Z",
-  "handle" : "https://www.example.org/2d92a823-e14e-4b86-a137-88c81b42467a",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/eb9fbcb3-2fde-4a87-b31b-a30799834188",
+  "createdDate" : "2015-11-05T13:10:46.023Z",
+  "modifiedDate" : "1983-01-28T17:27:08.600Z",
+  "publishedDate" : "1988-10-05T02:42:55.741Z",
+  "indexedDate" : "2016-03-15T22:52:11.288Z",
+  "handle" : "https://www.example.org/7cde59c9-1038-4c8d-9e4f-db79894956ec",
+  "doi" : "https://doi.org/10.1234/non",
+  "link" : "https://www.example.org/04adc5f4-fcf6-48db-a49d-4448c2698e46",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "8JZcdLrXJer",
+    "mainTitle" : "TXphprNODMp",
     "alternativeTitles" : {
-      "zh" : "B6kIYqLFDsbWw"
+      "cs" : "4WWHh6VLSnkmP9GdiW"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "QGOJ0k0Ag46FuhHqM",
-      "month" : "qD2X1RJbpi",
-      "day" : "pQlO8SjBNC6H"
+      "year" : "R1hndFW2rr0HXT",
+      "month" : "NLEHv6Nk64A7",
+      "day" : "VJcHegk3UAx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/92f2ef24-b369-4054-b640-187408524bce",
-        "name" : "msInytp9EwaifuS",
+        "id" : "https://www.example.org/97eb13a2-56a8-4dd3-b45e-7efa28f58fd4",
+        "name" : "IK7UURcTlp",
         "nameType" : "Organizational",
-        "orcId" : "J0u20Ctoko3Hd5X0u",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "iOeHXL9sHv",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "liZsRmu4NfBDy",
-          "value" : "3FjzofxJT3ueRRD"
+          "sourceName" : "v5wnzkqPBnoci1WCE",
+          "value" : "t8b8UKaMIGhFqWO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TT9ktLKHbaSaGI8E",
-          "value" : "04cSpl8GXBu"
+          "sourceName" : "bABJZF7HuzHM",
+          "value" : "CKj4omgh3gwr2udm3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/32baad1c-0528-4a8b-936e-1e70da1121e0"
+        "id" : "https://www.example.org/e07589a8-7ac0-401f-bef0-d5f0e1bc1458"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "InterviewSubject"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/08889ee8-7080-49b8-a718-e83104bcad8d",
-        "name" : "MwUThmh3FFsUZ",
+        "id" : "https://www.example.org/d11c7e5e-3e3a-4434-aba9-6e1f3e6cb3ea",
+        "name" : "CzTWypACbIW",
         "nameType" : "Personal",
-        "orcId" : "O1qMPhjOlsgdMUJDE",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "BXwyMCWUUIKeyeCR8Z",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vQO2JhgZk8mJ",
-          "value" : "8UYYmXhv6K0w"
+          "sourceName" : "kOenKPI8TXox",
+          "value" : "tdHIiQxa8l4a7xOtK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zTSkELd3We4qqQwq",
-          "value" : "b4bZnVRPFI8g8Px6DH7"
+          "sourceName" : "OPg29UOk2UoUd",
+          "value" : "gW4H79VUYX0V"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a58e97e9-f6f8-41d5-9686-8b69fd01c2f9"
+        "id" : "https://www.example.org/f2489624-f1a6-4646-8196-0edff70c82b2"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "9EBChoDoz6"
+      "fr" : "yVfPuze2M6L8XDHhd"
     },
-    "npiSubjectHeading" : "1gualF5ygHGN0DEK",
-    "tags" : [ "iYc1Ad303PslZu" ],
-    "description" : "oLaCBBRKkpVnoNin",
+    "npiSubjectHeading" : "eq7lZN302A48",
+    "tags" : [ "BVWrYBeM6MN" ],
+    "description" : "K0JghmX24v",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "ZbJntJKm7myiSr1r",
+        "label" : "K2y4kGKOX2QTW82dF1",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "Tv9JMLuxQAXP",
-          "country" : "Bbw5xdWo2578d8Ry"
+          "label" : "q4199PlFPJ4Am0q",
+          "country" : "YwtHGjLXr2"
         },
         "time" : {
           "type" : "Period",
-          "from" : "2024-03-04T22:44:28.533Z",
-          "to" : "2024-05-03T14:13:49.039Z"
+          "from" : "2003-11-25T00:34:35.301Z",
+          "to" : "2007-11-07T15:30:50.707Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/v6OnwUJC2oJ"
+          "id" : "https://www.example.com/WRkYx1d0eunap"
         },
-        "product" : "https://www.example.com/3rdzWCKIjIuI9zzsk"
+        "product" : "https://www.example.com/7KYClMAsjHlm33FY"
       },
-      "doi" : "https://www.example.org/b594f23c-e619-40c9-82ba-4d688e3daa77",
+      "doi" : "https://www.example.org/2b1d3191-8367-4fe2-8b5d-91fe56ab4ae5",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -122,93 +122,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/09a8f231-7c62-49ff-bad9-eeffe4066095",
-    "abstract" : "2FiXd1CRTrIB7"
+    "metadataSource" : "https://www.example.org/5294b8f2-ae96-4f05-915e-03a67b14f93f",
+    "abstract" : "xeboEaztnPcG5XeUgJ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3cc0c4c3-a5dd-42ee-831f-63335d30d374",
-    "name" : "nB5p2dgC57Qx1",
+    "id" : "https://www.example.org/853650c5-1ce8-496e-aa9c-ce9c581827f8",
+    "name" : "qbUd1usN2IyC6CH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1982-07-31T07:52:40.830Z",
+      "approvalDate" : "2018-10-03T19:48:26.927Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ttZ2qH6Fco"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "VghpzQhUZmCH0"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c1c5208f-6def-41fc-a1d3-35ab496ebc85",
-    "identifier" : "bvPfvMXK8XyBG4",
+    "source" : "https://www.example.org/80625254-722a-4b81-a88c-0fac5e618f13",
+    "identifier" : "FSbQcQ6fIzd",
     "labels" : {
-      "el" : "WmSprawRZ8dX"
+      "nn" : "rqGem3vqiyMEFvHE"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 62058299
+      "amount" : 618930041
     },
-    "activeFrom" : "1995-07-27T01:08:29.474Z",
-    "activeTo" : "2006-04-05T07:32:48.443Z"
+    "activeFrom" : "1977-10-06T03:53:54.934Z",
+    "activeTo" : "1987-11-09T19:01:47.863Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/393354b0-aa4c-403d-b5de-137b6c962c77",
-    "id" : "https://www.example.org/b85f60fd-20f2-4992-97b0-c2b68bab625f",
-    "identifier" : "nuElqFSaV9eAbb5BJr",
+    "source" : "https://www.example.org/cb7b55ac-1089-4ce3-92bd-606d21c01837",
+    "id" : "https://www.example.org/ba146fb6-f2e0-41de-bab4-491705c9fc45",
+    "identifier" : "XpE6qfZGwlUR",
     "labels" : {
-      "bg" : "3abJuYUJ5PRhB8KMOr"
+      "bg" : "smA2ASrANso77c9Af9"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1289734774
+      "amount" : 100642672
     },
-    "activeFrom" : "2004-01-21T00:45:17.576Z",
-    "activeTo" : "2019-05-20T14:14:17.361Z"
+    "activeFrom" : "1979-06-19T18:25:54.847Z",
+    "activeTo" : "1998-02-22T07:13:42.368Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d228a8d0-e2e1-4ce5-a571-225146426ea7" ],
+  "subjects" : [ "https://www.example.org/002b1e13-c6a0-43a3-a66d-496441a474a7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b6ecf8d5-73b4-4ad2-a0ab-a9003ab68be4",
-    "name" : "JPlsM4rXQxmUPe69",
-    "mimeType" : "3Ht1O2sQXQS",
-    "size" : 953627146,
-    "license" : "https://www.example.com/pyoeylqt9zfpvcw",
+    "identifier" : "f735a82c-b417-4f7a-8d0b-5a55298b99cd",
+    "name" : "zKb6xpxKOxUD9TOzL6",
+    "mimeType" : "HmWQ6Xulzaa4i",
+    "size" : 1612979560,
+    "license" : "https://www.example.com/kfcbp7dwx6b3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "bAqaJef8X0I",
-    "publishedDate" : "1987-10-17T05:53:34.178Z",
+    "legalNote" : "qxrv0yWlPeOk",
+    "publishedDate" : "1999-12-25T02:09:14.897Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "2zruTkzQXhYxC2pC",
-      "uploadedDate" : "1994-08-24T19:28:57.940Z"
+      "uploadedBy" : "jl59CvzxPGHJUC",
+      "uploadedDate" : "2009-05-25T18:40:43.191Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7L47baKYJweVXb0",
-    "name" : "SUUdc6qRyBV0o",
-    "description" : "CsmNOgtDbutEf"
+    "id" : "https://www.example.com/57aDhBvCX4qB8",
+    "name" : "kvvT39n2J0rn",
+    "description" : "jtYx3Mo1J3gcRF"
   } ],
-  "rightsHolder" : "xANTTZAzqKGAu",
-  "duplicateOf" : "https://www.example.org/357a842a-ab24-4716-82de-d30c1629eb44",
+  "rightsHolder" : "dlx8Rv364w3MaIZ",
+  "duplicateOf" : "https://www.example.org/90369b43-8a49-4558-85fb-14a1bef05403",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "34EcfKIkg5auT"
+    "note" : "lESDr0orMfZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "mntlxgTM7bQ6g2kZfVq",
-    "createdBy" : "16u7FW5ovyf",
-    "createdDate" : "2002-04-13T11:41:03.091Z"
+    "note" : "A2x55RoZ1mT",
+    "createdBy" : "mGQyW4ktpbq0",
+    "createdDate" : "2007-07-24T19:51:51.178Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/adbd666d-62ec-4390-8e8f-318fe8ff2bc3" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/e13ab624-9253-4471-9eeb-1fe4cfd6a955" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "inCOzW3haYccS",
-    "ownerAffiliation" : "https://www.example.org/c821db7c-35f3-440b-9e95-b50d1890a1e9"
+    "owner" : "5owxr8PNWPPGWb",
+    "ownerAffiliation" : "https://www.example.org/253e8c10-caa2-4140-adfa-c80d3fd899d2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/86342078-8704-45f9-8c46-a92a17f540b6"
+    "id" : "https://www.example.org/7b146529-3ee0-4257-9e57-882d19ad2ab3"
   },
-  "createdDate" : "1986-08-15T03:30:12.051Z",
-  "modifiedDate" : "2023-10-04T01:45:54.131Z",
-  "publishedDate" : "2001-11-20T17:57:53.443Z",
-  "indexedDate" : "2007-11-29T14:11:24.239Z",
-  "handle" : "https://www.example.org/23cfdf75-4192-4bee-b850-5612a9321e4c",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/71a91fc5-9976-48f5-8b8c-e15f6eac0129",
+  "createdDate" : "1971-06-14T16:28:18.024Z",
+  "modifiedDate" : "1975-11-20T20:34:02.967Z",
+  "publishedDate" : "1985-02-15T17:25:50.172Z",
+  "indexedDate" : "1974-12-14T09:16:15.822Z",
+  "handle" : "https://www.example.org/da7ad344-c220-4b0c-a95d-170d57f31c85",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/3737ea78-3060-478f-9600-c34b2140844f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0UlbxM5bh3",
+    "mainTitle" : "LJYKR1HH5a",
     "alternativeTitles" : {
-      "da" : "Du04dqb3rIW"
+      "en" : "XH7KCHnTEOxZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dfT8VPz2BE9xpu7Y",
-      "month" : "onOCZajXGLKbD7hSq",
-      "day" : "dbmfvxkXMK3KtG"
+      "year" : "a32Ke5f1szkl",
+      "month" : "78ciwpIzpkL0WSN",
+      "day" : "HyhG9fTcJhBh2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e6dfe1be-4349-4daf-9a88-5849ce1035f4",
-        "name" : "V1RWquwf4iCI",
+        "id" : "https://www.example.org/2c2ea3f6-2852-4e7b-8161-dcf7b584b5c4",
+        "name" : "aHhILCMnBpSyr92c25",
         "nameType" : "Personal",
-        "orcId" : "0cGOELD6HCP",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "xlTXJhdmJs1NQYh7O",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "alpISnv8oJs3FfijP0",
-          "value" : "6cML2kMGCix2ru3"
+          "sourceName" : "m5hTwb1fAu9AAtu",
+          "value" : "DdJBMFGqm7bMOGRFjAR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cWSzyMFc0x",
-          "value" : "SxWOYqadgPR9DwVmZ"
+          "sourceName" : "pwBzk3abfaD",
+          "value" : "wFH78kdjN3sslj8nJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9edc372d-db53-4813-9bba-7f630f783958"
+        "id" : "https://www.example.org/6abbcc06-0058-4009-a96e-77929f4debc2"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,216 +62,215 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/48186ad9-d6c2-4221-8559-023354ca11e0",
-        "name" : "qwW3ermXSRGds",
-        "nameType" : "Organizational",
-        "orcId" : "1X8XxrwGgO3rhv4QX",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/a6510dce-a41c-442c-84aa-72e53f6fdd70",
+        "name" : "Vzv4WGZVQTP3EjudO",
+        "nameType" : "Personal",
+        "orcId" : "eksaXQw8Fl0pcOM",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CMPFYsDmi6DS4xqT",
-          "value" : "T3Hi9pyKiqGVP"
+          "sourceName" : "yv5cybdarBo",
+          "value" : "NoSZbY66hiyA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "msvH2955yxBDxu9",
-          "value" : "M2c0SRLtR9C"
+          "sourceName" : "YZ7dDvjWuPK17",
+          "value" : "bDk1184ZMyhc0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/563501d6-0a73-4cba-8d87-73b606ab52f0"
+        "id" : "https://www.example.org/82df9564-a23d-4694-99ee-a67e63764cde"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "YnbewIGdRvV"
+      "nb" : "UxH3YLUFDHSCEXB"
     },
-    "npiSubjectHeading" : "78EXe5xOCcHEk7sZ6",
-    "tags" : [ "bFzdgKa1jbI" ],
-    "description" : "2ApISwKGAKKgp0k",
+    "npiSubjectHeading" : "tPxrIQc3emZMo3",
+    "tags" : [ "DPnIjOFcyzjmQ" ],
+    "description" : "anzbYkA9VBJJxA0Z",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/a268e850-d838-4643-99a1-9f9312c5bcf8",
+      "doi" : "https://www.example.org/2ecdb4cd-9689-4e71-9cca-8d60c0243fbd",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Novel"
+          "type" : "Novella"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "PoLzQ0demhTY",
+            "name" : "b3j2nE07A91UkOsFUc",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "Te3dE40nVbWtgMhc",
-            "month" : "TBOPsCKRKRzvBU",
-            "day" : "t1PuiGKuZBhUxPTX5B"
+            "year" : "jWwFWUnODA",
+            "month" : "eTr8ORH2UoBcQzQ8",
+            "day" : "eqmaGf848LiYNoHDp"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "DVz3dnqz1ELljQjZ",
-              "end" : "b3nmuww1dBdzOP9"
+              "begin" : "QFwrjH2FSHi",
+              "end" : "sCxdUgjKQAixU"
             },
-            "pages" : "30tc0O3Afej9KMTFq2",
+            "pages" : "rUsMfq4IIfOx",
             "illustrated" : true
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
-            "type" : "ShortFilm"
+            "type" : "Audiobook"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Bc7hKFA9eW5vC",
+            "name" : "PArO6wMaVsm24iiF",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "Tkmmy1XKew7",
-            "month" : "q25iBkPoPgZ4gd",
-            "day" : "9QiAJImAW8fSmra"
+            "year" : "m4aQQnJHQO93I",
+            "month" : "dgOujC9i9JtU2eG1wnv",
+            "day" : "O2gfgYTBFdQD6pHX"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 774301267
+          "extent" : 1845732736
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
             "type" : "LiteraryArtsPerformanceOther",
-            "description" : "qWD0hWDPW0Moe2zg7FH"
+            "description" : "BUccaqPhYj"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "pv9NG7xzrjotebg4Z8W",
-            "country" : "mrjbo9rAioj58fkw"
+            "label" : "Z2Ah0TpsxviRTTtuF",
+            "country" : "UiALaFXHfTpTq"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "H2JiyaKy1F0W",
-            "month" : "J3b29btDEd7",
-            "day" : "MizCMjErIr"
+            "year" : "FZjUVoqVKP4q3b",
+            "month" : "lry6GSF4uM8",
+            "day" : "HVtklD0HA7DX"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/5bDlEf7yDGBnIXv",
+          "id" : "https://www.example.com/9vDlRhFp49p",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "jTkHxhfVHoMqjagG",
+            "name" : "13dRCanmrpWOYyJEnnH",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "jxLbaf9Mk7ZhHD0",
-            "month" : "3jyfkUkbHV7MNRT7w",
-            "day" : "w908bPRaCm"
+            "year" : "G3JIa0gL3wDy52dEajC",
+            "month" : "Zlyc33LyVY3ko",
+            "day" : "aT0tax1l7C7b9cS"
           }
         } ],
-        "description" : "yEflPLPQ729ZLa",
+        "description" : "ohUNX7GR9cSGgX",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/05bc389d-c333-4fff-b946-6d579db05f58",
-    "abstract" : "VVQKFkaSIGe9ZcB3f"
+    "metadataSource" : "https://www.example.org/39692b1e-17c3-4e99-8eba-077a407b59f9",
+    "abstract" : "EvyOxD0mpYmXj"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/53a80df9-6cd9-4b8c-95c3-0f1c15da913e",
-    "name" : "WVk6FqPFQTRcZOB",
+    "id" : "https://www.example.org/9bac6d8a-299a-4875-a361-793edcac2c0f",
+    "name" : "S7K2Mcp5KKTu",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-12-04T16:53:50.504Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "4BkqzlP1lEusIGxJ"
+      "approvalDate" : "2008-08-06T15:45:30.482Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "PT0uUNITLs7"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1dbda331-7e40-4599-8e32-5716194ea1a4",
-    "identifier" : "bONplDtrLVKrvBsh",
+    "source" : "https://www.example.org/fa1358c5-d7f7-4201-85a3-43526490c005",
+    "identifier" : "EyOGsRmmkoyjUPlB",
     "labels" : {
-      "es" : "YV6f3GO3bRjlEYS"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1034226159
-    },
-    "activeFrom" : "2020-10-11T07:21:53.585Z",
-    "activeTo" : "2024-01-22T13:11:40.023Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ea003983-00e4-4ba3-b2e6-2a810061d0d5",
-    "id" : "https://www.example.org/c8668f4b-d085-423f-8969-dca0d2c1b705",
-    "identifier" : "omI5NAhh0qB1z8U",
-    "labels" : {
-      "ca" : "iQtxxBefaIb7"
+      "it" : "fMC2q6frd1HMGoDl"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 385439028
+      "amount" : 1656415748
     },
-    "activeFrom" : "1982-04-21T23:18:15.645Z",
-    "activeTo" : "1990-12-06T08:59:22.312Z"
+    "activeFrom" : "2013-03-20T07:05:08.979Z",
+    "activeTo" : "2018-06-17T21:41:21.665Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d8cc2a7d-6e64-4df6-b3d9-14416dde453b",
+    "id" : "https://www.example.org/73528bf5-a392-4110-9b2f-df7ef19fee74",
+    "identifier" : "t2ax63AyshiRjrp7F",
+    "labels" : {
+      "el" : "qHAmmCFqac6wv"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1701590349
+    },
+    "activeFrom" : "1992-01-09T21:23:26.625Z",
+    "activeTo" : "2023-11-17T19:21:05.859Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e37daeaa-84e8-40ba-8fe6-efff8b592264" ],
+  "subjects" : [ "https://www.example.org/71f2e555-118a-4097-b327-11422035e29f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "10db7366-8045-4451-9c8e-ce7e2b63f58d",
-    "name" : "KreRIaHo1qA6MQ127m",
-    "mimeType" : "kGuU4ghQHgkNAS0",
-    "size" : 507699197,
-    "license" : "https://www.example.com/duqhtmguinek2s",
+    "identifier" : "7532e731-9c0b-4129-afab-784c2522e0fc",
+    "name" : "F3V47i2sM42R",
+    "mimeType" : "ODD6yXmngVTaV",
+    "size" : 2085411724,
+    "license" : "https://www.example.com/4uwbibhwcugvbyn",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "hgEX66IK2MV"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "O6jXL7uiscisG92s",
-    "publishedDate" : "2001-08-26T22:43:40.467Z",
+    "legalNote" : "Q6ZLcQZVl3Hhf",
+    "publishedDate" : "2007-05-31T07:20:50.987Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "bXpC9OUDTjNit",
-      "uploadedDate" : "2009-08-26T13:26:36.192Z"
+      "uploadedBy" : "zPyTVsirak",
+      "uploadedDate" : "2009-12-03T06:33:11.505Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JzX0GHfjOSd1",
-    "name" : "6hkvwqOAMimyj",
-    "description" : "eds9JnYIoccdLIKKGb"
+    "id" : "https://www.example.com/B34qCNuaRIkWD",
+    "name" : "t872DFypZYsojm6ND5",
+    "description" : "zn1mpYdMwul"
   } ],
-  "rightsHolder" : "nKS4NiG7xWL",
-  "duplicateOf" : "https://www.example.org/087b269b-3946-48f2-a628-3cde74983100",
+  "rightsHolder" : "3rqBxUgBPBQ",
+  "duplicateOf" : "https://www.example.org/271e057d-a76e-43d9-8a31-c1228b07cfbc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kPIDRMO7WY13H4ibhO"
+    "note" : "S0j3qttA5IvtxG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "q6JczIUpDhJQZ34HLc",
-    "createdBy" : "V7CxfiAkqrwKSOK",
-    "createdDate" : "2016-08-14T05:54:24.766Z"
+    "note" : "CqqM39lGSB0XZkbLYW",
+    "createdBy" : "LCq3G8Pp9PYOjpg",
+    "createdDate" : "1973-07-12T23:39:44.934Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a6e5478d-0d55-4c44-9bf0-75a3384b2874" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/d6b35b31-29fa-45d0-a461-90853ad001b2" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "6slPXWCzh2Nfjyzk",
-    "ownerAffiliation" : "https://www.example.org/ea7e1fb2-1472-486c-9ca7-23cd0d004b30"
+    "owner" : "PgVjCDKcvbMp",
+    "ownerAffiliation" : "https://www.example.org/f816226c-8d62-4520-a0e3-9baf9f7a04c7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c395434c-b526-4a3a-8859-68cca99aa597"
+    "id" : "https://www.example.org/e283a90d-d708-40fe-bf56-90beb49c30d3"
   },
-  "createdDate" : "1973-05-02T07:20:52.633Z",
-  "modifiedDate" : "1989-03-10T15:32:09.975Z",
-  "publishedDate" : "2009-10-13T22:00:30.260Z",
-  "indexedDate" : "1971-08-20T21:03:13.419Z",
-  "handle" : "https://www.example.org/6ac4bd87-cf2f-48d0-b50a-01e5c1ddfbc7",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/1861a554-1715-4ebd-8ea0-c4ba597a31cf",
+  "createdDate" : "1975-07-15T00:48:48.112Z",
+  "modifiedDate" : "1994-03-18T06:54:56.726Z",
+  "publishedDate" : "2002-04-17T14:42:12.504Z",
+  "indexedDate" : "1980-10-12T05:11:54.795Z",
+  "handle" : "https://www.example.org/22a9c475-b476-40e8-85a1-3566df1fe34f",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/e34e7939-ea57-4e02-8a57-0680c08f4781",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Q51dYXO0zwr5zbmq2",
+    "mainTitle" : "xpYxqZ9A9S8CVbWQx",
     "alternativeTitles" : {
-      "fr" : "6QsySgSI6mJff"
+      "is" : "GPTFlHcvRDc8HMn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "tdg6feeukE",
-      "month" : "47Lk5dV6xZLFQ",
-      "day" : "OM5mrgaJY5zS1PM1BwM"
+      "year" : "bI9IefdsGpwJQ4iY9r7",
+      "month" : "5jw6DFMB6Js7h32c0ml",
+      "day" : "Kv8mzfdc8esCy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c8a1b690-4238-4a34-a5bb-90dce5896525",
-        "name" : "FP31qHAVUguRK",
+        "id" : "https://www.example.org/3264ccd2-4a3c-498f-a765-f6ea9e80b10f",
+        "name" : "ls8EONXeTgQNYLno",
         "nameType" : "Personal",
-        "orcId" : "ayPl1gzZ6b3",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "KeJNAIR4Ru",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2i8r1vo05LV",
-          "value" : "5riQbuKweupopJd"
+          "sourceName" : "Fa3K9xNfoQ",
+          "value" : "rjKrCW0rJGB9Fcv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w6TQ2kSHrL",
-          "value" : "hyDpwZarmVSj"
+          "sourceName" : "4bLzmYFVgyYFQ",
+          "value" : "HD7mXJApznnRnJrd0p"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/060c67c8-874f-4942-ac18-0fc0e107a3de"
+        "id" : "https://www.example.org/09fe5645-0367-4e0d-97db-41c6c0f5169c"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Dancer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,150 +62,151 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/741dffe2-ebed-4860-bdab-b89c61d0f081",
-        "name" : "rGpscSlwueTTl",
-        "nameType" : "Personal",
-        "orcId" : "MzC8qkgyhqZKCueNxz",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f64c1a13-7eca-4d8a-bf83-27917b180939",
+        "name" : "4LSj4JLNwvEr",
+        "nameType" : "Organizational",
+        "orcId" : "fZPF6YKhQP5q1j",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "X7vlDQoVbJqpGb29DjU",
-          "value" : "keqAF4azf1MqUoO"
+          "sourceName" : "1CPXSq1ww0NaV5pULbC",
+          "value" : "WQlGOkzGaFHU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PQckhQIVWVufyJiy",
-          "value" : "pK2aySklFVwm"
+          "sourceName" : "eiLY7C8zuz",
+          "value" : "QvKxFJdSjZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f7644d5b-b34e-4d88-a71f-c5248b3027cb"
+        "id" : "https://www.example.org/620a91c5-39ff-4f46-8c0a-a4220be6d08d"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "RoleOther",
+        "description" : "KsodcnPg39EZ9Gt"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "drZ01u7KokrFC"
+      "zh" : "SGgS49Nos6ywpTzMF"
     },
-    "npiSubjectHeading" : "uc0I0HatqGSYW",
-    "tags" : [ "4NAo7juXzT" ],
-    "description" : "S4AzXf8XAML9G",
+    "npiSubjectHeading" : "9UwhCkQyVTGqLbpdpx",
+    "tags" : [ "D6H0OaSLGhAL" ],
+    "description" : "XZwpX7ulNo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f713c6a2-04ef-4642-89fe-f7124f8a72d6",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3c0258c3-9b32-43d2-8c32-3392998b5709",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/37918f3e-7a06-41b2-9238-0c2531124d9b",
+      "doi" : "https://www.example.org/13eb3d8e-6517-49e5-afcf-723574b47948",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "XiZqkW2fmm27BPr37uz",
+        "description" : "ZbocEJBCHnK",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "KysTLcmlnR08Iiz6",
-            "end" : "2itVpTnVT8VrP6"
+            "begin" : "3MyqkwBOHLOV",
+            "end" : "qD6DSGWiQg7C6nJ"
           },
-          "pages" : "uq3i3OtRodDG8C1CT",
+          "pages" : "VX8ME6maH7kTaY5j",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4552ae5b-45ca-4bde-9512-09634f329120",
-    "abstract" : "gUbw6peKP1EcqHR"
+    "metadataSource" : "https://www.example.org/b1263aa2-dad7-4ed1-bafa-866afd05d751",
+    "abstract" : "mgXFP0ZUm7eiKTKx35B"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2a447d27-77ee-4d5a-a13d-994e21edc011",
-    "name" : "Kl4KMOafB3UEPMmxFn",
+    "id" : "https://www.example.org/2e040538-49c4-4f1d-a2db-e57a9af43457",
+    "name" : "MYR2Zy7RCOp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-12-20T16:48:14.045Z",
+      "approvalDate" : "1980-10-31T02:24:24.667Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "yoryllcFQGKSi5wT"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "AsXJxxGh1TZP6YZFL"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e970396e-203f-4f75-ba6a-cfc8e3b8673a",
-    "identifier" : "nN8sUvKJVwWL2hoc70O",
+    "source" : "https://www.example.org/9b493011-6a2a-457d-94e8-52e64c66bfb3",
+    "identifier" : "WLIqeTslqroDvG",
     "labels" : {
-      "pt" : "lw5XAbURNW"
+      "de" : "TtXZICTeyAYqbnkF"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 120230359
+      "currency" : "USD",
+      "amount" : 573075091
     },
-    "activeFrom" : "2005-04-13T22:29:18.045Z",
-    "activeTo" : "2007-12-21T22:31:20.871Z"
+    "activeFrom" : "1995-04-24T03:47:28.767Z",
+    "activeTo" : "2008-07-07T11:27:37.505Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5e998930-ebf1-4b51-98fc-566d7a59ce94",
-    "id" : "https://www.example.org/b74459ed-9dc1-4164-8835-10e197e0cc41",
-    "identifier" : "iC9bqx6DlTti7",
+    "source" : "https://www.example.org/62feb8cb-8110-49ff-af0d-19e0ce264e94",
+    "id" : "https://www.example.org/e0e6141b-41df-45b3-b800-c430fbf5a9df",
+    "identifier" : "Bi6v5BZWtY",
     "labels" : {
-      "sv" : "Y7aURB3bkC7y"
+      "pt" : "8tvjMRaqW18EqlERP"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1175511964
+      "amount" : 295066216
     },
-    "activeFrom" : "2000-05-20T04:03:12.167Z",
-    "activeTo" : "2020-02-21T13:36:55.628Z"
+    "activeFrom" : "2021-09-25T22:33:15.859Z",
+    "activeTo" : "2024-05-12T17:15:26.883Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c692a010-16ec-4781-a983-beaa06eddd93" ],
+  "subjects" : [ "https://www.example.org/00acedae-bb3d-41a9-841c-29e51de40396" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3fbc4e70-3906-45d2-9a12-31352b9287be",
-    "name" : "mvAnXg84V3",
-    "mimeType" : "pNRouNVke0Y",
-    "size" : 774129343,
-    "license" : "https://www.example.com/flfhoaws4xmbw4",
+    "identifier" : "276d4233-81f7-44cf-a412-750a71dc85a6",
+    "name" : "KiFi3HQon54cVn",
+    "mimeType" : "bIZYDnOwIIb",
+    "size" : 922549181,
+    "license" : "https://www.example.com/fotlgxzztmean",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mygddM4zXTSH",
-    "publishedDate" : "1973-06-03T05:50:44.109Z",
+    "legalNote" : "rqWpzXouIN3OuWJ5",
+    "publishedDate" : "2015-06-22T03:35:30.846Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "FxamfbB9uifR",
-      "uploadedDate" : "1977-07-06T17:13:11.112Z"
+      "uploadedBy" : "taE7sYuYTd0ihD",
+      "uploadedDate" : "1994-03-01T09:05:28.631Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/CgtzQe6TlkxpM",
-    "name" : "HFQHmKaK4IOZcd",
-    "description" : "gEVyhcNQwFTIO9U6Yd"
+    "id" : "https://www.example.com/lvpYiPdGOnkIqSswOJz",
+    "name" : "l8iIPDuJCzAM1",
+    "description" : "MM1ktLASj6pr0YaZI"
   } ],
-  "rightsHolder" : "HKWJwBb9uYf9fWcC5H",
-  "duplicateOf" : "https://www.example.org/9dd760d4-f17b-4bc8-a938-4a377370dff7",
+  "rightsHolder" : "OLPvCR3rGpRQ",
+  "duplicateOf" : "https://www.example.org/780caad1-2cf9-4cdf-9033-30db65b0cda6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "cp7dkNAn6Hr54Hvv7c"
+    "note" : "OMZnWLSja9N"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CMRYMViBqq",
-    "createdBy" : "MB5k2Q4ypHY3wf2Q",
-    "createdDate" : "2001-09-02T06:31:13.565Z"
+    "note" : "ZJYFTaEIwkecL",
+    "createdBy" : "lelSze4y5dW9baiY",
+    "createdDate" : "1977-06-25T17:15:09.059Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a96177e3-29d4-4a9b-9980-67ce8bc09a4d" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/bce7eb83-53fc-4d40-a7bd-34cbecf097b0" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "zUzV595aNX",
-    "ownerAffiliation" : "https://www.example.org/0d169701-8794-4b24-a3fc-8326e5d743bd"
+    "owner" : "DJjwDfn9co",
+    "ownerAffiliation" : "https://www.example.org/0e0634d4-b1a7-481e-98b5-836b66faca94"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b048c51d-4fc1-45c5-bfa9-1888e5acb9ec"
+    "id" : "https://www.example.org/fead4190-82b6-4039-83d0-7aec5c3deed0"
   },
-  "createdDate" : "1977-08-04T01:50:51.737Z",
-  "modifiedDate" : "1988-06-02T02:31:06.191Z",
-  "publishedDate" : "2003-02-06T02:58:36.920Z",
-  "indexedDate" : "2024-04-13T13:41:14.555Z",
-  "handle" : "https://www.example.org/e55c2d25-1989-4e78-9aca-8910cad37d14",
-  "doi" : "https://doi.org/10.1234/quos",
-  "link" : "https://www.example.org/ce425a84-89ad-4ebb-a208-a7dab22c1473",
+  "createdDate" : "1999-12-14T00:10:45.611Z",
+  "modifiedDate" : "2020-04-06T17:22:05.502Z",
+  "publishedDate" : "2018-04-05T05:31:20.137Z",
+  "indexedDate" : "2014-07-21T04:11:33.220Z",
+  "handle" : "https://www.example.org/9eee6772-8278-48d9-8e06-8c7b793f2e86",
+  "doi" : "https://doi.org/10.1234/ullam",
+  "link" : "https://www.example.org/e033df53-6739-4e53-bab4-243dcf90c535",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xwdOFTf3vpI",
+    "mainTitle" : "eiMGgG2Bqn481emKLKq",
     "alternativeTitles" : {
-      "af" : "9vbGnb6KHzzcWM"
+      "hu" : "0qNAyDCpc6rnKbF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qw3xfeWYBrts",
-      "month" : "JShOWprKtYI",
-      "day" : "KXIGGdRcRPo7pNe3e"
+      "year" : "SifcVfhLXfit5W",
+      "month" : "5RZXHClXkKZWSZerz",
+      "day" : "So7Z4Ij7JZxYZ6f"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/18441357-2c7a-4bf7-9495-b1590806ce6d",
-        "name" : "EDQ1wCaa7Cwu",
+        "id" : "https://www.example.org/6bb12a76-323d-4c70-8b30-fe1e2247c110",
+        "name" : "igLh2aE5TqHienpy",
         "nameType" : "Personal",
-        "orcId" : "sb3RdvYbSzBhQjKBS",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "iGiBjV7IfhqS",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9vPKGYLyfhmAVFGen",
-          "value" : "2yBkPEI2PEy6q"
+          "sourceName" : "BUGLgrFEv1TpSD0oDl",
+          "value" : "FPKtBbyk4QuY6T3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9hC7zsxUz4ovfn3",
-          "value" : "DnA9ITRP8L01e"
+          "sourceName" : "iDgrdIgG0OptR",
+          "value" : "hCLkSAqWyiT0c"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a977365-a4bd-4215-9c24-1325500b1765"
+        "id" : "https://www.example.org/b39f44c8-245a-49d6-b259-20b7979c4a07"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9f9fdb49-969b-4f71-ad34-50252221ee64",
-        "name" : "lGLe9lD7XN19UNpT",
-        "nameType" : "Personal",
-        "orcId" : "7EMfQmzUKY5KNyvxLxf",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/a5f8039d-b652-470d-827f-a0c1327fbd96",
+        "name" : "0uGn1ODUJ9Jg2",
+        "nameType" : "Organizational",
+        "orcId" : "JcW4TS3HnHKwfJz8JL",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "i2rbiCHkTTP5",
-          "value" : "aNyxEeMUgLm13C"
+          "sourceName" : "Esp8C4u2MhvAewL",
+          "value" : "wkd9KiUbKhrS0iw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yN6b2aMRRO1Tj8N",
-          "value" : "2FkVSYby7dQE"
+          "sourceName" : "i0YlxTJ1G42NGRJ",
+          "value" : "yC1if8LlUjLvOXY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/04dc36b4-3066-4800-b3fb-c8e3f454a3e7"
+        "id" : "https://www.example.org/be5c33de-59b4-446e-90e5-41aa4590de6a"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "ELOeOtdPNlnyti"
+      "is" : "d3G93v33SZrGx9HgYH"
     },
-    "npiSubjectHeading" : "1tZCyerME6H",
-    "tags" : [ "gmB68SKQAUnf2pxu" ],
-    "description" : "0rFOFlMTvt9Z7Z6C4R",
+    "npiSubjectHeading" : "415fFAgDcG6V",
+    "tags" : [ "xofIEUJqrpyeN8bXhAs" ],
+    "description" : "WJbyNCpKRpZsYopG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Internet"
         },
         "format" : "Text",
-        "disseminationChannel" : "hPuf1IqCBsc5qeh0L1",
+        "disseminationChannel" : "rrYWPpY1TQGszfPfg4",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "AwrG80k2VyiG",
-          "seriesPart" : "OkV4oKSFk6uFync1h"
+          "seriesName" : "f8gYCUN7fHbGfptIrE",
+          "seriesPart" : "xu1RUpDeMkek"
         }
       },
-      "doi" : "https://www.example.org/3882f1b5-093e-4880-8dfb-075281c74ea3",
+      "doi" : "https://www.example.org/437f92ce-0201-440a-8516-18d148e2f233",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -116,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/591e8501-5a38-4447-a74a-c1f383fcac4c",
-    "abstract" : "3ad24GH4iuQ4wUf7ZJC"
+    "metadataSource" : "https://www.example.org/93825c4d-a7f3-48ee-acd0-5af4cdbddb94",
+    "abstract" : "MgyAOKwpodRsTg"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f47a57df-b50e-4b1b-8b6b-46fbc9435cc5",
-    "name" : "ATUWVua1YWwa2v7f",
+    "id" : "https://www.example.org/035e604a-5063-4787-b3e2-227d7aea5a89",
+    "name" : "sKdCGvbGJh9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-07-22T16:03:42.243Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "41xu1spBJGQbh68IqA"
+      "approvalDate" : "1972-04-13T16:16:46.765Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "DnJScaiPOYYV59fZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9e85f1fc-621d-4450-b02a-425b91e2fce9",
-    "identifier" : "HeIkpEo8ABPVLsh1ca",
+    "source" : "https://www.example.org/96602227-c98a-41ca-97ba-8f6d0a630a28",
+    "identifier" : "WKoyYEc3aGt",
     "labels" : {
-      "af" : "OhTdJR9uUxV6ekGnbb"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2006972742
-    },
-    "activeFrom" : "1984-11-21T20:24:56.145Z",
-    "activeTo" : "1996-03-01T07:18:33.960Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0c0e9747-e727-4e10-bd2a-c84091e91c04",
-    "id" : "https://www.example.org/570d3ba6-20a9-4bd0-af96-c481fe5819fc",
-    "identifier" : "j2AB8WAS4ZAQU",
-    "labels" : {
-      "da" : "w9W3JEuYNEQU7ISb"
+      "zh" : "jfkJsm7htmxRn0IfXi"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1673718103
+      "amount" : 1851549038
     },
-    "activeFrom" : "2004-12-29T03:02:11.174Z",
-    "activeTo" : "2021-03-07T14:51:36.655Z"
+    "activeFrom" : "1999-09-01T15:26:07.650Z",
+    "activeTo" : "2014-11-24T07:39:51.216Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/13d2efad-ef46-4073-a03f-fbd08360f5ff",
+    "id" : "https://www.example.org/5a501344-af17-41a5-9220-5bfb0ea51a93",
+    "identifier" : "LeQX6ilXeKp",
+    "labels" : {
+      "en" : "sokoaV8bKL1"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1523821826
+    },
+    "activeFrom" : "1998-09-10T09:31:50.826Z",
+    "activeTo" : "2012-02-02T03:52:18.638Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8c0e7dd1-a28a-4ebd-bf35-04ff68b70b5d" ],
+  "subjects" : [ "https://www.example.org/1e2109d1-0926-4306-b1e1-80e47039886f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7e639d76-892a-4540-bd3e-503c5f1ed61d",
-    "name" : "xrUhdxxXiPyn",
-    "mimeType" : "JGgnpZ2OXKs9iN1tz",
-    "size" : 512949929,
-    "license" : "https://www.example.com/ecnkmqtzhvvh53t",
+    "identifier" : "c5683f87-a7c8-4a8b-8ac4-fe24eb5965be",
+    "name" : "ADhEf3m0heZPN",
+    "mimeType" : "O4XaEgzmShHT9Rqr",
+    "size" : 463971434,
+    "license" : "https://www.example.com/ay5tyr3be4pet",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "SNtL6m8xFdhof0Eae8",
-    "publishedDate" : "1974-03-10T17:46:12.235Z",
+    "legalNote" : "bLSH70HME6RZ8gd",
+    "publishedDate" : "2015-04-05T07:58:26.727Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "7rQqCz5yereKD5",
-      "uploadedDate" : "1997-07-08T02:51:26.668Z"
+      "uploadedBy" : "Xvt5MDZAlV7QhrD",
+      "uploadedDate" : "1993-05-03T03:35:18.453Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/QnaNSInzUw2w509",
-    "name" : "WGBBZ6Bobuedu9Y1unm",
-    "description" : "3iT5QQfTudW6"
+    "id" : "https://www.example.com/6Od3kEYmCh8SU",
+    "name" : "28PqOj87PvoSr0KUq2",
+    "description" : "TrgGYsHS8mFYWWovc"
   } ],
-  "rightsHolder" : "mjyaWX50wC310DaOg",
-  "duplicateOf" : "https://www.example.org/ade1973f-889d-4983-916b-22c384a57082",
+  "rightsHolder" : "AdsgxzS5jc1AN",
+  "duplicateOf" : "https://www.example.org/acddf80f-5644-42bf-ac66-9e9010ce8f4d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Psl5uyCjL2w"
+    "note" : "Z4DlgqFg7y3z"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8QoJnuaRIuJri",
-    "createdBy" : "5rehjn1w3zWfb0Hy",
-    "createdDate" : "1977-09-13T06:01:08.785Z"
+    "note" : "upxdNIZ4Aovu1XH8B",
+    "createdBy" : "xZxGNnIB6aOdSu",
+    "createdDate" : "2020-08-16T13:00:52.701Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a5e0b57a-baa9-4bcd-af1f-efeeaa9a9f87" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/cd532b3a-b6b2-4e41-920b-ebbdba64c164" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "ntvVd1Z0qWpXxD783Z",
-    "ownerAffiliation" : "https://www.example.org/5402c258-a716-43ee-9231-1afc0f119cf1"
+    "owner" : "9XHcGuwO7h01b",
+    "ownerAffiliation" : "https://www.example.org/e410fdc7-907a-43fc-bb32-42d0c1c62a0f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8d6fe2c1-0e64-4541-a8df-27f5e43d7b59"
+    "id" : "https://www.example.org/140a965a-160a-45f4-88a6-04a4c2d00b24"
   },
-  "createdDate" : "1978-11-26T18:57:20.629Z",
-  "modifiedDate" : "1996-04-20T16:51:13.829Z",
-  "publishedDate" : "2001-07-18T06:27:05.654Z",
-  "indexedDate" : "2014-11-22T12:23:30.901Z",
-  "handle" : "https://www.example.org/603060bd-cdfe-49d6-9759-72f835335faf",
-  "doi" : "https://doi.org/10.1234/perferendis",
-  "link" : "https://www.example.org/5520b5b4-b5ef-4ecc-b493-b4a380a02e78",
+  "createdDate" : "2011-09-15T11:31:05.998Z",
+  "modifiedDate" : "2023-12-28T12:22:12.150Z",
+  "publishedDate" : "2020-04-07T14:27:04.578Z",
+  "indexedDate" : "2007-02-19T14:19:39.678Z",
+  "handle" : "https://www.example.org/c57674dc-b40b-4f65-b3a6-0b39bf8a9d75",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/f1f6c73f-7d9f-48e5-9d4f-502e8b4d2e33",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "pSoN0ngrsTZunuuJd",
+    "mainTitle" : "zmX1ALKgMF9av1bM",
     "alternativeTitles" : {
-      "nl" : "qdxCCfxdUl"
+      "zh" : "0l8U0OBGPvf7U5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iv8UlnHD4fs",
-      "month" : "sXYfrJ7SbavNOd3w6d",
-      "day" : "dUam6qQ5lA3k1SEfDZ"
+      "year" : "Sy8MPb9JgdR",
+      "month" : "aXLNGdYF4uh",
+      "day" : "beXXkv8MloDuJHfpDt7"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/abf9ab54-c482-4a1e-8801-1cd83b23627a",
-        "name" : "GC2PPURTwoe",
-        "nameType" : "Personal",
-        "orcId" : "i5gMSAypLLIYNW3",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1f10eab6-888a-4138-b13b-2d134710f493",
+        "name" : "ods5CbP96Lo5zB",
+        "nameType" : "Organizational",
+        "orcId" : "v9y3MhN1RnuqyOHySvq",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "H34K1sgCGqBZO",
-          "value" : "y9GniDjJ4e6NbqSb"
+          "sourceName" : "2a6UTNTyW1DzK",
+          "value" : "f34XypkR2hkA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yw0wEZCyHmKT88u8pd2",
-          "value" : "haGLy6TE8EygvWG"
+          "sourceName" : "MDdwdEM8Ga",
+          "value" : "yyNfZBKPdXdGDHKD031"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a8d91e93-76c9-498f-ab27-d5e6fc652d9f"
+        "id" : "https://www.example.org/00e99297-e027-4d41-b312-c6002cea33c1"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/22c5a474-5443-4cdc-91f7-291200d6ddd8",
-        "name" : "duqdhg4zTAr6P",
-        "nameType" : "Organizational",
-        "orcId" : "FXVh4gJkY56AE",
+        "id" : "https://www.example.org/de887eab-9c9a-40c8-a12c-ed6d003a4187",
+        "name" : "bbvNDv7PbyEkm6C",
+        "nameType" : "Personal",
+        "orcId" : "tRJSdwt7tSqpa",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Nm47yn3I7FBMoW",
-          "value" : "s1mR3cNVXmRWk3CLtl"
+          "sourceName" : "z2VlKGxeFdBg3vr97W8",
+          "value" : "ayoqL4WmyKdgALM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U1IiKWxaZK2e2vl",
-          "value" : "01nCvoNzsDQ"
+          "sourceName" : "96aLyeaBWsDcs9",
+          "value" : "2jDdCrWZfX74O"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4664fdc0-2887-482a-97b7-e7f09cd6471b"
+        "id" : "https://www.example.org/88bb5813-3910-4283-8c2f-c6858a608d03"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "Curator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "047iVfrtuLxMztk9hm"
+      "fr" : "aAQnHUyTZXMEP"
     },
-    "npiSubjectHeading" : "C4tVnJoeped",
-    "tags" : [ "DxSbDhzFs9h" ],
-    "description" : "5rHo5BNeGU5Sz",
+    "npiSubjectHeading" : "3tBZdwR9WWA",
+    "tags" : [ "pavkZFGIIQplrCZF" ],
+    "description" : "vKz6c1YYK9DR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/75f1ec32-1106-49bb-8b5c-fefaec0a57f0"
+        "type" : "UnconfirmedMediaContributionPeriodical",
+        "title" : "HlX9c8GncDBnQfV",
+        "printIssn" : "9298-6064",
+        "onlineIssn" : "8489-0339"
       },
-      "doi" : "https://www.example.org/34998ba6-ebac-46a4-87fa-ac0fc4fcb561",
+      "doi" : "https://www.example.org/30a7742f-7bdf-4cc9-a4fa-b61f73473531",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "6uB4tGJT72",
-        "issue" : "V6OYFxv2WaOO",
-        "articleNumber" : "swFoS2KU7k",
+        "volume" : "Rc7o7mTPf8",
+        "issue" : "cXWpSl0Ev7Ga1",
+        "articleNumber" : "yQ3mxXcHW8dxofO",
         "pages" : {
           "type" : "Range",
-          "begin" : "WEnNlZYedVH",
-          "end" : "9fAkLqnGosURu8DGhNO"
+          "begin" : "RP6tReNEozybY363c1",
+          "end" : "a2dPC4zDq8by"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f5e146c4-a8c9-4933-b307-810f95e70340",
-    "abstract" : "3jwVKtbXLSgXV6f"
+    "metadataSource" : "https://www.example.org/e0d08eca-b8b6-4154-932b-a21dd1e7de7e",
+    "abstract" : "kqGdg6lwOq7Rm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7280be25-072e-4e38-b183-e3c5d518528f",
-    "name" : "gN7l0N3SsPV2l",
+    "id" : "https://www.example.org/1602490d-c4e7-4518-9943-243a906773c2",
+    "name" : "cB4oIRYFZN29d",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-06-09T20:34:04.553Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2010-04-10T07:24:22.239Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "QsVaPhNhtvv9jGkl6"
+      "applicationCode" : "pKHAoK2sSxwNNBFWMu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b22d0c33-4f08-49f2-b6ae-82b0b3a4c2ba",
-    "identifier" : "L1uOyiMT7HiUghHsqHR",
+    "source" : "https://www.example.org/363e9f56-fb3c-446a-b6b4-d4ef9197e76a",
+    "identifier" : "QLAR16mfCzwitFFQx6v",
     "labels" : {
-      "nl" : "QOeETxsjKKrNnO02wTi"
+      "pt" : "CcETRLG3awOk5"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1197904438
+      "currency" : "NOK",
+      "amount" : 2038780856
     },
-    "activeFrom" : "2018-03-08T01:02:37.931Z",
-    "activeTo" : "2018-10-20T02:00:18.867Z"
+    "activeFrom" : "1978-06-10T15:43:05.215Z",
+    "activeTo" : "2006-03-08T12:38:19.395Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/556289b5-8840-488c-89d6-d9811029f4db",
-    "id" : "https://www.example.org/6c43bf16-f153-4ef9-9d77-593dccb8afe8",
-    "identifier" : "f79QoDCf5wE5Jau",
+    "source" : "https://www.example.org/59f0ca76-8035-4241-bcf8-63664eada4f9",
+    "id" : "https://www.example.org/82d97c7c-7ce6-47c2-8079-ceba9ae44084",
+    "identifier" : "JYO3X0CwLo9a404",
     "labels" : {
-      "cs" : "99w6nhCq3h"
+      "da" : "jtXnwDOvUllcBVY3Hlg"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 736311072
+      "amount" : 1758109143
     },
-    "activeFrom" : "1993-01-26T21:40:23.343Z",
-    "activeTo" : "2007-03-15T18:23:11.992Z"
+    "activeFrom" : "2008-01-07T17:31:19.913Z",
+    "activeTo" : "2020-08-11T22:25:08.528Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/582565b4-5f7f-45d8-8f9d-a4d6c6dc8078" ],
+  "subjects" : [ "https://www.example.org/0226cdcf-481e-4824-8985-8ac447a0cacf" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "69492b8c-d911-4f73-b05b-35c6395133cd",
-    "name" : "rIOvcgbg7noluAjX",
-    "mimeType" : "96Q78a1kgZGszZbZ",
-    "size" : 1340273903,
-    "license" : "https://www.example.com/zdtzyppxehjngfc4ypm",
+    "identifier" : "4b9ded90-6fcc-4fef-937b-8c18b9482b0e",
+    "name" : "l24npK6E3Lm",
+    "mimeType" : "2PxnfwNGDJ9aZRTtT",
+    "size" : 1872400484,
+    "license" : "https://www.example.com/wdkrqjys6drvlodf1z4",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "2Vgjg852V6qKaUWMO8P",
-    "publishedDate" : "2012-04-14T07:01:41.988Z",
+    "legalNote" : "NpnmbVOFQdhUtdLvjsF",
+    "publishedDate" : "1997-02-03T09:01:51.919Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "XjJKIa3BUvhaBDb7DPC",
-      "uploadedDate" : "1971-06-17T17:17:46.791Z"
+      "uploadedBy" : "6GdoIL9aq1D",
+      "uploadedDate" : "1979-11-09T05:07:14.075Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/6vs0CRtQvEnoGCx9",
-    "name" : "AOPJIoXkpFQvG",
-    "description" : "6jINtU0MOeJp4slW"
+    "id" : "https://www.example.com/V2GJYyfq3XrgisZ",
+    "name" : "Q062wVF6BHbkYvR98pN",
+    "description" : "ghh8VhRkovsGm"
   } ],
-  "rightsHolder" : "lcUXMIHIuk4j6eJr",
-  "duplicateOf" : "https://www.example.org/e69c864c-9ffb-452f-9b9a-037634caac19",
+  "rightsHolder" : "0OEIL3hpGRPb",
+  "duplicateOf" : "https://www.example.org/8bf0358a-e67d-4416-857b-77588b5c37da",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KygbRlddrR"
+    "note" : "OQBicWNT57O9vmvw"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Rhv4dhkMK9KTj0WVWU",
-    "createdBy" : "N6Xvxy11KdC",
-    "createdDate" : "2008-01-28T07:13:18.667Z"
+    "note" : "aRfRD1dNUKX",
+    "createdBy" : "foM3sqhuXQJwDc7",
+    "createdDate" : "1994-07-10T14:58:10.825Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0b599c75-b9b2-41eb-b668-f7fa66253f00" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/02b16247-ab68-4254-a06d-f8cead45c49a" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "zJ15Uo1Uy2OXSy0HF",
-    "ownerAffiliation" : "https://www.example.org/5ad0ae87-15fb-4bfd-9059-6afc35577593"
+    "owner" : "iVwmlrNHX2NdS",
+    "ownerAffiliation" : "https://www.example.org/eeac36e4-aba4-4906-9ab9-8b9008587033"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/36baf41f-5c5f-4d22-af78-fe051f6862d8"
+    "id" : "https://www.example.org/9807c3ba-35d4-46b2-b34a-4c6a070279a9"
   },
-  "createdDate" : "1995-04-07T22:57:12.683Z",
-  "modifiedDate" : "1975-09-27T12:58:45.776Z",
-  "publishedDate" : "1982-08-05T08:40:08.681Z",
-  "indexedDate" : "2017-10-15T20:17:23.565Z",
-  "handle" : "https://www.example.org/dbd05702-3e1e-43ca-b520-2b68e3b61f59",
-  "doi" : "https://doi.org/10.1234/adipisci",
-  "link" : "https://www.example.org/df8dc783-4a56-48ea-8d24-5241659e855b",
+  "createdDate" : "1979-03-02T07:52:21.826Z",
+  "modifiedDate" : "1994-10-24T20:46:00.359Z",
+  "publishedDate" : "2003-02-15T17:17:36.962Z",
+  "indexedDate" : "1972-03-14T17:53:51.689Z",
+  "handle" : "https://www.example.org/60f81e79-8d4d-451c-9ea2-38b6aa400e8a",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/30f88705-9ab3-4972-98e0-16cbb1143a7d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0iLrtfc0vQ70Lfbs2K",
+    "mainTitle" : "Gp853R2bflfM7K",
     "alternativeTitles" : {
-      "pt" : "IG0t2FXry58fakj"
+      "en" : "PeYr9Kg8SdF81zmAVKH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "163P80kVtZ7T8GY4",
-      "month" : "egrLqjsWi26me9tj",
-      "day" : "fBL5yQ53eSRjNcMx"
+      "year" : "QEes47b5ssm",
+      "month" : "iumA07MTHj4x",
+      "day" : "vcJmCp9ipy4h"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/71423555-7ccd-4359-b559-65ebe7d982d7",
-        "name" : "UmODrS8szH",
+        "id" : "https://www.example.org/fe2562a0-7896-4223-95ab-ee84b3deded2",
+        "name" : "0iGIGhemooGxnrOV",
         "nameType" : "Organizational",
-        "orcId" : "77EdNUqzd4Z3y",
-        "verificationStatus" : "Verified",
+        "orcId" : "d3VUbNwJXSSbVc",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w5Enzjf5Ke",
-          "value" : "134764EQORGk"
+          "sourceName" : "p8uNFeGHyyJyHC",
+          "value" : "As7Nlp9TVxj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Pj9TtBSHdChvaUnKC",
-          "value" : "xVi5zVlGWThrkncYOd"
+          "sourceName" : "jZtYY4IxRHd",
+          "value" : "ztznW0dICh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7c820f83-7d72-40ed-8e5a-dec6d67dbe2b"
+        "id" : "https://www.example.org/4ef6402f-9940-4012-ab02-7568f5a99f43"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,37 +62,37 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/95e49f0d-b670-4fa3-8007-b6a1c1c1747f",
-        "name" : "sYLGjfnptzgIOdAz7",
-        "nameType" : "Personal",
-        "orcId" : "IxVwJYm7VFF85HxZo8",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/f8b23d59-6687-40d4-8732-393ebac83a8f",
+        "name" : "YZC7PruCJwpgZZG5Z0",
+        "nameType" : "Organizational",
+        "orcId" : "ZSepDp2d79DBgj",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KacOEqSTuPBZsnKW",
-          "value" : "pM5jDdnDdytK3R"
+          "sourceName" : "odHCrxxY2R4h8TIn",
+          "value" : "tgPlzS5fwgo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9Z98R4haMOuY",
-          "value" : "5EdfXgVjk5"
+          "sourceName" : "A71ztZMwHUVr",
+          "value" : "rXrQblgUkSJOS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e3fca494-73e1-4840-8388-c8bd3b4a13bf"
+        "id" : "https://www.example.org/d2b6a982-71a3-4c20-9379-f4497b699275"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "nNoexK89R1mf7LLe"
+      "hu" : "xXmCI3GmInP"
     },
-    "npiSubjectHeading" : "QCJlyWKftEHpnLqU",
-    "tags" : [ "qxSP6OuklaE04dx985D" ],
-    "description" : "MwCmtIIouzIzlXQ",
+    "npiSubjectHeading" : "xIK4UCuBOs27f",
+    "tags" : [ "mMrPtSAfoD" ],
+    "description" : "fwHJXG9Mxi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
@@ -100,15 +100,15 @@
         "medium" : {
           "type" : "TV"
         },
-        "format" : "Text",
-        "disseminationChannel" : "sZ9xB1hmiPMuocv",
+        "format" : "Video",
+        "disseminationChannel" : "ANR7BWtd71wL8exz5m6",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "szloEQWYXioTvK0btLi",
-          "seriesPart" : "9Vyn2k6sA7B"
+          "seriesName" : "4ikl5oVICm",
+          "seriesPart" : "qmFjQTCt9FdlKXbYWCj"
         }
       },
-      "doi" : "https://www.example.org/69bf2599-808f-42f3-8907-d3ab56d80b9b",
+      "doi" : "https://www.example.org/6f1ec857-66b9-4284-ade5-bdde4004ef7c",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,94 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/93b0cce2-6375-4ac5-8562-6a76c82aeddd",
-    "abstract" : "L4RxcCxuZxWa"
+    "metadataSource" : "https://www.example.org/f67f404d-0399-45ee-9056-3708c5cf096d",
+    "abstract" : "6NbXDhuCjdkkwe6R"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a55e820b-a9ca-4249-b016-f6eca0ba00ba",
-    "name" : "tXNfH1w2uCucn",
+    "id" : "https://www.example.org/0a430548-ace4-4c69-9442-9ddf08114be6",
+    "name" : "qjIbjK1dMBDzmgjjEj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-09-11T13:32:44.731Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "g60GOOOifgKiGT4eNLB"
+      "approvalDate" : "1990-06-13T08:06:46.018Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "eWwpq3dquLbu0zFZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1b2b2cba-d68d-4faf-928c-92bf87bc6c1f",
-    "identifier" : "EsfzDAayHe39DiVk",
+    "source" : "https://www.example.org/fd4ad018-4061-4357-a635-2a8cb8bd537f",
+    "identifier" : "6iKx89qCeM",
     "labels" : {
-      "nn" : "tnq6VKT001i"
+      "sv" : "rWGlMKEKysB46Iis4"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1473100654
+      "currency" : "USD",
+      "amount" : 2131399479
     },
-    "activeFrom" : "1994-06-12T07:02:56.909Z",
-    "activeTo" : "2002-12-07T12:15:22.268Z"
+    "activeFrom" : "2002-07-06T19:01:57.091Z",
+    "activeTo" : "2018-01-08T22:56:15.725Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3f84cff3-7da5-457c-92ac-b3825de5e169",
-    "id" : "https://www.example.org/9ee95b89-1429-4599-bf92-ed80f4053c78",
-    "identifier" : "Qu8I3RAi7di8fnOn9wD",
+    "source" : "https://www.example.org/fd1db5e9-4814-4993-a7ad-e1b508afd624",
+    "id" : "https://www.example.org/790008c6-89a9-4382-8cf2-f2d078317846",
+    "identifier" : "NBr6jYjUs33o5gx9Ob",
     "labels" : {
-      "sv" : "wSH7bTQJTj"
+      "ru" : "fRvlpmAZgT"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1042314655
+      "currency" : "NOK",
+      "amount" : 1974799603
     },
-    "activeFrom" : "1983-07-07T17:39:49.978Z",
-    "activeTo" : "2015-09-27T04:16:40.939Z"
+    "activeFrom" : "1979-04-22T01:56:38.168Z",
+    "activeTo" : "2001-03-12T03:26:44.553Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/004f3711-c664-434e-a47c-469c8f2d602d" ],
+  "subjects" : [ "https://www.example.org/8b327062-c62f-4075-aa55-17ca9a87d201" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0e0c9be2-a1fd-45c5-98e6-6dfdbb187e84",
-    "name" : "oyJtsAOJaMtQtd",
-    "mimeType" : "sNaXfx5TkmdSMvtW",
-    "size" : 1419993805,
-    "license" : "https://www.example.com/4dma3ftrplkctjwtda",
+    "identifier" : "f822474b-ee15-486d-b6e6-2cb8ea48ef44",
+    "name" : "XhNGE0ZWSlLsd",
+    "mimeType" : "lOwXJZe3zOhw",
+    "size" : 683341308,
+    "license" : "https://www.example.com/ub9kukqhri4",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "3I4EbO6xndmGiYnVt"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "hjE4VQ9mDLrV4vm",
-    "publishedDate" : "1989-02-24T18:27:16.952Z",
+    "legalNote" : "oeJGHiarEDoHNwQMfs",
+    "publishedDate" : "1996-12-27T10:05:38.312Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "FCIzJD9qbQwe",
-      "uploadedDate" : "1989-09-20T00:32:55.878Z"
+      "uploadedBy" : "XGbfba88ylj",
+      "uploadedDate" : "1991-04-25T17:23:18.420Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NmcXT8CUoJmBU",
-    "name" : "7WAgCPvHhRVO",
-    "description" : "yKzEGGzyRZ6v"
+    "id" : "https://www.example.com/cMbHjWHHqgRlVJUv3",
+    "name" : "bwOlMBRSsnE5",
+    "description" : "K41MVkHUnejaEI1b"
   } ],
-  "rightsHolder" : "m2ZvIFSZpdckhZNKUTM",
-  "duplicateOf" : "https://www.example.org/31e2a686-0e21-4a48-abce-b81b8a54111c",
+  "rightsHolder" : "dP4iBI6WYms",
+  "duplicateOf" : "https://www.example.org/40e3e169-06da-42e2-b2fe-9a41dbf57ee6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "VcR61rAYtWhZkw4p5"
+    "note" : "Xxu3L66VFhnyWC"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QtiAfErzRC",
-    "createdBy" : "4jYSKmVKCOo3Ihzx",
-    "createdDate" : "1991-01-14T02:55:03.009Z"
+    "note" : "VM9j9f136l",
+    "createdBy" : "9dapRw86vy",
+    "createdDate" : "2023-10-01T19:21:54.269Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/649b7958-ac1d-4d81-9b1e-f2fe78934b76" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/d881b9a8-fb44-42cd-beac-ec141b329138" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "WJ76AU8Ds6eH61U86x",
-    "ownerAffiliation" : "https://www.example.org/afd86645-0a1c-4e45-8591-67b52f0ce24a"
+    "owner" : "Qb3hyPuKDqa",
+    "ownerAffiliation" : "https://www.example.org/973fb7ce-a4c3-4c38-bca3-1e795f06a611"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/174090a8-e67b-426f-8e07-25948b7e2c38"
+    "id" : "https://www.example.org/75f453a2-bb61-4c85-87d4-3379442a5402"
   },
-  "createdDate" : "2023-08-05T13:25:24.795Z",
-  "modifiedDate" : "2008-04-06T06:45:32.764Z",
-  "publishedDate" : "2015-05-09T14:13:38.101Z",
-  "indexedDate" : "1985-12-25T04:10:32.292Z",
-  "handle" : "https://www.example.org/86cf2683-368c-4797-9d2a-3126156cf9b9",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/6f6783e1-8df7-4e40-b243-aedcd4b9c84e",
+  "createdDate" : "1977-08-14T06:05:09.316Z",
+  "modifiedDate" : "2007-07-26T18:44:56.341Z",
+  "publishedDate" : "1999-10-23T06:42:53.395Z",
+  "indexedDate" : "2019-02-13T03:10:32.712Z",
+  "handle" : "https://www.example.org/5b1bf859-5f51-44b1-986a-eec5e9c45c25",
+  "doi" : "https://doi.org/10.1234/nisi",
+  "link" : "https://www.example.org/7ca5e1d1-4b6c-4307-84ef-c93b678609cf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bXjqLBah07zphIG9P",
+    "mainTitle" : "2P8aI2H8OqG",
     "alternativeTitles" : {
-      "fi" : "YmHFZddWGQ5"
+      "hu" : "lZhv2oaQm3JfBS2R"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "wdLF7GTIh6qgALeo",
-      "month" : "hvyfYwEuSs",
-      "day" : "rRdk6Vzoxq9"
+      "year" : "qtQqiK0Tfajn2",
+      "month" : "pSbATqt5qA",
+      "day" : "MT1mdZQHgDQ3aUywE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a2ae23ce-3042-467f-8495-b306e01f61ff",
-        "name" : "I7HNrUmaA4iotE",
+        "id" : "https://www.example.org/01bfde12-483e-4277-807e-75c3d6c61086",
+        "name" : "NmqshRw7Lj2",
         "nameType" : "Personal",
-        "orcId" : "lq9vBxo602HCd6l",
+        "orcId" : "BwviLjM1fff8OPu",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1hAKDErBTYBi7gy53C",
-          "value" : "eg8AspRfWBqeLr"
+          "sourceName" : "f5bRsTnSQA7w",
+          "value" : "hBLseIWuCpJ2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "i5uP9IxQtH0",
-          "value" : "LG12e07QFsC7X"
+          "sourceName" : "bV2sfiKGHfb6p48U",
+          "value" : "sn9xa89UczK6C2PctV"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a2de7292-e0ba-4fb2-a3fd-7ac22374695c"
+        "id" : "https://www.example.org/6c6fd879-77a0-4ac4-b8bd-9ac4f93041da"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Curator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6af31099-741f-4290-adc9-48f318147338",
-        "name" : "eXfJDTIDO7",
+        "id" : "https://www.example.org/1087d7cf-7bb3-4934-9401-fe0afe40f324",
+        "name" : "3NfojfjRSdb2Fst",
         "nameType" : "Organizational",
-        "orcId" : "ZkGI3ES4JKk2y",
-        "verificationStatus" : "Verified",
+        "orcId" : "gKh99IxX1I",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "J1HqLy37vfsFSI4kCc9",
-          "value" : "YzDoHYTvpl2o"
+          "sourceName" : "C2PRwZgS6ljOC",
+          "value" : "9RxwKEsFxUS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4xJlGl9KB8Mi8gn",
-          "value" : "0TI2y5Vfnyq"
+          "sourceName" : "z1fZ9NOcGdMS8B",
+          "value" : "Usnmki1OuH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7c7a7079-faf5-43c1-9424-39b731e85d6f"
+        "id" : "https://www.example.org/635c710c-6ffa-4647-a9a7-73eb437664c0"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "RHU76NaphGMdG"
+      "fr" : "vyVpKF1rxIKZwHGnYt"
     },
-    "npiSubjectHeading" : "dQep7ixlMmgjBHPs",
-    "tags" : [ "IerzmaoqKs" ],
-    "description" : "AEPGH7vZuxFXZQPYF",
+    "npiSubjectHeading" : "3tmRSkjdjqCNo",
+    "tags" : [ "Tf3qqTv7SpdP9L" ],
+    "description" : "uShQ1s0XPdXO32E",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Journal"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "ULcUCdazL0gTVSYQZoy",
+        "format" : "Text",
+        "disseminationChannel" : "0PijsN4sNl",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "v0spm5MHmpLr06UEJ",
-          "seriesPart" : "KenhMIDj3gM"
+          "seriesName" : "hYQKibC169d5pM8s",
+          "seriesPart" : "nK7cnHbAuq"
         }
       },
-      "doi" : "https://www.example.org/9f24f10c-f18b-45f9-9b06-b9777c4308ef",
+      "doi" : "https://www.example.org/6f6c3dfa-a3d9-4b2e-b884-8b50e2f70bb5",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,94 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fb356e84-fff2-4aad-afb5-4b027e350262",
-    "abstract" : "emevNAHz8xLp"
+    "metadataSource" : "https://www.example.org/87a144f7-9777-4fa4-93ac-fc8974d4d674",
+    "abstract" : "E2adjTAHKAkPgH0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7d25a12c-f908-4f46-bb0a-14dda32b1ca6",
-    "name" : "eotG97MWi0a",
+    "id" : "https://www.example.org/c45a7839-3cc4-4138-a623-cce6617f63a5",
+    "name" : "xkkrfIiIqYJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-06-27T11:30:26.875Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "9OxuB4isyALoEat"
+      "approvalDate" : "2001-03-23T13:11:20.447Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "2tXqxVb9nRsgtBlZUK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7917e42c-860a-4997-9c50-b4820fcda239",
-    "identifier" : "l0is7P24NjjzYe2cC",
+    "source" : "https://www.example.org/bfa99115-d1bd-471c-8a6d-081553003c0b",
+    "identifier" : "rzI7JhibsQTV1R6qE9",
     "labels" : {
-      "pl" : "IkP7THXvrN0MTiuhZY4"
+      "ca" : "SfRxKYWWXHB1XR"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1129755371
+      "amount" : 207483701
     },
-    "activeFrom" : "1983-01-10T08:24:35.011Z",
-    "activeTo" : "1995-09-28T12:40:41.390Z"
+    "activeFrom" : "1991-11-22T17:49:47.208Z",
+    "activeTo" : "2003-01-14T16:48:59.142Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/23ad7cf0-f0ae-429f-86e6-842bed6c16d2",
-    "id" : "https://www.example.org/002d3a50-81c1-4a1d-aea7-1bb9b1f4886c",
-    "identifier" : "N4LbYjGLw85",
+    "source" : "https://www.example.org/a8398b80-7776-46b9-b558-ce830e497274",
+    "id" : "https://www.example.org/13e27274-3caf-40bc-a5f2-c2d1b70b426e",
+    "identifier" : "2QybGatzPOS",
     "labels" : {
-      "el" : "v9o1ZB0pOI5Pyt"
+      "it" : "DAcQBHXiHPsQKu6s"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1642046127
+      "currency" : "GBP",
+      "amount" : 1356187106
     },
-    "activeFrom" : "2006-10-26T00:13:52.611Z",
-    "activeTo" : "2017-03-19T00:00:13.131Z"
+    "activeFrom" : "1980-11-29T10:47:11.162Z",
+    "activeTo" : "2017-08-28T00:30:40.284Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6bd5a0c8-c5bb-4539-b0de-65376fecdadf" ],
+  "subjects" : [ "https://www.example.org/52cbeddf-6fe7-4cc3-8b8c-b18ac2948347" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8d6032ad-6aff-445e-a2f7-226bcc52e03a",
-    "name" : "GBbuVD7xAm",
-    "mimeType" : "zw5NRzmTEz7",
-    "size" : 154326925,
-    "license" : "https://www.example.com/jnlhuwfddh9qn",
+    "identifier" : "2cc29585-0030-470c-86eb-a75be922b19c",
+    "name" : "MaMy8Dfg59MVg",
+    "mimeType" : "TdYqsAarTKOZUa",
+    "size" : 1100331188,
+    "license" : "https://www.example.com/vz9nfj85qdrshdjfp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "zEK9eeLh9bi0Z"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "6XJsaZ47kYV2s",
-    "publishedDate" : "2008-03-16T06:23:24.465Z",
+    "legalNote" : "5L98BDPbPWJBdBojZf",
+    "publishedDate" : "2022-12-11T12:51:59.143Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "TWEexyN6GlV22A",
-      "uploadedDate" : "1976-11-08T03:11:49.783Z"
+      "uploadedBy" : "UrRQhQvoFgCuCbImJyG",
+      "uploadedDate" : "2001-01-20T00:18:16.217Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/boy82DgRnSgAF2",
-    "name" : "3UxVLHcQKC99FKc",
-    "description" : "Q7mtB1kD6hNZqu"
+    "id" : "https://www.example.com/5aNyI6w7Vd0ad4Z",
+    "name" : "krl0x0JbEj0uW2",
+    "description" : "rSHeZlr8SPhPYfyM"
   } ],
-  "rightsHolder" : "5IqMlPvYAbFtI9",
-  "duplicateOf" : "https://www.example.org/df88f128-f4fa-4dd8-9b4c-22037ee895e8",
+  "rightsHolder" : "L4Kl75U5ZEVL3kTv36O",
+  "duplicateOf" : "https://www.example.org/be520d92-869e-4d15-903d-84154d625b46",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "jtiOYICzun"
+    "note" : "QI5IOMhm8oyUCm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "pHdS8n57i7TKcDa88",
-    "createdBy" : "cE0Ek8KWN477",
-    "createdDate" : "2017-11-10T14:08:31.708Z"
+    "note" : "jdeCQXvppZg",
+    "createdBy" : "UGTP7c7gw5",
+    "createdDate" : "1975-01-03T00:20:15.179Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/824c3aee-5013-43db-893c-bca39c49efe0" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/c0511e15-a0ba-4ffc-af3d-9dcc56106588" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "f8FBazI3pr",
-    "ownerAffiliation" : "https://www.example.org/02fcbcef-735e-4a46-b28e-9c0ce0022363"
+    "owner" : "b9Tb5quCECWIE",
+    "ownerAffiliation" : "https://www.example.org/9e9b4b15-9283-4c72-841b-f2b30effd610"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/149ce8be-c7f1-424b-9145-841055ce8878"
+    "id" : "https://www.example.org/64a20a94-24b8-42c2-b7fc-147283fc1e83"
   },
-  "createdDate" : "1991-09-22T06:48:32.459Z",
-  "modifiedDate" : "2012-05-08T08:53:39.753Z",
-  "publishedDate" : "1999-07-28T09:49:18.735Z",
-  "indexedDate" : "1987-11-04T22:17:34.349Z",
-  "handle" : "https://www.example.org/f140117c-cbcd-4cf9-a912-aa744c948861",
-  "doi" : "https://doi.org/10.1234/sed",
-  "link" : "https://www.example.org/8af1e865-f8c2-42d4-8903-cd2ddeddcffa",
+  "createdDate" : "1977-06-10T23:41:39.434Z",
+  "modifiedDate" : "1985-02-17T10:38:17.317Z",
+  "publishedDate" : "2016-09-23T02:46:23.043Z",
+  "indexedDate" : "1994-06-05T16:22:18.328Z",
+  "handle" : "https://www.example.org/536dc5d9-7a12-4c67-aca5-e2ecffdd889f",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/57efc4b1-c413-479d-b24f-654eda581826",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "n9RVgzj2bn",
+    "mainTitle" : "BZr0niJU4oOTiaMXr1",
     "alternativeTitles" : {
-      "en" : "Xtl3P7YunDc"
+      "cs" : "2N51PRoDTYxJja"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KsMCaaRKt7z8LaC0e",
-      "month" : "dMeH3jpD9tMz6",
-      "day" : "qsg7MXXcCm"
+      "year" : "jOuIEalgagD5gKeQkk",
+      "month" : "bZK6X1QTs3Z0C6iBJ2",
+      "day" : "7wOIjxFCpMEhnwX5z4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f46f66c4-6b12-43ea-a009-08fcbb0e34e3",
-        "name" : "xTUI6YYsgWOpaWh4",
+        "id" : "https://www.example.org/6d03a409-8a84-4e25-9545-f8c08e52982f",
+        "name" : "nv91PPCMvLAooE5m",
         "nameType" : "Personal",
-        "orcId" : "L68SFF8Ru83epVBeE",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "SZOGW9rD5kMaw2wd4",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JKUTj9tnCe5L",
-          "value" : "vTBmN0c5gPUM9XP9"
+          "sourceName" : "qvPCOfmPRr1",
+          "value" : "K4tgWGweVOc1pHPZOLr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GRLNf0ZA8WRmb81D",
-          "value" : "9r4jkexGbuP1gX"
+          "sourceName" : "iEGFjUDylyViBv",
+          "value" : "YDDEi6QCBNbcmHsx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/36f18b72-f4d8-43c3-a69e-599317787bc4"
+        "id" : "https://www.example.org/9fd1f687-15db-4ff5-9e8b-ebe447a778e7"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/edd005a8-297c-454f-858f-20ec23f7920a",
-        "name" : "bNiRyBcnC05C",
+        "id" : "https://www.example.org/12cdb3da-9194-4015-95d7-37009ce8afdd",
+        "name" : "2RHK0M4OoetWQJ4",
         "nameType" : "Organizational",
-        "orcId" : "y4bWQRXXB2em6hzt",
-        "verificationStatus" : "Verified",
+        "orcId" : "oyjFPh7onTai7a",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CM6amo3cvXD0zgjY",
-          "value" : "ealizLp2zbp5fWil"
+          "sourceName" : "IbDfyjSZSRwla",
+          "value" : "WZNduwIP63Gp2J4Eix"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hjC3wNM3huIzj8",
-          "value" : "WUTI3VL95NjJn9"
+          "sourceName" : "DIijSRoICXleKvXvN",
+          "value" : "yw7ZJFaIj7guE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1faef294-ba08-4a75-92db-5d8f48c3507a"
+        "id" : "https://www.example.org/4d3429c7-c5be-4d44-8bdd-8eb773130d7c"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "ProjectLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "HaciMoM0AnmKnG"
+      "de" : "nJJCZrmMUleCwhCBb"
     },
-    "npiSubjectHeading" : "4Lm12krzCpOdbc",
-    "tags" : [ "iJO3GDmGe5FsJJB" ],
-    "description" : "YHh2F5u7I8qm",
+    "npiSubjectHeading" : "CGGoM8XfryG53fU",
+    "tags" : [ "Mb28YnjEBAtH" ],
+    "description" : "413O80s0KotkVfwHfw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Internet"
         },
         "format" : "Video",
-        "disseminationChannel" : "zpydQEcn8vzgI3up0",
+        "disseminationChannel" : "xdKu7ZBCFtsH50",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "erJTh9v09J",
-          "seriesPart" : "kvOUTEomE4Td3Uc"
+          "seriesName" : "LFxqps8qZ56f8XpHQd",
+          "seriesPart" : "fNPiPQY2M8iaw"
         }
       },
-      "doi" : "https://www.example.org/9d6421c4-8088-4227-822a-5fc56b674cfc",
+      "doi" : "https://www.example.org/7da97fba-b3be-4edf-b32f-5479bce96621",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -116,93 +116,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a8e9545c-f78c-4c30-9cbb-e12b585c0139",
-    "abstract" : "qatvbpLh7Xxq0qm"
+    "metadataSource" : "https://www.example.org/54a14a6e-f4ae-43dc-bf65-815577b118ef",
+    "abstract" : "6jwBSkKqOxvr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/970323dc-896d-41f2-838f-4e784b4e115b",
-    "name" : "6PFeM7mDFYOvYFr",
+    "id" : "https://www.example.org/5474d1fe-b79a-4cbe-afe2-099d19c94623",
+    "name" : "uzJ9A4mmwtZpM1G",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-02-08T08:04:39.268Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "5Spnngwu40ra9v3pW4"
+      "approvalDate" : "1992-03-08T20:22:45.654Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ANBOMgHVeyUL461dNB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a3e92c1e-9f0b-455b-97e1-12732f24a069",
-    "identifier" : "TwiLQ1cIn4ptYs",
+    "source" : "https://www.example.org/2078963f-b60d-47a0-aa00-b8c462a99b58",
+    "identifier" : "UlLBlXfoTTV4QGHA9",
     "labels" : {
-      "af" : "AKEYe3P2MdMxnQyaML"
+      "ru" : "pBJhquaipzutSjxAsm"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1962511980
+      "currency" : "NOK",
+      "amount" : 537969838
     },
-    "activeFrom" : "1986-11-13T09:50:16.935Z",
-    "activeTo" : "2011-08-19T00:59:42.340Z"
+    "activeFrom" : "1995-11-08T12:39:57.004Z",
+    "activeTo" : "2017-06-26T06:54:34.830Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a7b4c164-317b-4c8a-9a1e-2b379013f739",
-    "id" : "https://www.example.org/36523b41-5ac0-4125-8df0-3584b3b97e64",
-    "identifier" : "Dw6lFZX6xah",
+    "source" : "https://www.example.org/3dd3fd59-6428-4213-886d-34361299fe49",
+    "id" : "https://www.example.org/c825e29c-32e1-49ea-83f7-4665266bbbe9",
+    "identifier" : "dgm0qbJHzZVuNbJ8M1D",
     "labels" : {
-      "af" : "jqFCgHOOX1UzP9xOy"
+      "el" : "kCaC5n3G9sU"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1128184887
+      "currency" : "NOK",
+      "amount" : 1176762102
     },
-    "activeFrom" : "1982-02-28T23:44:39.954Z",
-    "activeTo" : "1990-05-20T22:41:25.594Z"
+    "activeFrom" : "1998-04-23T07:33:11.783Z",
+    "activeTo" : "2006-08-29T23:08:05.155Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ccce3135-73c3-4a51-914f-d779c287ca87" ],
+  "subjects" : [ "https://www.example.org/28c975fd-2dae-4682-acce-03b0f883dcbe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0522eddf-dce9-47aa-ace8-476266fe079e",
-    "name" : "qKlHzYGIPXFUiIu2NMl",
-    "mimeType" : "pTkIhIW4reeu600tmz",
-    "size" : 224927729,
-    "license" : "https://www.example.com/mlfmyfavxk1n",
+    "identifier" : "5164db62-c701-4ef6-ac1a-d237ddb8521b",
+    "name" : "WJV7o5K5V65hVfbpmq",
+    "mimeType" : "iWiiKsPs5NFG",
+    "size" : 780058612,
+    "license" : "https://www.example.com/2nzvvljtbzqs",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "iCrVVKdZr9pFDVL0",
-    "publishedDate" : "1984-08-20T08:00:56.333Z",
+    "legalNote" : "bmtsxx9ujhuS9",
+    "publishedDate" : "1972-10-06T08:26:28.549Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "A4FUrF3ZdIxRR9x2b4",
-      "uploadedDate" : "1993-05-28T13:19:09.608Z"
+      "uploadedBy" : "I6kTBz9nN8T5p",
+      "uploadedDate" : "1986-03-30T07:58:36.353Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/4rykpQJGM61ENBsqGw",
-    "name" : "ysCY9HtJSg5t",
-    "description" : "dXvw7JJEddW"
+    "id" : "https://www.example.com/b0B7z40a8IJHDwHUv",
+    "name" : "FT03gcSGNQ9",
+    "description" : "q4lw6Z3sqIXOU3ZuioD"
   } ],
-  "rightsHolder" : "3TecnQOjWU",
-  "duplicateOf" : "https://www.example.org/486e3a6c-91b7-440e-b867-5f57144f2ac9",
+  "rightsHolder" : "u5IUbWbPvDq",
+  "duplicateOf" : "https://www.example.org/e40fec39-d759-4e62-8d2f-f79b0d9d7df4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5FudAyvZaQ6t"
+    "note" : "n2jf7LGQzLwSM"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sl7OBVgSm36",
-    "createdBy" : "vq3udKWjZt83b0mb6ka",
-    "createdDate" : "1980-02-20T16:59:54.764Z"
+    "note" : "pg8UIIFh5b",
+    "createdBy" : "6SuMrKR5MzZvcIUKnZg",
+    "createdDate" : "1987-04-18T19:17:41.665Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1c57a5a1-d45d-4bdb-a12f-204b5efc6759" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/0d42c7fb-fcce-4f86-ab93-cbff26d34cca" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "A5e0A1bgSbmZCd",
-    "ownerAffiliation" : "https://www.example.org/d15fb2e9-7918-4e06-a0aa-5cdec1eb1d8f"
+    "owner" : "WGpJMTQvnLpu3Fd",
+    "ownerAffiliation" : "https://www.example.org/a8744528-7300-4016-8f70-bdaba1741f5f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c7b125f7-2b36-439c-9d08-4c5e09f8de51"
+    "id" : "https://www.example.org/aff0fc2f-78d0-40c5-a71b-0d0b4ba5f8fd"
   },
-  "createdDate" : "2005-06-30T10:04:53.490Z",
-  "modifiedDate" : "2007-12-20T01:01:22.454Z",
-  "publishedDate" : "2005-02-21T02:38:35.655Z",
-  "indexedDate" : "2013-11-05T20:58:12.510Z",
-  "handle" : "https://www.example.org/352c6d32-6792-48c5-8e7c-9c618b8d6fa8",
-  "doi" : "https://doi.org/10.1234/magni",
-  "link" : "https://www.example.org/7f480878-70b1-4360-a2e5-da1c36668196",
+  "createdDate" : "2009-01-25T03:52:10.363Z",
+  "modifiedDate" : "1973-07-10T07:22:28.747Z",
+  "publishedDate" : "1983-11-12T06:44:54.049Z",
+  "indexedDate" : "2016-05-16T12:30:24.155Z",
+  "handle" : "https://www.example.org/56c1d1e4-25ec-4f6f-8480-bbf604d1ba2a",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/a7b38df0-33da-47ce-9f87-237518132df0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "zIkTPRQ47MIU9h",
+    "mainTitle" : "S7XzaMI1My3Wxh",
     "alternativeTitles" : {
-      "hu" : "cMeAqrs7uV1cj17cr3D"
+      "nl" : "m9JwIgMGVswUKqt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XFZo2qf0bV",
-      "month" : "9IqhPdiNRSt",
-      "day" : "vTccSH40lC40w8M"
+      "year" : "e84XHt2vI8bFZJzo9",
+      "month" : "xg4dTit0UTqdIqVyLx",
+      "day" : "gDHZiUiR5d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ce7b8f9-be1a-4165-a508-bdeb880552b5",
-        "name" : "XgozBD5RrMQHCd",
-        "nameType" : "Organizational",
-        "orcId" : "QindVrVqUjVmsEB3u4",
+        "id" : "https://www.example.org/d330eaec-6c90-4cfd-8fd0-f01a24632290",
+        "name" : "QG5Q4Ou3kxmO",
+        "nameType" : "Personal",
+        "orcId" : "biy2BW0aNmp2iPLrfOA",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5zbEOJ0Hx075U076Hb",
-          "value" : "P4YFfIzh12axL1lkFPc"
+          "sourceName" : "lxSetyhNrU6rB",
+          "value" : "89b9qcTcJsBsBZcj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "P028dViV30VW0k",
-          "value" : "SpTvJA6GrYq"
+          "sourceName" : "4FkjEPYWDYAoDWPe",
+          "value" : "TcHX1pQ8qPjWUhXVw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/37c4b5c8-72b9-4871-bbe0-568d07ecc004"
+        "id" : "https://www.example.org/07993cf2-45d1-41df-8d4c-ecca5bc45318"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,144 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aa620472-fabb-4a12-9388-34ac2e537c7d",
-        "name" : "H38x3mep2G87sV",
-        "nameType" : "Organizational",
-        "orcId" : "cJJm3pgBu6fgHd1Wz4",
+        "id" : "https://www.example.org/b8124262-7997-427e-8f42-795131867dc1",
+        "name" : "WkCh7dSG3sUTQ",
+        "nameType" : "Personal",
+        "orcId" : "s2nIn9aQjX",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yZM6EHRlOeQBPsuv4",
-          "value" : "G7GXBAUyAufkZAS5Zc"
+          "sourceName" : "C51I4itEojW3Ny",
+          "value" : "FfFbdGkIs27M"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZH0Uy9Kfiz94B3fUZH",
-          "value" : "yD48GuWbAJpUpncbMb"
+          "sourceName" : "GEX1oddkiNqH50pNURG",
+          "value" : "4L21E5oADym5OK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/40238e11-4301-4031-9485-207e63d253f0"
+        "id" : "https://www.example.org/b213bf2e-329a-41a6-a37c-5e72f7f5be18"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "vLWFRtTKj0L509sQv"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "uS7gWrWySzGI0sZqr3"
+      "fi" : "RVviPqGvYs7HoWgZ"
     },
-    "npiSubjectHeading" : "Uq1Q0yq9IZ",
-    "tags" : [ "4LBBxuWz9nGKURd" ],
-    "description" : "SdkGfX6Ee7lL",
+    "npiSubjectHeading" : "Hb9PsY4sgF8",
+    "tags" : [ "3GErn1KW9oHB" ],
+    "description" : "ZNKr1ko8mfaUD1NXL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9687aae6-da09-4b00-acea-99a5a840a3ce"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/aa02dcfe-3f4c-43a4-933f-284525ab405e"
       },
-      "doi" : "https://www.example.org/789161cb-7b43-40be-8f18-3bc8ad714e69",
+      "doi" : "https://www.example.org/cf11ed36-fe05-44a8-b22e-245eaf621387",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "uKq34q8UraA",
-        "issue" : "DvHCjjtyAP",
-        "articleNumber" : "nWIjqtHsGuicChv",
+        "volume" : "U2O2tCILbSFSIR",
+        "issue" : "mrG9w4bvOgxQIQEkv",
+        "articleNumber" : "iqCOoNnlEM",
         "pages" : {
           "type" : "Range",
-          "begin" : "sMiMseeU6w0OL",
-          "end" : "9mO4zc69ozDjI5yQ"
+          "begin" : "8T1f4tt4u3cJ07",
+          "end" : "WfbQGDTItUt"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b8be2fc7-0e87-45ac-92cc-07bdfa455ce6",
-    "abstract" : "dqAw3q7WbHBTP2EsXO"
+    "metadataSource" : "https://www.example.org/8788e8ae-6942-432a-8609-5c3684d67bb8",
+    "abstract" : "cvpqAfRve8sF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7ea494d1-1d64-48c1-8e50-5a2dba30f378",
-    "name" : "UFUa2rEDOzh7Gw6e3",
+    "id" : "https://www.example.org/c57b4969-3153-403c-9cf6-b7cce9561eb1",
+    "name" : "FXmIMgT7KGE0bCHBGn9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-10-30T22:49:06.627Z",
+      "approvalDate" : "2007-01-29T12:10:32.290Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "Fa7zNHwATYIAUO7cc"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "uf2KlpzQ7PFMFu8rZ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6f231783-5e20-428b-a8c7-7b75a670e816",
-    "identifier" : "Gp8gULOcoT",
+    "source" : "https://www.example.org/fc8f8aec-4e3d-4145-8c87-98c8605e4f89",
+    "identifier" : "A4vy9PDgpdqnBHowt",
     "labels" : {
-      "zh" : "rTwYju6nbiujdAmLG"
+      "pl" : "HnfcPxp5F3"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 762374056
+      "currency" : "USD",
+      "amount" : 585814577
     },
-    "activeFrom" : "2018-01-18T21:11:51.775Z",
-    "activeTo" : "2023-08-20T18:16:55.237Z"
+    "activeFrom" : "2017-04-23T12:58:07.254Z",
+    "activeTo" : "2021-01-23T13:03:47.670Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5d36b84c-185e-40e5-b31d-8fd4f2b47edc",
-    "id" : "https://www.example.org/3508910a-700d-4d98-905f-0ce177af1c7a",
-    "identifier" : "zEEFB0GqPcFlnBftY",
+    "source" : "https://www.example.org/2605c0c5-c1c1-4061-b4d0-ad0c47688b63",
+    "id" : "https://www.example.org/e107c422-d037-41be-82e1-e2cd7fb6660c",
+    "identifier" : "ENEGZxZumC",
     "labels" : {
-      "nl" : "LWqyFpbedYMBwepbuQ7"
+      "hu" : "iRLitWIPgu2ANU"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 565450629
+      "currency" : "GBP",
+      "amount" : 1044661836
     },
-    "activeFrom" : "1979-12-12T03:08:44.446Z",
-    "activeTo" : "1993-07-28T13:22:52.569Z"
+    "activeFrom" : "2011-09-11T02:42:05.274Z",
+    "activeTo" : "2012-11-22T01:02:31.984Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2a38729e-6be8-46c2-9854-a098e7b0cc27" ],
+  "subjects" : [ "https://www.example.org/b24b3361-677f-43da-8dd4-9e6f8381de24" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3a734743-9a03-4d73-a5ea-cf22966be552",
-    "name" : "opuUweZRmai8hAx",
-    "mimeType" : "r0R0B30WII",
-    "size" : 408118901,
-    "license" : "https://www.example.com/0li6swiu0yo",
+    "identifier" : "72360e91-4228-4f82-b95f-d501c562f203",
+    "name" : "9K3l80HKkZ5",
+    "mimeType" : "N0EGjG6Nqch",
+    "size" : 1760928931,
+    "license" : "https://www.example.com/8dedwfwgddsnc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "zcCvgpyqBYuP",
-    "publishedDate" : "2017-12-27T10:03:11.868Z",
+    "legalNote" : "yNqmAUmb8QjJZ",
+    "publishedDate" : "1982-06-10T04:53:16.668Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Paffa4477RART2",
-      "uploadedDate" : "1993-11-05T01:31:45.349Z"
+      "uploadedBy" : "1wFY3osfF6",
+      "uploadedDate" : "1991-09-18T15:36:15.307Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Czh3yJlp2rwF820gg",
-    "name" : "O1PDcaPg1agHD1r8",
-    "description" : "FIvXim6UAnSo80"
+    "id" : "https://www.example.com/PmQJ3NXUnn",
+    "name" : "5SaNGu8tXG1SSJKfb",
+    "description" : "sx9mUB5ubNnQ6XK"
   } ],
-  "rightsHolder" : "23DCtjDyGJoU4s",
-  "duplicateOf" : "https://www.example.org/95251a8d-00ec-4e93-8e5e-186d18573b8d",
+  "rightsHolder" : "D1P20FCeck",
+  "duplicateOf" : "https://www.example.org/79f3d4bc-8bc5-4a35-aaa4-971d030843ec",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "H3ap9JtVDO"
+    "note" : "VV9sdveB8VVUmOc5FLy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RZWT8OUhjrR18BcwK",
-    "createdBy" : "gkxPLUJQgm",
-    "createdDate" : "1975-04-06T02:49:54.596Z"
+    "note" : "i0Vxg96H7vQV760LKBN",
+    "createdBy" : "zvqibyV4hU3twDWKb2",
+    "createdDate" : "2009-02-13T15:35:55.416Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d252cbce-9a9b-417b-b7a3-3d3155da1fdf" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/0cdfa95a-4400-4d62-aedc-a9edd7e32575" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "3HRxYPQtp4uSEjM",
-    "ownerAffiliation" : "https://www.example.org/75a8d1e4-ec88-41ec-9e75-42f662232d40"
+    "owner" : "REAaymjRbnkMhGQ",
+    "ownerAffiliation" : "https://www.example.org/c5b96552-28f4-4d3c-a0e0-649e68ce2d65"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9ddf3d5f-f17f-4d23-9b1a-e4e8ddacd8d5"
+    "id" : "https://www.example.org/a95b328d-6dfd-4053-b4c4-1cf4f7a9b241"
   },
-  "createdDate" : "2006-10-03T09:56:22.681Z",
-  "modifiedDate" : "2017-01-19T20:55:15.274Z",
-  "publishedDate" : "2001-11-14T14:07:44.038Z",
-  "indexedDate" : "1986-12-17T18:16:27.426Z",
-  "handle" : "https://www.example.org/f786e00c-4bd6-4463-89e0-2c0ee6dbf6c6",
-  "doi" : "https://doi.org/10.1234/laudantium",
-  "link" : "https://www.example.org/937d1d79-726c-4cab-ac2b-d7afde8683d7",
+  "createdDate" : "1992-03-06T00:18:29.904Z",
+  "modifiedDate" : "2008-06-21T19:35:59.214Z",
+  "publishedDate" : "2017-12-29T07:19:40.682Z",
+  "indexedDate" : "2018-02-18T03:10:04.428Z",
+  "handle" : "https://www.example.org/74d5e694-bcdf-43f3-9345-49b78daad051",
+  "doi" : "https://doi.org/10.1234/provident",
+  "link" : "https://www.example.org/f98ab869-2b9e-4748-9eaf-75a88ff0227d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3plQyD0OZpLaQxh5K",
+    "mainTitle" : "Uy8ReUz9USoy2rSUa",
     "alternativeTitles" : {
-      "cs" : "GH57huihhPbdn5bE9oz"
+      "zh" : "qjiwcxxUoK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "veHVq9HozDtABLF56h",
-      "month" : "ysgQ6tqMuqnFjsM",
-      "day" : "ekFckmQEwTjvMkRY2ll"
+      "year" : "ZTilhdxF3Z3AeuokKCU",
+      "month" : "JmVTrEV1mE",
+      "day" : "h8eZ7u3Uc3ak1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94ed3923-edc2-40ea-a93a-2371d27189c1",
-        "name" : "uSzZ5hFeeqLNN",
+        "id" : "https://www.example.org/9dd7a2f1-5c92-4b88-8eed-81d775e3fa20",
+        "name" : "T3vcm5ILxKKCe",
         "nameType" : "Organizational",
-        "orcId" : "RHZdMIlK2ExLguT",
+        "orcId" : "5c2Y7s6Ft7bYvnDYVY",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "STjvm2mmp1",
-          "value" : "KlIBCIrL6tiHwors5hZ"
+          "sourceName" : "v16y5orkvigiIFx",
+          "value" : "xc3vODBSih"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CMFBotE9rDRyxO",
-          "value" : "o09b0Wv31lW6NA0S4"
+          "sourceName" : "MXtLRVIelNUM",
+          "value" : "DUFZ7IFn1Zr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7a948ab3-1315-430e-8e6b-9c2b9b61f4ac"
+        "id" : "https://www.example.org/e70a8a81-55c8-4e0d-8ff6-5071d9b23d2d"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "Editor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,91 +62,92 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4ae34f40-2574-4f84-9d18-3eebc63105b3",
-        "name" : "gPVF1E3H2ZHUydS",
+        "id" : "https://www.example.org/154f7b46-9f84-4782-8c76-bcb04bf03e7d",
+        "name" : "zJOmOGDqp3A775",
         "nameType" : "Personal",
-        "orcId" : "ldjJaF2nM4ZBG4UlmI",
+        "orcId" : "4N6fx8oqIITbz1",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qfNm8eMSbJnnvnWOo",
-          "value" : "BA2DsiuPGzK"
+          "sourceName" : "GuNVwKLYXL",
+          "value" : "1W8RWVdfllmri"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XZLfrRbwYloDL9Q05N",
-          "value" : "R9aSgo3lkK7v"
+          "sourceName" : "cMvZbXZK3WcFmf",
+          "value" : "6BM35bwm19Lvi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/23d373fb-d524-48f7-9f56-34a72dff5ded"
+        "id" : "https://www.example.org/43279598-e4dc-435f-be96-ef36af754921"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fr" : "ExzIYz8dCbi"
+      "af" : "8mAYXEUrlokfGFeTC"
     },
-    "npiSubjectHeading" : "ct1fSSmuvwajZBWRv",
-    "tags" : [ "O3WubS278Rw5b3T7hlD" ],
-    "description" : "6WMJ56djRavFC",
+    "npiSubjectHeading" : "Xx3DmNXgvoZE",
+    "tags" : [ "3os74cYrgmczJ7V" ],
+    "description" : "L78UGEtCn3FGa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/abd22c61-a677-4cbe-9727-fbff0b4ad318",
+      "doi" : "https://www.example.org/cdb26d80-92cc-43ec-9645-77a6a8e38cb3",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "SerialFilmProduction"
+          "type" : "MovingPictureOther",
+          "description" : "6X719cNe7Oz"
         },
-        "description" : "nIbpikA6XWBaCEFpb",
+        "description" : "NEUWX1XQkrg",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "XY2FCYTn4T",
+            "name" : "FbJwvyOgjqBp3Bi",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2004-10-05T03:56:34.866Z"
+            "value" : "1971-06-27T11:21:10.682Z"
           },
-          "sequence" : 186496119
+          "sequence" : 1453266225
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "OT7UKvfF3Bw2w",
-            "country" : "GW8Ity0XLjl"
+            "label" : "iLgxunq1xEi",
+            "country" : "YCwYPFz0wVqdXu"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2009-03-16T04:39:37.125Z"
+            "value" : "2013-02-11T00:09:33.887Z"
           },
-          "sequence" : 1240623785
+          "sequence" : 611976758
         }, {
           "type" : "OtherRelease",
-          "description" : "atz6oprQFR",
+          "description" : "Fll6jWCKt4lHbmULhdy",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "OCk8VLyI4W50X",
-            "country" : "iSnbEszNnp8"
+            "label" : "U6rHEAcwzKjawdL",
+            "country" : "SOFO8QjSaYb3bZ"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "1jfVY9nDmsLO3Zu",
+            "name" : "Xcc4Pz654dJNQx7rn",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2002-01-31T02:54:53.919Z"
+            "value" : "1987-09-23T00:31:03.890Z"
           },
-          "sequence" : 1872894449
+          "sequence" : 1397759914
         } ],
         "duration" : {
           "type" : "NullDuration"
@@ -156,93 +157,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1d8ebda9-c798-4818-b8c0-65bb4ce347dc",
-    "abstract" : "J4Prpos9c6qBJep8dI"
+    "metadataSource" : "https://www.example.org/5b88c95e-a0ef-4001-98c7-44e8660c66be",
+    "abstract" : "Qo5ZTv7s42gus2d0j"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/deba5754-b67c-47d7-be8e-4bbb78beb52e",
-    "name" : "K1yfqj3MGFz1Bfuw",
+    "id" : "https://www.example.org/fed877dd-56d7-4b3e-855e-739167929957",
+    "name" : "3UAHSGJRLt",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-10-03T18:59:56.241Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1984-10-01T04:03:03.673Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "0NGGRKcSfii9Hx1GqM"
+      "applicationCode" : "IEW8z6e5guvzIZy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/23669695-c9ad-414a-8a8d-84608603bdad",
-    "identifier" : "MHw9SueGTGz1Tk0K",
+    "source" : "https://www.example.org/b92939b6-dcad-4b79-bed5-ca21c7872fd7",
+    "identifier" : "2jA5y3mKWAJtO",
     "labels" : {
-      "fi" : "Hbq2BnpuyxLnkBJyu"
+      "es" : "QgVLItXR78Iyq3IxAu"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 142073074
+    },
+    "activeFrom" : "1996-09-06T14:59:50.884Z",
+    "activeTo" : "2004-01-14T17:55:18.815Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/f4726d93-8421-4588-88f0-12fdcaed1d48",
+    "id" : "https://www.example.org/66485382-d7c5-4ac4-8b2f-5a5fcfb39842",
+    "identifier" : "EfloCgIGWmxxoZMQ",
+    "labels" : {
+      "is" : "BqhhTKd5YG"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 749669878
+      "amount" : 451576970
     },
-    "activeFrom" : "1979-04-02T14:45:29.655Z",
-    "activeTo" : "2000-11-20T09:38:56.819Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0c53793c-0d4f-402d-9197-b8c2eafe52ea",
-    "id" : "https://www.example.org/e296b618-9f43-4b2e-88bb-eecb36c05208",
-    "identifier" : "t7KZf6DJexuSJ",
-    "labels" : {
-      "cs" : "xoNiNQpU9s"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1151481803
-    },
-    "activeFrom" : "1999-05-29T01:12:48.356Z",
-    "activeTo" : "2015-03-11T12:28:57.414Z"
+    "activeFrom" : "1989-11-19T11:53:09.899Z",
+    "activeTo" : "2018-05-21T02:33:28.298Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/67d51494-f802-4bc1-878e-5c736f8aeb44" ],
+  "subjects" : [ "https://www.example.org/d6fbf9ed-3030-4c66-bad6-513c787e201c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ae5d28ff-c9d1-494c-ab54-923597227725",
-    "name" : "LHa21z2zGUhILeD2vNL",
-    "mimeType" : "tAEdRxm3WeXQmYoJ",
-    "size" : 1246510130,
-    "license" : "https://www.example.com/e23tuzlbcbefgigex",
+    "identifier" : "a32f5c91-fd95-4a19-9f83-ac61f8c11fae",
+    "name" : "8eA3MZ5HogL1DkC6gBG",
+    "mimeType" : "PPabnDvE9wrkgqAZFQ1",
+    "size" : 2002825670,
+    "license" : "https://www.example.com/buclaxcdeacgyehfbo",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "2ioaJMHh069I",
-    "publishedDate" : "1974-10-02T18:49:15.292Z",
+    "legalNote" : "rf2w2i04gqtxVK3Kw",
+    "publishedDate" : "1972-01-16T03:30:22.850Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GTn89g5OiO",
-      "uploadedDate" : "1984-10-08T05:11:08.810Z"
+      "uploadedBy" : "KzMW2mQXJPUwrJhf",
+      "uploadedDate" : "1993-04-18T03:07:31.910Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gBrsKxepmwfQjOY5jf",
-    "name" : "QTCaBHcjZqDRL7",
-    "description" : "ejiVzvJRr0lAPBZ8NT"
+    "id" : "https://www.example.com/momlyb9zIYxQE",
+    "name" : "YhJLX6BgEVTIFjq",
+    "description" : "ZSedpMOD2OnW"
   } ],
-  "rightsHolder" : "PjMTcdepPttb378Ty",
-  "duplicateOf" : "https://www.example.org/26e20e29-f027-4291-b882-9803104af7a6",
+  "rightsHolder" : "wpQIIYxNBP",
+  "duplicateOf" : "https://www.example.org/4bf36bb2-85ed-43ee-bb8d-c0a5139872e9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "r1OkWas0y5Vws"
+    "note" : "L1fAiEZEo7QZUnQG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "JGq95lAJ7BKa2W",
-    "createdBy" : "0yKLVKzQH6yyYAYc4CZ",
-    "createdDate" : "1974-07-28T17:36:17.682Z"
+    "note" : "QRXren6Vfs",
+    "createdBy" : "WmWQSe2k4W",
+    "createdDate" : "1991-01-07T07:21:11.290Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1b94c504-0fac-451b-af7f-b1421edbdf39" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/2b48f8fd-623d-4fec-b2f1-445fb2851b17" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "X2JvX2EWj0",
-    "ownerAffiliation" : "https://www.example.org/f35309a3-d5bc-40dd-9e9c-fc23a871c027"
+    "owner" : "CmVjZ2Qkyz",
+    "ownerAffiliation" : "https://www.example.org/c6cfe55d-1d45-4c31-9990-c9def30efc57"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/29029a39-186a-4c38-bfb4-fac6d1ede947"
+    "id" : "https://www.example.org/0a585f99-8ee2-421d-ba19-bdc4f615d51d"
   },
-  "createdDate" : "1997-11-24T07:17:09.759Z",
-  "modifiedDate" : "2000-09-12T23:11:56.351Z",
-  "publishedDate" : "1985-12-08T23:49:30.468Z",
-  "indexedDate" : "1995-07-02T00:22:37.413Z",
-  "handle" : "https://www.example.org/d7601746-5f3b-4e86-b27e-23e8af210914",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/d730d2d0-ad15-424c-bbd3-c27616e38aaf",
+  "createdDate" : "1978-10-14T18:48:39.929Z",
+  "modifiedDate" : "1988-09-07T20:25:38.358Z",
+  "publishedDate" : "1974-03-10T18:44:08.781Z",
+  "indexedDate" : "1979-06-22T19:52:27.555Z",
+  "handle" : "https://www.example.org/a2a34223-9c1e-4b2d-9290-5790cb221978",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/cec6f2c5-68fc-4266-9c62-d18b5cf2dd53",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZCudVX5X5Io37vVbt0",
+    "mainTitle" : "H2wkVxbShYRHRWpB",
     "alternativeTitles" : {
-      "se" : "KdcyzLPH6tsv0aub"
+      "de" : "O2SLgGPX5OpwtoowfYz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "CxdaNNAFpwKM",
-      "month" : "dkXnrgBSQOrRq6S6hAB",
-      "day" : "wANgeANqSo"
+      "year" : "g8ZELZYVALBYS",
+      "month" : "JYcp1xRp78",
+      "day" : "hn9S2qQzfsS44hDrxjF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b28d06c1-5df0-438c-8e60-0af9f4b567d1",
-        "name" : "GzZwPzpLIiHxtAv",
+        "id" : "https://www.example.org/5a180071-d1bc-45ef-95b5-8644df8a15be",
+        "name" : "K8vtEkpkMuxsjUaJI3E",
         "nameType" : "Organizational",
-        "orcId" : "0VrGsj4Y85A572idV",
+        "orcId" : "mw7AfL6o9HlPI",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FdhAnsowigCPvoWPD",
-          "value" : "Gf6No8USQHYC"
+          "sourceName" : "e3UcWW5ROpqhH",
+          "value" : "iLDpN3I0xoNZCdYVU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "W737SUFIG3Ac9",
-          "value" : "UXztsPFQRpJ"
+          "sourceName" : "U2wqGTDe6hJRnJ2KZw",
+          "value" : "KnIE5z64jASKWkn1A1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c1b75616-c4eb-4ffd-8321-4b7888991615"
+        "id" : "https://www.example.org/84e3c17f-c358-4b2e-8627-54fc842707d9"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,61 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/46851076-9ac4-41ab-97d4-62859133a166",
-        "name" : "Emz1fN8MYyaj",
+        "id" : "https://www.example.org/aaf47667-668d-4b2b-aa9f-2e85f15341ba",
+        "name" : "vznICZ6KVT5neNux2G",
         "nameType" : "Personal",
-        "orcId" : "bWR9kqqXkHC",
-        "verificationStatus" : "Verified",
+        "orcId" : "m1bYPSc4pOCSCcNr",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hl6ljKYwCyTIuOc",
-          "value" : "7knXJCdsHqnI3GLBi"
+          "sourceName" : "qZtY0pAAwarfAEx",
+          "value" : "7DVQuxehTuZo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fAE5Znllr1w",
-          "value" : "ntpnjTNZxWAHnt1D"
+          "sourceName" : "0cSforEgDIv1iDo7kK",
+          "value" : "tese6eHdrY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/efc53379-0bb6-4221-b289-bc9997a1fece"
+        "id" : "https://www.example.org/7a985dba-d3ef-4db0-9a0f-90a06c8213ec"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "Composer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "TzGNfmFPL0NG8v9s"
+      "nn" : "YXIWQQQKQj7p7"
     },
-    "npiSubjectHeading" : "mqjY6dQUFtQ24yxlai",
-    "tags" : [ "1R8UmiYnOJ" ],
-    "description" : "lB9W7pi3P3kT6pzL",
+    "npiSubjectHeading" : "KfA8UmsD5mU",
+    "tags" : [ "qFWkQqJGQA" ],
+    "description" : "3471qqvK8cm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/8e537f48-785b-4527-9487-b15e269be5cc",
+      "doi" : "https://www.example.org/ad056819-536b-4a38-b8f2-4fde7ce23e2f",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "DVD"
+            "type" : "DigitalFile"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "NtlZlVJXC76DcrUFW",
+            "name" : "UXTOvX76sxHPab",
             "valid" : true
           },
-          "catalogueNumber" : "IlP5USA8b8I",
+          "catalogueNumber" : "IZ7L0r3MpZRxXE8Tr",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "BnlwWssG970zRY1L",
-            "composer" : "FVeTKRuBPBXipdjlCb",
-            "extent" : "8SVArZkMNbP2TKxUJJw"
+            "title" : "sJvwBlfgvDPeeGM",
+            "composer" : "dQzLoxBSd0woBUbclce",
+            "extent" : "LmBNopH37sdmN60"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,30 +126,30 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Xy4z655En9ES8",
-            "country" : "wBzIiESGGG0r77fetWA"
+            "label" : "2zueErMhtoRW26",
+            "country" : "EwaalKglIAq4"
           },
           "time" : {
             "type" : "Period",
-            "from" : "2011-02-21T13:47:12.680Z",
-            "to" : "2023-01-14T00:27:01.657Z"
+            "from" : "2018-03-13T10:39:23.445Z",
+            "to" : "2021-04-17T03:39:55.742Z"
           },
-          "extent" : "VJpy3OGqv2H1oLR",
+          "extent" : "6hBEXwx5iYomgU0HQ",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "XmMomAzDm9fgQzF",
-            "composer" : "vvDo9pnLJEArN7SP",
-            "premiere" : true
+            "title" : "GPUnNq3mlrr8",
+            "composer" : "D5QWEnOjiEsv3QkX",
+            "premiere" : false
           } ],
-          "concertSeries" : "44edztDWExQsyz2"
+          "concertSeries" : "RZzF88rbg1aWSAm"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "ynJynXNvYb",
-          "movements" : "tgmzMpIwXQh",
-          "extent" : "hMWtlGb5gjh8ow",
+          "ensemble" : "HTol69QKsf3",
+          "movements" : "FF0ctryTO8vds",
+          "extent" : "2pxFizZajZjWS",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "8KnZUqQJoSTO",
+            "name" : "NjvhkixCgY",
             "valid" : true
           },
           "ismn" : {
@@ -159,17 +159,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "sMGXUXEW6L9Tef",
+          "performanceType" : "xgZSeGUfKFBuDIWKobX",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XzG7DPI4TkicHFkC",
-            "country" : "J4ib5P8g2C9"
+            "label" : "XrkPhfmYCa75uVNMZnB",
+            "country" : "HBzIBpAOfwIE91ANN"
           },
-          "extent" : "qar6pLJ21zCA",
+          "extent" : "mPfXFl0hEITQbcll7hY",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "rHf96239ck4X",
-            "composer" : "kdZP7RH6TE4"
+            "title" : "rMOp3wOiEfCcjL",
+            "composer" : "r5fMNt0io6S7zcjb"
           } ]
         } ],
         "duration" : {
@@ -180,94 +180,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4e55ffea-7246-4620-981e-ff577ca93c9f",
-    "abstract" : "L9r7qiO9T0OUZ"
+    "metadataSource" : "https://www.example.org/76d2ebbb-5733-4ea0-8a89-e4728eac550b",
+    "abstract" : "pCDlwAnhYf"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/121279ac-0e3e-40f3-8785-4d123f97c844",
-    "name" : "nUIxMmwMLoyUZwP",
+    "id" : "https://www.example.org/8b749db2-a11f-4e22-8f49-1cfaf3bde506",
+    "name" : "XbgjIurnG5K",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-10-23T06:41:18.651Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1989-09-15T05:39:04.813Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "v021pSInia"
+      "applicationCode" : "eAhrXyFR1mPFnx7s6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c2412f7b-9e92-4f38-a4fa-69268a83c9ee",
-    "identifier" : "fxNj2qHfhfXLXk",
+    "source" : "https://www.example.org/18e5cdac-6844-4748-b458-310cc41eaec3",
+    "identifier" : "LRNssPvfFGqYr",
     "labels" : {
-      "en" : "N2xzIik26QOsh"
+      "nb" : "tS7pyiBnwtysd"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1878588632
+      "currency" : "GBP",
+      "amount" : 811866046
     },
-    "activeFrom" : "1983-09-16T12:24:51.306Z",
-    "activeTo" : "2020-04-09T20:29:06.509Z"
+    "activeFrom" : "1994-05-16T04:17:57.557Z",
+    "activeTo" : "2006-03-13T20:07:26.014Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f9272b41-79c7-487e-8884-d9892b9fd473",
-    "id" : "https://www.example.org/d1946277-5bb4-4dfe-b55f-3dd0f8390f81",
-    "identifier" : "ZcZt4XgRMZoDXkzWUA",
+    "source" : "https://www.example.org/1f929107-bea8-47de-9d27-6eb0c25314ff",
+    "id" : "https://www.example.org/5c67bd1b-d30b-437b-93ad-ec098d07f16f",
+    "identifier" : "YJWZJ9PdAO",
     "labels" : {
-      "it" : "sTAymAm0vRcZ"
+      "cs" : "UA43lRnykvY1ANKb9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1068393300
+      "currency" : "EUR",
+      "amount" : 574565454
     },
-    "activeFrom" : "1977-07-03T22:24:50.166Z",
-    "activeTo" : "1992-05-09T17:10:47.827Z"
+    "activeFrom" : "1975-07-20T12:37:54.516Z",
+    "activeTo" : "2021-08-31T02:06:19.930Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/289b26be-e115-4d8f-93dc-7b8b3488fe95" ],
+  "subjects" : [ "https://www.example.org/2757973a-4f1f-49fa-9ee3-4c1372276e3a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b1931433-2c2e-45a9-baa9-a3a88ce445d8",
-    "name" : "iQJsYzhoTRaG8EfgVqe",
-    "mimeType" : "EMADWReyM0c",
-    "size" : 531968405,
-    "license" : "https://www.example.com/amfbmwfbjd",
+    "identifier" : "deefb95c-bf1e-4fd4-804c-1460781cce0e",
+    "name" : "Ru6fdTBjtcvoOysFf",
+    "mimeType" : "OjFFhG1vEx",
+    "size" : 469457907,
+    "license" : "https://www.example.com/yzpzecgywieisuusy",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "4a3UhgHoOMO7"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "E72XHkIk43Gct1bU1od",
-    "publishedDate" : "2015-01-14T06:41:23.843Z",
+    "legalNote" : "i5Wp7vCLOkfQrD",
+    "publishedDate" : "1992-08-01T09:07:59.829Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "BV1ELJK3bGCG6n",
-      "uploadedDate" : "1987-09-21T15:36:14.163Z"
+      "uploadedBy" : "4zC9kn1EwGP5QLB",
+      "uploadedDate" : "1996-04-23T02:09:26.359Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/rsNgkq2yVa",
-    "name" : "jFibKxY3AHBgcJB",
-    "description" : "pRTyumQjXUsh08nU"
+    "id" : "https://www.example.com/8t2C3dFlFiu",
+    "name" : "f5jq9sQ1V9PWKkTjGnB",
+    "description" : "urYOOff0tHxManN0Jp"
   } ],
-  "rightsHolder" : "8oomB58VKw",
-  "duplicateOf" : "https://www.example.org/4624de77-1120-4e43-880a-a6dbf0dd5d76",
+  "rightsHolder" : "yaCnNa3ASoD",
+  "duplicateOf" : "https://www.example.org/4e7f954e-a922-482f-a7f2-f18f68a51087",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lnGnMhdjH8F0"
+    "note" : "t8C1X4c20De"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "m6fdoQhupF1A",
-    "createdBy" : "YWdNxjaTJ2NwktJ",
-    "createdDate" : "2001-09-15T14:02:17.202Z"
+    "note" : "KL5uJp0DLV8Yb",
+    "createdBy" : "lAtr6GNEFfZUcUvF",
+    "createdDate" : "1975-04-25T09:25:37.929Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/89901ac7-e51d-4de7-bf2e-1cc5498407d1" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/86ff2334-3c08-437c-b3f4-6500f2ce7f63" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "CPTvoOhG0zK",
-    "ownerAffiliation" : "https://www.example.org/00f10e0b-5e66-4951-95d1-186af07fec08"
+    "owner" : "QFcNyav7PP",
+    "ownerAffiliation" : "https://www.example.org/ea01f936-c721-4de1-9f12-e8dccce24f45"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/56fec6b2-1dfa-4c32-9e74-d1532ccde726"
+    "id" : "https://www.example.org/1f7ee462-3979-4848-973c-1dccb9a88866"
   },
-  "createdDate" : "2014-12-23T13:11:26.554Z",
-  "modifiedDate" : "1971-10-12T18:27:58.183Z",
-  "publishedDate" : "2004-07-27T09:47:17.656Z",
-  "indexedDate" : "2019-12-18T00:17:38.528Z",
-  "handle" : "https://www.example.org/005c0d6a-366b-49fb-a461-decfda243e4f",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/c347bc43-e459-49fc-a1d4-bb969e6fcb49",
+  "createdDate" : "2021-08-18T02:03:17.707Z",
+  "modifiedDate" : "2008-08-18T14:09:03.715Z",
+  "publishedDate" : "2000-12-25T12:08:32.722Z",
+  "indexedDate" : "2012-09-19T20:49:34.549Z",
+  "handle" : "https://www.example.org/5f1ee08f-b3c1-44ad-a90b-bb869bbd8bba",
+  "doi" : "https://doi.org/10.1234/quidem",
+  "link" : "https://www.example.org/43d88e6e-c7a6-49ff-8801-f70b4d96cda5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0HdSwEJr3lJ9m2rGqs",
+    "mainTitle" : "XEXoM0SrSh99Mm",
     "alternativeTitles" : {
-      "ru" : "8cOJkjMGqa"
+      "hu" : "sE2FX8fuE5TAMD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Gqued8Wyt1G",
-      "month" : "dqtGdrURRigcb",
-      "day" : "gs84M8au1jvwVqS9"
+      "year" : "KUS3mcJEzBb",
+      "month" : "nkAVIMKQUTAcphNgn",
+      "day" : "HeJy1uh8z3d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c4521cd3-3558-4f4b-bf3a-84b7951b9003",
-        "name" : "a5j1yhG65LwKA5oBQ9",
+        "id" : "https://www.example.org/d215e6a0-1fd8-49ed-9b6d-79915c09b8cb",
+        "name" : "0HdVodFWgjLM",
         "nameType" : "Organizational",
-        "orcId" : "KZjtjdWWRg1ZA7",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ZkTbVXFhLBcYTBKDWz",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Np2SEe1rHFZTB",
-          "value" : "XznTLPBu9HfOl"
+          "sourceName" : "driNbaC1zLAfTU",
+          "value" : "qLosTAyLps5JzGS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EAoBhJaPea9Ol",
-          "value" : "Ji95VI7buj4jUb"
+          "sourceName" : "rjxoml1ckF93U0ZEU",
+          "value" : "ik9OHkUuIu7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/21213c78-d02c-4009-b7de-130848561c94"
+        "id" : "https://www.example.org/229d788c-1be0-46c6-b936-ceaebe357538"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,141 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/78c17e64-55ce-4f89-814b-a77aabd428ef",
-        "name" : "ObTPmVjC5ZkYzHfCZ",
-        "nameType" : "Personal",
-        "orcId" : "pi0LCEurQFMfl6KJ",
+        "id" : "https://www.example.org/fcf179f6-5984-454e-8ffb-ce069f2aa8e4",
+        "name" : "lMXphzNReo",
+        "nameType" : "Organizational",
+        "orcId" : "yMzsBX5i22kP",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "d9YklGfbD4ty",
-          "value" : "7IGA1T7X4ZX"
+          "sourceName" : "RVbRZjNaSE",
+          "value" : "2uWJLhW13jX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MJvy7yzXHxPP4z8VQhP",
-          "value" : "Gg88wXXXCi4kLUe"
+          "sourceName" : "X7pibLPZXya03",
+          "value" : "O7EGuB5idp9j"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8e4a7207-2a7a-4cf1-afc4-9f5f49584d9e"
+        "id" : "https://www.example.org/0413edbc-be4b-4973-a693-d05b3e292b71"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "NpI8n2M5gP"
+      "de" : "rZuH02YfrkpPhQ"
     },
-    "npiSubjectHeading" : "wJetnwm8zdChanZ0p",
-    "tags" : [ "AyKg7bLYvf2IU1IgZBj" ],
-    "description" : "C9luOKkAgQ",
+    "npiSubjectHeading" : "cSQpF44NHD",
+    "tags" : [ "uytjNn0iCSh0Pc" ],
+    "description" : "fysS3wRNcQl",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/zeWtLbH0MJKNBnfy"
+        "id" : "https://www.example.com/3GvXAgvcyKLqons"
       },
-      "doi" : "https://www.example.org/15f15ace-7f6a-41fb-b357-46f7b7b60bf1",
+      "doi" : "https://www.example.org/2d759278-dd18-4860-8b29-1f79c06ec22d",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "Ov97w0GcGkQ50o",
-          "end" : "FEM6Xgs0VN"
+          "begin" : "bryZXQGpeav",
+          "end" : "eaIdhd7HUq"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/30f1e755-1cf4-427d-9c26-1de93d111ac2",
-    "abstract" : "tIzMIiJkSIVwd3NZi3V"
+    "metadataSource" : "https://www.example.org/0f3d3750-2cd7-4232-91a4-cca4a76ee471",
+    "abstract" : "KNnCIMotGZnM8F"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1e99e9b2-8935-4edc-bf1b-f8c64950d228",
-    "name" : "F8ZC5Jxj3LR1JT0f4",
+    "id" : "https://www.example.org/859d85f8-a85b-4c03-b45a-4c1a3c01c42d",
+    "name" : "mm6xwGB95f",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-10-18T19:41:08.815Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "aPZN1tenwAcXH"
+      "approvalDate" : "2022-02-23T10:48:01.575Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "lwVpO4W1qNfEM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3d53ff04-2504-4a0d-a9f3-3ac5cd357d9b",
-    "identifier" : "EjgPHQsq7aopl",
+    "source" : "https://www.example.org/2ee099fb-cde5-4da6-b823-2d674a64e717",
+    "identifier" : "mKl6AwsntE",
     "labels" : {
-      "en" : "oAebyLhHxMG0K"
+      "el" : "Y3zJ4nhjwFcqg"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 777153172
+      "currency" : "NOK",
+      "amount" : 1497778755
     },
-    "activeFrom" : "1985-02-14T19:56:24.971Z",
-    "activeTo" : "2018-04-17T21:15:34.446Z"
+    "activeFrom" : "2001-05-31T15:06:12.902Z",
+    "activeTo" : "2018-02-26T07:36:28.368Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dab2ac7e-5558-4bbf-9719-2c4008d497c5",
-    "id" : "https://www.example.org/8944039e-a3df-4c2c-a295-27be5eb59102",
-    "identifier" : "ztdvV5OGg1",
+    "source" : "https://www.example.org/12c6df3e-f4b4-45c1-8729-8dce27995057",
+    "id" : "https://www.example.org/db9a9202-8085-4354-aad4-e559cb1b9079",
+    "identifier" : "1rIR1y0cog7a3w5bI",
     "labels" : {
-      "nb" : "ipx9EGnNv4Td"
+      "ru" : "EguDblLkzjuFJGm1if"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1262541023
+      "currency" : "NOK",
+      "amount" : 343996899
     },
-    "activeFrom" : "1988-04-15T16:41:23.514Z",
-    "activeTo" : "1998-04-25T17:31:03.822Z"
+    "activeFrom" : "2011-08-19T09:27:46.674Z",
+    "activeTo" : "2018-11-19T03:09:28.513Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/48276320-3f86-4558-bedd-80ef259e954f" ],
+  "subjects" : [ "https://www.example.org/485e15ab-34aa-45f6-81ea-44e21ed2abfb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "06ceaf64-560f-4e81-83a9-4d21f1418e9e",
-    "name" : "q1JKhO8M99hn9EGUVjl",
-    "mimeType" : "o0MCTrVcDK",
-    "size" : 1611107111,
-    "license" : "https://www.example.com/thyv4bulct94nmtb",
+    "identifier" : "4b6adaf2-ab15-436a-9923-ec2b5b020364",
+    "name" : "Ltx4i4zujn1zvzJui",
+    "mimeType" : "K2M0eejfa9L",
+    "size" : 664648406,
+    "license" : "https://www.example.com/lbhrwucltfdma",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "RqR21k7RNAdiZdgh"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "IjdiCRzhzQbP",
-    "publishedDate" : "2020-03-20T12:13:16.415Z",
+    "legalNote" : "tz8lbJ8QgyJUKZl",
+    "publishedDate" : "2019-05-08T23:40:41.415Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Tf9kAKtNYsSsUS",
-      "uploadedDate" : "2016-10-09T11:59:00.869Z"
+      "uploadedBy" : "7IOPL1SLUR",
+      "uploadedDate" : "2004-11-15T17:53:41.834Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/OYJimFxT40tsq",
-    "name" : "LwDdGbPuHQnO",
-    "description" : "xTDTZI9CWKUELE"
+    "id" : "https://www.example.com/GFrcQ6ZBOnDv",
+    "name" : "RI2bbJKvR9brDPIu",
+    "description" : "P54KqNHkQh"
   } ],
-  "rightsHolder" : "TbtPXt7kMJq",
-  "duplicateOf" : "https://www.example.org/dda52cef-b29c-4760-843b-e8c6c528a972",
+  "rightsHolder" : "GwOk9X4k2JPt87umN",
+  "duplicateOf" : "https://www.example.org/a392dd6c-0ac0-43bf-9f32-20dcb74e5041",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "K86RBZfju505e"
+    "note" : "uNYxo7JZPxt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "tj21cYBun58lfw",
-    "createdBy" : "AQZJQt3ONM",
-    "createdDate" : "1999-06-13T06:27:03.175Z"
+    "note" : "gbBh6FyfIEMj",
+    "createdBy" : "yp1J77K51r",
+    "createdDate" : "2004-10-03T18:33:26.339Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8574a81f-f35b-4c57-94f6-f3d2f586789f" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/cf57be49-22a3-4110-b173-f847cf6907b9" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "M4cfYKRJN0kJLOapz",
-    "ownerAffiliation" : "https://www.example.org/927c4e93-c076-4641-8f16-38706c510b6f"
+    "owner" : "uDq8kYsbQSSM7",
+    "ownerAffiliation" : "https://www.example.org/7eb4d559-8c1b-41dc-a0ba-c3d0218a6c92"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9bcde165-7d1e-476a-9bfa-a470841ae214"
+    "id" : "https://www.example.org/2b7a9af0-278c-4a77-8871-b7b6bcc04264"
   },
-  "createdDate" : "2012-01-17T23:41:21.906Z",
-  "modifiedDate" : "1992-04-20T23:06:56.505Z",
-  "publishedDate" : "2001-01-31T15:03:00.187Z",
-  "indexedDate" : "1992-04-10T22:21:25.834Z",
-  "handle" : "https://www.example.org/7fd208f2-5b8f-4473-a7dd-99bbc5733030",
-  "doi" : "https://doi.org/10.1234/consectetur",
-  "link" : "https://www.example.org/1adbec67-dcb0-4c0b-b2f6-8baa04267cc3",
+  "createdDate" : "1982-03-02T06:21:36.403Z",
+  "modifiedDate" : "2014-07-06T06:51:18.349Z",
+  "publishedDate" : "1982-11-25T23:39:25.823Z",
+  "indexedDate" : "2019-08-30T08:13:16.980Z",
+  "handle" : "https://www.example.org/77bed09b-3b88-45c9-a938-9441c26ab9b1",
+  "doi" : "https://doi.org/10.1234/beatae",
+  "link" : "https://www.example.org/5a5b2758-cde5-4ece-a117-ac69978cabcb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IYlPkGUdptm",
+    "mainTitle" : "W9VpcOE8vknu4NHq",
     "alternativeTitles" : {
-      "pt" : "x2jGeNsVgiOBlheM"
+      "ru" : "vx4nRAIySIceWy3Mtu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PgFhynaV6fjVusTpp",
-      "month" : "VtxPe0NaqzsuPefDi",
-      "day" : "mm2YwdQBPc1YKtuovn"
+      "year" : "r314r5BB7hhAvASUq",
+      "month" : "leLwksfoA8jqDt",
+      "day" : "HkWDd2KoT0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ba33f911-6ef2-48ac-b3c0-bcb4b8e740de",
-        "name" : "rRlXpiPjRE1Xe",
-        "nameType" : "Personal",
-        "orcId" : "h1QrfHrBOp77Tejk36",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1b856ded-e10f-45d7-a88e-4691f113c61d",
+        "name" : "Yg3txiCHQBK",
+        "nameType" : "Organizational",
+        "orcId" : "mK1zN4yZBQyC0",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "65Y6U73OclMWvA",
-          "value" : "IFr3WBEcEtjo"
+          "sourceName" : "OJnAycpT02",
+          "value" : "fMRWvn5gBh7xEZXN839"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rsbBr5wh075",
-          "value" : "DAEfXtpCgKgCT"
+          "sourceName" : "CXDETJC9zlKE2ozJcit",
+          "value" : "NHIULBRtC8ssReiFez"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0d24d5f3-29ab-4402-b073-c417ed857798"
+        "id" : "https://www.example.org/03027236-78c6-4adc-9594-c898fffb451d"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6573400d-6cc0-47c5-bf6e-f2a7b99c357f",
-        "name" : "jaIeDyoy3ji0sf1",
-        "nameType" : "Personal",
-        "orcId" : "vxiiSiLyJqI4RV8ck",
+        "id" : "https://www.example.org/ee544cb4-9609-4bb5-89b5-12b72cd0790e",
+        "name" : "QtLE7PezrYQpGrn",
+        "nameType" : "Organizational",
+        "orcId" : "QNuubDZhN92aAKn4qJ",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aJCJ16BAbq4czV8oD",
-          "value" : "EaBChZAwUxEat"
+          "sourceName" : "mPPgRMTZloSKmu07Yx",
+          "value" : "hJygmkLoQntpI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "x0PI81MMfPy",
-          "value" : "VYyZkxSXAN0GVK"
+          "sourceName" : "YNwtvpwMFxfIB8lSJ8",
+          "value" : "eM6Qxoqrhz90M"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ef5cdd4e-0685-4359-abaa-4ea84b71e599"
+        "id" : "https://www.example.org/8fcf6ebe-9f21-45d0-a3eb-fe9cc04f5edf"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "JE2WrCQNJrkzJ"
+      "sv" : "kDInza0YW8JjR5A"
     },
-    "npiSubjectHeading" : "CwcBR4e5hAcBeH5",
-    "tags" : [ "NuBylOdy5dzBjAB" ],
-    "description" : "0Ig0P8kFhA50",
+    "npiSubjectHeading" : "ousbJYafffjqJ",
+    "tags" : [ "WEZGblWqo9SBRO" ],
+    "description" : "e404iCSs99qWEFNmaY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/419d6a33-557f-40e5-b68b-408ab869f526"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0e6b770a-aea6-4c48-b949-b5dae846eaad"
         },
-        "seriesNumber" : "igKbGXj6BpYgLwEaM",
+        "seriesNumber" : "8fwcvXQu58OFlTlW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d976e799-dd01-444e-acaf-30de74e9baf5",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a2af69a8-626f-4a1d-b3a3-7008877fec04",
           "valid" : true
         },
-        "isbnList" : [ "9791961947572", "9780818203350" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9790970725850", "9780906749449" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0818203358"
+          "value" : "0906749441"
         } ]
       },
-      "doi" : "https://www.example.org/1b521bff-77fe-4f2d-a147-62e5d3d9b352",
+      "doi" : "https://www.example.org/cbd34522-a8e6-44d5-a7fe-69d7f631db63",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Tb7qSlAUEzg0gSpPVnN",
-            "end" : "B4HUWtJJwATHpLs1U"
+            "begin" : "CqrE3Xl635",
+            "end" : "rL2jDNUdlnJTksTvkOh"
           },
-          "pages" : "ktrVu0XGrdOhHEU50",
-          "illustrated" : false
+          "pages" : "qMc7OQES17itREACJ",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/977c351d-57af-437a-a4bd-1de1315f04cf",
-    "abstract" : "poroDcGKzcXRTyn"
+    "metadataSource" : "https://www.example.org/bb6d11c4-bb35-4bc5-a6a4-fd783b0e13a2",
+    "abstract" : "tAtIDC6r5xXW5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/03d87080-80f1-462a-854d-b5d38c6b71b4",
-    "name" : "F6kulzyWUn",
+    "id" : "https://www.example.org/17bf2866-b045-4de0-b946-d5137c4b7f8e",
+    "name" : "XdyhOVjSXIC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1995-07-08T22:09:37.178Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "dzaaDB4aivmBCm5L"
+      "approvalDate" : "1981-02-13T02:06:29.683Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "89IMAu9DIBD4q8T"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ab227e44-a2e3-4a24-bc5f-12212d31929b",
-    "identifier" : "6OqITc0NpAjXn6H",
+    "source" : "https://www.example.org/1215b3f0-66b0-4400-b627-002bca821e9a",
+    "identifier" : "VaeyTymEqT7fS5",
     "labels" : {
-      "fr" : "c79beiFQtEcX"
+      "cs" : "YBv98kWBhw"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1502572420
+      "currency" : "USD",
+      "amount" : 255126178
     },
-    "activeFrom" : "2018-09-20T22:11:51.236Z",
-    "activeTo" : "2024-05-09T22:20:37.776Z"
+    "activeFrom" : "1971-03-07T12:02:02.199Z",
+    "activeTo" : "2012-04-30T01:26:08.071Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/623cd1db-9bbc-4b2d-81d3-9656fa7ed200",
-    "id" : "https://www.example.org/1d000671-ebb0-4a20-be27-30a587854307",
-    "identifier" : "SRoX20SN1s42mi9",
+    "source" : "https://www.example.org/a75b69e8-d0d4-4a15-aa7c-30ae20e4b746",
+    "id" : "https://www.example.org/1a8055af-cc67-4ea2-90c4-b1c46435b503",
+    "identifier" : "oZkTqwjVmNTyYXXikQ",
     "labels" : {
-      "en" : "vS8ZZJmOfcyFSyuRLq9"
+      "es" : "LT6LA5f5UU"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 283783234
+      "currency" : "GBP",
+      "amount" : 836126158
     },
-    "activeFrom" : "1977-06-18T23:27:24.311Z",
-    "activeTo" : "2010-03-14T14:20:45.164Z"
+    "activeFrom" : "2023-12-02T09:51:18.424Z",
+    "activeTo" : "2024-02-01T10:03:23.481Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6acef22e-ae48-45a3-b84e-c20ce974f6e5" ],
+  "subjects" : [ "https://www.example.org/d56f5f65-e8e7-464c-af3c-81562c455fa4" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9c563ec8-266d-4c32-84bd-db55640b86d6",
-    "name" : "Gx2LGEkAfXwW",
-    "mimeType" : "1dFouPHBcdXcR1rF",
-    "size" : 659582613,
-    "license" : "https://www.example.com/iil6znb6a9z7uglcwm",
+    "identifier" : "2d17cdc8-49cc-456c-86d3-be8a76d8691b",
+    "name" : "24wUldIbLs",
+    "mimeType" : "2603j3xGBSiLfljqKz",
+    "size" : 1998207900,
+    "license" : "https://www.example.com/jgwthvgaeiu",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "ppa6Ze2VbCzg4AmdDu"
+      "overriddenBy" : "XeQbnxJORH5"
     },
-    "legalNote" : "ctefwaKMxwknS5Mrl",
-    "publishedDate" : "2017-06-28T11:44:06.104Z",
+    "legalNote" : "aTIPFqKEbJqqHK7tgz",
+    "publishedDate" : "1994-09-28T09:13:32.591Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "qneYAETrrpKWaMLmTx",
-      "uploadedDate" : "1973-05-03T12:42:15.887Z"
+      "uploadedBy" : "x8W0DTYf1HgT5qW6beh",
+      "uploadedDate" : "2014-11-30T23:06:13.787Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/bxCL00Yp3Dma6WSr",
-    "name" : "E6OIN87xQ12O77ECjH",
-    "description" : "doqRJ0Yz3iaBblm"
+    "id" : "https://www.example.com/MOnFnfEcQQL68",
+    "name" : "qIYxjApV6xiU",
+    "description" : "IKqHVf84UYa1nOfo2"
   } ],
-  "rightsHolder" : "OSglXcXypUmp",
-  "duplicateOf" : "https://www.example.org/422bc864-fa98-428b-82f8-126fb907a2d1",
+  "rightsHolder" : "F0hKQLHT6KJdQ",
+  "duplicateOf" : "https://www.example.org/e4b22d58-b6a5-4264-8d2e-b2fa57b2c77b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TShCjYRFdKe5"
+    "note" : "YQBu8qJ2R17nyoL88X"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "i9MXdta0faaDnnoPXX",
-    "createdBy" : "hwoN1FySsSOcK",
-    "createdDate" : "1998-11-09T19:54:10.150Z"
+    "note" : "6j7PQtsiiyhjAT7Vp",
+    "createdBy" : "3Q1BisRbysUAUxLDF",
+    "createdDate" : "1989-05-20T23:04:30.861Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/80395dc2-420e-4ae6-ab21-6dabc2d34310" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/17614833-5375-4d5e-889c-8311b8badb79" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Ow9gsltO87DgQIT",
-    "ownerAffiliation" : "https://www.example.org/69022966-deb6-42f3-a391-1fc5eab9ba97"
+    "owner" : "Q7KAaOjsdMnYDLfXQ",
+    "ownerAffiliation" : "https://www.example.org/441bb549-d4c7-4439-89cd-033ba4b20dd7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3f3beca9-4b36-4789-a90a-309534e62135"
+    "id" : "https://www.example.org/1dcb4ece-dac3-4363-9181-92ebf020bc4e"
   },
-  "createdDate" : "2016-12-09T04:25:03.382Z",
-  "modifiedDate" : "2015-03-14T20:37:39.998Z",
-  "publishedDate" : "2013-02-05T13:03:23.830Z",
-  "indexedDate" : "1974-04-21T19:43:47.961Z",
-  "handle" : "https://www.example.org/0d598b36-b79d-4f53-bcbf-a1eb70bce7a0",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/ab454e98-6ad6-44a9-8ba8-8a390078aa61",
+  "createdDate" : "2003-05-01T14:50:48.683Z",
+  "modifiedDate" : "2016-08-10T06:18:36.862Z",
+  "publishedDate" : "1972-03-12T10:23:44.658Z",
+  "indexedDate" : "2000-06-28T17:48:23.756Z",
+  "handle" : "https://www.example.org/426c179b-9ece-4dab-a4c6-4f3d4a1af5d5",
+  "doi" : "https://doi.org/10.1234/consequuntur",
+  "link" : "https://www.example.org/3689bfbb-fbba-40f9-adb9-14c3d5fea47a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kncj7eCEn03YrfL",
+    "mainTitle" : "eLpssafYEyHKHep",
     "alternativeTitles" : {
-      "es" : "qQ3jleSrtQiN"
+      "es" : "nfRQ1ZcZEjJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "2Xke5PvQwlHho",
-      "month" : "HR1N2dHZaYquSoRANXa",
-      "day" : "TMQEl2wCBSSb3lgNuC"
+      "year" : "koq9HSSY4w6VuO6mykm",
+      "month" : "10OOgEV1v5U4a0esZA",
+      "day" : "MTbxFbnnBY4i6ADZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c8fa0edc-2b3a-44d4-bcbf-b6b1e945c911",
-        "name" : "jccBVVVRXsIIih",
-        "nameType" : "Personal",
-        "orcId" : "J0mcx3Ju6d3mK",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/0e84f0d9-6de6-4e52-aec9-f86731f6468f",
+        "name" : "FrTSlOx4IL",
+        "nameType" : "Organizational",
+        "orcId" : "BSMRXeEdPPTJA",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "b55cEizGijb",
-          "value" : "cCVshfhnnQLZzvm4J6"
+          "sourceName" : "LVYiN74FKR9vzgAopKV",
+          "value" : "WArFDhobFef1av"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OcUbDSIF0g2AuX",
-          "value" : "IFwTC4oIVmZ5"
+          "sourceName" : "uDF7Ga7yvd1e5NVG",
+          "value" : "YhQcG4u8zNlfH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9b19287d-0009-4662-9183-9556a034cace"
+        "id" : "https://www.example.org/7aac4403-ae01-49c8-a456-b24789c60065"
       } ],
       "role" : {
-        "type" : "Musician"
+        "type" : "RightsHolder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/86711c3b-7d95-44b8-bbc1-322ec0b1e2f4",
-        "name" : "ETT7CTzQxcsGi",
+        "id" : "https://www.example.org/b3630deb-0fad-432c-bb76-154af759836c",
+        "name" : "pZlUUmU5WK91",
         "nameType" : "Personal",
-        "orcId" : "1vghalguumq1cT",
+        "orcId" : "1sIXpd0fES5",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z3piaic6GgYkoau",
-          "value" : "FlRPXdVTMdI"
+          "sourceName" : "3NpshpkyFoE3oGG2Y",
+          "value" : "EVrhBytXULiU8zzf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rC0kRoW3dmOHge",
-          "value" : "0NRzSFQld2r3km"
+          "sourceName" : "eYX5b1q4vrpTkq03y3",
+          "value" : "vkfmkIyiYnBvjPu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ea57384c-3d8d-42e5-b87d-2f380bcf4e96"
+        "id" : "https://www.example.org/fca1098d-f964-4fa1-a9e5-5ee08ed8bbfe"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "L6a02Pyft3v1ad"
+      "bg" : "IUTr0zpkIVdUQCy8rdM"
     },
-    "npiSubjectHeading" : "0fFMprE4rAo",
-    "tags" : [ "zv3renE4U4uBmMP" ],
-    "description" : "eoCgsbVwBRS5BMhZ0",
+    "npiSubjectHeading" : "MJqbQOHxjs",
+    "tags" : [ "OewrR3EnLvPuA96Z" ],
+    "description" : "EaCXKMh711gc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "jpAHq436E8ad",
+        "label" : "ap5Efa3tKWHT3dyvi",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "GNPXfU7lfBmfwS",
-          "country" : "gGXhltea8Ig9KZG"
+          "label" : "vkvTnij48JqnK",
+          "country" : "UgxAFDAHE9FX31gfia"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "1996-03-23T20:49:46.431Z"
+          "type" : "Period",
+          "from" : "1988-08-13T22:13:34.131Z",
+          "to" : "2003-10-11T23:17:53.023Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/jwsf6wqbLO2H24rbSo"
+          "id" : "https://www.example.com/FObFzRSTnjvuh8tW"
         },
-        "product" : "https://www.example.com/A6l4RmkuepRQWzE"
+        "product" : "https://www.example.com/7ScYxCUmEmLJ"
       },
-      "doi" : "https://www.example.org/8cdc9f27-3143-4b6a-8b5c-011a8a37b968",
+      "doi" : "https://www.example.org/f6b80dcf-c835-410f-af9c-7efdcd5588a5",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -121,94 +122,93 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/c94ad8af-7d77-44c7-a052-af8624f05f38",
-    "abstract" : "zZ4E0nF6lAhKn"
+    "metadataSource" : "https://www.example.org/0bf60cad-5a49-48d1-906f-edd5c545cb69",
+    "abstract" : "KXiNGYk5EOsznNH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9f394ba3-62fa-4aa3-8859-55f2aea858ed",
-    "name" : "YHXPqMp64qmfnDBd",
+    "id" : "https://www.example.org/fd39b831-be8d-4634-a2a0-719af5a7e72a",
+    "name" : "p8fxPL7reLtDZi3Ut",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-03-26T12:40:22.223Z",
+      "approvalDate" : "2010-10-29T19:25:39.461Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "7eeJ0PPGsT75"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Iwgv6mtl2whgo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b0afa427-bdac-4c4f-9422-f2cce096db25",
-    "identifier" : "EdLWrKnjeazI2h",
+    "source" : "https://www.example.org/d2d4bae9-13d3-4c71-bfa4-afb8d1fc400f",
+    "identifier" : "YcYqfSNlCb06FnA",
     "labels" : {
-      "sv" : "hdtNYFw1t64WU"
+      "es" : "LL3ThGPSoTmri"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1546382196
+      "currency" : "USD",
+      "amount" : 173426476
     },
-    "activeFrom" : "1992-10-04T14:01:30.683Z",
-    "activeTo" : "2012-05-10T21:58:41.554Z"
+    "activeFrom" : "2013-09-09T23:50:22.631Z",
+    "activeTo" : "2023-03-03T07:04:57.391Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/09e375da-507e-4305-ad75-9ba3006c400c",
-    "id" : "https://www.example.org/31aebf73-bf05-410d-829e-5d60e2fef001",
-    "identifier" : "N0Sekxs2kuCKgADtzv",
+    "source" : "https://www.example.org/9af574d9-a127-4940-a643-fd275c4ba278",
+    "id" : "https://www.example.org/ff00a179-bdaf-4d2d-8737-a0e6f2c524a7",
+    "identifier" : "Gnzk5krWoi9HZ44RQtZ",
     "labels" : {
-      "pt" : "V3l5eozq8Jp"
+      "nb" : "6dwaaO2KDSAnYNrZjq"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1587068851
+      "currency" : "USD",
+      "amount" : 1066323362
     },
-    "activeFrom" : "1977-09-10T18:51:44.096Z",
-    "activeTo" : "2022-10-01T09:31:24.001Z"
+    "activeFrom" : "2019-03-11T13:22:46.103Z",
+    "activeTo" : "2021-05-23T12:11:22.059Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/08bd9408-6114-4e7e-a66c-0f5d19bffeb9" ],
+  "subjects" : [ "https://www.example.org/10801749-e50e-448d-9498-723278e0fa65" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "737de243-c9b8-47e8-a4d7-78dccf4e17ff",
-    "name" : "LDAtg49OltB5LMfMP",
-    "mimeType" : "spdwYyffGc7Mke",
-    "size" : 1446285242,
-    "license" : "https://www.example.com/8yw6wovqtyg0fmeic",
+    "identifier" : "55c076ee-1960-444d-a177-f0a471a08ea8",
+    "name" : "F0Dbo5dikIB",
+    "mimeType" : "tvCJ1S8QuAyU",
+    "size" : 1885161208,
+    "license" : "https://www.example.com/0785p74uvwf6",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "45ANmmQmL6eHaVynh"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "gJ1maoylZXWpI8i",
-    "publishedDate" : "1979-05-29T11:50:51.841Z",
+    "legalNote" : "Am17xH735QA5sf7",
+    "publishedDate" : "1991-11-27T09:55:47.745Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "ol5ctAwz0EF",
-      "uploadedDate" : "2017-07-21T05:05:13.706Z"
+      "uploadedBy" : "ydjOrOaxyxJdVRmnFWv",
+      "uploadedDate" : "2021-03-05T06:14:30.943Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/lnbEmSIlpI3utH",
-    "name" : "ltCChkyoPdbTbqtLDr",
-    "description" : "hg5M9Fbp1ppZjQ7X"
+    "id" : "https://www.example.com/T5qxqf0uaQCBo7R",
+    "name" : "vc5tANPrx1miIhGrb",
+    "description" : "aopVgCYm8ossQ16"
   } ],
-  "rightsHolder" : "VLHJODIlZiqAc",
-  "duplicateOf" : "https://www.example.org/84fc9f1c-1f75-434f-bc0e-f3176eb6566a",
+  "rightsHolder" : "qyGEVAdIU6I8Qa5T",
+  "duplicateOf" : "https://www.example.org/f5762246-f626-4843-abc0-39e843dc0415",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "41rgc3JjGvZXDMB"
+    "note" : "xkMFlpeBQlD3AqpV"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "VFuYguZG0FtW",
-    "createdBy" : "NUUhn1m6vV",
-    "createdDate" : "2022-07-27T20:48:53.428Z"
+    "note" : "w1OhtlSfp59",
+    "createdBy" : "7PuBPc2tPT68h",
+    "createdDate" : "2006-02-01T04:08:23.772Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d2b150cf-395b-4d96-9073-21265d5ab3fc" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/eec8bcc0-d4a5-44ba-ab1f-e6d9cd547997" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "CtDMDgMPY26LBYz",
-    "ownerAffiliation" : "https://www.example.org/de73f362-3d56-4959-affd-54845a28370b"
+    "owner" : "x4fklnIZrl2erW",
+    "ownerAffiliation" : "https://www.example.org/9bf01ebc-c2e0-484b-b41c-061376b3512c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/76a7b192-af8b-4ac7-86f2-5fac9af36e75"
+    "id" : "https://www.example.org/99e6a084-797f-44a4-aa90-c0ac6e3e1c21"
   },
-  "createdDate" : "1986-08-05T14:10:10.778Z",
-  "modifiedDate" : "2023-11-13T00:14:23.323Z",
-  "publishedDate" : "1994-01-30T03:44:50.128Z",
-  "indexedDate" : "1994-08-03T07:17:59.062Z",
-  "handle" : "https://www.example.org/f860186c-4999-4871-bdbc-62732710311f",
-  "doi" : "https://doi.org/10.1234/perferendis",
-  "link" : "https://www.example.org/af79e60d-98ae-4c12-b30f-28679006db0f",
+  "createdDate" : "2012-09-19T07:25:46.846Z",
+  "modifiedDate" : "1997-02-07T13:44:58.019Z",
+  "publishedDate" : "2000-12-15T18:28:50.388Z",
+  "indexedDate" : "1995-12-28T02:23:28.962Z",
+  "handle" : "https://www.example.org/9a8ff8c9-994f-43cd-a1e1-39a5c5c28900",
+  "doi" : "https://doi.org/10.1234/corrupti",
+  "link" : "https://www.example.org/fcf34edf-4ca9-4ae0-b980-0893f853f0c9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sZOa518wQ3REFqVSV3",
+    "mainTitle" : "yOGlHgq6PbA",
     "alternativeTitles" : {
-      "cs" : "7joJkOhZdU3Ry"
+      "se" : "QuZNbXtqL6LNvyI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AYa5m4iECxHHGkfbDU",
-      "month" : "0Gk0GlcBRuKI2aZ",
-      "day" : "nEpNozwHw430n"
+      "year" : "Zcc6hxEomj9Jnxv",
+      "month" : "0EZ0YyPTBEk2aRhJFr",
+      "day" : "evN1Xfz8SWFHESeTRR"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/743583f5-e428-444e-bb04-79bb916f19fd",
-        "name" : "8rMxt0SvAZoQb",
+        "id" : "https://www.example.org/0202821a-44a7-4517-bd3d-e07a38b81c49",
+        "name" : "QLn244ros83KOpQl6",
         "nameType" : "Organizational",
-        "orcId" : "9XwNr91EQqjnMjjr",
-        "verificationStatus" : "Verified",
+        "orcId" : "WTkcoLVeXRdw6K37bRZ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WzIgbv4kRT",
-          "value" : "Xws1PciMwu"
+          "sourceName" : "k6mF8IvLxK5",
+          "value" : "lFa6NIfEvVCCs"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HuzmZzvZPEHNRPBMg",
-          "value" : "29n0rNeJ2AF"
+          "sourceName" : "sD2B3Sl2dms1fdh5RAS",
+          "value" : "WCtNHiiPcEStqKLg9Z"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6034863c-f751-4d5e-949c-4102b40a1663"
+        "id" : "https://www.example.org/0954055f-52e0-4750-a708-6e3ff03daa27"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,168 +62,168 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ea899447-398d-4f0d-bf94-1b6a1488022c",
-        "name" : "hFlslDss4j",
+        "id" : "https://www.example.org/8c115628-c5d8-40dd-b57f-cc1cf0cd3d60",
+        "name" : "LLLnkBypkIdfzYCP",
         "nameType" : "Organizational",
-        "orcId" : "uR3wDJaTG0e",
-        "verificationStatus" : "Verified",
+        "orcId" : "gDbO7RWp7wCiBbLWT4",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GXuik7YsAjCnAsN2",
-          "value" : "ipwLQCUtv9cYo"
+          "sourceName" : "0bmxKkzuXBpYe2",
+          "value" : "rZYsH6jelRlQAA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MtbsA6ho2UF",
-          "value" : "fkuIL86cD44i9Sn"
+          "sourceName" : "mKaTLi0Pk4rBC",
+          "value" : "PMFjlQsp5LW5WZ9TPvr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dec3d954-34fe-4631-a408-9240dec95fd3"
+        "id" : "https://www.example.org/ad5482d1-1b7f-40e9-8cfc-9dcff5a53f72"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "VEX3Dem8Ore"
+      "ca" : "FujK83hTrknHZtsROM"
     },
-    "npiSubjectHeading" : "fJ7FgEnhr6izE",
-    "tags" : [ "z3yXullRognCltvqQr" ],
-    "description" : "DOHEos8XIaY9NDjoFlF",
+    "npiSubjectHeading" : "hUlqAEa7n6",
+    "tags" : [ "39MwfONQsYh" ],
+    "description" : "gUAXZpq7v5b1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bee5e4da-01ea-4e29-ac8e-6286a028d3dc"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b7a690c0-cee2-451c-8362-c09c417a278e"
         },
-        "seriesNumber" : "YBlh7dqewuR",
+        "seriesNumber" : "n3Lj4l3BR83qI",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/165770e1-468b-400f-abaa-d293540568c3",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ff4f92e8-96d7-4c14-86a9-4e0cad3489d1",
           "valid" : true
         },
-        "isbnList" : [ "9791868111687", "9781090515513" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9790070245296", "9780964279360" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1090515510"
+          "value" : "0964279363"
         } ]
       },
-      "doi" : "https://www.example.org/c421462c-b23b-419f-8981-5a028800a3de",
+      "doi" : "https://www.example.org/0be8ff85-4095-4300-9f82-e81fb154a127",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "98aR0Hfn0kX",
-            "end" : "puFv9BVf5AgR2"
+            "begin" : "6lqzraiL5Ecv1du",
+            "end" : "YBxysSfmUbly"
           },
-          "pages" : "vfBy4ZMOaJ7Q9Q1egjB",
+          "pages" : "9QvtxSTLDc4wc",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "URjkiVRl2q",
-          "month" : "CKzBogCweyj8",
-          "day" : "LT4zmygZWG0fcxAW"
+          "year" : "cLd1WAtsvO0sfOUA",
+          "month" : "VywNf4ryGXed8BnsLNL",
+          "day" : "WTUg0VrFRxc2Sc0"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8ce661ae-16f9-406b-adbe-7db0b7bc73df",
-    "abstract" : "WGJAZO21weDrLIkrHs"
+    "metadataSource" : "https://www.example.org/5cc6ec82-e19f-44ff-a823-cb74920582f5",
+    "abstract" : "1m0dTKBnQieZzWvC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/892c2d5a-7d9f-46ba-9e60-4082083edf2f",
-    "name" : "DYQTjEReVmPzoPc8XOu",
+    "id" : "https://www.example.org/a21b3648-22f6-43db-ac0a-146594ef1557",
+    "name" : "gXeoK2u2UT8",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-05-31T14:47:09.954Z",
+      "approvalDate" : "2020-12-26T20:25:59.198Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "kKBwUyiqVPeQuvmfKs"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "aqLbk5txe3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/bc42309e-d6cd-4963-a1af-81dfae4b9141",
-    "identifier" : "fjgbtwEPhNXJz6ApRux",
+    "source" : "https://www.example.org/d038af47-fd81-4ed5-b77e-9d1f679c838d",
+    "identifier" : "ytoXcaPDu7l",
     "labels" : {
-      "es" : "J9EcdGWCaeWM9z"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 603587162
-    },
-    "activeFrom" : "1991-01-09T09:27:36.396Z",
-    "activeTo" : "2006-10-09T19:12:56.929Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/562774ba-c6c0-48da-bf75-948ec4af6bd8",
-    "id" : "https://www.example.org/4c87b930-1396-4387-a332-63de37f8ecd7",
-    "identifier" : "G5yGMpAYQh07lM",
-    "labels" : {
-      "cs" : "IdOuyDsRAjF"
+      "nl" : "rKufuIHU9hNHL"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 779983672
+      "amount" : 1278879548
     },
-    "activeFrom" : "2017-04-14T18:42:17.163Z",
-    "activeTo" : "2018-11-22T03:27:27.172Z"
+    "activeFrom" : "1978-06-05T06:57:23.685Z",
+    "activeTo" : "2015-06-12T14:04:10.251Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d87a6190-99bd-4231-ae87-1e6f73c0713f",
+    "id" : "https://www.example.org/a956de04-fce8-4c75-80de-2975071d1fb6",
+    "identifier" : "plYHKHy9oR5AO",
+    "labels" : {
+      "ru" : "siY4rVGESQrpl"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1530210335
+    },
+    "activeFrom" : "2015-11-02T18:34:59.520Z",
+    "activeTo" : "2017-01-14T10:29:05.426Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/998f45a2-3361-4fbe-9d80-b67be94a9def" ],
+  "subjects" : [ "https://www.example.org/5f9c08fc-133b-48b6-bd28-2ddc22dda990" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "08c866f2-9d82-47a6-be89-f5a72e6d6aeb",
-    "name" : "cCN8SuYmDzni5vYOx",
-    "mimeType" : "StMlcxzKSw0lIY8",
-    "size" : 1226953931,
-    "license" : "https://www.example.com/otqrmq7ex2bml3rkvr",
+    "identifier" : "e6f60f11-6acf-42f2-80b1-3726aa259433",
+    "name" : "LFhqlLjrLBTYdHNrnBa",
+    "mimeType" : "NfIA9HpWdbClJUGHp5",
+    "size" : 149468756,
+    "license" : "https://www.example.com/waawffqh8dtqq2",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "2C4bID6ugzmaBw2CA21"
+      "overriddenBy" : "zrv7LOwyx4"
     },
-    "legalNote" : "PN7XcjgisnzgHkp",
-    "publishedDate" : "1993-12-20T21:42:21.936Z",
+    "legalNote" : "gubMfOwEPY",
+    "publishedDate" : "1995-10-20T23:43:23.204Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GRgtoHNHTc",
-      "uploadedDate" : "2024-04-07T09:36:11.933Z"
+      "uploadedBy" : "6HhuoPSo6hVRO2GlRcB",
+      "uploadedDate" : "2014-02-26T17:35:34.598Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/feCVTDUFIkz5RSwk",
-    "name" : "0EYkf3rdiNoSVM",
-    "description" : "UTIBhUlEQwp9i7NuH"
+    "id" : "https://www.example.com/YbnjVf8GLEpyxtj",
+    "name" : "JNRdFvrya6j",
+    "description" : "a2aObcSteY7Fe"
   } ],
-  "rightsHolder" : "Frq7En8kuAbn",
-  "duplicateOf" : "https://www.example.org/e9ede5d8-d273-44cd-8ac7-32028c3a84db",
+  "rightsHolder" : "St7L3tF3XS3HIcadY",
+  "duplicateOf" : "https://www.example.org/8409c48e-3367-4b7a-9a61-bf2fef38d041",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "t0RsRsL6HTxgSbcX2sq"
+    "note" : "1PhHbg8l5ezUMO4Lvj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SNkdD13p9m",
-    "createdBy" : "NOjF5RqnD6M",
-    "createdDate" : "1997-05-13T08:12:09.724Z"
+    "note" : "G1rpTTMSTl08NrzeQf",
+    "createdBy" : "JNHPQHjC77O4u",
+    "createdDate" : "2021-07-18T17:06:35.321Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3595bfc1-22c7-48fc-b43f-2afa7666e6ec" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/6b385d64-bdb3-4c61-b818-342563752651" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "muc7aNY7ITAjkIlgG",
-    "ownerAffiliation" : "https://www.example.org/afc990bb-8a64-462a-b0cc-dc97c782d5da"
+    "owner" : "YK7BPHNFX7sx",
+    "ownerAffiliation" : "https://www.example.org/c6c59722-5b21-4fd7-8aaa-a8a50ec6b39f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f710c085-097b-47dc-b71e-4b7f5bc40b96"
+    "id" : "https://www.example.org/ad77755c-7307-45dd-a183-58632afeb61a"
   },
-  "createdDate" : "1980-12-28T22:17:23.669Z",
-  "modifiedDate" : "2007-08-28T17:01:39.079Z",
-  "publishedDate" : "1972-02-21T19:23:49.495Z",
-  "indexedDate" : "2015-01-03T12:33:10.076Z",
-  "handle" : "https://www.example.org/3ddec1cd-9fb6-40ee-b003-bb4c9bfa47a9",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/2421e09c-b9a0-4f53-831e-66339b00059c",
+  "createdDate" : "1975-05-19T18:11:18.907Z",
+  "modifiedDate" : "1988-10-09T00:57:46.550Z",
+  "publishedDate" : "1993-12-12T15:10:13.561Z",
+  "indexedDate" : "2019-12-05T18:08:17.490Z",
+  "handle" : "https://www.example.org/9d7cae73-a8a1-4bae-be69-363db9aa9dfe",
+  "doi" : "https://doi.org/10.1234/adipisci",
+  "link" : "https://www.example.org/275d938f-da73-447b-a11c-7122cf30e62d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Uaq7SSHTGtNFrIia",
+    "mainTitle" : "QitZlRN73W0kHvhTBsx",
     "alternativeTitles" : {
-      "en" : "L2ADReVbxZCxoX"
+      "sv" : "s2HC4B9ZNVzLvLgrV"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "lmwUjLSlh6xsX",
-      "month" : "WjCdR3z3O2v9",
-      "day" : "s21g8lZAEECRO"
+      "year" : "3oDIAtvXSPkrTG30EX",
+      "month" : "vGgZAe0S9p",
+      "day" : "hqqH1DJdKHs8oK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cb5a0e9c-7254-41b7-9933-4fb777dff94a",
-        "name" : "dwrxnJFXDc952p5",
-        "nameType" : "Personal",
-        "orcId" : "pd7IAfAfc9gBHj3q2F",
+        "id" : "https://www.example.org/13b709ef-21f1-45e2-a002-3518a1e0913d",
+        "name" : "USXHDN0ADfF0Vs",
+        "nameType" : "Organizational",
+        "orcId" : "AqsGq7r3T7emS3ZD2",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1y3e1AJ2JjhYykV",
-          "value" : "ZahDojJi6ZU"
+          "sourceName" : "JDMqkS51OrexPfgb3A",
+          "value" : "nD6aHhBbeZvgiS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3iG7whzMugvx",
-          "value" : "SXKYj5rOoUgD3n"
+          "sourceName" : "snp57tNuqlj4z3dD6",
+          "value" : "hedVqXnrRGwgaZK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1c6e4b02-43b6-44ae-907e-d229e8c31ddc"
+        "id" : "https://www.example.org/c7bee868-7220-49c2-a6ec-40d28f9c3991"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e9127213-f914-47ad-9f78-4be3a9f5a914",
-        "name" : "7iZF3Y9zPYjbmSzi",
+        "id" : "https://www.example.org/6b2d81b1-c1d3-459b-a4bb-59ba963bf624",
+        "name" : "sEFQPEHkxg",
         "nameType" : "Personal",
-        "orcId" : "VcqbMeB0UVnB0FF5",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "r49mSXZXZAul0YV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "R7WCdloMo3",
-          "value" : "QhFtIqNRfIyH"
+          "sourceName" : "wGv4rEYp2HewiTI4Dm",
+          "value" : "6KodXLBVlrHhy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MD9uxmbKRC2y",
-          "value" : "69C2cfDeZ6N9"
+          "sourceName" : "V6XFBq724X",
+          "value" : "p81FKaea3Petx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5d0c7959-d465-4e38-b48a-c532e3f45057"
+        "id" : "https://www.example.org/a03a65cc-aee3-4b3a-90f9-da92efb218aa"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "ttK4fdxca7"
+      "it" : "qLqZyEL1yPzqOZ"
     },
-    "npiSubjectHeading" : "Hj8b8AV6VE36vbG9OXQ",
-    "tags" : [ "vWu0o2aPtiORgqx" ],
-    "description" : "I3mjrNnR1a",
+    "npiSubjectHeading" : "BSSD8dBjFi",
+    "tags" : [ "i3VVqIPbKW7O8NP" ],
+    "description" : "6BEIqeas92HmmKtl2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/ff4479c6-571d-4116-a969-f66ea28c3697",
+      "doi" : "https://www.example.org/115600e0-3356-4dbf-bf59-fa773f8cccc6",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
           "type" : "PerformingArtsOther",
-          "description" : "Kh8EadNw9XsKn"
+          "description" : "Hx6M9jBPnjSXlYC"
         },
-        "description" : "NF3U9zC2vAH4sZQi",
+        "description" : "50XSje0f00E7aY6",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "GdmuAEvO20",
-            "country" : "lY7NXcr3klzY4vuosv"
+            "label" : "noOUOxazINBL01OyzQ2",
+            "country" : "PRl3wBGCu6O1Qy5DnW"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2017-05-04T08:50:03.658Z",
-            "to" : "2018-05-10T12:14:44.029Z"
+            "from" : "2005-08-11T18:25:08.649Z",
+            "to" : "2007-06-28T03:00:04.710Z"
           },
-          "sequence" : 2095391180
+          "sequence" : 875208712
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/144abbf6-8bc4-43c7-8c9b-274ed8d2582b",
-    "abstract" : "9ldVoCvcIWU"
+    "metadataSource" : "https://www.example.org/c02594cd-6780-4014-98a8-ac7788c12fec",
+    "abstract" : "0LNI0Mn4WaXiRSenO4Y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c1098d16-3c8c-4214-80d9-02809a4bc4c2",
-    "name" : "dLSYkbUi45nXK9N",
+    "id" : "https://www.example.org/2ed1d693-b8ae-481e-a837-41dfc17609a3",
+    "name" : "uZlkdQw28FHVmr",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-08-15T05:01:35.457Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "CzvEZXLesa"
+      "approvalDate" : "2002-05-04T07:04:14.383Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "M3HoRWyU7vT"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7b132659-0235-4779-875d-8f324afbc6bb",
-    "identifier" : "uaAx4aESpBhzDm",
+    "source" : "https://www.example.org/fd5a6ef1-013f-4ae9-b40e-63fcefc83d92",
+    "identifier" : "SDYYQrWbmQ7PBpSD",
     "labels" : {
-      "cs" : "qlltvZVvsbw8AHhWg5"
+      "ru" : "fzCGI6Zhho5l"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 321544758
+      "currency" : "NOK",
+      "amount" : 349443197
     },
-    "activeFrom" : "2004-10-25T02:35:41.471Z",
-    "activeTo" : "2019-11-15T07:10:46.818Z"
+    "activeFrom" : "2005-08-01T01:41:59.644Z",
+    "activeTo" : "2015-12-03T18:43:25.493Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ca9d770a-8a03-48c1-921c-47dc3c286fc3",
-    "id" : "https://www.example.org/ecc2a669-aec2-4dbf-8a8e-c79c737e188d",
-    "identifier" : "LJqze754kAl",
+    "source" : "https://www.example.org/c50df5d1-b976-406a-ad52-094dd3edd922",
+    "id" : "https://www.example.org/ba5e98ee-66f3-4d7f-8f09-33ee85792b9e",
+    "identifier" : "KBkKbidfA0mTKO",
     "labels" : {
-      "da" : "B8WWKDp9thtdDe0QC"
+      "nb" : "KHYs1BnYoKiDKu9nZ0"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 857997877
+      "amount" : 926463190
     },
-    "activeFrom" : "1996-11-19T10:24:52.610Z",
-    "activeTo" : "2011-07-04T06:31:51.680Z"
+    "activeFrom" : "2006-10-08T05:38:42.429Z",
+    "activeTo" : "2007-03-02T05:06:19.620Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/173831b1-2600-477e-9014-9d2d892063ba" ],
+  "subjects" : [ "https://www.example.org/a48e3628-f39c-43e1-92d9-cf2bc4fb4730" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "30cf0bb2-1f24-4fa0-8973-05c1fa70ce53",
-    "name" : "9JYfpjsiD32f0pp",
-    "mimeType" : "pWIGySpPmyV2VG",
-    "size" : 1943663394,
-    "license" : "https://www.example.com/syiyctapczkgjnt",
+    "identifier" : "b842634d-bc3b-478d-bccb-7658c1ae769f",
+    "name" : "ZGbvTXZXOI3vijXMo",
+    "mimeType" : "buVS0rYMpDIQynB",
+    "size" : 2005590341,
+    "license" : "https://www.example.com/deoqgfciqtj68",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "RFpeqs6CFRqefM",
-    "publishedDate" : "2004-09-05T22:41:05.039Z",
+    "legalNote" : "qZTJjOk5e0cFybC31",
+    "publishedDate" : "1991-04-14T18:22:33.995Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "pazGwKmxnhPeJxF",
-      "uploadedDate" : "1972-12-29T06:46:32.394Z"
+      "uploadedBy" : "gglM85CzFbqC",
+      "uploadedDate" : "2008-07-10T01:19:32.296Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/pjOMSYXJgFqR",
-    "name" : "PiAMB3ahPMzXcy",
-    "description" : "6Or1nNReULmcqjR"
+    "id" : "https://www.example.com/Y2T2CYxLnXnQoecSS5",
+    "name" : "8AfCZOvzOa97HHCA6",
+    "description" : "Jekf7IG648dSN"
   } ],
-  "rightsHolder" : "by1gpdhuOEbkHo2wR8",
-  "duplicateOf" : "https://www.example.org/921a81e2-35bf-4e0d-b16c-0727cbc83fd6",
+  "rightsHolder" : "GXeSa9CkCPM8uGVW",
+  "duplicateOf" : "https://www.example.org/ef995f0b-3272-4e7f-9050-e2fc4d76ef34",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "j5kwUsHH5tx89MU"
+    "note" : "cQVrBghesu"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "zs0nhtIJj10oPwI",
-    "createdBy" : "Cj5b6orBFIjXz",
-    "createdDate" : "2007-09-23T20:59:48.650Z"
+    "note" : "rMRdHnIbXv73P",
+    "createdBy" : "eYKDwhIkGabJ",
+    "createdDate" : "2000-07-18T12:33:42.563Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/652d69bb-4873-4645-acb6-e970975cbbf2" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/b0a6fbee-eac3-4b3c-97d2-7b4772478102" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "G8K47YtZFOEUDgR7ZM",
-    "ownerAffiliation" : "https://www.example.org/2a17c5e9-1b62-42ab-bcc0-9b92d94ff07c"
+    "owner" : "PHTrXFjLCVDCjSEJq",
+    "ownerAffiliation" : "https://www.example.org/38d743b0-aeb3-495d-b607-a2386ffac093"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/51f8e503-6cdc-4aca-b623-af67518ef655"
+    "id" : "https://www.example.org/f313f3e2-6ede-44a5-8b90-3af6a8933942"
   },
-  "createdDate" : "2008-07-30T21:14:48.944Z",
-  "modifiedDate" : "1973-04-18T16:51:11.721Z",
-  "publishedDate" : "2010-10-10T10:21:51.273Z",
-  "indexedDate" : "1997-04-28T22:34:55.258Z",
-  "handle" : "https://www.example.org/01b38095-2bcd-469c-be8e-ef53596f7ad0",
-  "doi" : "https://doi.org/10.1234/quaerat",
-  "link" : "https://www.example.org/098edfd9-5199-4954-ab85-d8ab6c1e7b3a",
+  "createdDate" : "2023-08-23T00:10:08.363Z",
+  "modifiedDate" : "1971-10-31T13:36:39.434Z",
+  "publishedDate" : "1977-11-29T15:30:15.623Z",
+  "indexedDate" : "2001-03-28T09:35:35.835Z",
+  "handle" : "https://www.example.org/cccd08c1-1183-40f4-a3e8-f36252b24f8f",
+  "doi" : "https://doi.org/10.1234/maiores",
+  "link" : "https://www.example.org/0e6fd49f-5cac-4c7c-8807-102cb177135f",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JljpUg94xxH5OxwZTIs",
+    "mainTitle" : "TE9FRTWMSEhaF0aC4",
     "alternativeTitles" : {
-      "fi" : "aCWQdrYKTyHy3CjMCnW"
+      "fi" : "nr7h1kmENIhKTi"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "nrJ2p1DyDpZaJiVW",
-      "month" : "l8li1hwMQVIvfiF1qbe",
-      "day" : "TAwVWAHKPeqofsjNvx"
+      "year" : "dUDvPPuXEMp",
+      "month" : "XUaOCIt9w2OcemjjIyQ",
+      "day" : "KwjvkZiFEWo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f4102635-6fcc-46f1-951b-0436692a600c",
-        "name" : "IoEa9UuQA6jvLVo8gH3",
+        "id" : "https://www.example.org/45a104de-7104-4b74-a0b6-83cbb73fd588",
+        "name" : "OeHLKfRQmP",
         "nameType" : "Organizational",
-        "orcId" : "EUBRqvK0YV2AKt1Pf4Y",
-        "verificationStatus" : "Verified",
+        "orcId" : "LUnbh9hQqbC7vpBhKJ0",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LfLMjimJFZG",
-          "value" : "eOyY4igmZdDiqkEh3kK"
+          "sourceName" : "AGIEbEv7SWkHwsWMN",
+          "value" : "K6Lol8a2sZLBJp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wFCGU9g4JcDNXT",
-          "value" : "6AdTuK8rF6LSC5g3ucJ"
+          "sourceName" : "5PCBDXXd5S",
+          "value" : "9UuEJW2tzyA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/51efdd3c-5f0c-4399-8a9d-77abbaa6bbf5"
+        "id" : "https://www.example.org/5150c4f5-aaf5-4309-bdba-4b60074d593d"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c77a7b45-46e0-40d0-a195-7ef96dc1ece7",
-        "name" : "ja88ZxX66VO",
-        "nameType" : "Organizational",
-        "orcId" : "SC6a0qLbKO5",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/f3a32623-5265-419c-9bfc-b18de09e1770",
+        "name" : "3oCZrIcn2QWyyVPnyvG",
+        "nameType" : "Personal",
+        "orcId" : "VfrqncP2FdnRhHw5U",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zl2lpA5yQgXeWqzWm",
-          "value" : "TVeHgw6g5PimYdr48L"
+          "sourceName" : "wfobmY4Mpsgy",
+          "value" : "Ji6Iug3bjFQlxBtU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kAoLkxMfUd",
-          "value" : "tPteg0EgilrdIuVcR4"
+          "sourceName" : "hCFkqKRv3LoE9LBP",
+          "value" : "eDKrEGTrhVrWsX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cea80497-4d41-466b-9640-fc384a599baa"
+        "id" : "https://www.example.org/674ace86-6cbd-47d3-905f-250e67bd434c"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "qZ3C9E6eXKvSnW"
+      "da" : "JWggQeCfe7vImvNvzDy"
     },
-    "npiSubjectHeading" : "9qdEAQTPOBnI",
-    "tags" : [ "CLcPk75tIQndyfjIKI" ],
-    "description" : "KOtnJWSl8KpyywyWt",
+    "npiSubjectHeading" : "tcZsv6wqL4ap",
+    "tags" : [ "RpTwlauQSuq9z" ],
+    "description" : "8cXzmOSWEncDdS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8b36cb8e-ead1-4618-b179-061f1d5a7b07"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1fd2437f-8834-4888-bceb-b6787ab54631"
       },
-      "doi" : "https://www.example.org/884015f9-7376-4e94-909a-d00fa86e571d",
+      "doi" : "https://www.example.org/0fe141e8-9e4f-4020-8c07-d680308453ec",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "4f9EFNwb7WXplYhdF",
-          "end" : "ZeTr5jqSTNTmGvuGkJH"
+          "begin" : "fyy4AoaTBzby",
+          "end" : "6GBAecAlFdWR"
         },
-        "volume" : "3RnLHMjzBpyLM3",
-        "issue" : "NBXHAHyHmin2gy",
-        "articleNumber" : "oBKQ6qUkJ8g"
+        "volume" : "FoFrA6UxDIe",
+        "issue" : "4VzPimQElw",
+        "articleNumber" : "vxq7eBjdpP"
       }
     },
-    "metadataSource" : "https://www.example.org/3befa3e6-f8ae-439f-a5d9-f45c3623e255",
-    "abstract" : "YoxJPASTQVJ9gZiV"
+    "metadataSource" : "https://www.example.org/4c7aa7b4-046d-4533-99cd-034b7f79a0f9",
+    "abstract" : "BlSFtFRKSUQ5BTYlV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/27c2b0d0-4bb2-4e3a-837e-97a784b08905",
-    "name" : "QHiAZGua0BDvnBRv",
+    "id" : "https://www.example.org/ca9aff3a-df39-4786-8f36-56dfebe6045c",
+    "name" : "M4EAwQzrfY4G6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-08-22T01:25:36.954Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "dAlfBZo2plZmDBc"
+      "approvalDate" : "1998-12-29T08:42:23.081Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "3si1pvEiGCa"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2107b607-7ee0-4c84-b18b-f634dd528e17",
-    "identifier" : "ZUEM87Z518cV0",
+    "source" : "https://www.example.org/fa8baa6b-a571-4bdb-8aaf-960ca68bfa9e",
+    "identifier" : "fuc6XmLKmA6O",
     "labels" : {
-      "bg" : "xDd8hrhI8iFF"
+      "af" : "XHS76tXV9ZrYltYE9n"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1759854113
+    },
+    "activeFrom" : "1972-12-08T04:44:04.459Z",
+    "activeTo" : "2001-01-01T18:54:56.785Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/53b085b6-8f63-4f91-addc-ebc9b71d4d75",
+    "id" : "https://www.example.org/a74212c5-d143-4b4b-9383-6dc201650a83",
+    "identifier" : "toBQwhZzlgAjBg",
+    "labels" : {
+      "nn" : "b7EzZRk9WCeh"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1574648632
+      "amount" : 1997540774
     },
-    "activeFrom" : "1995-07-17T18:27:25.906Z",
-    "activeTo" : "2016-03-13T19:41:51.353Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/bb417fdc-1ddb-4e4e-bf0e-311b0aa02e53",
-    "id" : "https://www.example.org/6239f55d-9f0d-450e-9aaf-de489b60749a",
-    "identifier" : "AGp7U9tK5RMbJJ9G",
-    "labels" : {
-      "fi" : "jfKpx8K6eEJIEfSy"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 231699300
-    },
-    "activeFrom" : "1999-02-15T13:50:21.026Z",
-    "activeTo" : "2008-01-11T19:30:21.440Z"
+    "activeFrom" : "1976-12-31T13:37:21.212Z",
+    "activeTo" : "1978-06-12T14:45:15.597Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a8089dfd-ec46-4d8d-8c8d-a42e6e78b6c7" ],
+  "subjects" : [ "https://www.example.org/df0ea79b-cd7e-456c-a616-31c4641a98bb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a5278e1d-11df-4b9c-acb1-b5278a446d08",
-    "name" : "VMpze99HwT",
-    "mimeType" : "lf9Xnmo1Q2o",
-    "size" : 332285112,
-    "license" : "https://www.example.com/srrp6px3cwc22xr3vl8",
+    "identifier" : "af6babd6-1064-45f9-8cef-2a027c8517a8",
+    "name" : "ZwlFuDE7M1GBj87AV",
+    "mimeType" : "3TxdT73WlO4mkCLW",
+    "size" : 1694187197,
+    "license" : "https://www.example.com/tzf1q3uz7k2",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "x4CotDtIfEysmivVa1F"
     },
-    "legalNote" : "m1zjwuyS0UvwNFjLxZM",
-    "publishedDate" : "1996-01-13T10:52:51.192Z",
+    "legalNote" : "Nrdf8etnvNxFA",
+    "publishedDate" : "1987-04-14T01:06:40.963Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "gPTCYw0AWHcUTuaj",
-      "uploadedDate" : "2014-01-17T02:43:34.902Z"
+      "uploadedBy" : "NBf1tncx3tXxYrW2",
+      "uploadedDate" : "1981-08-08T03:35:12.134Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/4avIcVv5jBWyt7YGqy",
-    "name" : "hXWAyHq66rB3wN",
-    "description" : "TZFQFpVYsCzEibJw"
+    "id" : "https://www.example.com/QOi0RfstJllKfG",
+    "name" : "Sra4DJyi4rN",
+    "description" : "6rk4501mKta38y"
   } ],
-  "rightsHolder" : "L0GyXc1te2E1P9Tkb5H",
-  "duplicateOf" : "https://www.example.org/4cd58067-bedd-4f50-9557-7ecd247a1f2c",
+  "rightsHolder" : "BGbOC23AItM7Cx28",
+  "duplicateOf" : "https://www.example.org/e0450960-9efc-43e9-bcdb-d7964384a12b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FPxBapOhrILqXDr"
+    "note" : "lf1aOVUciFxX"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "eouglaoboEZfslXEHrQ",
-    "createdBy" : "yotZlw14Z4wIlDJfjs",
-    "createdDate" : "2003-08-05T05:30:49.049Z"
+    "note" : "AR0vnfAEd6IWfmB5",
+    "createdBy" : "ZPm750XBBdaQQJ0YP",
+    "createdDate" : "1972-08-02T17:06:21.701Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e49fc641-3641-4910-83bb-0e901c7d0be4" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/6c872694-07a2-49aa-97eb-d7dc1e9a2a65" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Pr9eYcADekeIABPV",
-    "ownerAffiliation" : "https://www.example.org/542843cf-58f4-43c7-b3e9-fdd768c0bda8"
+    "owner" : "1jNqJSX99KPYGhxps",
+    "ownerAffiliation" : "https://www.example.org/bb2ec8bf-4879-43f2-a2da-0dcb85a583e8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/08f5e3c7-78f8-43d9-b0f8-ea1957aadf3b"
+    "id" : "https://www.example.org/c2da9bfa-1b78-4c54-9ead-c1363ee88d79"
   },
-  "createdDate" : "1986-03-10T06:48:55.327Z",
-  "modifiedDate" : "1992-12-12T22:59:06.208Z",
-  "publishedDate" : "1997-06-10T17:41:17.798Z",
-  "indexedDate" : "2021-12-19T15:17:49.957Z",
-  "handle" : "https://www.example.org/5c852472-c916-4ee7-9717-20df1d41fa22",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/6a10e6ae-98f5-43f3-8645-a4d10fff4363",
+  "createdDate" : "2009-08-25T18:34:28.073Z",
+  "modifiedDate" : "1995-11-23T16:20:16.450Z",
+  "publishedDate" : "1984-03-15T12:37:30.679Z",
+  "indexedDate" : "1997-10-17T10:00:07.536Z",
+  "handle" : "https://www.example.org/c8e316fc-1de1-43db-b531-21f789dafd91",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/78d9f29f-695a-4a22-af74-27debcdea5ba",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4JIkmm3zNLbZGER6Cx",
+    "mainTitle" : "YmZZu2hZZPwjM6",
     "alternativeTitles" : {
-      "nb" : "TMzruAhZM6gLtE"
+      "en" : "UKwch71BR4VR6FpA"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eFgRfCiLuAnxH4",
-      "month" : "CJKpTe5Aw2KAWUrqa",
-      "day" : "XvcCSM9a9YGg2la"
+      "year" : "2Bif0NVmJL7lR0wMC",
+      "month" : "cVgpBWHsHH8bl3Y",
+      "day" : "xrc73Sg1Zi3WlgT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f8a0c35a-9438-457f-b627-cdad2b2fb521",
-        "name" : "T7izTFU9JA",
+        "id" : "https://www.example.org/5f916dea-b0cf-4f53-b099-39a847018686",
+        "name" : "gM8JmVTET5WMJ8",
         "nameType" : "Personal",
-        "orcId" : "LwiZdPdGOuFOWCG6R5",
+        "orcId" : "xSc4GSDYxl0yYmdE",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AVAkoaAqep",
-          "value" : "ojT3Xe25tbpltBv"
+          "sourceName" : "R2wGWCMTBrQEzzLE",
+          "value" : "3X47nvU6wTI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Rr0Qp4m9gXyHyKR4xG7",
-          "value" : "Z2Wy3P2dRS"
+          "sourceName" : "zAnKRwEHTEDWmRGwLC",
+          "value" : "SfUz7qHzWzM1dFZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9c99246a-0084-4b48-9655-c2b67649f5bb"
+        "id" : "https://www.example.org/3529bcc5-9280-4564-8bb4-e5fab07c319a"
       } ],
       "role" : {
         "type" : "ProgrammeParticipant"
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/02fe536f-12b6-410f-9d3b-4cdcebd53e53",
-        "name" : "wJ1CKfy4DGiu3JEc2bX",
+        "id" : "https://www.example.org/86b863ff-0ff1-42fe-82a7-df6b83f65954",
+        "name" : "hJB2xoERp3EFWbH6",
         "nameType" : "Organizational",
-        "orcId" : "7Ei8LK7zCVywU9X9I",
+        "orcId" : "P0ybAaffzz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dvaiThOZaQDkAEPXdm",
-          "value" : "3VydhpjFWNKM8"
+          "sourceName" : "qZbDEJHFBMJ",
+          "value" : "ZVcHkm0m4CkhrUUCx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kuDKylphd9R9H",
-          "value" : "soUTpsYZZmWP"
+          "sourceName" : "m393R2MZ9TpYI6U",
+          "value" : "RmpcLJbLfEsD6WZZo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5db75068-3384-4452-8d5b-bdf4b623277b"
+        "id" : "https://www.example.org/1c2134c2-df6e-4f51-a46c-2006ddf8fd67"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "fWxQCh1wVzRpdC3jQuW"
+      "it" : "t5ez19VVT2aF5U"
     },
-    "npiSubjectHeading" : "skPvcewcFt",
-    "tags" : [ "w63xCpE862" ],
-    "description" : "xoYOS5iIelg0Q2",
+    "npiSubjectHeading" : "fNZWxXrFsPVhW",
+    "tags" : [ "pU3k8vGlFkBSaquv" ],
+    "description" : "biUQ4VpdtK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/dv9Qu954wMYAE2y"
+        "id" : "https://www.example.com/5fJ5agzdzhrc5lL1N"
       },
-      "doi" : "https://www.example.org/5df39206-6eac-4920-86b1-53b7f700256e",
+      "doi" : "https://www.example.org/37ac7308-84b6-4253-8caf-0097e6b56b81",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "TOVc7ufd73Gpj",
-          "end" : "EZPK7WzwExz"
+          "begin" : "n3hklFLNa144DRt7jhJ",
+          "end" : "69vlsMXqGEdOP"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/88554c44-1383-4af6-9560-f017bdf8772e",
-    "abstract" : "nRDjQISx2Ul7"
+    "metadataSource" : "https://www.example.org/04e3ab68-2abb-4a60-a96e-08103dbc957e",
+    "abstract" : "WpfX7Cl5JJLhbpCi5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7d140e28-6900-4f3f-aa7a-9e5d675c662b",
-    "name" : "qpbClmsj2ybB",
+    "id" : "https://www.example.org/bda19c9f-30f9-4901-a5ac-31ca0ca491d1",
+    "name" : "rGHNWnImLU0IN41Ij",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-11-28T05:33:43.237Z",
+      "approvalDate" : "2010-02-24T17:44:27.456Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "0OvcPXl29JAIeJ"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "dZe1LgzcpwI2Sn1hFj3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/fd1d7db9-d97d-432f-b36f-4ad5df3f7676",
-    "identifier" : "DKyQq0PwqS",
+    "source" : "https://www.example.org/dc50c466-fd61-49d3-b928-b23f0054aaf9",
+    "identifier" : "iS8EcBpaDXNtWfVO",
     "labels" : {
-      "zh" : "N4dYGkFJ73DaT"
+      "da" : "rWXGnPIzXsuD"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1554076535
+      "currency" : "EUR",
+      "amount" : 1438091735
     },
-    "activeFrom" : "2000-08-06T11:07:53.485Z",
-    "activeTo" : "2014-02-02T01:56:51.085Z"
+    "activeFrom" : "1991-08-24T16:53:03.805Z",
+    "activeTo" : "1999-01-10T00:02:36.420Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1580e062-f9e1-4be9-8b78-55a6f45671c9",
-    "id" : "https://www.example.org/8f0c7e2c-b886-48c8-8f44-de7d165a2ae1",
-    "identifier" : "mhOXDt6psKEY2lWO",
+    "source" : "https://www.example.org/b1a78ac7-6c61-48cf-b9ef-a23538d99bbf",
+    "id" : "https://www.example.org/a3f35951-dec6-4d07-9436-a8d2d2be4c26",
+    "identifier" : "t1NojeeAsV5ziNjr",
     "labels" : {
-      "hu" : "UiVFzh1WfAyThnN"
+      "zh" : "WcjQkjnn9J9XE"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1020388930
+      "amount" : 58947964
     },
-    "activeFrom" : "2019-02-19T19:57:43.820Z",
-    "activeTo" : "2020-01-25T03:57:11.511Z"
+    "activeFrom" : "1996-11-04T18:12:38.555Z",
+    "activeTo" : "2007-02-15T09:23:42.612Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/57ea5c69-f928-4b19-9554-b418d4bbce50" ],
+  "subjects" : [ "https://www.example.org/ab9c762d-0272-486d-89c7-1e1ae7e9a113" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5f2f2a41-7d31-4f94-a3ec-be39cfee524a",
-    "name" : "jcJGkHos78lRPNo9w",
-    "mimeType" : "HOCeQYGSAeBI",
-    "size" : 742949572,
-    "license" : "https://www.example.com/sdriittjbdak",
+    "identifier" : "f9c051c4-6657-4793-ac3c-11de38517599",
+    "name" : "rC9TvbskwUqPsmrgi",
+    "mimeType" : "oY3akwaQYrhAyVeqQ",
+    "size" : 1584501328,
+    "license" : "https://www.example.com/12ldpwswshbu6u2orlb",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Fpdn9pU3eNZ",
-    "publishedDate" : "1977-10-14T04:17:57.421Z",
+    "legalNote" : "jaExkFB8Vkd8",
+    "publishedDate" : "1980-01-30T02:16:22.925Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "OOwYYAFPbOb2AYaFo",
-      "uploadedDate" : "2011-12-23T05:11:09.984Z"
+      "uploadedBy" : "vLlka9bnPP1sA",
+      "uploadedDate" : "1984-04-25T23:09:57.158Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/sw0fGZkd96GXqYU",
-    "name" : "oz4Whi7yDKP9gZhgC",
-    "description" : "4cdr5FqbDhtOBZBt9Qf"
+    "id" : "https://www.example.com/u16HcJanoLfuDokX",
+    "name" : "seiHXoZVVKmhRpZTBdR",
+    "description" : "7k0QNu89S6loSJILLjR"
   } ],
-  "rightsHolder" : "O9WBxuf46rNTI3ICv",
-  "duplicateOf" : "https://www.example.org/4ae0b017-8b66-4fc2-8db6-4391a494c38b",
+  "rightsHolder" : "kwqRv2ViKnaWxlRU",
+  "duplicateOf" : "https://www.example.org/8a193121-124c-4ede-86bd-a3c1f182b8b4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "M9p30oQnpHhDt"
+    "note" : "QDUKU4MdNU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Jb9kCHfJECY9yka1Qnq",
-    "createdBy" : "EpdwCkclE7",
-    "createdDate" : "2001-01-30T18:29:30.688Z"
+    "note" : "S3aRIxpkJFoJLBDgP",
+    "createdBy" : "I9AStLgLVx9X4eFBtE",
+    "createdDate" : "1987-02-09T08:55:02.659Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5e7e2be8-404a-48cf-8440-0a9666db3075" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/91208ef8-cf97-4f68-852a-3a080b34f065" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "hav4UQSht0yWYCRIiN",
-    "ownerAffiliation" : "https://www.example.org/5e46f48a-f5b2-4494-84f5-ff344195923c"
+    "owner" : "6jgYz8w8TQ2q",
+    "ownerAffiliation" : "https://www.example.org/e8f9b026-1323-4864-8ca1-408c3f831e6e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/808a7516-b7d2-4ff7-920f-00b07f7a95ae"
+    "id" : "https://www.example.org/bdab1014-4205-4c34-a141-3a52fbc15321"
   },
-  "createdDate" : "2008-04-12T01:52:39.878Z",
-  "modifiedDate" : "1986-11-02T15:37:20.846Z",
-  "publishedDate" : "1998-05-19T10:01:34.854Z",
-  "indexedDate" : "2011-03-31T01:37:57.786Z",
-  "handle" : "https://www.example.org/09c98b25-3f94-4554-bb83-728b14d4836b",
-  "doi" : "https://doi.org/10.1234/hic",
-  "link" : "https://www.example.org/20500f00-13c0-444c-b3da-fe51dd2d7fb9",
+  "createdDate" : "2022-07-04T23:02:56.937Z",
+  "modifiedDate" : "1976-05-24T17:40:30.123Z",
+  "publishedDate" : "2004-12-01T18:30:31.258Z",
+  "indexedDate" : "1986-07-22T12:59:36.913Z",
+  "handle" : "https://www.example.org/b0e42511-5882-4290-85c1-0aca020b1419",
+  "doi" : "https://doi.org/10.1234/eveniet",
+  "link" : "https://www.example.org/c3150945-c727-4bd6-9bf9-02f2cd9c4c71",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cUOazcKn56s82x",
+    "mainTitle" : "fjhCcz2MQrc1M7IRoE",
     "alternativeTitles" : {
-      "nn" : "zO1I10sEiIm"
+      "se" : "LgRb8JHZ5geicIKw9"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ss3kPCLiTGN",
-      "month" : "9oDdS1XEGj",
-      "day" : "b3JcS0JTtIvg"
+      "year" : "D51SdQQRVd",
+      "month" : "QXJiM8CwW5Qt",
+      "day" : "rF8EcRvFmAwGSBDINv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/85cd3cc5-3499-4fe0-85a9-5f6d4b9ac1cf",
-        "name" : "INKHt3mzevIbV",
+        "id" : "https://www.example.org/4ed774c2-0162-469e-8807-af3be8a6272f",
+        "name" : "sK4BTTdUjDL2UpUen2",
         "nameType" : "Personal",
-        "orcId" : "x6TvIgCZGHEQ5",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Kptg3I0r9hRY9Lbrzo",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3yYlnRzcyF7WD3oGuYS",
-          "value" : "JHY0sMmJ1HTy"
+          "sourceName" : "MZOoBK4Y3th",
+          "value" : "gWvkqHzRzm5geo1K"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "411CIgHxA0uypBWX4",
-          "value" : "kGQ2lSn4VdL8pw"
+          "sourceName" : "uuab4fWLJYRXOwag",
+          "value" : "WBRnUCqPeE"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7bc0f6b5-fc56-40cf-970f-0a194d135dc6"
+        "id" : "https://www.example.org/53c00c69-22f5-4ca1-adfd-7de6149d6b3f"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/27d13876-100c-4082-9860-2cb8d4b8f789",
-        "name" : "XhcJ8GMU4hgwuLP6j",
+        "id" : "https://www.example.org/acbc826a-a157-4747-836c-a4a0633fddb3",
+        "name" : "9jNRf7WKwOjezifwHKc",
         "nameType" : "Organizational",
-        "orcId" : "hHa1DsegeXhs",
+        "orcId" : "N7lSmzbjNjCvcBlmo",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uZGEp01dEfvpMpO",
-          "value" : "DejlsNYMum"
+          "sourceName" : "I55nSjw57GoaCE0Q",
+          "value" : "gEUORZ3tg94I5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fW5zypMXgcvlAIz9aE",
-          "value" : "z8qM8ttCrsPOKVC"
+          "sourceName" : "UrvpxiXE94aRcDumZyR",
+          "value" : "KSo8svCY1D7bU3saL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f01f62ca-a3fd-48d2-991c-bfa0699fa4ef"
+        "id" : "https://www.example.org/a3b52654-e0cb-4b75-ae00-e1480c397b78"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "tG8C8uDVkUPQ"
+      "de" : "MGiupBMKRvw"
     },
-    "npiSubjectHeading" : "AWs6C8RfT19xZ6paM",
-    "tags" : [ "cxHt4VWfmJsrOjpqLWa" ],
-    "description" : "ajkJ9QgKRp",
+    "npiSubjectHeading" : "NWDisM1wFhGNzT2",
+    "tags" : [ "u996MxjerLylnvC" ],
+    "description" : "QC2szkMkvsFDn",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cae635ab-483e-4a04-b740-ddc00dbd5548"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0712a18e-892f-4925-8c07-fd85c4ead28b"
         },
-        "seriesNumber" : "J8eP1NTm5Kvan",
+        "seriesNumber" : "P1spcLarjKHmobX",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f2db4b49-2614-4db5-be43-58dabbfee75f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e8e1594a-6e54-4b11-9eb6-239060ea81f7",
           "valid" : true
         },
-        "isbnList" : [ "9781911547532", "9780984864058" ],
+        "isbnList" : [ "9790081405399", "9780443916700" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0984864059"
+          "value" : "0443916705"
         } ]
       },
-      "doi" : "https://www.example.org/c1e56c9d-e50f-4e6f-8f56-cabeaf988845",
+      "doi" : "https://www.example.org/c52662b7-7301-418a-bd68-80733b9e81af",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "K6yVr7rTm4poxVD",
-            "end" : "saA6AkL19ItKDq7MT"
+            "begin" : "AAjNDbN9zp",
+            "end" : "knauK5kQK3"
           },
-          "pages" : "jSVoS0UaqFronRY",
-          "illustrated" : true
+          "pages" : "UObj8LoyyRPKetKlG",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/32f136e3-9846-4f1e-8bc2-4e060c3473a1",
-    "abstract" : "USzF7ZB99SkI"
+    "metadataSource" : "https://www.example.org/8f4fdb8d-1e44-472f-8ae1-8ad988c40807",
+    "abstract" : "FvVweMWThV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/57de2cf2-8d8f-46ff-bb5b-84378eeaee98",
-    "name" : "PxcgSd815Ve042D",
+    "id" : "https://www.example.org/e4086712-f4f4-42de-ada8-ec2e9157e45e",
+    "name" : "U6sgds7BFx",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-01-01T13:24:55.589Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "WDThknOscs1"
+      "approvalDate" : "2001-04-10T00:47:40.905Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "maSPQp3F4NfL58"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/be3637b5-cc99-4a49-81ca-461afcc07d19",
-    "identifier" : "ujgZNPqQCLb",
+    "source" : "https://www.example.org/61248c58-30b2-4164-b405-94fd2ba7a73b",
+    "identifier" : "kikNxl6Yzf4ovO",
     "labels" : {
-      "fr" : "GkyIEHJWUNzdhUiA67"
+      "nn" : "TiuaxK2y0M"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 690091515
+      "currency" : "EUR",
+      "amount" : 2061538629
     },
-    "activeFrom" : "1998-11-26T04:55:25.995Z",
-    "activeTo" : "2010-09-02T04:03:52.366Z"
+    "activeFrom" : "1973-11-18T15:20:44.037Z",
+    "activeTo" : "2004-06-25T08:11:43.587Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/bad5cb0e-5b6c-4b2b-a48f-1d7ea64d98c4",
-    "id" : "https://www.example.org/dfd9eb69-6e39-4e04-85d2-4ca12053b395",
-    "identifier" : "u0ruDfVLA7x7wId2",
+    "source" : "https://www.example.org/71cb1865-b487-45b9-8a43-c6f9f9ddae1a",
+    "id" : "https://www.example.org/e6e0b2ca-5a2c-49c5-9ff4-e3fb2f85019d",
+    "identifier" : "lTWVsTmg5ZQTUDPp164",
     "labels" : {
-      "is" : "9JAwgq02INqXt"
+      "is" : "YRaDIHKN05NgJ6usBIu"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1309400038
+      "currency" : "EUR",
+      "amount" : 387158803
     },
-    "activeFrom" : "2023-08-14T11:25:49.423Z",
-    "activeTo" : "2024-03-12T20:01:38.527Z"
+    "activeFrom" : "1994-09-10T07:20:16.662Z",
+    "activeTo" : "1999-05-11T18:05:32.951Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2a1dd2f5-57f8-4017-ab9c-e7237121c6c9" ],
+  "subjects" : [ "https://www.example.org/f1c71644-43a8-411a-afe9-1d9608fc1f8d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b43d6d48-ad6f-4e31-9b3d-5bea62c0d850",
-    "name" : "lyA7IyL0nyCp",
-    "mimeType" : "UCJI5g1mUUHHC",
-    "size" : 151341786,
-    "license" : "https://www.example.com/ymzuhzayyvniobkxc",
+    "identifier" : "0dea26d3-088f-4a56-b8c7-bf6c628af43d",
+    "name" : "h9ukWNmQBHKn",
+    "mimeType" : "gN5jsiG88QHsgmS6p",
+    "size" : 361977825,
+    "license" : "https://www.example.com/4p1smumynyrf03nij",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "9KvMsvgHcxQ"
     },
-    "legalNote" : "qSZJf7j96ffiCIUcBTb",
-    "publishedDate" : "1992-11-22T03:59:51.342Z",
+    "legalNote" : "hUmSAAL6TXp7",
+    "publishedDate" : "2014-11-07T02:00:35.399Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "snq5AgWbACaYwqaZcmr",
-      "uploadedDate" : "2001-03-22T12:04:27.981Z"
+      "uploadedBy" : "izwjtitwecMYyf",
+      "uploadedDate" : "1996-01-18T07:49:17.056Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KbIurUFxsA",
-    "name" : "u8YGqQ0WN1eIVe",
-    "description" : "xRlL7GKAB3YcBb"
+    "id" : "https://www.example.com/rOyINEOZsb90BUC",
+    "name" : "8dIgLXVzWZJQ6K",
+    "description" : "VomjnYct4f4KqGsY96r"
   } ],
-  "rightsHolder" : "v81HYD0G97r",
-  "duplicateOf" : "https://www.example.org/149590e0-8ccf-4b99-b02a-f7c9bbace6ea",
+  "rightsHolder" : "PCVzQkEiZn3JnhSGPq",
+  "duplicateOf" : "https://www.example.org/a47772dd-e1e5-4116-bc5e-0bdacbc51d5b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ApXN7Mqlnl7"
+    "note" : "64TP2ttsXvxGzzX9wO"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "E5yD0FU0tSQzG5gIM",
-    "createdBy" : "VhmbkWjrxnDa0",
-    "createdDate" : "2018-01-19T02:06:53.724Z"
+    "note" : "iWaciSnLEXWZQjCNTQP",
+    "createdBy" : "H2LFr76x6vPUZGVIUQ2",
+    "createdDate" : "1986-05-01T09:49:53.732Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/35026150-6838-4122-a8fb-8a69e25e2f2d" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/1cba5f8f-05dd-4f76-8a78-c89603786d5a" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "QRdGclPTMTNfL",
-    "ownerAffiliation" : "https://www.example.org/bd9a41d0-5e6b-46ef-bb95-69b37029731a"
+    "owner" : "dFdkPsQG343jvVf",
+    "ownerAffiliation" : "https://www.example.org/e89580e0-d353-4834-92af-124e093232c2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1a825028-6911-420d-9db3-d7382a25f45b"
+    "id" : "https://www.example.org/1871164c-7b7d-4890-9f6a-76f0bca77a7b"
   },
-  "createdDate" : "1988-11-24T11:03:29.226Z",
-  "modifiedDate" : "1982-08-28T08:05:11.600Z",
-  "publishedDate" : "1997-05-11T01:53:49.633Z",
-  "indexedDate" : "1977-03-16T07:31:09.741Z",
-  "handle" : "https://www.example.org/a9f67258-8512-4105-b3b5-c724d99dac79",
-  "doi" : "https://doi.org/10.1234/eveniet",
-  "link" : "https://www.example.org/26017fb5-b0e7-42b8-8efe-78b9e8a2c825",
+  "createdDate" : "2017-11-17T02:24:00.852Z",
+  "modifiedDate" : "2011-03-22T07:47:07.720Z",
+  "publishedDate" : "1984-02-10T04:58:10.950Z",
+  "indexedDate" : "1978-01-12T04:04:53.830Z",
+  "handle" : "https://www.example.org/f048128a-745d-46a4-868f-80ff0f0eb2de",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/c31233c1-b81e-413a-b69a-4ee69b73f6d7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LzdWJ8o6b6",
+    "mainTitle" : "uYATgoDCRJ2rKG5GopL",
     "alternativeTitles" : {
-      "nb" : "9YmS3rfgY8vr7"
+      "af" : "lKclaGTTkLE"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "IGOpGZwXzbtlCVaq59r",
-      "month" : "IINWAA8S7zPg",
-      "day" : "LuO3H1sk9cIb"
+      "year" : "VPNqVmYOqmRf",
+      "month" : "5jWHVJKCY3PQEBGvHb",
+      "day" : "2VXDt4yEu8Z8CxVh2E"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/45e5547f-8c62-4c1c-954a-03ef8498a919",
-        "name" : "qLfDJ8veDF",
-        "nameType" : "Personal",
-        "orcId" : "CTDTitwjvXhG779uUn",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/8d733488-6c87-406e-86fe-c4cd4b61b506",
+        "name" : "BeHMsVor2l22Hf",
+        "nameType" : "Organizational",
+        "orcId" : "m0d3jjwp5tGmgwC",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DQC0sEgJ1jD3",
-          "value" : "7vnjos0N2LNvm3L4mfN"
+          "sourceName" : "JRYFrPUqw43Y2kE2bT",
+          "value" : "sNo4DoqPMC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8YaFipLMSRMsylMyT",
-          "value" : "EjU4XQBozF2ynZ0"
+          "sourceName" : "B1d19p3wNfbNNabVQV",
+          "value" : "4KZtm055roeHa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0a117d08-d7ec-4323-b5a9-eded5498af2e"
+        "id" : "https://www.example.org/adc57986-fb59-4557-a854-c7fe7ccfd951"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bc8428fa-2509-4b1b-87cf-408d97b5811d",
-        "name" : "GR6XanIBYTAn",
-        "nameType" : "Organizational",
-        "orcId" : "qG45UDP4REN3",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c4379b99-b9ae-422a-bf4f-5491d054cafb",
+        "name" : "xHSW3wBvHX",
+        "nameType" : "Personal",
+        "orcId" : "lBuEWanrMC0fK",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0K12T8QKXj",
-          "value" : "7G6AUJWFvVj5"
+          "sourceName" : "qPP5O2rO1I31",
+          "value" : "mmexMyxQHneeRvNe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pvXLSwj7xhQCQIQ0",
-          "value" : "YUJYh5NhCH5fVRTuy"
+          "sourceName" : "uPNgGWZGPSA00",
+          "value" : "yJqd33o9U4OaEJT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cf728890-01f5-41a3-bb77-370b96428ae0"
+        "id" : "https://www.example.org/6a493b9a-3021-4c72-8875-e5d486bfa7da"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "2z2PMNeLc4"
+      "de" : "8azEYwbEJveq10UAc"
     },
-    "npiSubjectHeading" : "zwWn1jjLa1PpGFyU2q",
-    "tags" : [ "vZVLj5MrTe" ],
-    "description" : "6K34wCCGxx20",
+    "npiSubjectHeading" : "DZ47Bbii0iQv9z",
+    "tags" : [ "ig6EYmh6BTtJRLM6T" ],
+    "description" : "OintUX2XKG0ZIYZhC86",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/171f09e8-0007-40c7-8443-06dd07eb9a9b"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6401de41-55d7-4555-aa41-423854e55405"
       },
-      "doi" : "https://www.example.org/2b654a91-103b-4a82-94c8-7d59b21d7cce",
+      "doi" : "https://www.example.org/acf7a64c-62ef-4992-b6fa-c53c94a0248f",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "sLUHFoBULJ5KMr",
-          "end" : "t9XRlHcLbgBiruquB62"
+          "begin" : "PEvNih46bcVt",
+          "end" : "mxuR7L0BGeX"
         },
-        "volume" : "JrtOZwJHDTPubcBqCU",
-        "issue" : "gWd89h5Nk6iSjUdtK",
-        "articleNumber" : "OEWBZvvYIPv"
+        "volume" : "W52xH9BnBl7uGQ",
+        "issue" : "L13cZMLEAlbUb9",
+        "articleNumber" : "3QeSVz2D9BSEP"
       }
     },
-    "metadataSource" : "https://www.example.org/bbe76e0e-6775-4559-bda4-43db4f95f0af",
-    "abstract" : "2uuKgxM9jBhkAHVjI"
+    "metadataSource" : "https://www.example.org/60cc3984-ecac-4dac-aa48-b61297272623",
+    "abstract" : "EoWiW3t8cl5Pn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6dc12440-0255-416c-a90f-815130837c2c",
-    "name" : "5vM2usVQwvW",
+    "id" : "https://www.example.org/228cd71d-1342-46f7-bc6e-4713f5c01596",
+    "name" : "1h5JYkWZRw2d",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-04-17T17:26:32.419Z",
+      "approvalDate" : "2021-10-29T19:15:57.833Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "xyQxfKYe12XEI"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "vLfcOjuuvuVhGorlid"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ce709e47-ddf1-4f02-8a17-613a1bb21720",
-    "identifier" : "PlK7ZFDg9HC5",
+    "source" : "https://www.example.org/5484b937-eb24-4ada-84d6-3c3677a9ec9d",
+    "identifier" : "Aqz4sqA2B6ECymHyz",
     "labels" : {
-      "nb" : "tMxsnz3TjHgQufCX1L"
+      "pl" : "WZhwBEgGaN"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 679284484
+      "amount" : 48330919
     },
-    "activeFrom" : "1997-05-08T11:24:36.078Z",
-    "activeTo" : "2024-04-16T16:08:33.907Z"
+    "activeFrom" : "2017-06-18T03:12:36.295Z",
+    "activeTo" : "2023-10-29T18:12:42.788Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e3144bd8-7e2d-42b8-af0b-21123410388d",
-    "id" : "https://www.example.org/d4a5863a-f467-4af9-aa00-9ac9d6615c5a",
-    "identifier" : "JugN7FnY6FuTtT1vS8q",
+    "source" : "https://www.example.org/17ac7994-ae18-4d17-b97a-8812eab1dec4",
+    "id" : "https://www.example.org/7024e124-4380-4e88-9b7a-e58ce8dd94e4",
+    "identifier" : "my7kpiAXAeew2jWE4",
     "labels" : {
-      "fi" : "98pxUfyPIMFxoEsU92"
+      "fi" : "cwbodQq9lX7m7yq"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1553971561
+      "amount" : 848864072
     },
-    "activeFrom" : "1972-10-25T17:33:37.114Z",
-    "activeTo" : "1998-01-13T20:52:54.414Z"
+    "activeFrom" : "2021-03-29T09:12:13.567Z",
+    "activeTo" : "2022-04-09T00:49:31.181Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/40f19ed7-7ecc-4fb2-bdf4-13f731c820d0" ],
+  "subjects" : [ "https://www.example.org/d22e10b1-bc1c-40b2-8bf2-ba36d4d3724a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "70f63793-49b3-4f8b-a575-8d27fe479925",
-    "name" : "TMtC99Yh1OMlU",
-    "mimeType" : "uyYRDkit6Q3yUBV0qr",
-    "size" : 409537155,
-    "license" : "https://www.example.com/xplekwpp2ufydzxeyr",
+    "identifier" : "d310674b-2ca8-411b-a80c-6bdf66a03389",
+    "name" : "MhWngaU8BPcEIvpR",
+    "mimeType" : "U9WX5JQTWqObFTiE80J",
+    "size" : 1323772446,
+    "license" : "https://www.example.com/pza5yuvivxdo3i3s",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "9Bo9kuHxwQ0hendJ",
-    "publishedDate" : "2001-09-09T04:02:38.223Z",
+    "legalNote" : "kzdCUKNmNk",
+    "publishedDate" : "2020-11-11T14:14:21.534Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "DtbLYZcIbzFSz",
-      "uploadedDate" : "2022-03-16T13:22:46.641Z"
+      "uploadedBy" : "GphC3grfLp",
+      "uploadedDate" : "2001-09-10T23:40:25.662Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/RS9MTmtaie0PTEk5",
-    "name" : "rac7lDzqiqEMBCqIIVq",
-    "description" : "A6R2UE9dfQMYxY0fBCG"
+    "id" : "https://www.example.com/rNtXXW1KWBHMuTLqQy",
+    "name" : "isCuvphnvVi",
+    "description" : "cp3DbnkjtL"
   } ],
-  "rightsHolder" : "0MTocsPULuLRjVf3oBm",
-  "duplicateOf" : "https://www.example.org/f9f14a16-8862-44d8-8ba4-b785d6ecc18a",
+  "rightsHolder" : "9GU5SrsFvs1yw",
+  "duplicateOf" : "https://www.example.org/fcd96573-bccb-407d-a6ce-ad694f61fa0a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "AFl1v4lCAGZhRWLVsF"
+    "note" : "2gKouRh31unyr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "y3SpUiZfMB0aej",
-    "createdBy" : "QGW58loIeWhIROwgVW",
-    "createdDate" : "1985-05-02T20:27:52.074Z"
+    "note" : "CeABM33DfKCf8",
+    "createdBy" : "PbRFkDIcBGWEKo",
+    "createdDate" : "1989-08-13T16:08:31.310Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/58ab853d-29f2-4a09-adf0-849fd6e47d6d" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/371922eb-17e1-4d33-8a2c-09cd4030c71b" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "HnSMmiCsH646",
-    "ownerAffiliation" : "https://www.example.org/d4ce0af6-7225-45c3-bd78-29c94138935c"
+    "owner" : "Ihj0Nq3WOER1B",
+    "ownerAffiliation" : "https://www.example.org/9a2483a6-0326-4111-b6d3-5e8878a5c359"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/78ad029b-a016-4037-9b62-a37acd1d0dca"
+    "id" : "https://www.example.org/bf0b84c1-cb99-45cf-a1c0-7e5348689c91"
   },
-  "createdDate" : "2007-06-16T22:04:11.072Z",
-  "modifiedDate" : "1988-02-03T14:02:36.164Z",
-  "publishedDate" : "1978-01-18T20:10:44.075Z",
-  "indexedDate" : "2007-08-28T09:54:05.318Z",
-  "handle" : "https://www.example.org/717ec245-6f9b-443b-9f96-8134807c777f",
-  "doi" : "https://doi.org/10.1234/sint",
-  "link" : "https://www.example.org/7de95ca2-9381-49b6-8c13-d4011205580d",
+  "createdDate" : "1985-12-12T09:38:19.259Z",
+  "modifiedDate" : "2001-01-14T06:37:55.228Z",
+  "publishedDate" : "1978-01-12T17:37:04.742Z",
+  "indexedDate" : "1990-12-29T18:49:32.691Z",
+  "handle" : "https://www.example.org/c952adaf-67fe-4991-8497-e5a70d99be27",
+  "doi" : "https://doi.org/10.1234/voluptate",
+  "link" : "https://www.example.org/40a86a3a-9c70-4a33-8d0d-1c67c0e692d5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LSDyqIRtzKo6P0oRKX",
+    "mainTitle" : "Hi1JodxqHa9eb4C7f",
     "alternativeTitles" : {
-      "en" : "a28bgvzjUejouQ9bG"
+      "it" : "tNbBRH7XuonG"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "evua7HXslpkzy9K",
-      "month" : "SVrrvYgVd81hVg",
-      "day" : "swXUjlDdph"
+      "year" : "W5gyGIR75CkTh6npG",
+      "month" : "EXpmEPPhVN5D2l",
+      "day" : "yx5kF8IZiuqLd22GDpm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/584402be-cae3-4d92-a0dc-1a599e4d1bbb",
-        "name" : "1SREo47QyDh",
+        "id" : "https://www.example.org/1f9fb192-70a4-4def-a741-f9377177117c",
+        "name" : "GjyYqS9UNtkB",
         "nameType" : "Organizational",
-        "orcId" : "WCUWkQcsTA21Rip2kf",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "yu8mk1p5vJJ2YEn8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gacdwKl2K5tivLSCSz",
-          "value" : "g3HEw92ODF4CQ"
+          "sourceName" : "o8MLGYhK9BtM8bwNcX",
+          "value" : "R1MEjuxpTPCx8qGZf3D"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "poAesWG15PPL",
-          "value" : "aeryrEGxb6YFBJcTF"
+          "sourceName" : "FRJRcss9qIa5",
+          "value" : "Bd16V5ZbORpCb2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8a7c0a8e-fe40-4f34-a944-0acc5ffc20ec"
+        "id" : "https://www.example.org/fadf4bad-8333-44ec-babb-bad7bf70b9c4"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f5d23b48-b0f3-4724-8634-bc1782540150",
-        "name" : "qK9LP3KifG8APCZ",
+        "id" : "https://www.example.org/d2c889ab-6227-4a5a-a2fa-2d555691de4d",
+        "name" : "fKMSm9fFf5D3vZr",
         "nameType" : "Personal",
-        "orcId" : "YxKRUXKV56L",
+        "orcId" : "WvVJgXj9Dl2",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jb7ciCuVcsmKA",
-          "value" : "UlVQY4MGA2ymhSCFWK"
+          "sourceName" : "DzOwHmQyB8O8PF",
+          "value" : "rL35FXNxDUZIe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7ySfx2Jk8ytz6zNNeh",
-          "value" : "9GWXQng5jDxNGRs"
+          "sourceName" : "i6sRnZ09qMegnEb",
+          "value" : "PjQHxAlVmGyTRs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e09d16e7-bbea-4b8a-8bb2-2ba5e5bec702"
+        "id" : "https://www.example.org/3c049106-536b-4a83-bea4-69bb379e6882"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Actor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "nVrdX7kUehlhf29"
+      "ru" : "YZSKhhvxiz0RT"
     },
-    "npiSubjectHeading" : "7OXSXKCdg79eU5",
-    "tags" : [ "cpnX8Uokzfhm7Q43" ],
-    "description" : "gBzialnncWl4Pv8o3dL",
+    "npiSubjectHeading" : "YUt4vRcwq3LT1",
+    "tags" : [ "a2IBnfmbDlMFgioN" ],
+    "description" : "q0CDwDX6X8fFRmqJHV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/54171f92-97e0-460c-8caa-3fb4b9d2df3b"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1331c0d8-6a59-4c53-8c91-e1cef71ef6ef"
         },
-        "seriesNumber" : "bw2tXcxiMQq93V95UsP",
+        "seriesNumber" : "Gpi1DD6hD67DnT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dfebb045-43fa-4ac1-aebb-b4f1808786b1",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/72732341-18d7-4cc7-94ea-40e249c13840",
           "valid" : true
         },
-        "isbnList" : [ "9780999861813", "9781869049300" ],
+        "isbnList" : [ "9780901414106", "9781096930426" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1869049306"
+          "value" : "1096930420"
         } ]
       },
-      "doi" : "https://www.example.org/30779af6-36c0-46d4-ad9f-f5d718d9e233",
+      "doi" : "https://www.example.org/bd165bd2-600c-41c2-9964-4d609330ec80",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "x6ArMX3yEwT5VI9",
-            "end" : "9vvNi12YC1iv"
+            "begin" : "C0NGIX5lT6h2eCnd10h",
+            "end" : "FWoHhnGz1ZGWD1Ul"
           },
-          "pages" : "dhHdiF8vgEUVRzE4huz",
-          "illustrated" : false
+          "pages" : "DtSVl5s9XI8TUu",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3ab0b425-29e1-4489-88ed-1752e284de33",
-    "abstract" : "SRMMo2bbN0kZ0M43yO"
+    "metadataSource" : "https://www.example.org/b454578d-bcf6-4020-9b61-c47273795717",
+    "abstract" : "6eoBxnjOkrrwhp"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b4a07528-8f56-4c69-a803-9bd18589d533",
-    "name" : "veDg9JOsJh7m",
+    "id" : "https://www.example.org/18c8e403-6d2b-4ead-9ac3-faf07d188592",
+    "name" : "AJFUUFXosb",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-08-25T13:54:39.134Z",
+      "approvalDate" : "2009-09-18T12:38:19.329Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "6SfKPBnddPJvFcsC"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "K8wY8KSmKM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cea6bf63-f288-4c15-b340-de8077411330",
-    "identifier" : "bskXpARLHCFnu",
+    "source" : "https://www.example.org/f0c7d818-937e-4cdf-ad98-c3052b928d6d",
+    "identifier" : "DBuBsCORjCOh7Af",
     "labels" : {
-      "nl" : "aSWZMXUKCaJh"
+      "nb" : "1a0IfSZXNc11hmksK"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 76444735
+      "currency" : "GBP",
+      "amount" : 610253791
     },
-    "activeFrom" : "1978-10-13T04:03:49.294Z",
-    "activeTo" : "1995-03-20T07:57:42.187Z"
+    "activeFrom" : "2002-02-15T15:30:08.227Z",
+    "activeTo" : "2005-07-16T09:34:40.024Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/07e403ae-d25f-4e01-b1f4-519fe16c63b2",
-    "id" : "https://www.example.org/f58feefa-6840-4216-be97-a1e1b0ce7997",
-    "identifier" : "qOKzqbhi1t",
+    "source" : "https://www.example.org/09c1e033-ad88-46e2-92c2-f51fd3d517fc",
+    "id" : "https://www.example.org/291ccbaf-a500-4771-bd7d-3e6133e7fd85",
+    "identifier" : "8PweIDsqfdAt6yiUj",
     "labels" : {
-      "se" : "CHhw79iICEqbgsJn9eq"
+      "zh" : "mtGsMw1EY9rGu"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1230039442
+      "amount" : 2118608968
     },
-    "activeFrom" : "1987-10-03T02:52:06.184Z",
-    "activeTo" : "2021-11-27T19:30:12.703Z"
+    "activeFrom" : "2016-10-07T15:37:07.246Z",
+    "activeTo" : "2017-07-26T12:58:05.820Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4aef3527-a467-42fe-9d81-5083c73226fa" ],
+  "subjects" : [ "https://www.example.org/099ce071-50d4-441f-8d36-1a8c9a865cac" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "771d4da9-ad37-4a55-bf10-94eb9a246074",
-    "name" : "ScBTzHFAP4",
-    "mimeType" : "X0928KXmsIX33Z",
-    "size" : 201625931,
-    "license" : "https://www.example.com/olhxgkbvnegfoi0bu3d",
+    "identifier" : "2b47ba97-9c91-4d68-8706-ef303dc1c8a5",
+    "name" : "noCgq15C0mD",
+    "mimeType" : "25djrrgBRr",
+    "size" : 2072010334,
+    "license" : "https://www.example.com/awzfrxnwwsigcpacvbn",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "vpPHlk9XNz"
     },
-    "legalNote" : "8dVGtbMkqx53Gj",
-    "publishedDate" : "2008-07-18T05:43:08.251Z",
+    "legalNote" : "XB3xGJA3Rxrv6yQv3i",
+    "publishedDate" : "2003-07-11T09:58:35.268Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "QFQn25Eu2b",
-      "uploadedDate" : "1977-11-16T15:20:02.317Z"
+      "uploadedBy" : "dmN6wKvciSAr0",
+      "uploadedDate" : "1996-02-01T21:57:30.673Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/U1YwEEP5QBYcQKy3u",
-    "name" : "6Rjt8AGGU9ZJP",
-    "description" : "wOArepU56s66DqzBQOf"
+    "id" : "https://www.example.com/RrKjk3pGf0J9t",
+    "name" : "gzRa8ojmHeEd25rwa",
+    "description" : "44jqegkuzO5gU6tp6"
   } ],
-  "rightsHolder" : "HVSFCEO2xWa",
-  "duplicateOf" : "https://www.example.org/756e3df9-ea76-41a0-937f-b29467a07d5a",
+  "rightsHolder" : "uUBv6NZOsevCfGzEJjC",
+  "duplicateOf" : "https://www.example.org/e94b2ee0-d3f5-4373-ad95-ede7e81c0d1c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "j2DHDPeefsm4ZavbK"
+    "note" : "kpNaB2zW5dmDR8m1DD0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "5EBoecMCeop46",
-    "createdBy" : "5314YDjh7xBJq",
-    "createdDate" : "2021-03-28T04:08:34.327Z"
+    "note" : "sS6yziZejTcT5Q",
+    "createdBy" : "hyuLwBLwgv9YqxrbRT",
+    "createdDate" : "1987-08-11T15:25:55.174Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b9b866c8-2566-4144-acb9-1534a3dfac18" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/3d703e10-b8bb-42b0-b5cb-784d00b927f2" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "2XgR2qwHbyFduxEu",
-    "ownerAffiliation" : "https://www.example.org/6375529d-f998-4d8e-9f73-5ddfeccc7566"
+    "owner" : "ePqMqY82ED",
+    "ownerAffiliation" : "https://www.example.org/d8badac0-e44f-4c9e-9426-c461f108ca74"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5c94c9e0-7b79-4019-b66c-29a0cf931de7"
+    "id" : "https://www.example.org/8dbf79d1-6ae7-494d-b665-506508df081d"
   },
-  "createdDate" : "2014-05-15T14:38:27.182Z",
-  "modifiedDate" : "1978-09-25T20:03:25.315Z",
-  "publishedDate" : "1993-01-06T00:18:19.375Z",
-  "indexedDate" : "1972-07-28T12:47:07.943Z",
-  "handle" : "https://www.example.org/9126d70f-1f0e-414f-8c3d-6f7928e0f223",
-  "doi" : "https://doi.org/10.1234/rerum",
-  "link" : "https://www.example.org/081cf461-57b2-4b59-9afd-cbf4e13e66ef",
+  "createdDate" : "1992-01-07T19:41:30.260Z",
+  "modifiedDate" : "2016-12-03T08:27:55.376Z",
+  "publishedDate" : "2008-04-22T05:18:59.523Z",
+  "indexedDate" : "1989-01-23T11:59:35.459Z",
+  "handle" : "https://www.example.org/0e863704-31da-4ec3-a3c1-e1f49ac59b58",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/f6475ffd-63e7-439c-9cf0-88d190c0dbe1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mig3wlietKSlN",
+    "mainTitle" : "l1GrE7BLS0fQFso",
     "alternativeTitles" : {
-      "af" : "8K9Nvh3S3oACUZHHES"
+      "pl" : "RD0NVI5pnf4knghu24"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "81v7gtPuzYLvl",
-      "month" : "dtle84CSLnsOAo58t",
-      "day" : "JrBFoKrpdNlbsr5ZO"
+      "year" : "ebrApd9W4fddgIbX1tY",
+      "month" : "kfIA1TGNq6PVfo0q",
+      "day" : "W1VKyRaoygjQnKvvF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a4485c4f-3167-43a7-88bc-8e468b685d1b",
-        "name" : "AzXLrm6TkMqOFrEtKVe",
+        "id" : "https://www.example.org/334a7240-f9db-42e5-a3b4-055fbe066ae6",
+        "name" : "IyHm3OqWGUCabXby6c",
         "nameType" : "Personal",
-        "orcId" : "LraljwVTmdqVURSz6k",
+        "orcId" : "YAn5Ps5yO1",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fqc3lO9tAgkcor",
-          "value" : "ic4KXcrd81RIZ"
+          "sourceName" : "YZnR2qfKlsqcRfI71hb",
+          "value" : "NEf3UYmrkb7H5L3wyNJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zUWmKDCpU8GDv",
-          "value" : "2kBzpFjwFRpNDLeVU"
+          "sourceName" : "PaQOiiEadLyHM",
+          "value" : "eDtyzUEdwSoklxYaf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/99edee4c-1945-44f4-bff1-05da0c287ad2"
+        "id" : "https://www.example.org/342c37b4-f59c-4c29-aa8e-70d92a3ddbd8"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5f8b29cd-a2cf-4b57-9d70-38f6afe72cc4",
-        "name" : "kr5N5Q9FSKhULB",
+        "id" : "https://www.example.org/1a1671e6-c896-4ff5-aece-61f10377bc5a",
+        "name" : "ArC6yGdj0G349Z",
         "nameType" : "Organizational",
-        "orcId" : "SjKfsfF2GMuLpoYE",
+        "orcId" : "mNPQTOmCbwAniS",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "h9gcERXvOsvTJjoJ",
-          "value" : "GEwbqwuzOMbQDPyv"
+          "sourceName" : "nrdw0BRc2I",
+          "value" : "qKwT49E6gJHA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "abcO99Yj1ZV",
-          "value" : "CeLWKsfmuXs8Mis"
+          "sourceName" : "FpCXPW00XX",
+          "value" : "cHXqHjYgWD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d87c3a0a-2e3d-466e-8a12-6dcde707a070"
+        "id" : "https://www.example.org/0fb1b84e-9873-4cb8-9e8a-0201c4b05211"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "EDsVGI6T356kY"
+      "pt" : "udGXwgCUvZwCYVn"
     },
-    "npiSubjectHeading" : "nJVJvtgldM2gN",
-    "tags" : [ "Hcw66Sp6lR1gj817Bv6" ],
-    "description" : "nlsCr5iyxJ",
+    "npiSubjectHeading" : "M5hKXChdZhq",
+    "tags" : [ "P4jL8CUwjzzlA6" ],
+    "description" : "scalRHharg77MtpxRSe",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6f0b77dd-ee54-4544-b529-e0794b4d23e1"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1e16eba5-c21d-4336-a761-3992909249fe"
         },
-        "seriesNumber" : "jhaTvGCF5Dl7xkEBM",
+        "seriesNumber" : "NwgUMOgcUiR3y",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/440abba3-06b6-4116-aa51-8779de71880d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2e74195a-5259-4233-a523-e4ba4cd73146",
           "valid" : true
         },
-        "isbnList" : [ "9781218961130", "9781375900737" ],
+        "isbnList" : [ "9791987037196", "9781891906046" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1375900730"
+          "value" : "1891906046"
         } ]
       },
-      "doi" : "https://www.example.org/ade56242-0c67-42ff-bf25-10e820173950",
+      "doi" : "https://www.example.org/ba9ffb22-cba1-4024-abc3-4a1a1f604194",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "vGZ2l6zHQhuQm3Y6",
-            "end" : "Z41Goi6m5nt93GOL"
+            "begin" : "AEBRLUUJ7A8zGDT46",
+            "end" : "DNiIYebqALF"
           },
-          "pages" : "AYGvPKAYD5e9",
+          "pages" : "t7q4CweDj3",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fc21c879-bf94-407e-b5a1-331e6cbbfba7",
-    "abstract" : "vd2UW1hd1qJfJajm"
+    "metadataSource" : "https://www.example.org/9fbe1007-ae6a-4da3-8f16-8da1936cad22",
+    "abstract" : "JbmV8iMMmYb8v"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f55815d5-e474-4f86-b28d-d6e9704201a9",
-    "name" : "qv7fDffo51nfiB",
+    "id" : "https://www.example.org/a066877e-7f43-41e5-95eb-2f054b526642",
+    "name" : "mN2bchJgY9lsK8Y",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-03-05T03:01:56.200Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "bbFPXWfJP7Z7lodASk"
+      "approvalDate" : "1978-06-01T16:50:07.923Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "mWIQU12kZBJP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/26d5280c-8f22-4427-a530-79ae085d647b",
-    "identifier" : "k2UsMTxulREaBYQxoij",
+    "source" : "https://www.example.org/ad043ab3-fa13-419b-9ed3-5a6624aabc96",
+    "identifier" : "wvueBMpYuq",
     "labels" : {
-      "sv" : "xRnS85IqdeMnhxn"
+      "af" : "4QZtMvK6GIOdS1"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1913307862
+      "currency" : "EUR",
+      "amount" : 500520770
     },
-    "activeFrom" : "2020-07-14T07:00:25.251Z",
-    "activeTo" : "2021-09-22T00:18:59.471Z"
+    "activeFrom" : "2001-08-26T14:13:50.850Z",
+    "activeTo" : "2004-02-22T20:48:10.590Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/14e46101-e2d4-426b-bb06-16c86962e05d",
-    "id" : "https://www.example.org/8f15e4e9-612a-4dc4-8467-ccf161903b64",
-    "identifier" : "Zj1xNiPTksC2",
+    "source" : "https://www.example.org/cda7d84d-cace-4a1f-8666-7dccc35fe125",
+    "id" : "https://www.example.org/fee01f50-a31b-4d2a-9cb5-c2902e0804a1",
+    "identifier" : "jSY7voBmJQL1fnqZ",
     "labels" : {
-      "de" : "HY56tH1igPvX"
+      "is" : "3vTdsO14DYNZ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 132797976
+      "currency" : "USD",
+      "amount" : 1040109671
     },
-    "activeFrom" : "2018-06-09T15:39:24.195Z",
-    "activeTo" : "2022-02-03T17:10:21.902Z"
+    "activeFrom" : "1977-11-24T05:08:38.629Z",
+    "activeTo" : "2018-07-31T21:00:44.339Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5380a7a2-27fb-480b-9bd5-c157ec0d0ed5" ],
+  "subjects" : [ "https://www.example.org/c5c9ab38-1ea1-469c-8da2-cb511e3c53de" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bf08e827-9d57-42eb-a4a2-5ed3b40e7e63",
-    "name" : "UE6ZiYHuiw8FUexV",
-    "mimeType" : "GaWrbkdvU2uDraamzSa",
-    "size" : 2124923706,
-    "license" : "https://www.example.com/xggrfuzc1w",
+    "identifier" : "73a7f2da-db29-40c6-b551-b500c7e64fc7",
+    "name" : "M1z07YpQfD6Gm",
+    "mimeType" : "SFaclVNl6NJ",
+    "size" : 417682343,
+    "license" : "https://www.example.com/xux5efq9eo",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "EBWt9GQP92NaiqtWpA",
-    "publishedDate" : "1985-11-18T05:01:49.053Z",
+    "legalNote" : "Qs0gXno38PLDlZzdxlC",
+    "publishedDate" : "1988-09-30T10:12:00.997Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "RRqhcjqmke88xYtpE",
-      "uploadedDate" : "2010-07-06T11:53:15.574Z"
+      "uploadedBy" : "zh4Hsz8rv5fH57w",
+      "uploadedDate" : "1979-04-18T12:28:33.349Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/jnzsrFyiBni3hBNB",
-    "name" : "G3Ugt0AD9XdYapmVi",
-    "description" : "emgCd8J52Sdq8kt"
+    "id" : "https://www.example.com/eCK60GIV4oO",
+    "name" : "qZo5xEjD2q3aQ",
+    "description" : "XZSGntrUVoPFa1JhIC"
   } ],
-  "rightsHolder" : "v2h4dYEMpQQzGC0rAnI",
-  "duplicateOf" : "https://www.example.org/7f45fba8-3d6c-4c48-8055-ea671114ddf5",
+  "rightsHolder" : "PF0CERWLHSTJh21psDh",
+  "duplicateOf" : "https://www.example.org/409093fc-8fa4-475a-aff9-f8f0c1f40a1b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "qfBB5BYF03bTWaKzd"
+    "note" : "SuxIjzL4J5xiUdvaZy0"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QJDiq7FJYzbP",
-    "createdBy" : "BEIwT7ZBA0GrDyI",
-    "createdDate" : "1977-06-22T22:43:32.036Z"
+    "note" : "DpJIgtf6gFCaNRb",
+    "createdBy" : "TOBdMM7D7NCu2Wo",
+    "createdDate" : "1974-09-15T23:44:53.096Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b5d535b1-b6dc-4de6-a4cc-4e2232ccb29d" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/a4a46da1-07d2-40e2-bfca-f8e38b74ba0b" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "90DfwloxCUYz",
-    "ownerAffiliation" : "https://www.example.org/6dee42d6-15f1-44fe-bcde-b4a33c0cd38b"
+    "owner" : "xshFtWXerR97F8c8",
+    "ownerAffiliation" : "https://www.example.org/5d4919d3-9f5c-4331-95a2-2683b47f9463"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/77cd123c-fef3-4614-ab63-45c261fa90a0"
+    "id" : "https://www.example.org/b77cdc45-bd4f-4b55-af38-382f831060d9"
   },
-  "createdDate" : "2024-05-20T20:09:54.198Z",
-  "modifiedDate" : "2022-09-05T21:56:15.015Z",
-  "publishedDate" : "2017-03-07T20:08:21.330Z",
-  "indexedDate" : "2006-10-10T22:12:03.753Z",
-  "handle" : "https://www.example.org/3bbf34a8-74e7-469e-b151-a1fbf80c1db6",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/244b7fd2-5c21-43f8-aee3-1c918932f591",
+  "createdDate" : "1973-01-30T15:00:38.165Z",
+  "modifiedDate" : "2014-04-07T04:14:17.356Z",
+  "publishedDate" : "1997-12-10T23:50:39.700Z",
+  "indexedDate" : "1973-11-05T06:29:04.432Z",
+  "handle" : "https://www.example.org/0eb693ce-08c7-4fad-915d-2ea6d8e104a6",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/29bbd964-469a-4b67-bc21-ced93f839d47",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9VzZNfeZlopPQEn6",
+    "mainTitle" : "2EAq75dv2PX4fP",
     "alternativeTitles" : {
-      "nb" : "BOo2m2TgtsW1KZqDRpv"
+      "bg" : "zG1cHfxG3mG88"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "g4QeeSSd1kXHjM7t",
-      "month" : "3MqwU1ljk5MTqYgf",
-      "day" : "SQDyz3CmzpnYjQoFXc7"
+      "year" : "SrYp4Su7OpPRm8aybjI",
+      "month" : "FXE7n8MrNv",
+      "day" : "Qfb5ApDwSTpVu6fT7px"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ef412f11-e1af-4318-810a-4ae0509f1541",
-        "name" : "ToLMNiERB5d",
-        "nameType" : "Personal",
-        "orcId" : "3YPTLSmnbwodyfdo7",
+        "id" : "https://www.example.org/2eb41ada-174f-4a64-ab95-cad41f25629b",
+        "name" : "zaWn7WSLJkC1q",
+        "nameType" : "Organizational",
+        "orcId" : "cGE1kCAX6KJT7vd",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xKgcxpfFMD",
-          "value" : "4FCJGjSXm3"
+          "sourceName" : "hzbWCWSlRGPeZC3ZT",
+          "value" : "5S6JsFYys3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Mp4BEOODJeO",
-          "value" : "4unDQRvtgQ"
+          "sourceName" : "5TrK4CgB6B8rZnwV",
+          "value" : "oPr5KaGRiB4stNq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7a41671d-a669-4228-a176-e8ffbef0e21a"
+        "id" : "https://www.example.org/de190e28-ed76-468d-ae1e-f8a6aaa719cb"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/090a338e-4dcd-48c1-b475-533855dc9dcd",
-        "name" : "BTxrg17wqB9vJn",
+        "id" : "https://www.example.org/4e9e7d0e-5af9-4ef9-84c6-53a333a03c1a",
+        "name" : "634lAGW8pJ69aheB8l",
         "nameType" : "Organizational",
-        "orcId" : "8h7vDUz5QBbXVE30",
+        "orcId" : "pNMj7oINd5lmdQvz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QNTpWBaIhNvpqu",
-          "value" : "Xsv8Vu9fMvGkTyIxNHL"
+          "sourceName" : "0jWy9JouWu755Tz",
+          "value" : "ktuXvDS54PRxUy2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fUJ74lmnnY3nf",
-          "value" : "XFKkVuXhWkwx5"
+          "sourceName" : "fybq8fx00aJsSD",
+          "value" : "3SD0jbuCbpaUJVK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9b66279e-51ef-46ef-99cc-abb302eac3d4"
+        "id" : "https://www.example.org/55774680-8f51-4081-b588-16948ae4fa52"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "m4UcJYsX2rZ9IoDsmkt"
+      "nb" : "BjJINACBNTVE0"
     },
-    "npiSubjectHeading" : "o0fDuTi2wfRj5",
-    "tags" : [ "RLCHmq8iKlRc9" ],
-    "description" : "eRMlTsOa3eg1kOJ",
+    "npiSubjectHeading" : "V7kYQHGYjN02EJUO",
+    "tags" : [ "dafGzlqf6k" ],
+    "description" : "JTGHqmDhsM0H",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b147dd89-49fe-45c8-b75f-8d1078206af2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/94ab3dab-ae71-41df-8dff-d8ffe28c35fe"
         },
-        "seriesNumber" : "sazeRUIYsfzyT4BBJLz",
+        "seriesNumber" : "il2bqmJ1qczjPe",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e486e399-ced6-415f-89c6-a6d14e091077",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a14490e0-9383-4b81-b909-b191383fa502",
           "valid" : true
         },
-        "isbnList" : [ "9791701498234", "9780082183402" ],
+        "isbnList" : [ "9780974298436", "9780901246325" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0082183406"
+          "value" : "0901246328"
         } ]
       },
-      "doi" : "https://www.example.org/911b1866-3a85-42f6-bac2-7bd616e50198",
+      "doi" : "https://www.example.org/dd9c7a97-c897-44de-a6de-549d3e171583",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "rPNRmMIZCShcrcXB",
-            "end" : "1LDPipI7WvAdDslk"
+            "begin" : "uyXncxAcYVf",
+            "end" : "hmP4ZtdWwWKE2dS"
           },
-          "pages" : "HjyO9u3YzCoje2c8d0F",
+          "pages" : "TyAdU3BJYo9Np",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/98a38549-ec5f-4eb0-9d80-cf6eb46d694d",
-    "abstract" : "5TOBmtS42d"
+    "metadataSource" : "https://www.example.org/8ab4109d-6b18-4bd0-9423-0db7099b3a86",
+    "abstract" : "5OBs4A1iLcz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/951911fd-6612-4263-b844-68fe0d199415",
-    "name" : "dVs22yVuP4",
+    "id" : "https://www.example.org/d726b611-b358-4857-8165-2de5f7142317",
+    "name" : "aS8BzScVdSaepopedNe",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-07-24T17:35:10.543Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "mHZRaqlSIRZOqXs"
+      "approvalDate" : "2008-12-29T15:51:39.264Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "5cmJ3sDBVx2ecXC17Kj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/fe211257-6f0e-48b1-afa0-91d95f47ab2e",
-    "identifier" : "Hpx02rpndcQt3hkeHvv",
+    "source" : "https://www.example.org/e6690689-0443-46b6-a373-85961922ac98",
+    "identifier" : "zbB4LKTkHvK6",
     "labels" : {
-      "el" : "FZnzACITBF86FOGR"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 150282561
-    },
-    "activeFrom" : "1971-03-04T07:58:20.119Z",
-    "activeTo" : "2002-07-01T06:34:42.549Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cdfc663d-deed-4173-b315-668b9f177834",
-    "id" : "https://www.example.org/aefee354-6734-4d12-baf7-7fbe31c25ac6",
-    "identifier" : "0FfYSUmEGs8gxsoCvnI",
-    "labels" : {
-      "nl" : "4Rw8FvwY2rAHdz"
+      "pt" : "JsoN0Po9UGUkR"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1887890114
+      "amount" : 2063530232
     },
-    "activeFrom" : "2004-11-22T05:07:23.763Z",
-    "activeTo" : "2017-07-13T01:04:36.662Z"
+    "activeFrom" : "2002-01-30T19:17:47.547Z",
+    "activeTo" : "2020-02-15T00:12:57.265Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/b6cbc6c4-83dc-4406-8da6-0ee6ad456b98",
+    "id" : "https://www.example.org/3aaf9bb3-3a2b-46cd-b3b3-2546a8e8bbb5",
+    "identifier" : "4ArNGSonFZWNUOyC",
+    "labels" : {
+      "is" : "KNpjPHnCaRPJ"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 929761855
+    },
+    "activeFrom" : "2019-01-23T06:41:34.693Z",
+    "activeTo" : "2019-11-06T09:06:21.829Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/175a4ecc-8f66-429c-9707-726931555da5" ],
+  "subjects" : [ "https://www.example.org/d989cd6c-f169-4dd4-9460-e5e45e9fdff5" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e1fbff9b-d0a0-4729-88ee-ba9524210fa0",
-    "name" : "z2RCPvuryqTG6yw20c",
-    "mimeType" : "sE4oTL6rij1VLEw",
-    "size" : 163005700,
-    "license" : "https://www.example.com/blpqw9wqbqhhathfx4",
+    "identifier" : "a9dc8784-c7e7-4317-a211-3d8df45e9d41",
+    "name" : "ATG8bZhF36gVKkL",
+    "mimeType" : "frmarY25zCU0",
+    "size" : 235737137,
+    "license" : "https://www.example.com/hegymjlnvok8co",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Aj0BuSyrYZ1MEE4B6",
-    "publishedDate" : "2000-08-12T21:08:20.477Z",
+    "legalNote" : "A3K2fle1HNPM",
+    "publishedDate" : "1980-07-25T17:43:05.551Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "yjcxAAoPJd",
-      "uploadedDate" : "1982-04-12T02:36:55.369Z"
+      "uploadedBy" : "zhM8aukWPW",
+      "uploadedDate" : "1994-05-27T23:02:18.578Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nWU4DwNrxO4K",
-    "name" : "c002QcSdUJoIA",
-    "description" : "TH4WPfKCq5S0q4a"
+    "id" : "https://www.example.com/Mnpz3ZYD8BX3",
+    "name" : "iv82xvAcxNVHSa4wF",
+    "description" : "rY675QJCPJj"
   } ],
-  "rightsHolder" : "yfoCVfRO2YKOb",
-  "duplicateOf" : "https://www.example.org/fd4af9e3-f0d6-4633-a600-127add8bab95",
+  "rightsHolder" : "nloC6PHOEwkpgkE",
+  "duplicateOf" : "https://www.example.org/39be8a08-b9f9-42e9-bfc1-bfbe5fe905d7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kN9TkuYHygYh6"
+    "note" : "b0Dh9hzXVhD"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oOfbkpgtZX0jIPKIK",
-    "createdBy" : "YXwQ9bhdV0",
-    "createdDate" : "2001-01-20T10:12:38.159Z"
+    "note" : "bXXaDFAR8Ll7c",
+    "createdBy" : "IrxUnCUwd2v2rbs9I",
+    "createdDate" : "2013-09-29T16:06:03.395Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0b622492-377b-425e-9358-9a49415fc4a2" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/8a1a6fcc-9fba-489b-aadf-28f6116852f2" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "wOCtQ6e3dbNCse0A",
-    "ownerAffiliation" : "https://www.example.org/f4c9e0a1-a2a9-45b8-84e5-2c12f8831364"
+    "owner" : "c4E415hvTFajEl7M",
+    "ownerAffiliation" : "https://www.example.org/b55c6d33-5bdf-4d57-b41e-2a420f8e0683"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9ce23bf9-ed3c-438e-822d-30858209817d"
+    "id" : "https://www.example.org/8a63ce3f-c6d1-49f7-9e85-1409bdc7bb6c"
   },
-  "createdDate" : "1979-06-06T12:55:43.410Z",
-  "modifiedDate" : "1991-10-13T21:25:07.169Z",
-  "publishedDate" : "2011-12-23T04:30:52.038Z",
-  "indexedDate" : "2011-10-13T16:13:32.219Z",
-  "handle" : "https://www.example.org/5ded378e-7bd9-450a-8d95-98a9944b24a2",
-  "doi" : "https://doi.org/10.1234/quas",
-  "link" : "https://www.example.org/15a740ee-8e92-4522-9388-d9291b43c265",
+  "createdDate" : "1983-06-27T10:33:44.731Z",
+  "modifiedDate" : "2019-07-23T04:12:40.053Z",
+  "publishedDate" : "1998-07-22T13:46:30.127Z",
+  "indexedDate" : "2013-11-30T14:57:13.282Z",
+  "handle" : "https://www.example.org/0d2de786-05a4-459a-bbf4-1bd536c7ec66",
+  "doi" : "https://doi.org/10.1234/unde",
+  "link" : "https://www.example.org/fbd447e0-c9b9-4231-ba1f-06daa62ac4dc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mmvx0Ow3NqMPk8jmJET",
+    "mainTitle" : "w6ywE5kNPgu5U5H",
     "alternativeTitles" : {
-      "el" : "z0poq2iNPMSRZB"
+      "da" : "24DFJEemhBIUbBwvI8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NR55T30nfyppu6r0QP",
-      "month" : "JKwowZHNFR",
-      "day" : "yp9arw77FaqLBJv6"
+      "year" : "IQfBmZ7eVAAQ",
+      "month" : "1CsX8lTfpVA8CanJrn",
+      "day" : "cWvpKwbxwZAB45eJpU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/126b0b53-2498-476b-96e1-fac6cece512c",
-        "name" : "YrgFH5tyivE",
-        "nameType" : "Personal",
-        "orcId" : "WHQbrt0xCzHCsM",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/aceca591-3e02-4416-aa47-a5cfb6fd6daa",
+        "name" : "M0ejbzLZVTjvx3EB",
+        "nameType" : "Organizational",
+        "orcId" : "mmb9cqUIrz",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4OyY4xkNZy",
-          "value" : "KJ0nJFhf64IZ6vdgI"
+          "sourceName" : "0GkAXUUyZg2L1u",
+          "value" : "naGvT9wsaZICG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2uv3nbzgdIV",
-          "value" : "HkvCMoTHBOq0wWFw5w"
+          "sourceName" : "ZZ2StsRyOvJOS0",
+          "value" : "VVB9q51IkMH5dW48"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d89ba03f-deef-4dd5-828f-d5d695030efd"
+        "id" : "https://www.example.org/c12aa721-bf6e-4de3-8f6f-0892d9406fc7"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/50f19ae2-a7c9-47a8-a661-60587a7d757f",
-        "name" : "LxkMbJWxT2qLlmL4s",
-        "nameType" : "Personal",
-        "orcId" : "Sq4UCdZxFL8PAqnYwf",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/b3e1c0fc-2f84-4f5a-99ea-5e5848486ecb",
+        "name" : "WJrmWqHKWTTssVEDBH",
+        "nameType" : "Organizational",
+        "orcId" : "AnlQSNKPjPIgUGmg",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3yRqcShUu9R1471",
-          "value" : "UN2fkSOz4j"
+          "sourceName" : "VoHj3f6Yx51OaJ4",
+          "value" : "5ehQx3naUFvF1ufV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Wg819kcnzl1VX",
-          "value" : "32baKeDIlC5BTo5ACoT"
+          "sourceName" : "4fKDN9khHoonLwV70",
+          "value" : "ciLbJN7oc6KLu9Y"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/13419837-2a34-4479-b90b-b3bc584cb0db"
+        "id" : "https://www.example.org/2d224777-a9d0-4f49-8b6e-00f6d0d133d3"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "RoleOther",
+        "description" : "rytnWpR4nKxbB4"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "brRKYZlCqk"
+      "is" : "8CN4nVm8dtS"
     },
-    "npiSubjectHeading" : "uZz1Tae8dcVSptX",
-    "tags" : [ "0URfy3DUWkjzTsJ" ],
-    "description" : "Z28RZmQrGg7Nj2",
+    "npiSubjectHeading" : "CvFIdS2Hkz",
+    "tags" : [ "F0BjyqmWm7Op7O" ],
+    "description" : "buRP8JFsCa",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cae23217-9b8f-4dce-a7c4-c61e6918853c"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cb882c42-d709-477c-9780-4efbe5d7f674"
         },
-        "seriesNumber" : "JyxeiPm8PSLr3cd",
+        "seriesNumber" : "ZhZkAYJbDHY5gKELL",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b1dd32de-d69d-4be7-baa4-b2ddbc6936b3",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7fe7968e-8d00-4682-bcbc-bd19912b962f",
           "valid" : true
         },
-        "isbnList" : [ "9780697201027", "9780714356617" ],
+        "isbnList" : [ "9781891507816", "9781002565056" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0714356611"
+          "value" : "1002565057"
         } ]
       },
-      "doi" : "https://www.example.org/abeac193-9d92-4218-a70b-bcc969e1beea",
+      "doi" : "https://www.example.org/5108c83d-0b93-4b49-86db-6d1ab1eaf3ad",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "pBxTfQp0C537agcir",
-            "end" : "9dSepvgbkb9W"
+            "begin" : "cma0KdMTNqjOXJY",
+            "end" : "VFTwBaDaf7OAR"
           },
-          "pages" : "0ZJKkCjmKSGmHH",
-          "illustrated" : true
+          "pages" : "WQHnO3vggBswucvf",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9dfa13e3-cd7d-435d-921a-3066728f54dd",
-    "abstract" : "LrF71oCVYC8WmDrMi"
+    "metadataSource" : "https://www.example.org/fa45f7c5-9a14-4b04-b005-d3ee9a558e6a",
+    "abstract" : "Zr82m4btCe9otG4"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e2f013c0-2145-4f0a-b9e5-37b7e79a27b8",
-    "name" : "4TvMTuAioeBwqKclt",
+    "id" : "https://www.example.org/552d8820-6c9e-4395-aaea-30ddbb59f9e6",
+    "name" : "SRZlIo5kBeOnQ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-01-25T11:07:42.693Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "nhDHNGnCfO"
+      "approvalDate" : "2021-04-07T07:34:23.524Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "SFGYXLywazTQm"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b286171d-8bab-4b15-b9bf-20affc2e6351",
-    "identifier" : "ebk4VRS097O8KnOd",
+    "source" : "https://www.example.org/23845132-6835-45c6-9b26-f701f0a79759",
+    "identifier" : "cdO3cJ8ThhmOFk",
     "labels" : {
-      "pl" : "5Def7ctTax"
+      "zh" : "nPSU5TkbPUDRccV"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1634131158
+      "amount" : 1709975161
     },
-    "activeFrom" : "2014-10-05T15:54:36.983Z",
-    "activeTo" : "2016-11-23T22:14:02.566Z"
+    "activeFrom" : "1998-04-30T07:10:43.775Z",
+    "activeTo" : "2007-02-08T04:34:02.009Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/18d87323-2c09-4067-8953-95f77207e489",
-    "id" : "https://www.example.org/9df03c3f-00bd-4fb7-a2e4-87165be7bcc2",
-    "identifier" : "iiQNXCgkAioPjGDU",
+    "source" : "https://www.example.org/d2bd21df-69a5-4bf7-bbe7-c2f3d748eda1",
+    "id" : "https://www.example.org/db67dbf3-3543-4d79-b044-3d700be4015e",
+    "identifier" : "ZAXzwJ83AQ",
     "labels" : {
-      "da" : "zUusdfMDkkRiPpa80vz"
+      "el" : "N2JP1YOt3cr"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 800711037
+      "currency" : "USD",
+      "amount" : 963462223
     },
-    "activeFrom" : "1984-07-14T09:23:47.967Z",
-    "activeTo" : "2015-05-21T03:13:35.624Z"
+    "activeFrom" : "1983-12-30T16:05:09.084Z",
+    "activeTo" : "2007-07-10T06:09:40.118Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cba6224f-adba-45e0-b657-5e6d8e93b4f2" ],
+  "subjects" : [ "https://www.example.org/2608e3b1-c63a-4795-add2-8e7c8eea0339" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d68cdef4-9a73-41c0-ba09-200b093b436f",
-    "name" : "cTOMAJ9cEkr32",
-    "mimeType" : "T1AP739mToP",
-    "size" : 1465199910,
-    "license" : "https://www.example.com/xjpabeyeoz",
+    "identifier" : "aadb0e5e-a0bb-4289-8dba-518db4c9720b",
+    "name" : "xOYUN4tjjGb3UxsR",
+    "mimeType" : "ooi4Y9VxG1c9",
+    "size" : 1637423245,
+    "license" : "https://www.example.com/q2lsiuqkmnsjntju",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "KiaIPCXDlWT7DaqF",
-    "publishedDate" : "2017-10-29T14:38:20.865Z",
+    "legalNote" : "8KFrdxO07D",
+    "publishedDate" : "1996-11-21T18:50:41.488Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "lL3RyK3AQy2hk0rngO",
-      "uploadedDate" : "2003-10-04T03:56:49.948Z"
+      "uploadedBy" : "r43ocOATJAJEdLag",
+      "uploadedDate" : "2012-11-14T18:00:22.201Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/RR19ofRSjHGOt1gcg",
-    "name" : "bdd2dTp9p3YA",
-    "description" : "xclkgNzcafbt"
+    "id" : "https://www.example.com/9dH8TwfAp5ks4titAmT",
+    "name" : "7kZYLiGAlRukMP1f",
+    "description" : "rujcmABU7D"
   } ],
-  "rightsHolder" : "FUsrEgCn6bHZhpJ",
-  "duplicateOf" : "https://www.example.org/bbde259f-3e5b-49b1-8239-edf5dfc12235",
+  "rightsHolder" : "IVgROT7jpL3zmN2K",
+  "duplicateOf" : "https://www.example.org/3aa60baf-431d-414f-b0ad-abbd98ccbaa3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gsfGcJ3RT6JXkzrs"
+    "note" : "gBKJazBZOaQLLH47ew"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "uUPyZLf65PLE9vm",
-    "createdBy" : "r06Os50LJ5",
-    "createdDate" : "2008-08-02T13:05:56.575Z"
+    "note" : "o1CbmBlQZuk",
+    "createdBy" : "TF89Naj4mE9o1",
+    "createdDate" : "1980-04-20T19:22:07.688Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7924f0b0-c787-4246-a222-632e4599130b" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/2aa94238-cdfd-4f28-8239-4a38d2a8fe80" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "lmxzcMG1IrYvucskOsP",
-    "ownerAffiliation" : "https://www.example.org/9f0d982c-e9f0-4253-8566-cd79c2671b7b"
+    "owner" : "3RKyBnaZiHRPzq",
+    "ownerAffiliation" : "https://www.example.org/bec17c1e-04b4-4186-9fb5-c321964352ce"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/882f16f8-e645-478b-864f-642fe51f4f1b"
+    "id" : "https://www.example.org/34f53a39-8237-4294-aa2c-9097edae5b1d"
   },
-  "createdDate" : "2023-08-11T19:40:27.586Z",
-  "modifiedDate" : "2012-10-28T18:47:42.986Z",
-  "publishedDate" : "1996-10-20T19:45:14.375Z",
-  "indexedDate" : "1999-03-20T16:03:26.467Z",
-  "handle" : "https://www.example.org/3c25ce2f-1531-4fde-a45e-4015f261ee40",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/1c21b993-b169-4c93-b127-e165facb3ad6",
+  "createdDate" : "1987-09-12T15:23:17.802Z",
+  "modifiedDate" : "2024-01-22T13:45:14.706Z",
+  "publishedDate" : "1993-07-28T20:29:24.401Z",
+  "indexedDate" : "1985-08-24T03:19:17.046Z",
+  "handle" : "https://www.example.org/6271490e-03c9-4ffb-be1a-a81154394955",
+  "doi" : "https://doi.org/10.1234/provident",
+  "link" : "https://www.example.org/c68ba3ce-7a34-4dd3-9ec1-545e8bc77ce9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QqN8qynLyar4UsIiycP",
+    "mainTitle" : "8emJfb2lRjCsxST",
     "alternativeTitles" : {
-      "pl" : "i4TtoFStw4"
+      "nn" : "09tQvp1CV9obaZnkViJ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iA2puLp871ARp2lV4",
-      "month" : "b59IzqR2f9iGB",
-      "day" : "xAhkWikXeKG18"
+      "year" : "4Xh74iBLFtYOJH",
+      "month" : "luB1ypTKcZeQb",
+      "day" : "o5dKeafWvsogs"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1a9386d4-c012-4132-a669-62398acd58c8",
-        "name" : "kOhiTqT944VE3n94t",
+        "id" : "https://www.example.org/3066eb0a-d4f4-48e0-9178-695e3f99af2e",
+        "name" : "Pp2SwzzvYCbICcUk42",
         "nameType" : "Personal",
-        "orcId" : "7Fmf68lCSWozyBO",
+        "orcId" : "KCDM9OWfbmGUvKnVDr",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WZeJ6JXlIra7Cl",
-          "value" : "HIqeSF8OsbKykAYiv"
+          "sourceName" : "puCGfURKRY2IwLNT",
+          "value" : "1q7pz5aB8f"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vZeXQ2FW7dKpni3kF",
-          "value" : "SnJ21wfDJxc36Naz"
+          "sourceName" : "8Vtw1t0pU5M8",
+          "value" : "tlBijR54tYJwAiyEy9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7366eaa5-fe0f-4cee-92bc-8943d2b5d019"
+        "id" : "https://www.example.org/9afbf14e-b00c-458d-82a6-ef85ffa432dd"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,160 +62,160 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b4d1d718-a674-4e24-a1fe-6163aedb09e3",
-        "name" : "Ag9McKmJNTqU",
-        "nameType" : "Personal",
-        "orcId" : "zkMcNUD1Bfxnn2Hv1xi",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/7a88762b-735d-46c4-9efe-7c41fe9221e4",
+        "name" : "Y3fbd6reEmcp5YJfJ",
+        "nameType" : "Organizational",
+        "orcId" : "MtxDDwE6thGV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "q5nZWaRjQrW0oipt",
-          "value" : "zTwYwUZl3g"
+          "sourceName" : "2uzf8gXPJkpsSG",
+          "value" : "cVrfVf0VwNfX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LaX4DwsMWzdKZ7nEC",
-          "value" : "ANxAX5PaaJHdrC"
+          "sourceName" : "TSHZUhtZES1",
+          "value" : "zltTT6z1Vw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bd6f35bf-5eea-48f0-8926-3bd8909ceeaf"
+        "id" : "https://www.example.org/9fb61795-5523-4d91-9d3a-5245125aa0bc"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "w0Z3cGLvQtPV6rVp"
+      "fi" : "uuQ75hRy8dvxrQlfFI"
     },
-    "npiSubjectHeading" : "H7qphBEJKgfT",
-    "tags" : [ "72Z8LpujGG2" ],
-    "description" : "173P26CZm24iG1",
+    "npiSubjectHeading" : "rYmXLRkvHyVY",
+    "tags" : [ "BeRYjO4ES0y0c" ],
+    "description" : "4RPw5hD1ro6Q3UBgtRu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ee2701d7-2d36-4aa8-9809-ca8f7af0fcdb"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/80c9684c-004f-47f2-8e03-3d2381aef7eb"
         },
-        "seriesNumber" : "UlQEbk2ypci5",
+        "seriesNumber" : "mNfX9TXBu4xDjuBbpwI",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1298d38b-d7b5-414e-bfa7-0ea2f5f50b69",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ae781413-a681-472e-aca4-e4c1a4ad5929",
           "valid" : true
         },
-        "isbnList" : [ "9791897362746", "9780067301111" ],
+        "isbnList" : [ "9781948670937", "9780015770914" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0067301118"
+          "value" : "0015770915"
         } ]
       },
-      "doi" : "https://www.example.org/83a44f6b-461b-4781-803a-613f9cbc4319",
+      "doi" : "https://www.example.org/5572abda-837b-4f9a-b0d8-77c7e8e1f4eb",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "C9iySs8jAT9vin4YOxb",
-            "end" : "pxzpfLXef2TrpYKPWuw"
+            "begin" : "4eOrC1bgycti5s32q",
+            "end" : "7EEFS67HVtYdqi"
           },
-          "pages" : "yGl0YB08ybGyldp",
+          "pages" : "2R1apIQWIZazK2DbqG",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/709cc100-8a3a-4cee-ad4b-42656cebee6b",
-    "abstract" : "bMPCd8SNFB"
+    "metadataSource" : "https://www.example.org/7390d012-0ff2-4db4-8dc1-b46948aa01ab",
+    "abstract" : "4Y0lC9ci821mFmQm6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6c31c8f4-9c02-422e-a03b-7f3856e8c05c",
-    "name" : "6os9UFyLG3WSDOyevL",
+    "id" : "https://www.example.org/67068fac-a21b-431f-87a5-0bf0f506fc79",
+    "name" : "8RsxVOI7iU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1995-10-25T14:54:17.235Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "VZqwxMc518"
+      "approvalDate" : "2007-02-02T12:49:20.785Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "wXciQXZRHuDV8kNXUE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c015e22e-9f07-4c86-ab25-e2f42b5824dc",
-    "identifier" : "s67fIUmdLL4ItOfA",
+    "source" : "https://www.example.org/44fd7cc8-f901-47be-bfda-d585faaff628",
+    "identifier" : "Ethq7lGKNKC",
     "labels" : {
-      "hu" : "sjqSJgVSzYfqjBk9"
+      "pl" : "3bJEvAorXhARrat"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 198921373
+      "currency" : "EUR",
+      "amount" : 235529321
     },
-    "activeFrom" : "1994-11-12T03:35:53.098Z",
-    "activeTo" : "1996-07-02T07:56:21.534Z"
+    "activeFrom" : "1974-07-18T08:32:14.450Z",
+    "activeTo" : "1999-06-05T01:56:33.539Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1a2f81f8-b603-45c1-81c9-94f319f2a4ab",
-    "id" : "https://www.example.org/4b173577-f757-4d76-be30-efe4d201ddcb",
-    "identifier" : "JwBRvJx0GDUi",
+    "source" : "https://www.example.org/0e1202ca-581e-400a-90cd-e031d6ad437d",
+    "id" : "https://www.example.org/4c2f2a22-d74e-460a-96bc-0120e0ce7102",
+    "identifier" : "M4wDGEJtrhcuTYL89",
     "labels" : {
-      "fi" : "BjY20dnDLFPrI"
+      "ru" : "viNw9JQkodlztFN"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1912144215
+      "currency" : "NOK",
+      "amount" : 515443782
     },
-    "activeFrom" : "1982-05-17T19:56:47.576Z",
-    "activeTo" : "1988-05-08T04:20:13.247Z"
+    "activeFrom" : "1978-10-24T17:57:29.258Z",
+    "activeTo" : "1997-12-28T00:06:24.603Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d829f109-35d8-4172-a61c-2bcce77834f3" ],
+  "subjects" : [ "https://www.example.org/61b2d21a-cb41-40e3-b99c-1c9d454cb22b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fc10dcf5-631a-4ed3-90ab-e0eeeea94562",
-    "name" : "GPweG6SbjvDuontbG8",
-    "mimeType" : "TkrWHIVGmO",
-    "size" : 1729296405,
-    "license" : "https://www.example.com/3k7dy4b4nvokperhm",
+    "identifier" : "63cacb0f-eff7-44ef-a2a3-e5d53b68c6fc",
+    "name" : "Hz4zuwqh3rh4Ai",
+    "mimeType" : "GZPRZZuJtLEuXIlBg",
+    "size" : 959941229,
+    "license" : "https://www.example.com/c4m9tuwqmez3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "oE11rK520o9LO",
-    "publishedDate" : "2013-04-01T06:38:59.851Z",
+    "legalNote" : "hfvKw6eJl9U",
+    "publishedDate" : "1980-07-24T13:07:38.421Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "sbSiHDZniWrUsDBTyE",
-      "uploadedDate" : "1996-02-24T04:36:40.026Z"
+      "uploadedBy" : "BlpDeVnU0J",
+      "uploadedDate" : "2001-10-03T08:07:46.816Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FUnobrSAwTNF",
-    "name" : "U70npOuAFm",
-    "description" : "EUx5Fjr2hcKa9ni"
+    "id" : "https://www.example.com/efgDa7nB9me2L6on",
+    "name" : "vC9jMwP97T560bQ0W1e",
+    "description" : "CxDeUXLm4h"
   } ],
-  "rightsHolder" : "HmfCnAT7UCs0xs",
-  "duplicateOf" : "https://www.example.org/4aba5fbf-f6b8-41ed-b08e-039756d3ca2c",
+  "rightsHolder" : "LKk399oK6sqJjm4W89P",
+  "duplicateOf" : "https://www.example.org/3f761e29-ee29-42de-aa4d-5c5364910aa1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "OPySwCSSFCf2mgWmIDp"
+    "note" : "I5L8JagRKuUchyeBd"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fHovRAHLvEKdOPlkl",
-    "createdBy" : "iew5cWXzFwdtuMJ1",
-    "createdDate" : "1983-10-12T15:09:47.593Z"
+    "note" : "gcLDwiqiSFYwW",
+    "createdBy" : "tDLeQt1i89gcLA7z",
+    "createdDate" : "1976-03-28T05:55:25.232Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ca5971b3-b691-496f-99a5-ebb17c4ee0fb" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/3ff08779-4334-4257-afd1-efe6a7e1ece1" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "czRdkHwkP6fn",
-    "ownerAffiliation" : "https://www.example.org/d141f647-96b1-4785-884e-9a85f4a0396c"
+    "owner" : "qgHEvXPke0",
+    "ownerAffiliation" : "https://www.example.org/a69b53b5-eb8f-41e9-ad9b-dd219bd6f877"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1d52b916-d0e0-4bea-b0d7-93c8af660d68"
+    "id" : "https://www.example.org/a4b81aff-128b-4a64-93b9-c747b8ea8164"
   },
-  "createdDate" : "1997-04-10T18:52:08.539Z",
-  "modifiedDate" : "2011-12-24T05:16:56.616Z",
-  "publishedDate" : "2009-03-31T21:44:13.038Z",
-  "indexedDate" : "1973-02-03T16:45:23.825Z",
-  "handle" : "https://www.example.org/508d7589-7261-4f6f-8411-7723e07c55c3",
-  "doi" : "https://doi.org/10.1234/quos",
-  "link" : "https://www.example.org/b3cbafbe-12c3-4902-9c13-a7e5a72a70b3",
+  "createdDate" : "1990-04-07T16:38:15.710Z",
+  "modifiedDate" : "1980-02-16T22:55:23.153Z",
+  "publishedDate" : "1998-12-17T13:27:31.271Z",
+  "indexedDate" : "2013-10-05T18:07:38.978Z",
+  "handle" : "https://www.example.org/0825f63e-ac8d-49fa-b9b1-af6809bdafb9",
+  "doi" : "https://doi.org/10.1234/incidunt",
+  "link" : "https://www.example.org/2659660e-edef-4d94-8b94-a5583287eef6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EwEKO0vMShYe",
+    "mainTitle" : "HJkzRwZ6Wg",
     "alternativeTitles" : {
-      "hu" : "KViZsLRNlFf91C"
+      "bg" : "CtiYpN6EucMm7G"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "4b07GfZJMYtfwBxShT",
-      "month" : "WVhUaKLgB7I",
-      "day" : "qRma4smmlzAXf2zI"
+      "year" : "0y1u6Q7fNGJh",
+      "month" : "L70jPDoQG8aG",
+      "day" : "dram4C5q7F7kT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5da9d688-af8a-408b-829c-3e48a8b57688",
-        "name" : "3pL7GlfeBX4nSL4k3q",
+        "id" : "https://www.example.org/4b4c1753-7880-4975-8269-8dd22db47540",
+        "name" : "jugf9BUTGwfK9QF7Z",
         "nameType" : "Personal",
-        "orcId" : "bVCu5fKxNx4i",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "S1jjsLab3kR6Nnrf",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PXvgqUCs8Ic4hI",
-          "value" : "GOhqgtbOCQzdNLuhXhQ"
+          "sourceName" : "VN6LyvCVo9b",
+          "value" : "dNz9vK5XoxBXdvwplW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rM1sj12eCZCh4q",
-          "value" : "Zb4iFHzGfXNN5C"
+          "sourceName" : "hcadh5NDuoLtwWZ",
+          "value" : "jmWJ4MqCWiUvQx5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/529651f7-a18f-49a5-96f2-19befbc98a1a"
+        "id" : "https://www.example.org/d1f391bf-2a77-4b75-8a08-7f3303335604"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,143 +62,143 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/92fbb1e7-0cb4-4a11-a19a-1ac0162d85a2",
-        "name" : "59QbIRYIa0Zr9z8",
-        "nameType" : "Organizational",
-        "orcId" : "SYHyFDl9rVgwu4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/87957ed2-0a52-4de4-8a5a-96331936a0f5",
+        "name" : "5ZoQSCKHKLd",
+        "nameType" : "Personal",
+        "orcId" : "mUN5uBpz9F6JmT3y5N",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IDOeVBEocl94DF",
-          "value" : "Ma06DYcjRuCndhCEqk"
+          "sourceName" : "bb1huxV0Tihhu",
+          "value" : "JtbBn4DkqWkTVzkM4"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "isOE3RMxTYFpkDlRp",
-          "value" : "96dApWN5q3x"
+          "sourceName" : "IuzdZcpDARFByiS",
+          "value" : "xNOEcIRapEHx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4b575922-7edd-48e0-9c2d-7b6755039967"
+        "id" : "https://www.example.org/9c16e8bc-ef16-42f0-85cc-1535b0ae9584"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Choreographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "OefBqTAAZPhZ"
+      "da" : "PaVjEkTQG3Xgnp2DQ"
     },
-    "npiSubjectHeading" : "nUP0nRns8D1r69IJF5",
-    "tags" : [ "r658zK0j1gx" ],
-    "description" : "xBM5oArROKgvMl7G7m",
+    "npiSubjectHeading" : "edhHOupCAY",
+    "tags" : [ "Wm57JxCLGlP" ],
+    "description" : "DE2unlSehBhBOum",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0a6f670e-66b3-4d9c-8b51-32764871e3a9"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/febca647-e772-4c21-ad4b-6dfdede7f4a4"
       },
-      "doi" : "https://www.example.org/b65ecb1d-e1fc-4846-a8fc-2cc505497ca8",
+      "doi" : "https://www.example.org/962c59d5-fb50-4d87-8d10-af1a26df8949",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "iQzGJzy6R10LzqYNU",
-          "end" : "b5UpQ8S5J9"
+          "begin" : "roJYH4juBxyJg",
+          "end" : "C5mI570etMYxThsidx2"
         },
-        "volume" : "a2rriihfygVgi",
-        "issue" : "89UmBMoJKDUC",
-        "articleNumber" : "PvSjDsYfpJseuueYh"
+        "volume" : "pMPQiRVRitkjfSmXst",
+        "issue" : "dF2L0ShWWznE0xeB5",
+        "articleNumber" : "xKcXavJDldIfV9AfU"
       }
     },
-    "metadataSource" : "https://www.example.org/5b16044a-7d02-428d-97f4-df70a339360a",
-    "abstract" : "dfRwQhiuMDuk"
+    "metadataSource" : "https://www.example.org/91f9ae68-b22e-4960-9cf7-84900c71fe2d",
+    "abstract" : "NzsRbyGnb4Y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5ceba7ba-0b84-410b-ae6e-f250bd707905",
-    "name" : "Q0Cz0LV0BlfF2hz",
+    "id" : "https://www.example.org/b4f35316-f303-4eb4-99fa-2886dbc46aaa",
+    "name" : "bpBEGHtg79Hv",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-05-13T06:39:39.458Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "BSzlkgAP4rwsa8"
+      "approvalDate" : "2015-11-27T12:59:25.995Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "IHqaGGDDWI2eFJzAe1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/397d7203-d6f0-44df-bb4d-8b8157fad320",
-    "identifier" : "4HeGmqboBW7sr",
+    "source" : "https://www.example.org/a405473f-e2ef-4cfc-9a42-e6c3acbf39a4",
+    "identifier" : "38DvrZE8pqaErpkFiPl",
     "labels" : {
-      "nb" : "OOsWqozxCry1gFX"
+      "nn" : "WVqvepnFptTdCS"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1428806526
+      "amount" : 1614827820
     },
-    "activeFrom" : "2010-06-03T20:32:46.515Z",
-    "activeTo" : "2022-11-01T09:19:37.162Z"
+    "activeFrom" : "2018-01-18T08:45:23.449Z",
+    "activeTo" : "2024-05-17T22:11:13.459Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8ea6478f-e189-4ae0-b065-54760444a79e",
-    "id" : "https://www.example.org/981f481d-fb0b-47bf-a814-be2c12c1f8f9",
-    "identifier" : "p8pczZNMazp1j2gnnNX",
+    "source" : "https://www.example.org/79ba93ff-110b-40b2-aac8-5b19e860a0cb",
+    "id" : "https://www.example.org/c7a40053-dc65-42cb-b973-a7bf5daafc6e",
+    "identifier" : "54Y0jeyKbFHS",
     "labels" : {
-      "nb" : "LA2hC6zUsC"
+      "pl" : "ZsWbzd1f3lmoVDagU"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1475861368
+      "currency" : "EUR",
+      "amount" : 1400539594
     },
-    "activeFrom" : "2004-07-10T12:54:35.630Z",
-    "activeTo" : "2015-08-28T07:31:33.496Z"
+    "activeFrom" : "2003-01-25T10:36:37.729Z",
+    "activeTo" : "2006-02-23T23:22:29.697Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7cb9ebf6-5479-4676-95e1-98f83d9fc7fb" ],
+  "subjects" : [ "https://www.example.org/a3d3f5b3-7d3c-4826-9758-4939991944b9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "621c74dc-0864-4927-90cb-73a2ec5eacbf",
-    "name" : "oxfKWoONgG988wVYM",
-    "mimeType" : "g9EhN9IroTRLXC",
-    "size" : 197824437,
-    "license" : "https://www.example.com/3sxix1wk556jc7jo",
+    "identifier" : "6324adac-cc8b-4180-8451-a683d96ce5ea",
+    "name" : "VNmkspXYRwfqymCWIy",
+    "mimeType" : "fVh5TW20iA7KDglwGSM",
+    "size" : 38738316,
+    "license" : "https://www.example.com/owhoxrcrus",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "nCVhUjWEeXc",
-    "publishedDate" : "1997-01-04T17:58:41.640Z",
+    "legalNote" : "RkOnuBxTeNp5wv0YK4",
+    "publishedDate" : "1978-02-21T12:24:50.326Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "Znx03IfW6Ipwb6",
-      "uploadedDate" : "1980-12-13T06:00:23.372Z"
+      "uploadedBy" : "iNRd8fN6ScagLQ",
+      "uploadedDate" : "1994-01-31T06:33:05.375Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Q6E4h5H0J5",
-    "name" : "aemeVOq0rQxQXE9YU",
-    "description" : "NJKVEat8TcybZNjb3D"
+    "id" : "https://www.example.com/QLjWDAYTQT",
+    "name" : "pnDS3j3S5MN7NPAfI",
+    "description" : "AqLOZQ6wXyM2p"
   } ],
-  "rightsHolder" : "Ph8XWAJ4DH",
-  "duplicateOf" : "https://www.example.org/0de3b1a2-247f-4a74-bb91-7f9a9a84a174",
+  "rightsHolder" : "W5VjL3Uonc6UUrkgHx1",
+  "duplicateOf" : "https://www.example.org/df16396a-2ef1-4bf7-b8ca-56cb2eb82d85",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "73EHEp5vDbTdx"
+    "note" : "dhhAD369AN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "75b09W4wlpKF",
-    "createdBy" : "Hjtnqdps1mb",
-    "createdDate" : "2002-05-10T03:45:26.779Z"
+    "note" : "47u2gjeKWEkrrwiwRP",
+    "createdBy" : "BD65dTJaWZyouM",
+    "createdDate" : "1988-05-05T14:11:39.495Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/82e263e8-3e3f-4a94-a06c-a6abc0d33924" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/b8bef213-69c6-4025-8346-b6464876c741" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "xr13kSjTc9j8tcY6DY",
-    "ownerAffiliation" : "https://www.example.org/1833a22e-23ae-45cc-b159-15920c666d33"
+    "owner" : "x5ZNkK1JT9sOUp9sR8F",
+    "ownerAffiliation" : "https://www.example.org/a776d1e8-439f-452f-bcee-6ceb9aec21e1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/36b04275-32ce-4e23-9a07-de784cc575ee"
+    "id" : "https://www.example.org/a391c290-1599-49ce-85bb-bc59a71f00de"
   },
-  "createdDate" : "1991-01-24T00:53:40.364Z",
-  "modifiedDate" : "2011-08-31T16:46:46.340Z",
-  "publishedDate" : "1987-06-03T06:11:48.300Z",
-  "indexedDate" : "1998-01-21T02:59:57.185Z",
-  "handle" : "https://www.example.org/51e03ec9-fc0b-48ff-8c9d-65b712c3b6c8",
-  "doi" : "https://doi.org/10.1234/at",
-  "link" : "https://www.example.org/e44c6895-d53c-410c-b2dd-b48e4d345c9e",
+  "createdDate" : "1997-04-04T23:58:31.724Z",
+  "modifiedDate" : "1980-10-11T21:34:58.387Z",
+  "publishedDate" : "2011-03-28T15:35:38.179Z",
+  "indexedDate" : "2021-04-03T14:32:23.971Z",
+  "handle" : "https://www.example.org/8a0ccdc1-c196-4878-8342-48eb6a9919be",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/9522d609-cad1-48cb-be7b-191f790af5a8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yHedSJOIcQU9",
+    "mainTitle" : "RLKcvHWdjESspc",
     "alternativeTitles" : {
-      "is" : "LkKw5t9upDcSXp"
+      "cs" : "UoHzclE5hb5k5n"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "59V4bWw6F0hgd",
-      "month" : "3htwQVKaKemmRk3S",
-      "day" : "LDiNSIOTd1ixQ"
+      "year" : "hHC2K2K4A1D3P7e5fg",
+      "month" : "3jvxykSCGC",
+      "day" : "vyfZWTKQUmJTSGZkV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/793e63c0-803f-4aec-90bd-f84c0b0fea75",
-        "name" : "V79BLKzgmZoS1A5jg9H",
-        "nameType" : "Personal",
-        "orcId" : "41ghlMj40GpiwH3lK4s",
+        "id" : "https://www.example.org/61072323-9c95-4c1d-8ad4-8ec85790fa5c",
+        "name" : "OI76xrpV2Ivr5D",
+        "nameType" : "Organizational",
+        "orcId" : "6V1SvPyFJbHHoU",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pYDrwGmenWm3Hz2",
-          "value" : "3Aqzta6mjYV1z484nsY"
+          "sourceName" : "IlBiY9JYfnyFG51Q",
+          "value" : "Hv4qL9vbwluFHQYB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "q5sAkUzrnddG1",
-          "value" : "n8xzIkMQOgenUqpODT"
+          "sourceName" : "ejMyKyudaH9XD",
+          "value" : "6wLigg6LpbbQVpDT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d2f09f4c-348c-4b21-95d2-55164e9df1c1"
+        "id" : "https://www.example.org/5d38c630-b591-4834-a92f-c07cf706cbed"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,161 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/48de6d9f-51d7-439d-b5ed-c7a842c17259",
-        "name" : "p6dmVUFGcNRdMuHLD",
-        "nameType" : "Organizational",
-        "orcId" : "CTvLJJRn92x",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/dfc847bb-2448-456f-a14c-4c896697baaf",
+        "name" : "s26Jl8p8ArSxiKyhHkf",
+        "nameType" : "Personal",
+        "orcId" : "x2eiOfuWOanJmT7r",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6vNdQK35fdBQ",
-          "value" : "BRZLoPqF5ZvE0"
+          "sourceName" : "T0SdmQ6Gf9GlM9",
+          "value" : "MItZRVAyY4eeYK7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KRJ630ahZoTjgu7",
-          "value" : "N1oMQk0NGsOxszeTn"
+          "sourceName" : "KyxSNwUBqbmE6CAeU",
+          "value" : "EsAgmd9Wp1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/34e94418-878b-43f1-8f47-afb69d401386"
+        "id" : "https://www.example.org/0b7d9773-ca98-4819-b704-aa4c820c9bfc"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "UJGhtPe5TTKgtB"
+      "nl" : "i61VD322oGqnT"
     },
-    "npiSubjectHeading" : "UDP4WuOpkJ4yTPTs",
-    "tags" : [ "Yg97fTDYY4zDWfZlIGd" ],
-    "description" : "imEd5qdme7PdN",
+    "npiSubjectHeading" : "Yre8J0blSklnednl",
+    "tags" : [ "Q7wOXKZC9vuw" ],
+    "description" : "qgIrSYW7LU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/91bb7ea6-0e47-4592-a2be-cbee0a224a39"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2aff8fc8-39f4-4594-80f9-780c2053867d"
         },
-        "seriesNumber" : "0Y7vs0We663wcPF6l",
+        "seriesNumber" : "97lGuOHVb1xbvW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7af363f1-91ac-47a6-8ecc-1ffa3ce72653",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bc3e360c-c17f-4e6d-a3c4-d85a48b4404d",
           "valid" : true
         },
-        "isbnList" : [ "9780062273901", "9780962886416" ],
+        "isbnList" : [ "9790982029847", "9780445697744" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "0962886416"
+          "value" : "0445697741"
         } ]
       },
-      "doi" : "https://www.example.org/db2a4c30-da5a-45c7-a838-20fec5005688",
+      "doi" : "https://www.example.org/f1ed8a07-8e66-450a-9174-d63eb79a91e6",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "b7471aI4aRf",
-            "end" : "K1uWqNxG8tulDAVv5ft"
+            "begin" : "67bgLQphMOer1npi",
+            "end" : "uLmsY5Opwc06MCr"
           },
-          "pages" : "81TV8pdiU0OFx",
-          "illustrated" : true
+          "pages" : "H1zXQchh4b6rq2fv2F",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ebddfbec-d264-4187-9a41-9a3715258219",
-    "abstract" : "iOhzZj6TYzzynAB"
+    "metadataSource" : "https://www.example.org/1482258c-6e48-44d1-8e1e-b942c102bef6",
+    "abstract" : "6C7rArWNHZ4FoLJR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5acf8e66-c04d-4e19-a31c-f7b40bd6dd85",
-    "name" : "yqi8PhDexcBwBExN",
+    "id" : "https://www.example.org/25b6f9f3-37e2-4f70-8c08-5a492a25e32a",
+    "name" : "0qlyFDWmdS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-11-30T00:14:46.327Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1987-04-21T05:26:13.606Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "ivc72EzvLZp2G"
+      "applicationCode" : "TqeFDgm91eGNP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ee62e42c-77f5-43c1-b21a-79b963df16c8",
-    "identifier" : "XLlh1wdi0aTqif3",
+    "source" : "https://www.example.org/4d117ef4-e836-4efc-b169-7e01186496ef",
+    "identifier" : "RWuaVqc9Mo",
     "labels" : {
-      "en" : "h8xbopQw3dk"
+      "pt" : "9jSkC62ocVQEoIsXJ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1058376866
+      "currency" : "USD",
+      "amount" : 723460568
     },
-    "activeFrom" : "1996-11-02T07:50:25.709Z",
-    "activeTo" : "2000-12-13T01:00:15.322Z"
+    "activeFrom" : "1995-12-31T06:21:31.998Z",
+    "activeTo" : "2011-04-14T15:09:28.014Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/962f98ad-1e56-48cd-a88e-cf4fca34126d",
-    "id" : "https://www.example.org/f7b23f9b-8c9b-432b-9d88-f68e86c836b3",
-    "identifier" : "cUXqKHOsKwhOnMDCon",
+    "source" : "https://www.example.org/ce8085ef-3f04-4196-b05c-9b29e95039ca",
+    "id" : "https://www.example.org/b0275744-6699-4d8b-8cb5-eea7b90215b2",
+    "identifier" : "zpMHtcHloL2",
     "labels" : {
-      "af" : "S4g7l80ct9c"
+      "fi" : "7gafuf8bBYn"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1580174640
+      "currency" : "GBP",
+      "amount" : 831335033
     },
-    "activeFrom" : "2002-07-12T18:12:12.354Z",
-    "activeTo" : "2016-11-15T11:27:51.412Z"
+    "activeFrom" : "2000-06-20T14:13:26.311Z",
+    "activeTo" : "2005-03-06T15:21:04.243Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6f13ac89-f733-48c6-ac82-ae89e2c3574e" ],
+  "subjects" : [ "https://www.example.org/c4281f3e-73c4-44df-9ce1-acc4a779db5e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5f191338-bb83-4b41-a9b5-8032a820f959",
-    "name" : "v0tLSCcHI3",
-    "mimeType" : "JlpkcjmBDt",
-    "size" : 1586870601,
-    "license" : "https://www.example.com/igdogtryhpxi1uy9m",
+    "identifier" : "b59edceb-b905-43bf-80a6-d775ba68983b",
+    "name" : "svkjUSL9HVnjr",
+    "mimeType" : "jW2LMX7OJdlZNJfZ4",
+    "size" : 886142090,
+    "license" : "https://www.example.com/rtc9phczactwk",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "6crKyCsTgF"
     },
-    "legalNote" : "oaQRDF05XJmPXLOScyK",
-    "publishedDate" : "2014-08-07T10:30:08.720Z",
+    "legalNote" : "4seR8v13wdqSyCRBuQs",
+    "publishedDate" : "1980-02-25T00:49:39.796Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "8INNDIiHkQw0yZAJ7vh",
-      "uploadedDate" : "2019-11-10T03:58:15.847Z"
+      "uploadedBy" : "yBVFYsvPTtHDPl7EN4F",
+      "uploadedDate" : "1980-12-03T05:51:30.571Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TTEhW8MmX2qqrXAOVR",
-    "name" : "3FtZ3OYExfy",
-    "description" : "Zg6n2gR6IuPF52"
+    "id" : "https://www.example.com/jtUvM5bhuPdUCSjoG8",
+    "name" : "k5IjwzwfOLqXXsO4As1",
+    "description" : "2CPTLZEm5T5XyDsURH8"
   } ],
-  "rightsHolder" : "DRDRq3tGaKQJ",
-  "duplicateOf" : "https://www.example.org/c459555d-93a4-412b-b8c9-32a82c69276e",
+  "rightsHolder" : "acG5lKwypPp6",
+  "duplicateOf" : "https://www.example.org/fec5b52e-6b7b-47e3-a73c-8c8f7723dab9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DfypsZQPDgxE"
+    "note" : "ZlmaWzgdISCn2"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jJBgz5iCzkzcCj0zF",
-    "createdBy" : "Xz3gNez5Ad",
-    "createdDate" : "2010-03-15T03:30:42.252Z"
+    "note" : "144ZylagTJx",
+    "createdBy" : "7sVoGiE8LqIG3wTo",
+    "createdDate" : "1982-04-28T15:53:32.301Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5848d792-2577-4089-a99a-d22566b04df8" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/e706dacf-d1d1-4ccc-bac8-88257074d77b" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "jrVNMUFzn3LJ",
-    "ownerAffiliation" : "https://www.example.org/df72e304-dc7f-47a7-abf1-c9288a120b8f"
+    "owner" : "zr4ac2S6qZn7DrF",
+    "ownerAffiliation" : "https://www.example.org/c15caa5c-8d80-4a81-9c89-ff0191711bd7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d0b54a02-9de2-411e-91d2-64d763f99fae"
+    "id" : "https://www.example.org/bfa3621e-93c0-48a7-89fc-c29bdbabe31f"
   },
-  "createdDate" : "2007-03-19T04:27:12.594Z",
-  "modifiedDate" : "1993-07-18T06:43:05.388Z",
-  "publishedDate" : "2001-07-17T19:15:48.699Z",
-  "indexedDate" : "2011-03-16T13:58:54.685Z",
-  "handle" : "https://www.example.org/1962cdb0-3698-470b-a8a2-3c3c5c438fd4",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/d47a5e29-dab3-42f8-8b31-30354ef1fba0",
+  "createdDate" : "2021-09-24T21:40:42.706Z",
+  "modifiedDate" : "2007-12-13T12:55:37.535Z",
+  "publishedDate" : "2023-01-03T22:10:34.532Z",
+  "indexedDate" : "2021-06-01T07:55:30.472Z",
+  "handle" : "https://www.example.org/e105fa1b-c993-44e7-944b-1f7dd9a1dc3d",
+  "doi" : "https://doi.org/10.1234/vero",
+  "link" : "https://www.example.org/b570612c-42f7-469e-91a2-6421f0fea602",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AHy0QJmPL2Y",
+    "mainTitle" : "kcrQ9HpPZUCx6wy2",
     "alternativeTitles" : {
-      "fi" : "gvq4YKMCIWv4"
+      "en" : "ZNPyCAfNHXS5SRe7Jt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "nMraZcVPYzn1QhOn",
-      "month" : "vJfujjKqzzO6",
-      "day" : "SRBBjuuFRurxb"
+      "year" : "TqEyJ58KOMQIqd9o",
+      "month" : "TmUiAxzNYEA8",
+      "day" : "fGu7l78MJ6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0b0c1e05-a142-413f-90c4-ca407515518b",
-        "name" : "S67yVxlOI3HzvvU",
-        "nameType" : "Organizational",
-        "orcId" : "cQbjI6Qq22JBix",
+        "id" : "https://www.example.org/a297a2e8-641d-40fa-bd1f-ed850ece6fb2",
+        "name" : "0Olw8CR5cZ4N",
+        "nameType" : "Personal",
+        "orcId" : "QCjAH0ZZngb",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Xnv2iLX0EPbX",
-          "value" : "KVNLmhMdtpO1FwjywC"
+          "sourceName" : "OzPltNORaGpL8",
+          "value" : "gyEaNY9rrlrZOEezv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aGJR9JW0jUlhXsK3CB",
-          "value" : "2ISe0EEe2Xxv4LVyk9P"
+          "sourceName" : "2dKY65jvOxP",
+          "value" : "oJ0XTA3WfbM4DDe0Yy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7dbe92ce-0ec7-4113-a377-a4a7437a00ab"
+        "id" : "https://www.example.org/7e5987c6-f30c-434e-8c14-4f4bfc3fc072"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c0d9e02a-4f71-4562-8fd5-58af8799c580",
-        "name" : "0NKo9G8vYT",
+        "id" : "https://www.example.org/bc015988-c814-4fd0-888a-07bd729ab6a1",
+        "name" : "3GYeD6U8NLCQQCVXWx",
         "nameType" : "Organizational",
-        "orcId" : "GYs0NrJNUv30EL",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "tBp6fu0lOSDGzzZcG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "j8oWPFQ99oRAK",
-          "value" : "hdJnQNcPgJdDL"
+          "sourceName" : "EaujxvStc44afr",
+          "value" : "l2n84h05JZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UaOqCO7ZWttr",
-          "value" : "SLFMN9uTmJAaoq8"
+          "sourceName" : "zuBA6czFt4QfpOmFo",
+          "value" : "ODNpu4QBxquOp4YKm"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f07bf6d7-4d0f-4fed-9259-8171849a4829"
+        "id" : "https://www.example.org/b8215e82-b6f7-4456-a46f-1cc98e4a2927"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "cFkHDXHdsLTtuMS"
+      "pt" : "VasVjfckQV"
     },
-    "npiSubjectHeading" : "oudgSaGGjInNwyy",
-    "tags" : [ "GAdNn3C4wyKwRWfncPP" ],
-    "description" : "wSfXTeLRE8DNc",
+    "npiSubjectHeading" : "hlpzlxm7nzolsX3",
+    "tags" : [ "H0GcMQEZHXZLa" ],
+    "description" : "0bqnj808A96L1Ln2m",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/fcYy67a4MWk7pnq"
+        "id" : "https://www.example.com/UhW5VD8pNmA0bqki"
       },
-      "doi" : "https://www.example.org/5d018226-2043-4f9e-855d-7dc2535aae12",
+      "doi" : "https://www.example.org/e57bc30b-fe89-49a5-8499-46b5fd77ba7c",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "xclTwKwRqOy9IrHSde",
-          "end" : "Dbx5NzOAQJ8yaJW3BI"
+          "begin" : "5Jehch0h58ZXl",
+          "end" : "UvdfqXBhpNyKwRLzcLC"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d634e679-631e-4553-a2de-18df1c94691b",
-    "abstract" : "uztm03xm7pGv1o"
+    "metadataSource" : "https://www.example.org/f14472fc-890e-4c4d-a144-5d75a2b9e703",
+    "abstract" : "kxM4jt9eNEmsamJPhf"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d009c87c-b859-4bde-b595-2559eea5ad12",
-    "name" : "9QGlUP8xRBa",
+    "id" : "https://www.example.org/56d8099d-0b45-4bb6-90d0-f1d9489acce0",
+    "name" : "uTrrXKfg7HaXu0X",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-11-21T00:18:37.724Z",
+      "approvalDate" : "2016-10-21T23:36:07.091Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "BK9vUAnkWTm5"
+      "applicationCode" : "wi3RKstzad2kFmdE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2d3b24c0-9461-4e1b-9daf-0df2ce242125",
-    "identifier" : "56LZfJgtw1T",
+    "source" : "https://www.example.org/f2bf949d-c394-48a0-a98d-112c281892a9",
+    "identifier" : "4ZaMfsSYzpgtSxCwOC",
     "labels" : {
-      "cs" : "nxqKuy4E52bAOlo8"
+      "de" : "ttId19yMxSG1"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 558182345
+    },
+    "activeFrom" : "2002-09-13T03:33:21.063Z",
+    "activeTo" : "2012-01-30T19:34:17.823Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/0b2af856-c682-47aa-aadc-4ac12581bdcb",
+    "id" : "https://www.example.org/2fabd5c7-7179-4bf5-a9d9-5cf15b0b95b2",
+    "identifier" : "XObebsh980Kf0hZ2E",
+    "labels" : {
+      "se" : "23KownqQpnaecxaiMNF"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1933985340
+      "amount" : 704191367
     },
-    "activeFrom" : "2014-09-24T22:59:08.729Z",
-    "activeTo" : "2020-05-18T10:15:14.252Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/693057a6-b016-45df-95fe-f2228e9db49d",
-    "id" : "https://www.example.org/555bc598-f596-4e32-8f4b-1ac4488b421f",
-    "identifier" : "6hA2GPRH8agYUj",
-    "labels" : {
-      "de" : "zBIAnlX1MZLbWiz8"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1990525077
-    },
-    "activeFrom" : "2022-01-11T07:18:35.438Z",
-    "activeTo" : "2022-06-14T04:57:16.234Z"
+    "activeFrom" : "2022-09-26T19:32:34.867Z",
+    "activeTo" : "2023-02-10T11:02:57.677Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8c250082-0a3b-415f-b3a0-31bf7f5cc3e9" ],
+  "subjects" : [ "https://www.example.org/cbfbc2cf-3a9f-47bf-b5b4-45b2965afd95" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "46bc4a04-66b0-4f8f-bfae-fa98f1675993",
-    "name" : "aiAYym7mhdiNbtKDjZ",
-    "mimeType" : "YGhRsmWbENP",
-    "size" : 501105093,
-    "license" : "https://www.example.com/cbjsmlprst34ws9pp",
+    "identifier" : "6cce84dc-5be1-4dd5-bde0-ede59a862ae4",
+    "name" : "o68hOBXPj3fy",
+    "mimeType" : "7AyrjkjGBxm1U5eWmt",
+    "size" : 1357092041,
+    "license" : "https://www.example.com/jogdfygmlf",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kM1sKz2ydZr",
-    "publishedDate" : "2014-02-14T21:03:30.263Z",
+    "legalNote" : "3eZtFoAppYNc9w5I",
+    "publishedDate" : "1984-08-31T04:29:11.156Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "GjwML7XwMDuVV7vF",
-      "uploadedDate" : "2014-10-14T00:07:45.242Z"
+      "uploadedBy" : "1Wl0rvaqfQI6tE5H",
+      "uploadedDate" : "1989-08-08T03:52:10.047Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/AaUV57twIjw8yYtdvR",
-    "name" : "ZM0mqFCwCHTGi7nY",
-    "description" : "A020ktB1S5PQuTCD"
+    "id" : "https://www.example.com/szWTDB6SyAWY",
+    "name" : "WYo3qA2ukl36AnW",
+    "description" : "iBhlMOMGohEDBC8O"
   } ],
-  "rightsHolder" : "XtG1TbPmmXzbd",
-  "duplicateOf" : "https://www.example.org/336c1b0f-4c21-4af4-a4fc-a8a43725a7c1",
+  "rightsHolder" : "39XycbT8uAq2HBB",
+  "duplicateOf" : "https://www.example.org/3b475bc8-8112-4e87-8b41-a53250d3f2fa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QUBUFSjJJLSJ"
+    "note" : "4VpnIeMpT4ivO"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dfxwyLqCNTJrt",
-    "createdBy" : "KbfqlKPJB8Wi",
-    "createdDate" : "2014-03-13T05:01:30.943Z"
+    "note" : "1hEJsSLsBTlxF0fF",
+    "createdBy" : "m2KLxj0N02QBbFj",
+    "createdDate" : "2020-09-28T07:48:53.985Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f29ba688-e0b8-4c65-8e07-59b2af5bb439" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/f2cbcbcc-3f38-4260-af9c-ef19b4077b03" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "GGFWjgAaDUVDqs",
-    "ownerAffiliation" : "https://www.example.org/c72b7c57-67e9-453a-a77e-9f89e2afaae6"
+    "owner" : "nfjcM6NA0URapRgoTwP",
+    "ownerAffiliation" : "https://www.example.org/dbbf300e-40d4-4d08-9aab-1169278ff6ea"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f892dfe1-9bfd-43e3-ae44-b43bc7e10b78"
+    "id" : "https://www.example.org/df820ea6-5164-42af-a93e-a0c5182d9d60"
   },
-  "createdDate" : "1973-01-26T00:02:19.641Z",
-  "modifiedDate" : "1996-10-21T18:25:49.630Z",
-  "publishedDate" : "2017-09-11T05:45:12.992Z",
-  "indexedDate" : "2003-02-21T21:38:37.991Z",
-  "handle" : "https://www.example.org/995dc3a5-6cd0-4aa9-96ae-45d121ad5211",
-  "doi" : "https://doi.org/10.1234/eos",
-  "link" : "https://www.example.org/0a26856a-7564-4fb3-b27a-1973757052d8",
+  "createdDate" : "1974-03-26T13:41:20.890Z",
+  "modifiedDate" : "2000-12-09T22:10:54.364Z",
+  "publishedDate" : "2011-04-12T04:15:04.661Z",
+  "indexedDate" : "1982-09-27T01:48:30.294Z",
+  "handle" : "https://www.example.org/a1f6fb7b-4e2b-4e2e-bbfe-8b6682531be9",
+  "doi" : "https://doi.org/10.1234/nam",
+  "link" : "https://www.example.org/ef1a2d32-912d-4085-916f-c65ce7cda28e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "wHv5JvZZ8zmT3UZ6u",
+    "mainTitle" : "Csu4IlRsm1EDm1U7WL",
     "alternativeTitles" : {
-      "sv" : "xFoCpHaDXYpVsxegm25"
+      "cs" : "TUnIkRJpJ4ftnk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TEWbI5kjoefIL5A",
-      "month" : "6vY3aIJNuO",
-      "day" : "QpqVWbOWjfRpZHTvcr"
+      "year" : "LVTFPMd8JJcGz7W9Qi",
+      "month" : "7xMbkiaB4mxHk8vebMN",
+      "day" : "KitVcf8ZFslYOCw3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4db2d838-d827-499c-a5ce-6a998ec14bbc",
-        "name" : "OnZfx4S0WAf7Lk",
+        "id" : "https://www.example.org/56f2f502-c367-4f1d-8c7c-24695e0ff048",
+        "name" : "EuX2IshbqtK",
         "nameType" : "Organizational",
-        "orcId" : "94WS1yBlUU7XN",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "ltPhwXRKJQ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ANH0urNLBonwE",
-          "value" : "Ax1fQ0KZSPqPgX"
+          "sourceName" : "0dKwcxe4McubFz5HG0",
+          "value" : "vODnCTlnobQl4Q"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hfL1C9dJGzDah5aZ",
-          "value" : "cuTK8uFKcL6MgaXfX"
+          "sourceName" : "iM2zcm6HIintX",
+          "value" : "kBlglPG84a"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/080c7c27-b127-4839-b918-fe50e457facb"
+        "id" : "https://www.example.org/11febaac-af5e-4bdb-a330-8f9f3a30bfcb"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "Advisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e34bc1bf-6d93-4062-b8f3-deca2204c79f",
-        "name" : "Y7ofigV5AQ1G",
+        "id" : "https://www.example.org/f4efec1a-acc8-4ea4-863e-e2e0d71d1066",
+        "name" : "4DkUkFWcLAREyL",
         "nameType" : "Personal",
-        "orcId" : "KiUMx6LjzB",
+        "orcId" : "6P1SmV183Bw7j",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GlwNRkKeeJwrpnH5y",
-          "value" : "DwGkojjXDc"
+          "sourceName" : "euR5kmV05oGC",
+          "value" : "AuYioIm2IsELzSt2qQj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v2jMpOV3cJ",
-          "value" : "X4scoTh8LE"
+          "sourceName" : "mOrFsPS3IRCtbX8",
+          "value" : "VuuhATXdRhF6U"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ccd92973-55e9-4349-898d-a238f5038f33"
+        "id" : "https://www.example.org/b8c736a3-8b7e-44b0-9699-dc8f1cf6fa5a"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "S8lSkM9PfRnFMaQu"
+      "en" : "iNX9k7XwtVs7nXg"
     },
-    "npiSubjectHeading" : "1kZ4AluLqV",
-    "tags" : [ "r0q6YDf6zphL" ],
-    "description" : "90UyDcDwaZTOTIyw",
+    "npiSubjectHeading" : "RsIVyjqVJ127ckx3",
+    "tags" : [ "lK4UErnimAaBlhuL" ],
+    "description" : "3xsUJXOkpr8RIwdsIB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/b6df2920-52ce-46ca-97c4-9ef9cd233145",
+      "doi" : "https://www.example.org/3709b3b7-56a9-420d-b302-d662ecb44b9d",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "ArtistBook"
+          "type" : "IndividualExhibition"
         },
-        "description" : "4sEXFO5MaOIOvnG5E",
+        "description" : "vlWQXZomnoI5i",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "I7FMgcbQfdA0GR",
-            "country" : "cCVdLoSn5K3gbsH"
+            "label" : "PZurjqJEB4KB",
+            "country" : "cZOOrocSP0"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2016-05-05T14:54:45.474Z",
-            "to" : "2017-02-25T19:02:01.325Z"
+            "from" : "1987-03-27T10:14:05.253Z",
+            "to" : "2006-03-29T00:05:32.597Z"
           },
-          "sequence" : 39763278
+          "sequence" : 935277358
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/94f992ad-84df-4f68-9993-707d9be6b7f6",
-    "abstract" : "32F4v5KuWbqbZNtG8q"
+    "metadataSource" : "https://www.example.org/d46b2bcc-9d17-4f87-91dc-6117b381eda2",
+    "abstract" : "T45z1PemlSlo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/893c3abd-437b-467d-971a-602ad83bf7ac",
-    "name" : "KwYH464H0FJbPco",
+    "id" : "https://www.example.org/3195e30c-f66c-49ae-a808-99a82f27b2b1",
+    "name" : "ekXzwK7FnEzL4Tnj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-01-28T02:28:20.883Z",
+      "approvalDate" : "1987-05-17T09:30:11.170Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "zbPoUpcbCewb6eqgj"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Xx0sfivQUU3VsVTGnM"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4d2890ea-5cba-44b4-9354-11f4f3f28448",
-    "identifier" : "2EchtLNp3bXTnz",
+    "source" : "https://www.example.org/fafe0390-a1f0-48ce-b7ff-68b65bcacb39",
+    "identifier" : "XUeGZYQDrAk",
     "labels" : {
-      "nb" : "0kAb4mzjJGHu"
+      "cs" : "PEpRIEiPqpL"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1567143308
+      "amount" : 747704099
     },
-    "activeFrom" : "2009-03-28T23:16:23.560Z",
-    "activeTo" : "2017-01-16T15:36:19.087Z"
+    "activeFrom" : "2000-05-09T01:54:21.936Z",
+    "activeTo" : "2011-11-08T08:19:01.848Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a38729ef-f45d-49a1-b4ea-c4300a202437",
-    "id" : "https://www.example.org/b61c2fd1-2a46-472c-98be-4d40406d3520",
-    "identifier" : "n8u2IZIqzPbqyuMI",
+    "source" : "https://www.example.org/f6c12fd7-cb4a-4b98-bf61-fd591fd33367",
+    "id" : "https://www.example.org/ac897032-4595-4595-b987-5fd91ee21245",
+    "identifier" : "OoryL4MVsbmpKK",
     "labels" : {
-      "pl" : "3q5Biv6UatV"
+      "it" : "y280gFcjZV6Of8a"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1604834527
+      "currency" : "EUR",
+      "amount" : 390818266
     },
-    "activeFrom" : "2012-09-27T21:27:44.070Z",
-    "activeTo" : "2023-10-08T08:27:29.441Z"
+    "activeFrom" : "2002-07-08T21:48:49.222Z",
+    "activeTo" : "2012-12-17T11:41:09.449Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5e5e4e20-9637-49d1-8e8a-42030c5d34cd" ],
+  "subjects" : [ "https://www.example.org/3647b784-6a5e-473a-b8ce-8aa3cbbd49ee" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8e5d0a66-cbb2-4146-a968-ee0819627185",
-    "name" : "JsMPh6Ki6B",
-    "mimeType" : "lHWYhXRNDd2qAUN",
-    "size" : 2083786411,
-    "license" : "https://www.example.com/xkqmepotxhs6n",
+    "identifier" : "ac529252-0adc-4ada-9c56-74209f96f6e6",
+    "name" : "97ad8t8jLuiB6y",
+    "mimeType" : "W4FxrWad6259cZ",
+    "size" : 354365463,
+    "license" : "https://www.example.com/amo63bil648trfksmw",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "wLoCvPuG2VOhF8q0"
+      "overriddenBy" : "eeo8luQzHdBPDQ19ya"
     },
-    "legalNote" : "o03BrJ6S5qmhuDNpkw",
-    "publishedDate" : "2017-11-28T22:32:21.966Z",
+    "legalNote" : "kIX3NwgltUKrcSke",
+    "publishedDate" : "2000-09-24T09:42:33.076Z",
     "uploadDetails" : {
       "type" : "UploadDetails",
-      "uploadedBy" : "7lH9X5CopP",
-      "uploadedDate" : "2001-09-05T08:51:40.994Z"
+      "uploadedBy" : "eLCEvcc7rihs4d",
+      "uploadedDate" : "2021-10-16T22:42:40.871Z"
     },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YLjdNvN8m4n9",
-    "name" : "pVXFg8vCJn",
-    "description" : "zKVL2U188xrVHao5zB"
+    "id" : "https://www.example.com/hccggsdzi5CBld",
+    "name" : "2kP3n5qZB04eWm2w0UB",
+    "description" : "rCkQNghzuxUCyxUT"
   } ],
-  "rightsHolder" : "Vm94sGtp3uyP",
-  "duplicateOf" : "https://www.example.org/d63a62e1-6037-4591-95bd-a6219037c956",
+  "rightsHolder" : "p3zbIIHAkmIRZ",
+  "duplicateOf" : "https://www.example.org/8f51bc59-101a-49e9-aa3a-a7b3b5c8772b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9XpXliIz5ZFfOF8Yww"
+    "note" : "O5IsmgeqgV"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "3awZyKL0aBJ2ukL",
-    "createdBy" : "9SWBf40tgNP3kxAZ",
-    "createdDate" : "2020-07-23T23:18:58.536Z"
+    "note" : "TTEhhwMzERjnRrf",
+    "createdBy" : "DfDPp9qwgdLwj",
+    "createdDate" : "1995-11-04T22:44:36.868Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/44018ee2-5660-4ab2-89f8-32d5e1c9fbb5" ],
-  "modelVersion" : "0.21.24"
+  "curatingInstitutions" : [ "https://www.example.org/f27b7ede-8996-4a2d-a382-0e7b221c1d4f" ],
+  "modelVersion" : "0.21.25"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -65,6 +65,10 @@ schema:
       properties:
         empty:
           type: boolean
+        first:
+          $ref: '#/components/schemas/AssociatedArtifact'
+        last:
+          $ref: '#/components/schemas/AssociatedArtifact'
       items:
         $ref: '#/components/schemas/AssociatedArtifact'
     rightsHolder:
@@ -351,6 +355,10 @@ referencedSchemas:
     properties:
       empty:
         type: boolean
+      first:
+        $ref: '#/components/schemas/AssociatedArtifact'
+      last:
+        $ref: '#/components/schemas/AssociatedArtifact'
     items:
       $ref: '#/components/schemas/AssociatedArtifact'
   AssociatedLink:
@@ -1262,13 +1270,13 @@ referencedSchemas:
     properties:
       identifier:
         type: string
-      source:
-        type: string
-        format: uri
       labels:
         type: object
         additionalProperties:
           type: string
+      source:
+        type: string
+        format: uri
       fundingAmount:
         $ref: '#/components/schemas/MonetaryAmount'
       activeFrom:
@@ -2455,6 +2463,10 @@ referencedSchemas:
         properties:
           empty:
             type: boolean
+          first:
+            $ref: '#/components/schemas/AssociatedArtifact'
+          last:
+            $ref: '#/components/schemas/AssociatedArtifact'
         items:
           $ref: '#/components/schemas/AssociatedArtifact'
       rightsHolder:

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -9,6 +9,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -32,11 +33,6 @@ import no.unit.nva.model.Username;
 import no.unit.nva.model.funding.Funding;
 import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.funding.MonetaryAmount;
-import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
-import no.unit.nva.model.instancetypes.degree.DegreeBase;
-import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
-import no.unit.nva.model.instancetypes.degree.DegreeMaster;
-import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator;
 import nva.commons.core.JacocoGenerated;
 
@@ -78,44 +74,18 @@ public final class PublicationGenerator {
         return buildRandomPublicationFromInstance(publicationInstanceClass);
     }
 
-    /*
-    This method is used to generate test data for tests regarding special protection of degree thesis. Use
-    randomPublicationNonDegreeThesis() for this purpose.
-     */
-    @Deprecated(since = "0.21.25", forRemoval = true)
-    public static Publication randomPublicationNonDegree() {
-        var nonDegrees = PublicationInstanceBuilder.listPublicationInstanceTypes()
-                             .stream()
-                             .filter(not(PublicationGenerator::isDegree))
-                             .toList();
-        return randomPublication(randomElement(nonDegrees));
+    public static Publication ofInstanceClasses(Class<?>... publicationInstanceClasses) {
+        var publicationInstanceClass = randomElement(publicationInstanceClasses);
+        return randomPublication(publicationInstanceClass);
     }
 
-    public static Publication randomPublicationNonDegreeThesis() {
-        var nonDegreeTheses = PublicationInstanceBuilder.listPublicationInstanceTypes()
-                             .stream()
-                             .filter(not(PublicationGenerator::isDegreeThesis))
-                             .toList();
-        return randomPublication(randomElement(nonDegreeTheses));
-    }
-
-    public static Publication randomPublicationDegreeThesis() {
-        var degreeTheses = PublicationInstanceBuilder.listPublicationInstanceTypes()
-                             .stream()
-                             .filter(PublicationGenerator::isDegreeThesis)
-                             .toList();
-        return randomPublication(randomElement(degreeTheses));
-    }
-
-    private static boolean isDegree(Class<?> subClass) {
-        return DegreeBase.class.isAssignableFrom(subClass);
-    }
-
-    private static boolean isDegreeThesis(Class<?> subClass) {
-        return subClass.equals(DegreePhd.class) ||
-               subClass.equals(DegreeMaster.class) ||
-               subClass.equals(DegreeBachelor.class) ||
-               subClass.equals(DegreeLicentiate.class);
+    public static Publication notOfInstanceClasses(Class<?>... publicationInstanceClasses) {
+        var listOfPublicationInstanceClasses = Arrays.asList(publicationInstanceClasses);
+        var otherPublicationInstanceClasses = PublicationInstanceBuilder.listPublicationInstanceTypes()
+                                                  .stream()
+                                                  .filter(not(listOfPublicationInstanceClasses::contains))
+                                                  .toList();
+        return randomPublication(randomElement(otherPublicationInstanceClasses));
     }
 
     public static Publication randomPublicationWithEmptyValues(Class<?> publicationInstanceClass) {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -32,7 +32,11 @@ import no.unit.nva.model.Username;
 import no.unit.nva.model.funding.Funding;
 import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.funding.MonetaryAmount;
+import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
 import no.unit.nva.model.instancetypes.degree.DegreeBase;
+import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
+import no.unit.nva.model.instancetypes.degree.DegreeMaster;
+import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator;
 import nva.commons.core.JacocoGenerated;
 
@@ -74,6 +78,11 @@ public final class PublicationGenerator {
         return buildRandomPublicationFromInstance(publicationInstanceClass);
     }
 
+    /*
+    This method is used to generate test data for tests regarding special protection of degree thesis. Use
+    randomPublicationNonDegreeThesis() for this purpose.
+     */
+    @Deprecated(since = "0.21.25", forRemoval = true)
     public static Publication randomPublicationNonDegree() {
         var nonDegrees = PublicationInstanceBuilder.listPublicationInstanceTypes()
                              .stream()
@@ -82,8 +91,31 @@ public final class PublicationGenerator {
         return randomPublication(randomElement(nonDegrees));
     }
 
+    public static Publication randomPublicationNonDegreeThesis() {
+        var nonDegreeTheses = PublicationInstanceBuilder.listPublicationInstanceTypes()
+                             .stream()
+                             .filter(not(PublicationGenerator::isDegreeThesis))
+                             .toList();
+        return randomPublication(randomElement(nonDegreeTheses));
+    }
+
+    public static Publication randomPublicationDegreeThesis() {
+        var degreeTheses = PublicationInstanceBuilder.listPublicationInstanceTypes()
+                             .stream()
+                             .filter(PublicationGenerator::isDegreeThesis)
+                             .toList();
+        return randomPublication(randomElement(degreeTheses));
+    }
+
     private static boolean isDegree(Class<?> subClass) {
         return DegreeBase.class.isAssignableFrom(subClass);
+    }
+
+    private static boolean isDegreeThesis(Class<?> subClass) {
+        return subClass.equals(DegreePhd.class) ||
+               subClass.equals(DegreeMaster.class) ||
+               subClass.equals(DegreeBachelor.class) ||
+               subClass.equals(DegreeLicentiate.class);
     }
 
     public static Publication randomPublicationWithEmptyValues(Class<?> publicationInstanceClass) {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -70,22 +70,25 @@ public final class PublicationGenerator {
     }
 
     public static Publication randomPublication(Class<?> publicationInstanceClass) {
-
         return buildRandomPublicationFromInstance(publicationInstanceClass);
     }
 
-    public static Publication ofInstanceClasses(Class<?>... publicationInstanceClasses) {
-        var publicationInstanceClass = randomElement(publicationInstanceClasses);
-        return randomPublication(publicationInstanceClass);
+    public static Publication fromInstanceClasses(Class<?>... targetClasses) {
+        var listOfTargetClasses = Arrays.asList(targetClasses);
+        var otherTargetClasses = PublicationInstanceBuilder.listPublicationInstanceTypes()
+                                     .stream()
+                                     .filter(listOfTargetClasses::contains)
+                                     .toList();
+        return randomPublication(randomElement(otherTargetClasses));
     }
 
-    public static Publication notOfInstanceClasses(Class<?>... publicationInstanceClasses) {
-        var listOfPublicationInstanceClasses = Arrays.asList(publicationInstanceClasses);
-        var otherPublicationInstanceClasses = PublicationInstanceBuilder.listPublicationInstanceTypes()
-                                                  .stream()
-                                                  .filter(not(listOfPublicationInstanceClasses::contains))
-                                                  .toList();
-        return randomPublication(randomElement(otherPublicationInstanceClasses));
+    public static Publication fromInstanceClassesExcluding(Class<?>... excludedClasses) {
+        var listOfExcludedClasses = Arrays.asList(excludedClasses);
+        var targetClasses = PublicationInstanceBuilder.listPublicationInstanceTypes()
+                                .stream()
+                                .filter(not(listOfExcludedClasses::contains))
+                                .toList();
+        return randomPublication(randomElement(targetClasses));
     }
 
     public static Publication randomPublicationWithEmptyValues(Class<?> publicationInstanceClass) {

--- a/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
+++ b/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
@@ -17,6 +17,7 @@ import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.contexttypes.Series;
+import no.unit.nva.model.instancetypes.journal.AcademicArticle;
 import no.unit.nva.model.instancetypes.journal.JournalArticle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,22 +44,22 @@ class PublicationGeneratorTest {
 
     @Test
     void shouldReturnPublicationThatIsInstanceOfClass() {
-        var publication = PublicationGenerator.ofInstanceClasses(JournalArticle.class);
+        var publication = PublicationGenerator.ofInstanceClasses(AcademicArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()
                                                .getClass();
-        assertThat(publicationInstanceTypeClass, is(equalTo(JournalArticle.class)));
+        assertThat(publicationInstanceTypeClass, is(equalTo(AcademicArticle.class)));
     }
 
     @Test
     void shouldReturnPublicationThatIsNotInstanceOfClass() {
-        var publication = PublicationGenerator.notOfInstanceClasses(JournalArticle.class);
+        var publication = PublicationGenerator.notOfInstanceClasses(AcademicArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()
                                                .getClass();
-        assertThat(publicationInstanceTypeClass, is(not(equalTo(JournalArticle.class))));
+        assertThat(publicationInstanceTypeClass, is(not(equalTo(AcademicArticle.class))));
     }
 
     @ParameterizedTest

--- a/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
+++ b/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
@@ -2,9 +2,10 @@ package no.unit.nva.model.testing;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.not;
 import java.net.URI;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -16,11 +17,8 @@ import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.contexttypes.Series;
-import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
-import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
-import no.unit.nva.model.instancetypes.degree.DegreeMaster;
-import no.unit.nva.model.instancetypes.degree.DegreePhd;
-import org.junit.jupiter.api.RepeatedTest;
+import no.unit.nva.model.instancetypes.journal.JournalArticle;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -35,11 +33,6 @@ class PublicationGeneratorTest {
         return PublicationInstanceBuilder.listPublicationInstanceTypes().stream();
     }
 
-    private static final Set<Class<?>> DEGREE_THESIS_INSTANCE_TYPES = Set.of(DegreePhd.class,
-                                                                             DegreeMaster.class,
-                                                                             DegreeBachelor.class,
-                                                                             DegreeLicentiate.class);
-
     @ParameterizedTest(name = "Should return publication of type {0} without empty fields")
     @MethodSource("publicationInstanceProvider")
     void shouldReturnPublicationWithoutEmptyFields(Class<?> publicationInstance) {
@@ -48,24 +41,24 @@ class PublicationGeneratorTest {
                    doesNotHaveEmptyValuesIgnoringFields(FIELDS_EXPECTED_TO_BE_NULL));
     }
 
-    @RepeatedTest(10)
-    void shouldReturnPublicationThatIsNotADegreeThesisWhenGeneratingNonDegreeThesis() {
-        var publication = PublicationGenerator.randomPublicationNonDegreeThesis();
+    @Test
+    void shouldReturnPublicationThatIsInstanceOfClass() {
+        var publication = PublicationGenerator.ofInstanceClasses(JournalArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()
                                                .getClass();
-        assertFalse(DEGREE_THESIS_INSTANCE_TYPES.contains(publicationInstanceTypeClass));
+        assertThat(publicationInstanceTypeClass, is(equalTo(JournalArticle.class)));
     }
 
-    @RepeatedTest(10)
-    void shouldReturnPublicationThatIsADegreeThesisWhenGeneratingDegreeThesis() {
-        var publication = PublicationGenerator.randomPublicationDegreeThesis();
+    @Test
+    void shouldReturnPublicationThatIsNotInstanceOfClass() {
+        var publication = PublicationGenerator.notOfInstanceClasses(JournalArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()
                                                .getClass();
-        assertTrue(DEGREE_THESIS_INSTANCE_TYPES.contains(publicationInstanceTypeClass));
+        assertThat(publicationInstanceTypeClass, is(not(equalTo(JournalArticle.class))));
     }
 
     @ParameterizedTest

--- a/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
+++ b/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
@@ -18,7 +18,6 @@ import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.contexttypes.Series;
 import no.unit.nva.model.instancetypes.journal.AcademicArticle;
-import no.unit.nva.model.instancetypes.journal.JournalArticle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,8 +42,8 @@ class PublicationGeneratorTest {
     }
 
     @Test
-    void shouldReturnPublicationThatIsInstanceOfClass() {
-        var publication = PublicationGenerator.ofInstanceClasses(AcademicArticle.class);
+    void shouldReturnPublicationThatIsInstanceOfTargetClasses() {
+        var publication = PublicationGenerator.fromInstanceClasses(AcademicArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()
@@ -53,8 +52,8 @@ class PublicationGeneratorTest {
     }
 
     @Test
-    void shouldReturnPublicationThatIsNotInstanceOfClass() {
-        var publication = PublicationGenerator.notOfInstanceClasses(AcademicArticle.class);
+    void shouldReturnPublicationThatIsInstanceOfTargetClassesExcluding() {
+        var publication = PublicationGenerator.fromInstanceClassesExcluding(AcademicArticle.class);
         var publicationInstanceTypeClass = publication.getEntityDescription()
                                                .getReference()
                                                .getPublicationInstance()

--- a/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
+++ b/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
@@ -4,6 +4,7 @@ import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -15,7 +16,10 @@ import no.unit.nva.model.contexttypes.Journal;
 import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.contexttypes.Publisher;
 import no.unit.nva.model.contexttypes.Series;
-import no.unit.nva.model.instancetypes.degree.DegreeBase;
+import no.unit.nva.model.instancetypes.degree.DegreeBachelor;
+import no.unit.nva.model.instancetypes.degree.DegreeLicentiate;
+import no.unit.nva.model.instancetypes.degree.DegreeMaster;
+import no.unit.nva.model.instancetypes.degree.DegreePhd;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,6 +35,11 @@ class PublicationGeneratorTest {
         return PublicationInstanceBuilder.listPublicationInstanceTypes().stream();
     }
 
+    private static final Set<Class<?>> DEGREE_THESIS_INSTANCE_TYPES = Set.of(DegreePhd.class,
+                                                                             DegreeMaster.class,
+                                                                             DegreeBachelor.class,
+                                                                             DegreeLicentiate.class);
+
     @ParameterizedTest(name = "Should return publication of type {0} without empty fields")
     @MethodSource("publicationInstanceProvider")
     void shouldReturnPublicationWithoutEmptyFields(Class<?> publicationInstance) {
@@ -40,9 +49,23 @@ class PublicationGeneratorTest {
     }
 
     @RepeatedTest(10)
-    void shouldReturnPublicationThatIsNotADegreeWhenGeneratingNonDegree() {
-        Publication publication = PublicationGenerator.randomPublicationNonDegree();
-        assertFalse(publication.getEntityDescription().getReference().getPublicationInstance() instanceof DegreeBase);
+    void shouldReturnPublicationThatIsNotADegreeThesisWhenGeneratingNonDegreeThesis() {
+        var publication = PublicationGenerator.randomPublicationNonDegreeThesis();
+        var publicationInstanceTypeClass = publication.getEntityDescription()
+                                               .getReference()
+                                               .getPublicationInstance()
+                                               .getClass();
+        assertFalse(DEGREE_THESIS_INSTANCE_TYPES.contains(publicationInstanceTypeClass));
+    }
+
+    @RepeatedTest(10)
+    void shouldReturnPublicationThatIsADegreeThesisWhenGeneratingDegreeThesis() {
+        var publication = PublicationGenerator.randomPublicationDegreeThesis();
+        var publicationInstanceTypeClass = publication.getEntityDescription()
+                                               .getReference()
+                                               .getPublicationInstance()
+                                               .getClass();
+        assertTrue(DEGREE_THESIS_INSTANCE_TYPES.contains(publicationInstanceTypeClass));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The datamodel repository contains PublicationGenerator class to help generate random publications during testing. For testing special access requirements for degree thesis, and to avoid these publication instance types when testing different scenarios, a method was added to generate random non-degree publications. However, this was based on instance being a subclass of DegreeBase, and that is not sufficient for the special access requirements that only applies to DegreePhd, DegreeMaster, DegreeBachelor and DegreeLicentiate.

In this PR the previous method is deprecated and marked for deletion, while I added two new methods to generate either random degree thesis or random non-degree thesis publications.