### PR TITLE
Np 46791 add import details to publication

### DIFF
--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.27'
+version '0.21.28'
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.15'
+version '0.21.26'
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nvadatamodel.java-conventions.gradle
@@ -10,7 +10,7 @@ plugins {
 group 'com.github.bibsysdev'
 
 
-version '0.21.26'
+version '0.21.27'
 
 repositories {
     mavenCentral()

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "UbrbUUDxhqHF4vBTtw",
-    "ownerAffiliation" : "https://www.example.org/0a29e270-4f3f-4f3d-afdc-3380a52d8252"
+    "owner" : "wBvoDFCvSq",
+    "ownerAffiliation" : "https://www.example.org/f16f57ad-ccb5-4ab1-8af0-923e70b05d51"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/448ff3f0-8365-4e7d-88b1-27b737a4d622"
+    "id" : "https://www.example.org/bf9677fe-66c3-490c-87e7-21beba161694"
   },
-  "createdDate" : "1988-02-16T22:28:05.971Z",
-  "modifiedDate" : "1990-11-04T19:35:15.712Z",
-  "publishedDate" : "1991-08-18T17:59:54.489Z",
-  "indexedDate" : "2004-10-23T07:08:23.318Z",
-  "handle" : "https://www.example.org/fe556feb-59df-48aa-b312-4bab73cf9723",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/7854bb21-c121-45ca-ac25-8442214c9bf0",
+  "createdDate" : "2001-08-13T12:05:47.338Z",
+  "modifiedDate" : "2021-09-21T02:23:33.130Z",
+  "publishedDate" : "1988-06-09T07:33:28.750Z",
+  "indexedDate" : "2004-05-31T07:16:55.342Z",
+  "handle" : "https://www.example.org/721f77e1-776a-4078-bf73-3f93f94fbada",
+  "doi" : "https://doi.org/10.1234/architecto",
+  "link" : "https://www.example.org/e7cb36ce-2e38-457a-a56f-80df422a2aa3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FZOxZqgEncyz86",
+    "mainTitle" : "W345EWY0yH3AUt",
     "alternativeTitles" : {
-      "fr" : "Itu3XdXEOOEg"
+      "el" : "qRSEpPvYgeHL8C2fqs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ABM8Vlny1VFojO4jEi",
-      "month" : "6PiWuuvnhD62YGGVV",
-      "day" : "US6R3TEQbR6p4s"
+      "year" : "jeumryldBNtruQ1U",
+      "month" : "vb2qAVJYdVIMj9",
+      "day" : "pRO2MDoV1MYAuOCusO"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4b556d86-deb6-4525-b3dd-454a1915ca04",
-        "name" : "Ny7BNQK967O2f3HmEfl",
+        "id" : "https://www.example.org/b1b54c5f-f4ba-46e6-b874-0b20445818bb",
+        "name" : "4IeTikBQRp2mCs9Y231",
         "nameType" : "Personal",
-        "orcId" : "xdvnQ6k7VrAg5",
+        "orcId" : "uy3KfCbGCNZMvcw",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ro4SWEXas1iiShDmnE",
-          "value" : "LOfSuKcd4fI7Y74n"
+          "sourceName" : "dp2NI5fsuic5K6x",
+          "value" : "TXNeVzCwcFMLso"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T8A1LotI6y2G3Hn",
-          "value" : "nTHY07kHFt"
+          "sourceName" : "YJ169qrHnLUCjqUQuAa",
+          "value" : "gIgMfCpjaSUlKxox"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d9dfc8f4-307c-4160-88be-8d2a8ccf60c0"
+        "id" : "https://www.example.org/1b6593b8-83c5-4cc5-b922-f2e209aa6a38"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c230af25-aba0-4f67-95e5-f61721630caa",
-        "name" : "Trjp8PmsUpZPafUGSq",
-        "nameType" : "Organizational",
-        "orcId" : "7rJdkvaboq5nUGw",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c242594c-15fe-4449-8523-fe4ea624fc93",
+        "name" : "6BzGcvq4rh0ag",
+        "nameType" : "Personal",
+        "orcId" : "faydqu0FI6vbK3i",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NPewjGKCYh5uxx53o7V",
-          "value" : "ebm9etTOjXLT"
+          "sourceName" : "aR8ffVfxhFCRI32Z",
+          "value" : "oxZPy4Ys6BbvnCiUZvZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JQEcyPeQ3msOTz7o",
-          "value" : "M5BbnUZDLxUYttZ0"
+          "sourceName" : "ZYuA4uPVDMfKllO",
+          "value" : "gXzH35MxmP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1562b87b-0680-45f4-9377-22f610280af2"
+        "id" : "https://www.example.org/aadaff6b-0559-4b93-8105-8cf1d0cd6da1"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "rfy1wtPGKZqX9Chwq4"
+      "is" : "0XyuLS51zvW66kOyiKc"
     },
-    "npiSubjectHeading" : "JU1IybLYkWJmq2g2BOl",
-    "tags" : [ "vXdRcXZ0M5" ],
-    "description" : "djn7TRNrLQ",
+    "npiSubjectHeading" : "u9WTg96Yxkld4b",
+    "tags" : [ "FnBYs4XnnvSd1Bz" ],
+    "description" : "o8VqJwWKpfb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9e7f17e4-0589-493e-a67b-5e0e20abaa65"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/982761e0-8f4a-4af4-bbb2-03a9033d9390"
       },
-      "doi" : "https://www.example.org/7369c6cb-33c8-4163-8d1d-a808e326e73b",
+      "doi" : "https://www.example.org/c2a94626-e410-4edd-93fe-7f69737da563",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "9EAjLA8snST",
-          "end" : "6u9ly0b5FSwCicg7dK"
+          "begin" : "ZBdoohOGiVKw2tpbDB",
+          "end" : "p7TtDgjxNGN3czesPAc"
         },
-        "volume" : "bdnAxu42ajSR0744Ian",
-        "issue" : "yNb6klBaCaz",
-        "articleNumber" : "35xfzT1cBkyJm"
+        "volume" : "a1aXf5jf1rbYUY",
+        "issue" : "pylbWEUpl7tKsfMm8S",
+        "articleNumber" : "9tlzAYlKBrpZ8ZHkj"
       }
     },
-    "metadataSource" : "https://www.example.org/0bf75e9c-5b0a-433b-be4c-8c652409e200",
-    "abstract" : "ojWXUZIND3uOOZ"
+    "metadataSource" : "https://www.example.org/681c9fd9-75a7-4409-96fb-dd2b582c0926",
+    "abstract" : "dHducApO1LQf"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4efe4d5a-d457-4d30-b495-acc2f7f16f20",
-    "name" : "pkQ70ITdGug",
+    "id" : "https://www.example.org/6d2e072f-791f-4e9d-9e17-9c3342cb21b2",
+    "name" : "4ZyAQ7ItgX0y",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-10-27T14:58:06.328Z",
+      "approvalDate" : "1983-03-05T19:54:56.472Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "8F35fx0t1JJ7Tk7r"
+      "applicationCode" : "7RQCcMaj4WHE8CSeo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d4e830aa-1f35-4f43-b25d-81bd75582361",
-    "identifier" : "nAQp7iVeN8zMVSbk",
+    "source" : "https://www.example.org/82423297-36a4-4ab2-9d6c-d157718fc25c",
+    "identifier" : "lRzciCFICI",
     "labels" : {
-      "el" : "89P7nboYXt9po"
+      "zh" : "teMg2fB3e4r8Jp3NGR"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 824852044
+      "currency" : "GBP",
+      "amount" : 756369687
     },
-    "activeFrom" : "1999-02-27T15:33:22.701Z",
-    "activeTo" : "2009-02-03T17:24:18.452Z"
+    "activeFrom" : "2004-11-08T00:11:40.808Z",
+    "activeTo" : "2010-11-15T10:07:47.795Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cf9e986d-f324-45c6-b5b8-ca39f5daa3f2",
-    "id" : "https://www.example.org/d49034c5-838e-40fb-bb6a-9de01d1e53d3",
-    "identifier" : "SRMhEjKoI2w",
+    "source" : "https://www.example.org/e08e0040-e7da-48e0-9fce-878d1ed25c1b",
+    "id" : "https://www.example.org/6ad533d7-a087-4b55-bfcb-43884b021339",
+    "identifier" : "TO5jeXT2iwayKELgMg",
     "labels" : {
-      "en" : "cdCQ846kSgex"
+      "de" : "DBjNaMDtW3Jv6Cs5LW"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1920322504
+      "amount" : 614554347
     },
-    "activeFrom" : "1988-01-13T02:33:32.664Z",
-    "activeTo" : "1992-05-18T06:12:27.120Z"
+    "activeFrom" : "2007-12-10T06:13:18.756Z",
+    "activeTo" : "2024-03-10T22:27:10.481Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3657a139-63f2-4542-99d2-7ebb813c8c08" ],
+  "subjects" : [ "https://www.example.org/dc6e5733-192a-46e9-bb6a-cdf759a9f9f0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "426dfb56-2c38-480b-abe1-413d9e6d108c",
-    "name" : "GbwGfqBf6QEQL7WyD",
-    "mimeType" : "rJMtxnJLjUEm",
-    "size" : 760614736,
-    "license" : "https://www.example.com/pzhid0pvw2e",
+    "identifier" : "1607d559-d99c-455b-88e7-2cdb9ddc11bc",
+    "name" : "7YIi8hO5ivqe",
+    "mimeType" : "eSvnDmfSpi6d6",
+    "size" : 1828279429,
+    "license" : "https://www.example.com/r5aunj9a6w",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mF6qIxtuRK",
-    "publishedDate" : "1984-09-04T07:59:02.142Z",
+    "legalNote" : "f3PMfThUm7B6x0yiu9a",
+    "publishedDate" : "1985-05-24T18:29:46.225Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "Kwny9KcKBM3",
+      "uploadedDate" : "1985-10-10T14:12:43.740Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zLbrnQZhb1",
-    "name" : "xmpl6YMOn5f4mNVV60A",
-    "description" : "eQTgt3ErJVw22GNae"
+    "id" : "https://www.example.com/nM4J7Rfvb9rJMiFB7t",
+    "name" : "pcIGsNfiSoxFYzgaDl",
+    "description" : "cRV4IXe0Jug5S"
   } ],
-  "rightsHolder" : "Qoc9ahP7GVt0ck51",
-  "duplicateOf" : "https://www.example.org/dc9c96ee-7b44-486d-bbaf-a31346492fec",
+  "rightsHolder" : "wLBmLggCvNcTED",
+  "duplicateOf" : "https://www.example.org/112ee8a7-5459-485e-82ef-77a3e8794ab2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Frt7vRBhyhcxpmh"
+    "note" : "fvUeMgjULkHp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "eejNPzT8XRbOiike",
-    "createdBy" : "a91A3yU6TZj",
-    "createdDate" : "2007-04-18T13:47:43.175Z"
+    "note" : "QwUim44k2eHYcOEZIkm",
+    "createdBy" : "ilu8mGFrm0NVlz29FZ4",
+    "createdDate" : "2004-08-20T10:05:12.985Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/250ffc6e-1c22-4b67-9a4f-802a839093d3" ],
+  "curatingInstitutions" : [ "https://www.example.org/5a9cca61-870d-4eef-a29a-64a3b99ef24e" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/AcademicArticle.json
+++ b/documentation/AcademicArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "LP74QYoJgV",
-    "ownerAffiliation" : "https://www.example.org/578f2612-0d58-4934-b53e-cb785cd8574e"
+    "owner" : "UbrbUUDxhqHF4vBTtw",
+    "ownerAffiliation" : "https://www.example.org/0a29e270-4f3f-4f3d-afdc-3380a52d8252"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c30cfbeb-e135-428a-8b00-eb3d7fec3bc9"
+    "id" : "https://www.example.org/448ff3f0-8365-4e7d-88b1-27b737a4d622"
   },
-  "createdDate" : "2004-01-02T02:37:44.325Z",
-  "modifiedDate" : "2011-05-26T02:03:29.004Z",
-  "publishedDate" : "1977-12-16T23:07:51.671Z",
-  "indexedDate" : "1987-08-04T13:39:12.626Z",
-  "handle" : "https://www.example.org/df6f8c67-155b-420a-9574-5a0e99dbf18f",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/00406736-4cd2-481d-aff9-a6ae38347b80",
+  "createdDate" : "1988-02-16T22:28:05.971Z",
+  "modifiedDate" : "1990-11-04T19:35:15.712Z",
+  "publishedDate" : "1991-08-18T17:59:54.489Z",
+  "indexedDate" : "2004-10-23T07:08:23.318Z",
+  "handle" : "https://www.example.org/fe556feb-59df-48aa-b312-4bab73cf9723",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/7854bb21-c121-45ca-ac25-8442214c9bf0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Yxa0fvtU6Ws",
+    "mainTitle" : "FZOxZqgEncyz86",
     "alternativeTitles" : {
-      "bg" : "o5pnzS7fn2zuVb81VUv"
+      "fr" : "Itu3XdXEOOEg"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "oehOzfPbI0hNi8IcsMe",
-      "month" : "o5EqBZDcGwhVkNUrqVh",
-      "day" : "71fi2Zdo9w"
+      "year" : "ABM8Vlny1VFojO4jEi",
+      "month" : "6PiWuuvnhD62YGGVV",
+      "day" : "US6R3TEQbR6p4s"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3568a31d-f5ee-4005-8b15-6f81fff18e95",
-        "name" : "JWUejkJz6y",
-        "nameType" : "Organizational",
-        "orcId" : "qeOQn2SMAymNmH",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/4b556d86-deb6-4525-b3dd-454a1915ca04",
+        "name" : "Ny7BNQK967O2f3HmEfl",
+        "nameType" : "Personal",
+        "orcId" : "xdvnQ6k7VrAg5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CVjbEE7SRm5rZLgn1E",
-          "value" : "lFRrj0MCMm40utKy"
+          "sourceName" : "Ro4SWEXas1iiShDmnE",
+          "value" : "LOfSuKcd4fI7Y74n"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VISGgWYInLMrZS",
-          "value" : "X7g2kODGBZ1bEr"
+          "sourceName" : "T8A1LotI6y2G3Hn",
+          "value" : "nTHY07kHFt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/eb92ea00-b5f7-47d2-93eb-e3cc7e3d3702"
+        "id" : "https://www.example.org/d9dfc8f4-307c-4160-88be-8d2a8ccf60c0"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "Scenographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4d337e5f-9fd4-4b85-8c91-e3f0a682bb1a",
-        "name" : "nXpJrizZxlFzAly0X",
-        "nameType" : "Personal",
-        "orcId" : "FoVVWxicuercr6",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/c230af25-aba0-4f67-95e5-f61721630caa",
+        "name" : "Trjp8PmsUpZPafUGSq",
+        "nameType" : "Organizational",
+        "orcId" : "7rJdkvaboq5nUGw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pxO2afVteUiNXETITyj",
-          "value" : "NvyxyFV3TSnM1ov"
+          "sourceName" : "NPewjGKCYh5uxx53o7V",
+          "value" : "ebm9etTOjXLT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PcEhCH4wmpMNJD",
-          "value" : "FK4nZ8fPUxMDR1RyNxa"
+          "sourceName" : "JQEcyPeQ3msOTz7o",
+          "value" : "M5BbnUZDLxUYttZ0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1a1e0b56-5eef-40a1-b850-f09340e490e1"
+        "id" : "https://www.example.org/1562b87b-0680-45f4-9377-22f610280af2"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "SLVcIOeYWnljn"
+      "cs" : "rfy1wtPGKZqX9Chwq4"
     },
-    "npiSubjectHeading" : "A1nwwF0nPBunmWpue",
-    "tags" : [ "1WbhkpQNFGn2IaX" ],
-    "description" : "vtdZgfaFC6UAw7",
+    "npiSubjectHeading" : "JU1IybLYkWJmq2g2BOl",
+    "tags" : [ "vXdRcXZ0M5" ],
+    "description" : "djn7TRNrLQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af403a88-ba42-46dc-a750-76b9e8c852dc"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9e7f17e4-0589-493e-a67b-5e0e20abaa65"
       },
-      "doi" : "https://www.example.org/987968b3-07ca-4b99-9af1-8daf07e1228c",
+      "doi" : "https://www.example.org/7369c6cb-33c8-4163-8d1d-a808e326e73b",
       "publicationInstance" : {
         "type" : "AcademicArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "EEzLHFfxRsUqQrvXQN",
-          "end" : "LuIvu2bzTU"
+          "begin" : "9EAjLA8snST",
+          "end" : "6u9ly0b5FSwCicg7dK"
         },
-        "volume" : "YfYfRuqDnZ9g9P",
-        "issue" : "gMpuB2eqHQc69wa7P",
-        "articleNumber" : "jUSn6Q1W0Aq"
+        "volume" : "bdnAxu42ajSR0744Ian",
+        "issue" : "yNb6klBaCaz",
+        "articleNumber" : "35xfzT1cBkyJm"
       }
     },
-    "metadataSource" : "https://www.example.org/1cb0307d-c3d2-4f2a-84dd-e06a2b5c05f2",
-    "abstract" : "Gvvpyo40mb4hL1oT"
+    "metadataSource" : "https://www.example.org/0bf75e9c-5b0a-433b-be4c-8c652409e200",
+    "abstract" : "ojWXUZIND3uOOZ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c2335dd4-164a-4868-9b1e-2498df052c06",
-    "name" : "hulr2YYTbxtU",
+    "id" : "https://www.example.org/4efe4d5a-d457-4d30-b495-acc2f7f16f20",
+    "name" : "pkQ70ITdGug",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-07-30T19:46:49.724Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2005-10-27T14:58:06.328Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "TYvBqjcaGA1TUHEOmW"
+      "applicationCode" : "8F35fx0t1JJ7Tk7r"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b8bd63f4-b2de-44f8-b258-149a6ce53638",
-    "identifier" : "UVZmsD1iTdNReJIa",
+    "source" : "https://www.example.org/d4e830aa-1f35-4f43-b25d-81bd75582361",
+    "identifier" : "nAQp7iVeN8zMVSbk",
     "labels" : {
-      "sv" : "EmVNPV5ii5mtemt"
+      "el" : "89P7nboYXt9po"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 418278625
+      "currency" : "USD",
+      "amount" : 824852044
     },
-    "activeFrom" : "2003-10-10T21:42:39.653Z",
-    "activeTo" : "2004-07-14T11:56:46.994Z"
+    "activeFrom" : "1999-02-27T15:33:22.701Z",
+    "activeTo" : "2009-02-03T17:24:18.452Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c220940d-6091-486c-85cc-b077364ccef0",
-    "id" : "https://www.example.org/86f49535-36cf-45db-9002-4649fc98c108",
-    "identifier" : "f4L7p5FHBQ",
+    "source" : "https://www.example.org/cf9e986d-f324-45c6-b5b8-ca39f5daa3f2",
+    "id" : "https://www.example.org/d49034c5-838e-40fb-bb6a-9de01d1e53d3",
+    "identifier" : "SRMhEjKoI2w",
     "labels" : {
-      "fi" : "u9GONZSeOeUwsBA"
+      "en" : "cdCQ846kSgex"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2025611457
+      "currency" : "USD",
+      "amount" : 1920322504
     },
-    "activeFrom" : "2018-02-03T11:41:44.937Z",
-    "activeTo" : "2021-09-04T15:05:09.616Z"
+    "activeFrom" : "1988-01-13T02:33:32.664Z",
+    "activeTo" : "1992-05-18T06:12:27.120Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/51842472-973e-4d34-a53f-cafbc406a719" ],
+  "subjects" : [ "https://www.example.org/3657a139-63f2-4542-99d2-7ebb813c8c08" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3d1ab76b-225c-4d25-93fa-9aeb4118c326",
-    "name" : "KPUy9qxU1jXw",
-    "mimeType" : "Uq7C1PlFbmpMh47aAV",
-    "size" : 1971910967,
-    "license" : "https://www.example.com/hlxfe8v00cjo94f",
+    "identifier" : "426dfb56-2c38-480b-abe1-413d9e6d108c",
+    "name" : "GbwGfqBf6QEQL7WyD",
+    "mimeType" : "rJMtxnJLjUEm",
+    "size" : 760614736,
+    "license" : "https://www.example.com/pzhid0pvw2e",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "94eM3JR4gL8GDZqF9W",
-    "publishedDate" : "2008-10-28T16:24:24.398Z",
+    "legalNote" : "mF6qIxtuRK",
+    "publishedDate" : "1984-09-04T07:59:02.142Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/76McRq5nlOcfXZm",
-    "name" : "od4RknlPSKvwY2SrWF",
-    "description" : "rlDezDL4Nqos9OJcR3n"
+    "id" : "https://www.example.com/zLbrnQZhb1",
+    "name" : "xmpl6YMOn5f4mNVV60A",
+    "description" : "eQTgt3ErJVw22GNae"
   } ],
-  "rightsHolder" : "xfkLldvKjYdZQ1C1mm",
-  "duplicateOf" : "https://www.example.org/fae25478-dc21-483f-bb6d-354e1151a37e",
+  "rightsHolder" : "Qoc9ahP7GVt0ck51",
+  "duplicateOf" : "https://www.example.org/dc9c96ee-7b44-486d-bbaf-a31346492fec",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "PwAwiM7MDxZWEhgSO"
+    "note" : "Frt7vRBhyhcxpmh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Wg2CNugF9QpXSSC",
-    "createdBy" : "T3ufr2i2kHtTgqPpJ",
-    "createdDate" : "2012-04-22T08:01:34.799Z"
+    "note" : "eejNPzT8XRbOiike",
+    "createdBy" : "a91A3yU6TZj",
+    "createdDate" : "2007-04-18T13:47:43.175Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6ac572c5-1fb1-4068-9425-2fd735d9066d" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/250ffc6e-1c22-4b67-9a4f-802a839093d3" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "qHh9ecZy4Uk93TG",
-    "ownerAffiliation" : "https://www.example.org/b7524367-8583-4dfb-81bc-3987d8b5b6a2"
+    "owner" : "ub0uUyFhFO",
+    "ownerAffiliation" : "https://www.example.org/185bca52-a07a-4bb8-94eb-00d4fa7fff46"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9147022a-ffac-4d53-8392-5ddd0ef3e9ea"
+    "id" : "https://www.example.org/ac5fe5b3-6e2d-4674-9aed-9598944ef203"
   },
-  "createdDate" : "2018-03-24T17:38:16.097Z",
-  "modifiedDate" : "2012-08-19T07:23:36.292Z",
-  "publishedDate" : "2005-06-11T15:03:23.626Z",
-  "indexedDate" : "2014-01-15T06:53:05.276Z",
-  "handle" : "https://www.example.org/d6f04218-b55e-48f5-8f09-93cc4253bfbf",
-  "doi" : "https://doi.org/10.1234/veniam",
-  "link" : "https://www.example.org/1b5a6a5a-353e-41af-af1f-768b220fdad1",
+  "createdDate" : "1986-02-17T15:03:44.714Z",
+  "modifiedDate" : "2014-05-07T22:56:14.183Z",
+  "publishedDate" : "2006-10-20T13:27:05.451Z",
+  "indexedDate" : "2009-03-17T18:41:15.714Z",
+  "handle" : "https://www.example.org/7d07da56-647d-4d04-8394-2a21fb4641a1",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/32d9922e-0cfd-47a3-8412-63891d68ff2e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "onrfMyOLeFSP7J6",
+    "mainTitle" : "89pO6oZkjc5QL3NBy8",
     "alternativeTitles" : {
-      "es" : "NKtG8tNEffYiG7R7V"
+      "fi" : "4sJUfKPRKW3zPDk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zvCUCjVXMbBSJTBEc",
-      "month" : "EY1t2lSE83ZE6dqO",
-      "day" : "nCCQ1XWypL2CYEdVnw"
+      "year" : "X4OkxLzpnkyXwcTJ",
+      "month" : "vgJBRBFVj2i39sd1vuq",
+      "day" : "UTIFWXFYO7HBObo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a59f64e-e25d-4e07-832b-f43e3195e15a",
-        "name" : "RDIbHtFk09gnj",
-        "nameType" : "Personal",
-        "orcId" : "XatbvpAgwXmFE",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/b594a8b0-4180-472b-b587-d077a1956180",
+        "name" : "izaZVWDPwR16YqMXe",
+        "nameType" : "Organizational",
+        "orcId" : "u752wr1klIWkWAilKlI",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aKswD14MrpBG10JHYPc",
-          "value" : "pHCSfrHXQU"
+          "sourceName" : "AvzVUitRPzoucoCkAPg",
+          "value" : "Me4jC2UcOyI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kiJ2WHxPsU",
-          "value" : "PQ06UelNViWv"
+          "sourceName" : "RTjarxfwrlKwlmF",
+          "value" : "cV0AiXI2M7lk0tu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9045eac3-d77a-4580-a2ca-f087c58478d4"
+        "id" : "https://www.example.org/49d9e1b9-ca76-4d9e-be45-c4a0e1874fb5"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c3765c62-0874-4816-8b0d-e03365139039",
-        "name" : "xRGodkpYCRp9",
-        "nameType" : "Personal",
-        "orcId" : "JHSu1NuB7mvB7t",
+        "id" : "https://www.example.org/ad009ffc-ca60-4b8f-9e6b-c97714e2b138",
+        "name" : "VYanNIMw1Ad",
+        "nameType" : "Organizational",
+        "orcId" : "OfeGYEASvFQ3z",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2BgJokWVhpjhcxI9BDL",
-          "value" : "0M1zuD1zwG"
+          "sourceName" : "yo0Nx3PpYiB3M",
+          "value" : "ffqPA3lndFCLB3m70"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kmdGrVMBeWgpx0a",
-          "value" : "Sy792yd6wH3Mom"
+          "sourceName" : "jwgAdtj1mcFndk",
+          "value" : "tjeJh9yEDExC1GVe9d0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0f6d74b5-f489-40ab-af05-eb80dc09d2bb"
+        "id" : "https://www.example.org/35fa230e-636a-4794-9fa7-1b35c9696f86"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "HostingInstitution"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "fPjmuiQF8Igtj0gIU"
+      "es" : "NJkfOhsHKJPTAee"
     },
-    "npiSubjectHeading" : "mM18ON9eY7tEE9CVKe",
-    "tags" : [ "Zehhz5gLB36hl9PsvhS" ],
-    "description" : "oJcOWKVcR5h6GR8kB1",
+    "npiSubjectHeading" : "OAMyapFfuK1VVWh9aO",
+    "tags" : [ "f56wbBey0vo" ],
+    "description" : "YpF63Orqw9Q",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/vmffcAfUroaBzcnz"
+        "id" : "https://www.example.com/wvu7KueLy3g"
       },
-      "doi" : "https://www.example.org/1af75b82-88fa-4d27-8a8d-34c24e4e2997",
+      "doi" : "https://www.example.org/a5b5b4bd-8454-437c-8fa7-73e632e0ba13",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "WUrWCe7gFhBb",
-          "end" : "8IPv8BCtUTzv"
+          "begin" : "CpdmN8GZKe65fSv",
+          "end" : "2NZaBjNVwSBpugQyk0e"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/353c03c8-a1a5-4fa2-b708-276a28bc1fcb",
-    "abstract" : "UEbFkEnlzr"
+    "metadataSource" : "https://www.example.org/c5978a3c-5a37-4e6c-9518-faf79cfd9051",
+    "abstract" : "8GT0GD7odhsWShBGz6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fd425cf5-8b40-4262-912e-ad23cf41a02f",
-    "name" : "2Uus7zrR9zkoCVLhlC",
+    "id" : "https://www.example.org/c73e0cac-4bf9-408e-8500-5ddec69d80b7",
+    "name" : "eFNmiDewdvV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-11-07T20:27:02.341Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Rnn1sGX8RS"
+      "approvalDate" : "1980-01-03T21:08:58.059Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "YYBdboVacmnoU8kTG"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7214c263-6548-4440-90c3-6a76181d9075",
-    "identifier" : "ALdlqZMHo5v",
+    "source" : "https://www.example.org/e941c1af-65ae-448b-818d-629be9d5dca9",
+    "identifier" : "cxLVjs7XwDHp3Ld0TO",
     "labels" : {
-      "es" : "sLjkULtSD4IKZP"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2130021114
-    },
-    "activeFrom" : "2017-08-11T23:40:52.540Z",
-    "activeTo" : "2022-01-31T20:50:12.726Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/62b4e040-73c9-45bc-ba57-0ae2374c66e4",
-    "id" : "https://www.example.org/1d71c6b4-bc65-48fa-9eec-11baeb9ac1a1",
-    "identifier" : "zTTrTcXDgr",
-    "labels" : {
-      "se" : "iRxUPCKLBI"
+      "fi" : "0jBvolf3UhKv0"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 338971862
+      "amount" : 184202471
     },
-    "activeFrom" : "1994-12-21T14:32:28.205Z",
-    "activeTo" : "2022-06-08T05:56:12.212Z"
+    "activeFrom" : "1974-05-19T16:46:05.097Z",
+    "activeTo" : "2010-12-24T19:31:16.064Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/707344c2-a2d6-485f-93a6-c10048865b7e",
+    "id" : "https://www.example.org/fd8c104b-1a3e-4a9c-9c4f-8740d714ce65",
+    "identifier" : "FbvexOQXngZSRHccl",
+    "labels" : {
+      "de" : "fYGBsuqgyci"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 46461314
+    },
+    "activeFrom" : "1997-06-17T04:48:04.536Z",
+    "activeTo" : "2011-02-15T01:07:49.069Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8e0f374e-6640-4d6f-86df-dd3bc278b533" ],
+  "subjects" : [ "https://www.example.org/11648074-e24b-41d8-adde-40e4a149f5ba" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2178fda4-2ca6-473f-8bf6-a79f50a08901",
-    "name" : "cWwUo69nJpV",
-    "mimeType" : "LtDplPP8tXOz",
-    "size" : 1152390291,
-    "license" : "https://www.example.com/inda5zs7fzvk",
+    "identifier" : "c75b7e68-57af-444d-a9a4-7ae59b69610d",
+    "name" : "XON7KxrADxmz3IY2zda",
+    "mimeType" : "wcXjyY9KN4uuTTE",
+    "size" : 1646816745,
+    "license" : "https://www.example.com/b9bgfiq1d3a",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "AzArhcMXYw74WQEeG6",
-    "publishedDate" : "2000-08-03T07:19:31.943Z",
+    "legalNote" : "Cg9Fq47CDe41Bbe",
+    "publishedDate" : "1974-12-17T08:54:24.791Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "sQWRQxjm7Mv",
+      "uploadedDate" : "1977-01-21T20:10:52.173Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3fFGDXQRGi13t3oGE8",
-    "name" : "z0zTj8liaE",
-    "description" : "6MjK8uHiRnYErCsVib"
+    "id" : "https://www.example.com/rmGt7C6gerRPwqo2",
+    "name" : "K8xS9SDcPTaFsW",
+    "description" : "3PGzbeX3G1xDePJr"
   } ],
-  "rightsHolder" : "Gho3amg6ht2m5F",
-  "duplicateOf" : "https://www.example.org/136a6b6d-dce4-411c-8826-a79bc87338ea",
+  "rightsHolder" : "2LqQzgtF6lxaRn3z",
+  "duplicateOf" : "https://www.example.org/44d7d59c-89c9-4dd4-b64e-df273d975616",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5gzQpgwM6Yc"
+    "note" : "g5KRKOKXOU92apy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8h2miSznqMKwG",
-    "createdBy" : "to3oAM1rplxJh",
-    "createdDate" : "1980-09-26T13:08:31.710Z"
+    "note" : "deoHfxV1FiYN9fwMHsu",
+    "createdBy" : "zdDCyHEviFs5m1n9vQb",
+    "createdDate" : "2005-01-28T02:51:52.122Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c9f324a7-3499-42e2-927a-8f51c4b6f568" ],
+  "curatingInstitutions" : [ "https://www.example.org/2a2c4628-66c8-46eb-b358-79ddfff4a563" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/AcademicChapter.json
+++ b/documentation/AcademicChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "Wonv3lp3wuNSN",
-    "ownerAffiliation" : "https://www.example.org/c8b8adc4-fbb5-4b96-a05c-c08a7640a67e"
+    "owner" : "qHh9ecZy4Uk93TG",
+    "ownerAffiliation" : "https://www.example.org/b7524367-8583-4dfb-81bc-3987d8b5b6a2"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a93aef3e-64c0-48de-b8ff-e88a4014aac5"
+    "id" : "https://www.example.org/9147022a-ffac-4d53-8392-5ddd0ef3e9ea"
   },
-  "createdDate" : "2015-01-08T11:27:45.913Z",
-  "modifiedDate" : "1997-12-15T09:50:24.989Z",
-  "publishedDate" : "1994-01-30T03:56:52.771Z",
-  "indexedDate" : "1973-10-06T14:33:21.629Z",
-  "handle" : "https://www.example.org/b77ced7d-387f-4a19-8fbc-609c0f432efd",
-  "doi" : "https://doi.org/10.1234/iure",
-  "link" : "https://www.example.org/d22fe209-22a6-4767-899b-0756a5aa3921",
+  "createdDate" : "2018-03-24T17:38:16.097Z",
+  "modifiedDate" : "2012-08-19T07:23:36.292Z",
+  "publishedDate" : "2005-06-11T15:03:23.626Z",
+  "indexedDate" : "2014-01-15T06:53:05.276Z",
+  "handle" : "https://www.example.org/d6f04218-b55e-48f5-8f09-93cc4253bfbf",
+  "doi" : "https://doi.org/10.1234/veniam",
+  "link" : "https://www.example.org/1b5a6a5a-353e-41af-af1f-768b220fdad1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FUvx4ZNHHpUMRw2NsZh",
+    "mainTitle" : "onrfMyOLeFSP7J6",
     "alternativeTitles" : {
-      "pl" : "P526QycKlX"
+      "es" : "NKtG8tNEffYiG7R7V"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "X9mLYm3CRhwM",
-      "month" : "MwJFFPupCeeApqZJO3h",
-      "day" : "N0DucbaHe2MQlx"
+      "year" : "zvCUCjVXMbBSJTBEc",
+      "month" : "EY1t2lSE83ZE6dqO",
+      "day" : "nCCQ1XWypL2CYEdVnw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3564f1fe-82d8-4e46-8683-2f41c420c26f",
-        "name" : "LqSM6q7iVOQ2bEyS7",
+        "id" : "https://www.example.org/8a59f64e-e25d-4e07-832b-f43e3195e15a",
+        "name" : "RDIbHtFk09gnj",
         "nameType" : "Personal",
-        "orcId" : "eYA4qPv60w",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "XatbvpAgwXmFE",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tSu8DdIejAkzw9v",
-          "value" : "02e1p5OTbot"
+          "sourceName" : "aKswD14MrpBG10JHYPc",
+          "value" : "pHCSfrHXQU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BNMk7mYXLo",
-          "value" : "TXP1Lvmrrs"
+          "sourceName" : "kiJ2WHxPsU",
+          "value" : "PQ06UelNViWv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/115af939-d782-45aa-9632-b0f199491190"
+        "id" : "https://www.example.org/9045eac3-d77a-4580-a2ca-f087c58478d4"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9c63715d-379f-48cd-851e-3a952aa8ac2c",
-        "name" : "GVmuI02cAVaBn",
+        "id" : "https://www.example.org/c3765c62-0874-4816-8b0d-e03365139039",
+        "name" : "xRGodkpYCRp9",
         "nameType" : "Personal",
-        "orcId" : "eWhXWmBLajVN",
+        "orcId" : "JHSu1NuB7mvB7t",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MxtpQxVRqLSbokijn",
-          "value" : "UvKe55LVQr39g"
+          "sourceName" : "2BgJokWVhpjhcxI9BDL",
+          "value" : "0M1zuD1zwG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MIesW9ZcKnIO",
-          "value" : "9uDQbElTyw"
+          "sourceName" : "kmdGrVMBeWgpx0a",
+          "value" : "Sy792yd6wH3Mom"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fda5edfc-efd9-4ea0-a18d-155ee4a429ce"
+        "id" : "https://www.example.org/0f6d74b5-f489-40ab-af05-eb80dc09d2bb"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Conservator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "1A6MUEu8VRwoJK1tWG"
+      "is" : "fPjmuiQF8Igtj0gIU"
     },
-    "npiSubjectHeading" : "aHMktuiCmsFRZZp",
-    "tags" : [ "3O8x2gAZiQz" ],
-    "description" : "8QECraEPSnkyDdkIaXl",
+    "npiSubjectHeading" : "mM18ON9eY7tEE9CVKe",
+    "tags" : [ "Zehhz5gLB36hl9PsvhS" ],
+    "description" : "oJcOWKVcR5h6GR8kB1",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/wDYITfoOzskiMIKO"
+        "id" : "https://www.example.com/vmffcAfUroaBzcnz"
       },
-      "doi" : "https://www.example.org/f1023833-d21f-4080-b318-0656b1a56460",
+      "doi" : "https://www.example.org/1af75b82-88fa-4d27-8a8d-34c24e4e2997",
       "publicationInstance" : {
         "type" : "AcademicChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "QpbEEtRr4D",
-          "end" : "Ezn6lvZXmGY62YHz8rD"
+          "begin" : "WUrWCe7gFhBb",
+          "end" : "8IPv8BCtUTzv"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/92fc3a8d-f254-4d74-a201-39a59f4c7eab",
-    "abstract" : "gRj0thxL7vccRpgJs"
+    "metadataSource" : "https://www.example.org/353c03c8-a1a5-4fa2-b708-276a28bc1fcb",
+    "abstract" : "UEbFkEnlzr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/af136826-270a-4e83-b63e-2c0ddad75798",
-    "name" : "uhwzOydceL7eTlHJz",
+    "id" : "https://www.example.org/fd425cf5-8b40-4262-912e-ad23cf41a02f",
+    "name" : "2Uus7zrR9zkoCVLhlC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-01-31T06:19:04.950Z",
+      "approvalDate" : "2002-11-07T20:27:02.341Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "1oIeDm8jOxA"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Rnn1sGX8RS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/715f6d0d-00ab-4890-abb1-40f7f80fe162",
-    "identifier" : "xhb67KBfq4eXBUieclW",
+    "source" : "https://www.example.org/7214c263-6548-4440-90c3-6a76181d9075",
+    "identifier" : "ALdlqZMHo5v",
     "labels" : {
-      "cs" : "nIXYUTWw0GHbA"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 284843297
-    },
-    "activeFrom" : "2005-12-22T12:53:17.283Z",
-    "activeTo" : "2014-11-13T01:45:20.117Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e3ccc668-7e3e-4377-93cf-6d074d5fe53e",
-    "id" : "https://www.example.org/1e6666d1-511d-45eb-89df-2fd33941367f",
-    "identifier" : "ByLz7IaNnmuLPM",
-    "labels" : {
-      "sv" : "0iNEOolKflZpKSrA"
+      "es" : "sLjkULtSD4IKZP"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 883541715
+      "amount" : 2130021114
     },
-    "activeFrom" : "2006-11-01T22:58:33.609Z",
-    "activeTo" : "2012-04-11T04:41:38.440Z"
+    "activeFrom" : "2017-08-11T23:40:52.540Z",
+    "activeTo" : "2022-01-31T20:50:12.726Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/62b4e040-73c9-45bc-ba57-0ae2374c66e4",
+    "id" : "https://www.example.org/1d71c6b4-bc65-48fa-9eec-11baeb9ac1a1",
+    "identifier" : "zTTrTcXDgr",
+    "labels" : {
+      "se" : "iRxUPCKLBI"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 338971862
+    },
+    "activeFrom" : "1994-12-21T14:32:28.205Z",
+    "activeTo" : "2022-06-08T05:56:12.212Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5a4952a0-c50d-4dd7-ba06-640a68f98585" ],
+  "subjects" : [ "https://www.example.org/8e0f374e-6640-4d6f-86df-dd3bc278b533" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ad0fc912-97ee-4da6-a38d-a3250d0f0f6a",
-    "name" : "U05cnAqIHjxzA2nS2",
-    "mimeType" : "lmLDWjghPNxhh7lP6F",
-    "size" : 1147265186,
-    "license" : "https://www.example.com/eutffmsxbpyr6za5qhw",
+    "identifier" : "2178fda4-2ca6-473f-8bf6-a79f50a08901",
+    "name" : "cWwUo69nJpV",
+    "mimeType" : "LtDplPP8tXOz",
+    "size" : 1152390291,
+    "license" : "https://www.example.com/inda5zs7fzvk",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "9WRWxLQfs63hSxi836",
-    "publishedDate" : "1975-11-01T14:33:54.896Z",
+    "legalNote" : "AzArhcMXYw74WQEeG6",
+    "publishedDate" : "2000-08-03T07:19:31.943Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XuC2NzzwriLiCN",
-    "name" : "WGQSp1vBDt",
-    "description" : "DvegEw4dN70IV6EjY"
+    "id" : "https://www.example.com/3fFGDXQRGi13t3oGE8",
+    "name" : "z0zTj8liaE",
+    "description" : "6MjK8uHiRnYErCsVib"
   } ],
-  "rightsHolder" : "aYTQbamXSWg7L",
-  "duplicateOf" : "https://www.example.org/383c5205-d892-48d5-847f-70743376e166",
+  "rightsHolder" : "Gho3amg6ht2m5F",
+  "duplicateOf" : "https://www.example.org/136a6b6d-dce4-411c-8826-a79bc87338ea",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QHVrYyI7zWPFU6"
+    "note" : "5gzQpgwM6Yc"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dnfducWYtp1A3",
-    "createdBy" : "XkApDm4cLvZCYY3DY",
-    "createdDate" : "2016-06-08T11:34:24.085Z"
+    "note" : "8h2miSznqMKwG",
+    "createdBy" : "to3oAM1rplxJh",
+    "createdDate" : "1980-09-26T13:08:31.710Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7c9af85a-a97f-4d78-b58d-9082858f2d5f" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/c9f324a7-3499-42e2-927a-8f51c4b6f568" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "vUdbDKn01gr",
-    "ownerAffiliation" : "https://www.example.org/d1d09ac2-c03c-49a4-8a5e-b722521ee637"
+    "owner" : "bvkTUPcAfQ",
+    "ownerAffiliation" : "https://www.example.org/956248e8-ffeb-4d2a-974a-bcf0817629ca"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/14d0983f-9ce0-4bfe-af65-687179e3a3f2"
+    "id" : "https://www.example.org/39077bd7-e232-4613-b7f0-2cefe887923f"
   },
-  "createdDate" : "1999-08-15T11:15:18.406Z",
-  "modifiedDate" : "1989-03-17T06:30:18.310Z",
-  "publishedDate" : "1999-07-06T19:57:48.777Z",
-  "indexedDate" : "2011-01-13T12:45:48.305Z",
-  "handle" : "https://www.example.org/fbcc754d-ef47-49db-a295-699ca2d77555",
-  "doi" : "https://doi.org/10.1234/repellat",
-  "link" : "https://www.example.org/12b678a4-28e8-4983-b156-8c6db9ad506b",
+  "createdDate" : "2013-02-10T03:08:31.817Z",
+  "modifiedDate" : "1980-10-08T22:22:56.510Z",
+  "publishedDate" : "1976-10-30T07:00:39.445Z",
+  "indexedDate" : "2020-10-11T08:21:56.724Z",
+  "handle" : "https://www.example.org/828b4096-2007-416a-bd79-7fb4d223507a",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/2813ef0b-1677-40ca-abbc-f17aede4ce73",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RHmx3OYArhoQmk8A6C",
+    "mainTitle" : "p9tuKu4YRX5yVw9DIk",
     "alternativeTitles" : {
-      "nn" : "kS52Ytrb5ux"
+      "is" : "njXzHwoIJC5uq"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "q8E5o1wr5F4",
-      "month" : "Xb7ewVYetmfaq18PUb",
-      "day" : "mDq1ITaKF7p08wJkYI"
+      "year" : "5sEy7Tv79y0w",
+      "month" : "hH0BtX8KVfZZY",
+      "day" : "oHjesFey1YdQ2DLDE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/44f5a03f-cf87-4965-9ec3-392709196a10",
-        "name" : "Ahdoof5TJbPU6VrtQd",
+        "id" : "https://www.example.org/827309b5-fd75-40a1-92d6-f75a81a9fc60",
+        "name" : "FHlNydIG9VWZ",
         "nameType" : "Organizational",
-        "orcId" : "4k0IGKNbHOnxIEn81A",
-        "verificationStatus" : "Verified",
+        "orcId" : "84nrOWjeMr0",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "017clGHrjZ0gojSHY",
-          "value" : "lztjZiq78QZpff"
+          "sourceName" : "WV4lpXhi6rVWJOhWyH",
+          "value" : "YB6bR64XkplNpE2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gU21tjBDeKC",
-          "value" : "C2D1JsBtMeyqq2p"
+          "sourceName" : "0U1Iildtkx2",
+          "value" : "hxYS5Vw7zoTBBjD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9b269757-b309-47f8-aa93-289bb889d396"
+        "id" : "https://www.example.org/fca689a6-b168-4327-8a89-0272e6ee6b1e"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1b0e28be-8f4c-4c12-a5c3-f2ee5611adf3",
-        "name" : "xOS9mmXZzoe",
-        "nameType" : "Personal",
-        "orcId" : "QL97S6DhDkzsoU0M",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ae72851f-6f16-4d0c-bc8e-6c2e48cbc560",
+        "name" : "EHyObmY7SEyJG4Qbe",
+        "nameType" : "Organizational",
+        "orcId" : "MVrdstjY9Gg4WRT",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qxlOShKaK3DnIeq",
-          "value" : "oFYUSSY8AXiEo"
+          "sourceName" : "RQbu15eBsehjrTAC3S",
+          "value" : "QAoF45SgmQzke"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oZL6qMiOXG9E",
-          "value" : "MEIRBOzN01SnU"
+          "sourceName" : "gUEyRtX59iK8TplM",
+          "value" : "q2x2UXZRigHBuAw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4d774c54-4539-4580-a20e-228bbdff6819"
+        "id" : "https://www.example.org/ccb0170b-2713-49b9-a8f2-69af361d3e22"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Designer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "apA6aupca3orIo5m"
+      "pl" : "OBSxi3H9h05FxzKrcRX"
     },
-    "npiSubjectHeading" : "b9859DxKZU",
-    "tags" : [ "1Ldy3RW1BPAcP" ],
-    "description" : "jmXYFOxweoJLBtdw54A",
+    "npiSubjectHeading" : "SxakLPWnar0",
+    "tags" : [ "HlBoYIk6PBJcqb5" ],
+    "description" : "41LSccwyrKQ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2f7b0005-a2e6-4647-aa66-21e6722bcb5a"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d0bc2d57-76b0-408e-ad6c-c452d12088c4"
       },
-      "doi" : "https://www.example.org/075df0bc-05fe-42b3-b0db-d075794b4dca",
+      "doi" : "https://www.example.org/8954425d-dde7-4724-9db9-78e56aed65f2",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "NbGYpfmHy01l",
-          "end" : "1lfUmdX3CiV"
+          "begin" : "tMf0nUp9OLabb6",
+          "end" : "lunn7WjtOpBfU23qU"
         },
-        "volume" : "KF8pnBeWLq0U",
-        "issue" : "xTcOMPEqpVRCp",
-        "articleNumber" : "P1K6wXtzd8wcuVW"
+        "volume" : "Rsj5Wtp7ifw",
+        "issue" : "jmVPgAzfzscKWr",
+        "articleNumber" : "ow4MmYGzrpbdxVNc"
       }
     },
-    "metadataSource" : "https://www.example.org/9e5bec23-31cb-4bc4-aaae-dcf525634579",
-    "abstract" : "MrHH2XAvb0z5ejbNom"
+    "metadataSource" : "https://www.example.org/d138cdcc-e203-41b8-bfa1-b80a07ddae90",
+    "abstract" : "OauYta6VJmM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e88db12f-4d5d-4ba7-acc0-5812486bd73c",
-    "name" : "oU3zFPl0I5m1Qc7bU",
+    "id" : "https://www.example.org/137f520a-ef93-4414-9386-ec161044f2c6",
+    "name" : "SgW5hrXpewWK",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1995-12-30T00:20:55.341Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "OFt4uqO36ts5azFSGh"
+      "approvalDate" : "1995-01-08T01:05:11.388Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "HccxkKnTBEnrLjk8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/74c08a88-4bfc-4553-8569-757650133f13",
-    "identifier" : "Fwj92K0z3h",
+    "source" : "https://www.example.org/5e7acb30-19c4-47e4-96ab-bae7937d67a9",
+    "identifier" : "ixeyjXVbJFohioT9r",
     "labels" : {
-      "ca" : "87dIG82mxz4Tkq"
+      "fi" : "Iw1RtwOKfOORAWimt"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1653441716
+      "currency" : "USD",
+      "amount" : 152017094
     },
-    "activeFrom" : "2004-12-10T16:12:06.901Z",
-    "activeTo" : "2021-03-23T19:47:45.654Z"
+    "activeFrom" : "1979-03-07T12:36:05.467Z",
+    "activeTo" : "1979-06-01T13:49:30.754Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/fc434249-4001-48e5-88ad-f4157345d2ee",
-    "id" : "https://www.example.org/c1ec406e-ee99-439c-a2bc-9b3f638b603b",
-    "identifier" : "JQ5y23VYnE5P",
+    "source" : "https://www.example.org/18f2d256-d6ce-4561-a05f-4383a2c1d986",
+    "id" : "https://www.example.org/1fb78eee-a34e-480e-8c49-7147dd9f9b0a",
+    "identifier" : "8sd0SF7Yes",
     "labels" : {
-      "ca" : "tvnxM9ePDspqDQ"
+      "fr" : "hDp9WOsXsVv"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2093255645
+      "currency" : "USD",
+      "amount" : 1069380599
     },
-    "activeFrom" : "1977-05-15T12:55:53.362Z",
-    "activeTo" : "1991-06-15T18:50:30.022Z"
+    "activeFrom" : "1981-09-08T17:18:01.114Z",
+    "activeTo" : "1986-08-13T01:04:53.342Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1d1953e9-8df3-4b3e-8053-6f32e49d3987" ],
+  "subjects" : [ "https://www.example.org/fc5f6ff5-3989-49a6-83c8-ed16d9a6f7a4" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b58cd1a7-afd0-48b6-a2b2-813824f739d3",
-    "name" : "B5K4iNNdz5dQIB2SO7",
-    "mimeType" : "zYUBzXxzR7",
-    "size" : 1045099668,
-    "license" : "https://www.example.com/s2arl7c1t0n",
+    "identifier" : "26cbdbac-90f9-406f-ada4-3cadc4a093cb",
+    "name" : "8X5FyzkIJVIa",
+    "mimeType" : "xZMMFx2zxlNxYzluM2I",
+    "size" : 1670739139,
+    "license" : "https://www.example.com/zigfaao8psma",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "NI8OuQ1VxctJf5"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "TtZNJUalz0",
-    "publishedDate" : "1993-06-27T15:50:13.080Z",
+    "legalNote" : "EXu9hRNpxxjKQY3",
+    "publishedDate" : "2008-10-22T01:03:39.763Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "xtHvCKnbzkwBxanOUCQ",
+      "uploadedDate" : "2009-04-26T07:50:53.176Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7jxTpJQtXRbK6JV3",
-    "name" : "XLsNOdIh5IHgrqb1Zu",
-    "description" : "0N7Kw6DFg4HYZr2pW"
+    "id" : "https://www.example.com/ncFCFqMEGyx9YQyX",
+    "name" : "IlPQ41wcP6ZLM",
+    "description" : "rkJboI30YGzxQj"
   } ],
-  "rightsHolder" : "e7fSgZUojw6iDhs55Ms",
-  "duplicateOf" : "https://www.example.org/264b173e-f2ca-4cec-8cb9-df0a94351c45",
+  "rightsHolder" : "fD4k1PyNXbkxtdLew",
+  "duplicateOf" : "https://www.example.org/f621922b-95ed-4a02-b9fa-4bac5a728c55",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "AGoQdPmWwOIp2NvZ"
+    "note" : "yJoCJT8rFBLdUeRd"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DgghvfinSQvn",
-    "createdBy" : "QPxgx8KV11",
-    "createdDate" : "1980-01-27T18:35:08.975Z"
+    "note" : "u5cUczmy3l65MZNaxb",
+    "createdBy" : "RChWYvyNaP9",
+    "createdDate" : "2013-07-04T20:52:11.061Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1f10e3fe-03dc-45a7-846d-4397901772d9" ],
+  "curatingInstitutions" : [ "https://www.example.org/032cbc7c-3116-4700-9b59-0e1066266993" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/AcademicLiteratureReview.json
+++ b/documentation/AcademicLiteratureReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "YdHLhkTaQjI6ZeH8A",
-    "ownerAffiliation" : "https://www.example.org/78a9f61c-499d-479b-8d95-053cb11b1b7e"
+    "owner" : "vUdbDKn01gr",
+    "ownerAffiliation" : "https://www.example.org/d1d09ac2-c03c-49a4-8a5e-b722521ee637"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/dd5468a0-7dd6-46a5-b385-56763412dbeb"
+    "id" : "https://www.example.org/14d0983f-9ce0-4bfe-af65-687179e3a3f2"
   },
-  "createdDate" : "1990-06-08T13:45:03.566Z",
-  "modifiedDate" : "1996-07-06T09:01:42.838Z",
-  "publishedDate" : "1987-02-10T17:59:40.665Z",
-  "indexedDate" : "1996-02-02T14:15:33.316Z",
-  "handle" : "https://www.example.org/58099b83-8750-4b64-b9ae-7f32e0c02e5c",
-  "doi" : "https://doi.org/10.1234/illo",
-  "link" : "https://www.example.org/200a5b2b-eee3-42d6-b195-35ec0857f129",
+  "createdDate" : "1999-08-15T11:15:18.406Z",
+  "modifiedDate" : "1989-03-17T06:30:18.310Z",
+  "publishedDate" : "1999-07-06T19:57:48.777Z",
+  "indexedDate" : "2011-01-13T12:45:48.305Z",
+  "handle" : "https://www.example.org/fbcc754d-ef47-49db-a295-699ca2d77555",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/12b678a4-28e8-4983-b156-8c6db9ad506b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "viCe2GHpH5PP3",
+    "mainTitle" : "RHmx3OYArhoQmk8A6C",
     "alternativeTitles" : {
-      "nb" : "o71yk8t8zCwmXTK1aew"
+      "nn" : "kS52Ytrb5ux"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "84hXlufESL6F0",
-      "month" : "m4XN4XsNZAMAdR",
-      "day" : "n0pQ7uFZUcO6"
+      "year" : "q8E5o1wr5F4",
+      "month" : "Xb7ewVYetmfaq18PUb",
+      "day" : "mDq1ITaKF7p08wJkYI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/46aa31a9-bb3f-4e03-a972-2dcbb09bc082",
-        "name" : "iQcy1Um9ZZ2",
-        "nameType" : "Personal",
-        "orcId" : "MUxyRavwUbbtXgOF",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/44f5a03f-cf87-4965-9ec3-392709196a10",
+        "name" : "Ahdoof5TJbPU6VrtQd",
+        "nameType" : "Organizational",
+        "orcId" : "4k0IGKNbHOnxIEn81A",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z7zYqQO3RN6XOBL",
-          "value" : "t7JolUSpEcpEJEDIt"
+          "sourceName" : "017clGHrjZ0gojSHY",
+          "value" : "lztjZiq78QZpff"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "osNyE9eTFQ3Ke",
-          "value" : "iitO2NZ1kIP3bLU"
+          "sourceName" : "gU21tjBDeKC",
+          "value" : "C2D1JsBtMeyqq2p"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9da97ff2-49ff-4d1f-b246-115e1bd28138"
+        "id" : "https://www.example.org/9b269757-b309-47f8-aa93-289bb889d396"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a7553cbd-e64c-4e2c-a379-ffeec11665e0",
-        "name" : "lIgTjCPDN80e",
-        "nameType" : "Organizational",
-        "orcId" : "Rt2YUiSrAO",
+        "id" : "https://www.example.org/1b0e28be-8f4c-4c12-a5c3-f2ee5611adf3",
+        "name" : "xOS9mmXZzoe",
+        "nameType" : "Personal",
+        "orcId" : "QL97S6DhDkzsoU0M",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qGeeRKX9aLQEEglABsn",
-          "value" : "hOZwMBbqrl"
+          "sourceName" : "qxlOShKaK3DnIeq",
+          "value" : "oFYUSSY8AXiEo"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oI78xS6Tg6gbev7kj",
-          "value" : "tEEjol9zrQ9nW"
+          "sourceName" : "oZL6qMiOXG9E",
+          "value" : "MEIRBOzN01SnU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/91e14c3e-db54-4ba0-8f32-978a556660af"
+        "id" : "https://www.example.org/4d774c54-4539-4580-a20e-228bbdff6819"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "URJfEPC0aXqEduyiP"
+      "sv" : "apA6aupca3orIo5m"
     },
-    "npiSubjectHeading" : "EmOdsG5uIE",
-    "tags" : [ "4OGD8MWO3hwNKH2tvG" ],
-    "description" : "BqsqJJfSVrtHWRK",
+    "npiSubjectHeading" : "b9859DxKZU",
+    "tags" : [ "1Ldy3RW1BPAcP" ],
+    "description" : "jmXYFOxweoJLBtdw54A",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7db7939c-18fd-4d38-a574-97ce056b1225"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2f7b0005-a2e6-4647-aa66-21e6722bcb5a"
       },
-      "doi" : "https://www.example.org/7eb76f16-8a5b-4872-9758-6e756cce1242",
+      "doi" : "https://www.example.org/075df0bc-05fe-42b3-b0db-d075794b4dca",
       "publicationInstance" : {
         "type" : "AcademicLiteratureReview",
         "pages" : {
           "type" : "Range",
-          "begin" : "xHplNakTyY",
-          "end" : "cTb5C2I4vdFMztZ0El"
+          "begin" : "NbGYpfmHy01l",
+          "end" : "1lfUmdX3CiV"
         },
-        "volume" : "6SRbgt75FUUk",
-        "issue" : "ajjreXeNnzWisw8LCTT",
-        "articleNumber" : "5GD0loxMzNOdW1V4a"
+        "volume" : "KF8pnBeWLq0U",
+        "issue" : "xTcOMPEqpVRCp",
+        "articleNumber" : "P1K6wXtzd8wcuVW"
       }
     },
-    "metadataSource" : "https://www.example.org/173492be-2751-4439-927d-222de4c0c8fe",
-    "abstract" : "QLUsqZNulGy6aTrnrT"
+    "metadataSource" : "https://www.example.org/9e5bec23-31cb-4bc4-aaae-dcf525634579",
+    "abstract" : "MrHH2XAvb0z5ejbNom"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d794a346-a4af-4b73-8792-9aa46a88999a",
-    "name" : "s15t0ITOWkxVziOE9kd",
+    "id" : "https://www.example.org/e88db12f-4d5d-4ba7-acc0-5812486bd73c",
+    "name" : "oU3zFPl0I5m1Qc7bU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-12-13T05:50:03.378Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "EifeKMmQQI80eOv"
+      "approvalDate" : "1995-12-30T00:20:55.341Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "OFt4uqO36ts5azFSGh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/020a0369-9297-438e-9f25-30b42d5acb28",
-    "identifier" : "c1VkNizp4MvfOGH7Thg",
+    "source" : "https://www.example.org/74c08a88-4bfc-4553-8569-757650133f13",
+    "identifier" : "Fwj92K0z3h",
     "labels" : {
-      "en" : "ko9GRufs7iVi"
+      "ca" : "87dIG82mxz4Tkq"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1108241998
+      "amount" : 1653441716
     },
-    "activeFrom" : "2014-03-16T20:26:51.027Z",
-    "activeTo" : "2020-08-22T15:23:59.476Z"
+    "activeFrom" : "2004-12-10T16:12:06.901Z",
+    "activeTo" : "2021-03-23T19:47:45.654Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/af537b60-45ef-4b2d-9308-c86a21931e11",
-    "id" : "https://www.example.org/03cc9c73-ac79-4ed8-a520-138329dc60c1",
-    "identifier" : "lzVyKoRriZRikNCbLa",
+    "source" : "https://www.example.org/fc434249-4001-48e5-88ad-f4157345d2ee",
+    "id" : "https://www.example.org/c1ec406e-ee99-439c-a2bc-9b3f638b603b",
+    "identifier" : "JQ5y23VYnE5P",
     "labels" : {
-      "da" : "1DdkbMOtcX4OX"
+      "ca" : "tvnxM9ePDspqDQ"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1864857948
+      "amount" : 2093255645
     },
-    "activeFrom" : "2008-01-25T13:41:29.474Z",
-    "activeTo" : "2023-03-15T04:52:31.166Z"
+    "activeFrom" : "1977-05-15T12:55:53.362Z",
+    "activeTo" : "1991-06-15T18:50:30.022Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0a16dace-afee-4201-84ed-b89cc0a7fff2" ],
+  "subjects" : [ "https://www.example.org/1d1953e9-8df3-4b3e-8053-6f32e49d3987" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "59e08419-2edc-4399-a096-b7fcb9863582",
-    "name" : "7wBYoaTbXTLtMJbWzHk",
-    "mimeType" : "IKj43EkFzQChbISn8",
-    "size" : 436031671,
-    "license" : "https://www.example.com/gr7yvsolqzmohei5",
+    "identifier" : "b58cd1a7-afd0-48b6-a2b2-813824f739d3",
+    "name" : "B5K4iNNdz5dQIB2SO7",
+    "mimeType" : "zYUBzXxzR7",
+    "size" : 1045099668,
+    "license" : "https://www.example.com/s2arl7c1t0n",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "NI8OuQ1VxctJf5"
     },
-    "legalNote" : "teIGRQClZYwQkQ1sCjD",
-    "publishedDate" : "1990-12-28T23:59:21.871Z",
+    "legalNote" : "TtZNJUalz0",
+    "publishedDate" : "1993-06-27T15:50:13.080Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/142Cbg1DQxFMarRj",
-    "name" : "JtVQnc8l4BuNBw",
-    "description" : "cTddaauqRVP"
+    "id" : "https://www.example.com/7jxTpJQtXRbK6JV3",
+    "name" : "XLsNOdIh5IHgrqb1Zu",
+    "description" : "0N7Kw6DFg4HYZr2pW"
   } ],
-  "rightsHolder" : "3HTUsAh0CGjyRwea7D",
-  "duplicateOf" : "https://www.example.org/b1202fe2-eac0-43f1-86c2-1a2a98cf9d65",
+  "rightsHolder" : "e7fSgZUojw6iDhs55Ms",
+  "duplicateOf" : "https://www.example.org/264b173e-f2ca-4cec-8cb9-df0a94351c45",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "uhZkw6GhU2oGvep9Q"
+    "note" : "AGoQdPmWwOIp2NvZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ThY7uk36Eu5",
-    "createdBy" : "larJCfmFDpopOxATcX",
-    "createdDate" : "2012-09-02T12:44:20.272Z"
+    "note" : "DgghvfinSQvn",
+    "createdBy" : "QPxgx8KV11",
+    "createdDate" : "1980-01-27T18:35:08.975Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/22670e92-5c59-47ce-a5ca-d12cc51140e6" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/1f10e3fe-03dc-45a7-846d-4397901772d9" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "om7eG57IS0PZsNln",
-    "ownerAffiliation" : "https://www.example.org/c9db875f-7d2d-44d0-bbba-60c5a3b7b5e3"
+    "owner" : "bC12pH51YjeYtT7y",
+    "ownerAffiliation" : "https://www.example.org/a521301f-e987-48c1-a6d0-e2090c397ff0"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3383e54f-adba-4ecd-ae6f-5dc44bc86fed"
+    "id" : "https://www.example.org/f8547b62-2c08-4f7d-989e-edcf873c9403"
   },
-  "createdDate" : "1996-03-11T12:42:11.884Z",
-  "modifiedDate" : "1984-11-28T21:35:36.701Z",
-  "publishedDate" : "2002-09-04T17:24:48.218Z",
-  "indexedDate" : "1986-11-24T11:27:36.772Z",
-  "handle" : "https://www.example.org/de8ce673-a105-4c88-83ab-9df3154e1ed0",
-  "doi" : "https://doi.org/10.1234/reiciendis",
-  "link" : "https://www.example.org/a2eb7cec-d301-46a1-9d26-34a53181bddd",
+  "createdDate" : "2024-03-07T02:09:33.969Z",
+  "modifiedDate" : "2001-06-21T06:43:43.360Z",
+  "publishedDate" : "1992-09-14T03:45:32.353Z",
+  "indexedDate" : "1978-03-21T21:06:36.019Z",
+  "handle" : "https://www.example.org/05bdb419-a5ec-4655-80dc-f1fbbc0dc9c3",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/32bc9ec5-d2c7-4885-b03e-b53d076dbbbb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "MGGP2teIa1NfM",
+    "mainTitle" : "Tk07KczTTDlX2H",
     "alternativeTitles" : {
-      "pt" : "BI9dloM0Qp4kwb"
+      "en" : "V1Guo0ZL1BuwQ3L85pN"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "QXYeQeJdp6",
-      "month" : "wyRwcfdsyTQO2smMr",
-      "day" : "0HR0ceD3CXbX2g8"
+      "year" : "dCwNADqvzs7",
+      "month" : "wUTrNFritI176p",
+      "day" : "ifE79nxW1IhQbTu"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aec72bf4-1e63-48df-a851-c4f6f3e61df4",
-        "name" : "3tsj2j2jRIPrn",
-        "nameType" : "Organizational",
-        "orcId" : "uTOpVY3o41Pv",
+        "id" : "https://www.example.org/32733f8f-0c53-4028-ac9d-6b8a0f1158de",
+        "name" : "SwcYaZJcZYkfL",
+        "nameType" : "Personal",
+        "orcId" : "61LVtQwZFrzz1Zkq172",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5GSEub4cZWi",
-          "value" : "kHQluVTNdfFrZzY"
+          "sourceName" : "egc2zz6KiCM",
+          "value" : "RmdATuiHq3uHq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "b9pdo6RhzOg",
-          "value" : "P3PSGcjMwAs"
+          "sourceName" : "VFYog8CbeA4hoACmJ9",
+          "value" : "70RbPwUhAlko7AsR9aj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c2a22a0f-5b93-41e7-be85-49b26751869b"
+        "id" : "https://www.example.org/1437aaa3-03e9-49b7-a124-258fadc5a83f"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a22e0d35-e22b-4a17-aa6b-57b7813a07e6",
-        "name" : "I3Q0LvmJofMVqKS1",
+        "id" : "https://www.example.org/7426f274-00f6-43b0-a88d-45c0de6f0790",
+        "name" : "kgmwM5BT7HEZ32u",
         "nameType" : "Personal",
-        "orcId" : "k7R0xwPobaPNcFK",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "pGYMNMUqDbqd5uRWz",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aYsoI3qxgFyDuy",
-          "value" : "UBZFQ42x32ohPCQSDW"
+          "sourceName" : "X9JUOKGdERQa5mY",
+          "value" : "iz7qDqGXpEgDNh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ATwu1Q5TPqXv",
-          "value" : "bo2MO59ihtWJzi"
+          "sourceName" : "93d1chwbGtcr",
+          "value" : "alyMbfR04PY9Bt1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/832d8725-a86a-4561-8374-c1d32ab0db91"
+        "id" : "https://www.example.org/8eec23ae-3ca8-4c7d-ac12-63e5b8dc69ca"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "mzRTKb0IWT"
+      "pl" : "hXAzvTRCjl5f"
     },
-    "npiSubjectHeading" : "N1oO5XMOjz",
-    "tags" : [ "a6q7owkYfYk02O1W9xh" ],
-    "description" : "Wkx1NnNVqk",
+    "npiSubjectHeading" : "h3ncfdA9cmgOlwJ4",
+    "tags" : [ "hILdPn5yp0kVnu" ],
+    "description" : "yuz3DE210Z4NsBiCwTd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2917da11-a475-4d47-aa3a-8a1bd761014a"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d343c994-bbd9-4936-9954-8e5ff751bce6"
         },
-        "seriesNumber" : "SM7hFAka2ltnX9",
+        "seriesNumber" : "016jmzjLPoKuT",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/534ce59f-8e0c-42bd-b10e-a39c17ad533d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/558a7ce3-7916-4156-8d81-148d8f8e9781",
           "valid" : true
         },
-        "isbnList" : [ "9790992677519" ],
+        "isbnList" : [ "9791068514783", "9780604433282" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "DEFZI4Ou00ffrOp"
+          "value" : "060443328X"
         } ]
       },
-      "doi" : "https://www.example.org/8b7dafdb-8583-4a83-85b1-808f276d7dcb",
+      "doi" : "https://www.example.org/87e8956d-aa4c-44d4-b8a5-42bbbccd73ff",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "lhQhWFAlMUdn",
-            "end" : "I24SbrfR9MEkaxabboo"
+            "begin" : "keEsRx0LVZ",
+            "end" : "UUYBAf3xCKXHALHoB"
           },
-          "pages" : "o6c0ucSEE9dtjAUM9",
-          "illustrated" : false
+          "pages" : "Elkqyk2o4ToDT8qNAja",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/dd9d7b66-f1ac-463e-9e17-c6449f1c8217",
-    "abstract" : "oWeQv8pIQnpqyCCD"
+    "metadataSource" : "https://www.example.org/4a208827-881d-486d-8b1c-129a42d43dc2",
+    "abstract" : "Cn405bxD3u"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a1901278-e7b1-4ccb-80b9-ddbbe0dc3d8a",
-    "name" : "O1dfNMZ8js47",
+    "id" : "https://www.example.org/8067f7f2-8a46-409a-9094-b18ab1fc6f7d",
+    "name" : "W3wyk61k5Abv",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2015-12-26T10:22:31.222Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "17FV37DNwcN"
+      "approvalDate" : "2008-01-26T13:54:55.284Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "D5UbfMayj8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dcfc2f64-aa29-4c24-ac87-8036dc35de59",
-    "identifier" : "D1i5iMfKXkF2V3",
+    "source" : "https://www.example.org/caa92675-f0ef-40a2-ae8e-d789d03acb26",
+    "identifier" : "7o009QUlBDO",
     "labels" : {
-      "pt" : "OF5XaP6ZPeiG1"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 583394816
-    },
-    "activeFrom" : "2016-06-23T22:04:58.927Z",
-    "activeTo" : "2018-11-05T22:40:27.542Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/994b2dd7-d922-4010-ba67-9ac55b226e83",
-    "id" : "https://www.example.org/4cc7188e-9ad0-460f-8c51-0908e8995eb7",
-    "identifier" : "4DAbvFpWbsG",
-    "labels" : {
-      "hu" : "D5KrpmnwDLF7x"
+      "af" : "RDwr1ccwhvDLBsI2KXV"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1515697010
+      "amount" : 1283736319
     },
-    "activeFrom" : "2005-10-18T15:34:51.503Z",
-    "activeTo" : "2017-08-06T13:15:39.816Z"
+    "activeFrom" : "2016-08-19T16:53:26.969Z",
+    "activeTo" : "2020-08-27T10:42:02.687Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/bf003fef-a8e9-46b0-8308-9417ee9e8668",
+    "id" : "https://www.example.org/53ef40ac-96b0-4040-a462-ebd5d95f0aec",
+    "identifier" : "SYHg3BjyrS15W",
+    "labels" : {
+      "pl" : "VpPI4mJ5xnUUBajoBqv"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 372942356
+    },
+    "activeFrom" : "1999-04-20T21:04:04.212Z",
+    "activeTo" : "2020-11-06T02:54:10Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/86779beb-343e-49d1-b7f8-87794ccbcebb" ],
+  "subjects" : [ "https://www.example.org/4fe11ae5-f16c-423d-bde8-979c99000a32" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "77eab06a-d6a4-4623-878f-d43b326d4372",
-    "name" : "4zc0oPjXCOj7",
-    "mimeType" : "tY85UM1JfaI6Xcd",
-    "size" : 599855943,
-    "license" : "https://www.example.com/dy9c1ozejj",
+    "identifier" : "1fd07d00-c0cf-457f-86a4-a8e2b61aa054",
+    "name" : "ixy1w3lOtuKA80",
+    "mimeType" : "DnsBKciIneI",
+    "size" : 1092941474,
+    "license" : "https://www.example.com/njnobbkbqd",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "E5mvbiP3xE1",
-    "publishedDate" : "2017-02-15T13:15:12.129Z",
+    "legalNote" : "32YsdXy31G",
+    "publishedDate" : "1976-04-30T18:54:49.613Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "NvfZjwR9JBmVQplzo",
+      "uploadedDate" : "1983-01-22T02:45:53.850Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PT2wzjUmJFW0",
-    "name" : "VVAgBK2PZRYaj",
-    "description" : "Bx3D57PhnnOZj3GBN"
+    "id" : "https://www.example.com/NorEOCEJa79",
+    "name" : "C0MPdw5svR2T6n",
+    "description" : "3BEcSRwNk7D"
   } ],
-  "rightsHolder" : "wy8G4uF11Q1azRRwfd",
-  "duplicateOf" : "https://www.example.org/7ac81de7-e854-4cc7-b57d-b6c311ed37ac",
+  "rightsHolder" : "Z5gehyJlYjFMpU3EyY",
+  "duplicateOf" : "https://www.example.org/d09a5207-7ea8-4f80-9c5d-e8bede9ae9e3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "mbeDVbZI7x"
+    "note" : "hnWLBCfVQSblTYVI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "S2JaXvw50WEhTXXr",
-    "createdBy" : "ShnBC4t3s54",
-    "createdDate" : "1975-05-27T19:00:50.621Z"
+    "note" : "xWWmSHcOv4PoHVwbQ",
+    "createdBy" : "hEI5MD6oXyL",
+    "createdDate" : "2005-06-05T18:09:29.873Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1112b266-374c-4750-9a72-a56eca475d7a" ],
+  "curatingInstitutions" : [ "https://www.example.org/6b3416bf-d587-4f23-a593-557a04ee7aed" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/AcademicMonograph.json
+++ b/documentation/AcademicMonograph.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "jWHzkSY1zDqr",
-    "ownerAffiliation" : "https://www.example.org/f5094d77-0cc6-4820-8dd0-3998654e14d8"
+    "owner" : "om7eG57IS0PZsNln",
+    "ownerAffiliation" : "https://www.example.org/c9db875f-7d2d-44d0-bbba-60c5a3b7b5e3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1d92c6b1-7871-4de6-ab53-ba34fca2b1f8"
+    "id" : "https://www.example.org/3383e54f-adba-4ecd-ae6f-5dc44bc86fed"
   },
-  "createdDate" : "2017-03-24T17:30:09.367Z",
-  "modifiedDate" : "2013-07-18T16:00:32.517Z",
-  "publishedDate" : "1973-08-27T01:34:34.802Z",
-  "indexedDate" : "2008-03-09T19:49:04.221Z",
-  "handle" : "https://www.example.org/2a018f9c-31b4-400c-9c84-24e16d35f421",
-  "doi" : "https://doi.org/10.1234/corrupti",
-  "link" : "https://www.example.org/4f8d4c92-4f75-4e5a-a362-714c692a5f45",
+  "createdDate" : "1996-03-11T12:42:11.884Z",
+  "modifiedDate" : "1984-11-28T21:35:36.701Z",
+  "publishedDate" : "2002-09-04T17:24:48.218Z",
+  "indexedDate" : "1986-11-24T11:27:36.772Z",
+  "handle" : "https://www.example.org/de8ce673-a105-4c88-83ab-9df3154e1ed0",
+  "doi" : "https://doi.org/10.1234/reiciendis",
+  "link" : "https://www.example.org/a2eb7cec-d301-46a1-9d26-34a53181bddd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oHojG9DsPdiPYoNQ",
+    "mainTitle" : "MGGP2teIa1NfM",
     "alternativeTitles" : {
-      "de" : "cjW9SgTKZ6QvZDMmh9S"
+      "pt" : "BI9dloM0Qp4kwb"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "z1hNFcwlWdn0YwMQ9Zg",
-      "month" : "Bj7urGrYiZkKwUx",
-      "day" : "yU3Ye7tAEld4"
+      "year" : "QXYeQeJdp6",
+      "month" : "wyRwcfdsyTQO2smMr",
+      "day" : "0HR0ceD3CXbX2g8"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9783a5a2-ae68-4a73-a31d-c61f1a1461c4",
-        "name" : "DJSbITLyzz",
-        "nameType" : "Personal",
-        "orcId" : "vmNPW6duvNoj2VNC3M",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/aec72bf4-1e63-48df-a851-c4f6f3e61df4",
+        "name" : "3tsj2j2jRIPrn",
+        "nameType" : "Organizational",
+        "orcId" : "uTOpVY3o41Pv",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZvGK8prmszEurKs6oB",
-          "value" : "3pcJB5PuezeKEn2bRIZ"
+          "sourceName" : "5GSEub4cZWi",
+          "value" : "kHQluVTNdfFrZzY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1b9HLsxcTRAhsxzYT5",
-          "value" : "F4p29jiI6uv18DYUIUl"
+          "sourceName" : "b9pdo6RhzOg",
+          "value" : "P3PSGcjMwAs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/91287ff3-5447-48b0-b23a-69d69e5726b5"
+        "id" : "https://www.example.org/c2a22a0f-5b93-41e7-be85-49b26751869b"
       } ],
       "role" : {
-        "type" : "Composer"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fa28b841-b45c-415b-a690-e3eb19efcfbd",
-        "name" : "J1VjD1tHqqBEw6qMF",
+        "id" : "https://www.example.org/a22e0d35-e22b-4a17-aa6b-57b7813a07e6",
+        "name" : "I3Q0LvmJofMVqKS1",
         "nameType" : "Personal",
-        "orcId" : "y0Tzifn9W6Om7LSt2s",
-        "verificationStatus" : "Verified",
+        "orcId" : "k7R0xwPobaPNcFK",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RADMqQ5sQrz24v8eS",
-          "value" : "RBbBjZN2WC0PT"
+          "sourceName" : "aYsoI3qxgFyDuy",
+          "value" : "UBZFQ42x32ohPCQSDW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cDIHGvDERB",
-          "value" : "zTqpHGSpTJg"
+          "sourceName" : "ATwu1Q5TPqXv",
+          "value" : "bo2MO59ihtWJzi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/79b5794f-8235-4cd2-8bbd-c1dabdfc9db9"
+        "id" : "https://www.example.org/832d8725-a86a-4561-8374-c1d32ab0db91"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "p3ggORrOcGv"
+      "it" : "mzRTKb0IWT"
     },
-    "npiSubjectHeading" : "L7M947WCkpzJsjlm6TY",
-    "tags" : [ "MV6umpfufiHQeb3J" ],
-    "description" : "DHJIA9OEMf1jn4LLn",
+    "npiSubjectHeading" : "N1oO5XMOjz",
+    "tags" : [ "a6q7owkYfYk02O1W9xh" ],
+    "description" : "Wkx1NnNVqk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b0fae6e4-6167-4999-9a47-fe2b13c1bee7"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2917da11-a475-4d47-aa3a-8a1bd761014a"
         },
-        "seriesNumber" : "Tn8BeCVLc2",
+        "seriesNumber" : "SM7hFAka2ltnX9",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/06df8043-a2f2-4c88-bfd6-4a4c8ecbc954",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/534ce59f-8e0c-42bd-b10e-a39c17ad533d",
           "valid" : true
         },
-        "isbnList" : [ "9791516318345" ],
+        "isbnList" : [ "9790992677519" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "8jLMx6BRaXpwQc6MU"
+          "value" : "DEFZI4Ou00ffrOp"
         } ]
       },
-      "doi" : "https://www.example.org/c83aa0d9-a652-4bda-b4ab-2769bc88c828",
+      "doi" : "https://www.example.org/8b7dafdb-8583-4a83-85b1-808f276d7dcb",
       "publicationInstance" : {
         "type" : "AcademicMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "E45CT2X9FqHi",
-            "end" : "lBb0IM1GXtNfVuXvdh"
+            "begin" : "lhQhWFAlMUdn",
+            "end" : "I24SbrfR9MEkaxabboo"
           },
-          "pages" : "39I9RFQyJIUrPv9soh",
+          "pages" : "o6c0ucSEE9dtjAUM9",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9fdd26bc-566b-49d8-92fc-96194e1317cc",
-    "abstract" : "ZpHTA6GWfXM"
+    "metadataSource" : "https://www.example.org/dd9d7b66-f1ac-463e-9e17-c6449f1c8217",
+    "abstract" : "oWeQv8pIQnpqyCCD"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3825cd30-66f8-404b-83bd-68a64b327e0b",
-    "name" : "Fo0bXsDfmheeQcM",
+    "id" : "https://www.example.org/a1901278-e7b1-4ccb-80b9-ddbbe0dc3d8a",
+    "name" : "O1dfNMZ8js47",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-11-04T08:04:16.746Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "TusRmvxZxGd4"
+      "approvalDate" : "2015-12-26T10:22:31.222Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "17FV37DNwcN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/46d5fbbb-208f-4cdc-a04d-e306680789d0",
-    "identifier" : "ZSQ9XnZpls",
+    "source" : "https://www.example.org/dcfc2f64-aa29-4c24-ac87-8036dc35de59",
+    "identifier" : "D1i5iMfKXkF2V3",
     "labels" : {
-      "fr" : "CijNV7FsyvLU6a"
+      "pt" : "OF5XaP6ZPeiG1"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1632795899
+      "currency" : "GBP",
+      "amount" : 583394816
     },
-    "activeFrom" : "1981-10-24T12:05:33.224Z",
-    "activeTo" : "1988-06-18T00:02:04.417Z"
+    "activeFrom" : "2016-06-23T22:04:58.927Z",
+    "activeTo" : "2018-11-05T22:40:27.542Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/428669d8-dcf1-4d05-8570-3c0599c479a2",
-    "id" : "https://www.example.org/c802fbbc-c5dd-405a-87f8-682e1f8ae18f",
-    "identifier" : "YZw4GCdbxzsO6uQ",
+    "source" : "https://www.example.org/994b2dd7-d922-4010-ba67-9ac55b226e83",
+    "id" : "https://www.example.org/4cc7188e-9ad0-460f-8c51-0908e8995eb7",
+    "identifier" : "4DAbvFpWbsG",
     "labels" : {
-      "nb" : "IxWDUynw7Xycl"
+      "hu" : "D5KrpmnwDLF7x"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1075427681
+      "amount" : 1515697010
     },
-    "activeFrom" : "2011-06-15T15:45:10.342Z",
-    "activeTo" : "2019-07-14T20:52:55.043Z"
+    "activeFrom" : "2005-10-18T15:34:51.503Z",
+    "activeTo" : "2017-08-06T13:15:39.816Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9e319731-c720-4a4b-8fa6-006f7a3ebcfb" ],
+  "subjects" : [ "https://www.example.org/86779beb-343e-49d1-b7f8-87794ccbcebb" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8db5a527-fc6e-4a85-9543-82bd0309ae81",
-    "name" : "wVckF1cLDbo4GoFDk",
-    "mimeType" : "UMZ7ClkX8pVv",
-    "size" : 975365579,
-    "license" : "https://www.example.com/ibi4sw2tmu",
+    "identifier" : "77eab06a-d6a4-4623-878f-d43b326d4372",
+    "name" : "4zc0oPjXCOj7",
+    "mimeType" : "tY85UM1JfaI6Xcd",
+    "size" : 599855943,
+    "license" : "https://www.example.com/dy9c1ozejj",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "bxA2MURyq4vU6W"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "4zufpEy3nLdFhWdUG8P",
-    "publishedDate" : "1995-02-10T21:12:00.407Z",
+    "legalNote" : "E5mvbiP3xE1",
+    "publishedDate" : "2017-02-15T13:15:12.129Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NQqCY54P97zc",
-    "name" : "SlHhlzhLYzPka",
-    "description" : "i6ZPg5XntJJjKO"
+    "id" : "https://www.example.com/PT2wzjUmJFW0",
+    "name" : "VVAgBK2PZRYaj",
+    "description" : "Bx3D57PhnnOZj3GBN"
   } ],
-  "rightsHolder" : "Wrtpzbd7NR88LOSUWlw",
-  "duplicateOf" : "https://www.example.org/a0f5560d-4a47-4799-bf9c-a61f3ef20ff6",
+  "rightsHolder" : "wy8G4uF11Q1azRRwfd",
+  "duplicateOf" : "https://www.example.org/7ac81de7-e854-4cc7-b57d-b6c311ed37ac",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0LH4qTEgI29d"
+    "note" : "mbeDVbZI7x"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "yarU17igYZObXcZZ",
-    "createdBy" : "1bB94dXRnO5",
-    "createdDate" : "1975-08-31T22:26:47.463Z"
+    "note" : "S2JaXvw50WEhTXXr",
+    "createdBy" : "ShnBC4t3s54",
+    "createdDate" : "1975-05-27T19:00:50.621Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b85f9342-cd78-4e2c-8da6-a61637b83d97" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/1112b266-374c-4750-9a72-a56eca475d7a" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "tZp3oV9hi99TS4QgQ",
-    "ownerAffiliation" : "https://www.example.org/cce66f32-86d2-4b36-aa08-1413c88b76c1"
+    "owner" : "XLL9pwGvqLEA",
+    "ownerAffiliation" : "https://www.example.org/44b28f16-7f8d-40d7-b37c-86a1132a832e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ac36a663-841f-44d7-ac4e-8e0d31db101d"
+    "id" : "https://www.example.org/ce1534ec-dde3-4ecb-9b6d-d405b9b58e79"
   },
-  "createdDate" : "1976-11-02T05:49:57.278Z",
-  "modifiedDate" : "1996-12-04T14:49:28.716Z",
-  "publishedDate" : "1986-12-24T07:31:47.192Z",
-  "indexedDate" : "2008-12-08T07:48:49.244Z",
-  "handle" : "https://www.example.org/8ed2d698-7103-40d0-a8f5-c09e9459c8ca",
-  "doi" : "https://doi.org/10.1234/molestias",
-  "link" : "https://www.example.org/f6242333-feb8-4199-aa5e-061a368dc482",
+  "createdDate" : "2016-08-26T13:13:35.620Z",
+  "modifiedDate" : "1989-08-13T14:19:37.599Z",
+  "publishedDate" : "2008-04-23T12:52:05.458Z",
+  "indexedDate" : "1983-03-07T21:27:29.439Z",
+  "handle" : "https://www.example.org/80aaaae5-1b86-487e-bbb8-753cdeb3e8d4",
+  "doi" : "https://doi.org/10.1234/animi",
+  "link" : "https://www.example.org/af55b015-d928-40ca-824d-9dd719b3bdfd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iRf623DipVh2q",
+    "mainTitle" : "bV6LGvBfnVmq2",
     "alternativeTitles" : {
-      "sv" : "wl7UMLFpJMUmXz"
+      "nb" : "Ckp94y6MCaZu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0wnF377ZUHYZU4",
-      "month" : "u8LZaYsAna4AHX",
-      "day" : "WfLU4wEdeQ"
+      "year" : "EVjff23QDz3",
+      "month" : "ZhIbOXmwzfweTLpOWm",
+      "day" : "eihH6l1IuqvZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f28e6dbf-57af-4139-8e4d-90f17ffa4160",
-        "name" : "NqwkfS31gZIABH0w",
-        "nameType" : "Personal",
-        "orcId" : "91WbABEdDlB8Vb1",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/32f25ad9-e714-4784-894a-e3015aecd603",
+        "name" : "q5lKT9lFxbVyAiFH",
+        "nameType" : "Organizational",
+        "orcId" : "14klWvIll1Of6uVDhrG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zDENkijGs5wfW",
-          "value" : "HblHH863CueokLr"
+          "sourceName" : "ct4PioKesMv2D",
+          "value" : "ragElWhTD6l264vFXV"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ifHYj3cSOVX3tuJClH",
-          "value" : "NfdreaJuWzKkey5ouBK"
+          "sourceName" : "Kj7PswE6fTOMcrtG7",
+          "value" : "asshxY95mEcTtQWP0X"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bfc4fb6b-1aa7-4fa7-a4aa-9d67c08814e0"
+        "id" : "https://www.example.org/2aad2791-6eb5-4709-91e6-4dd747a40523"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,185 +62,184 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/04cba979-de04-4934-8165-cee938b2f200",
-        "name" : "dIZemJWOVQvpDDVhErH",
-        "nameType" : "Personal",
-        "orcId" : "AcGWaI7nUY2x8mLl",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/a9961b64-9369-443d-910f-c983261b1702",
+        "name" : "51rNXBpBOw964",
+        "nameType" : "Organizational",
+        "orcId" : "V4G0vEpudV4nSC8S",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZTL06Y6ZqvYzIS",
-          "value" : "fVLulr1ajZgen"
+          "sourceName" : "U755GrBBNjbIhnnhPE",
+          "value" : "ZJjZAwUDx7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "q83pF3e8Ha8R",
-          "value" : "FZIuSC9qdqkZMV"
+          "sourceName" : "qQi7k4bA6dpu3DOGnw",
+          "value" : "hWn53PXKaf9YOKXY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3b6010ef-62e8-4faf-b391-eca8a312c393"
+        "id" : "https://www.example.org/b7401651-a8a7-4807-a522-b9d49febdf06"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "0eBLLoFS33LY6Vz7x"
+      "sv" : "45arTtxxhV"
     },
-    "npiSubjectHeading" : "5V3a5IGj2HFAAX2kR",
-    "tags" : [ "1OGVzec1g2WRAfmXS" ],
-    "description" : "n3pKW3hVqt00A3",
+    "npiSubjectHeading" : "ECOyXbV1lKFWYzNhTtS",
+    "tags" : [ "jfLPm7wmYQJBqZ" ],
+    "description" : "JNDNkQFQ1D6oGf7hUSq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/89309364-3965-420c-b30c-317909af0c94",
+      "doi" : "https://www.example.org/f64a4597-65ef-4ea7-b0ed-7da6ce2e7ff5",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "ArchitectureOther",
-          "description" : "SShApqkq6OS6yAg"
+          "type" : "PlanningProposal"
         },
-        "description" : "uGItzs9dAmwtoO",
+        "description" : "zQBUWItuo7UEISm",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "JUYzOAIs9m31Mh",
-          "description" : "wnXbnfOoribOfaQJJe",
+          "name" : "m9X1Wy1oucuSEK8AXk",
+          "description" : "AlqTfvCpQ8T9q1zV2x",
           "date" : {
             "type" : "Instant",
-            "value" : "2016-04-07T05:41:40.756Z"
+            "value" : "2012-03-28T04:29:10.058Z"
           },
-          "sequence" : 1105970881
+          "sequence" : 1532607142
         }, {
           "type" : "MentionInPublication",
-          "title" : "K2wcFZt5365WmQ",
-          "issue" : "LpRgUtwpyAJuQj",
+          "title" : "ugVOrgsIfaXgOi3f0",
+          "issue" : "23Gdi881DfI0fnFEG",
           "date" : {
             "type" : "Instant",
-            "value" : "1994-10-25T21:14:46.122Z"
+            "value" : "1999-02-20T18:21:27.255Z"
           },
-          "otherInformation" : "1o6u6HuZaqcSWgmSpVX",
-          "sequence" : 853747291
+          "otherInformation" : "eNNh0WePWzr",
+          "sequence" : 672353991
         }, {
           "type" : "Award",
-          "name" : "oq4juBuuGD",
-          "organizer" : "oEarLATY5gSKFpO5LZ4",
+          "name" : "ScpKnGO55g",
+          "organizer" : "vlYqqwyCFYPUomF",
           "date" : {
             "type" : "Instant",
-            "value" : "1997-04-25T10:38:23.611Z"
+            "value" : "2001-10-15T18:42:26.983Z"
           },
-          "ranking" : 1759402579,
-          "otherInformation" : "gnOMqcBqnMb9J3Djil",
-          "sequence" : 1595384806
+          "ranking" : 2014503331,
+          "otherInformation" : "0L5Nzau2CarM",
+          "sequence" : 1422646603
         }, {
           "type" : "Exhibition",
-          "name" : "q8qMFOaMmvfNF9cRl",
+          "name" : "E1ovq7DjoDFS",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "q6zjZqfVLcrd",
-            "country" : "m7qqAzeaUPY3niKD"
+            "label" : "EJBkv6Op6AZi",
+            "country" : "v5M7eu28OvC"
           },
-          "organizer" : "jpYdH3tUKcZZKiip7FJ",
+          "organizer" : "It7WukKCY7Ggt",
           "date" : {
             "type" : "Period",
-            "from" : "2022-11-06T04:48:54.441Z",
-            "to" : "2023-12-05T15:45:44.210Z"
+            "from" : "1971-12-31T10:29:55.413Z",
+            "to" : "1995-03-20T14:13:18.765Z"
           },
-          "otherInformation" : "A9pTKFuIR7SW",
-          "sequence" : 2094937261
+          "otherInformation" : "LUufu9k4sq5",
+          "sequence" : 2010377492
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b5336cd5-54f0-47bc-a319-a814e9e28e3c",
-    "abstract" : "uqZ0p0G7IPgRHMhP"
+    "metadataSource" : "https://www.example.org/089b039a-bbfa-431a-935b-d8fa95e8606b",
+    "abstract" : "m2SrAa7afD3dF"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ae665d72-9b4f-4971-bf6c-099c1e227aad",
-    "name" : "pQuIl035YSWzY",
+    "id" : "https://www.example.org/953b0601-c602-4d78-befd-c1c551eec93b",
+    "name" : "eXc3bhJbHOEL2nRi",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2014-11-25T05:06:06.019Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "zT9OT00sdfNs"
+      "approvalDate" : "1976-02-13T03:40:55.295Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "OBbKvBZAnqXpJbWqn"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/45e19811-ac47-4d11-9e74-e697e1cdc141",
-    "identifier" : "q4VIib456IaJYflij",
+    "source" : "https://www.example.org/7de73245-2ff4-48ab-97b5-4b9dffcbcdf5",
+    "identifier" : "Ezl5zfOd1e",
     "labels" : {
-      "en" : "XHDD99kmLP"
+      "es" : "WqduJ5YXCzT"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1880394927
+      "currency" : "NOK",
+      "amount" : 1818659983
     },
-    "activeFrom" : "2023-02-07T13:36:47.586Z",
-    "activeTo" : "2024-01-20T22:59:38.455Z"
+    "activeFrom" : "1991-10-27T03:37:11.503Z",
+    "activeTo" : "2011-07-22T16:29:03.875Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9f629f1d-a6cc-42e2-b8b3-b4383c583d85",
-    "id" : "https://www.example.org/790dc980-5a21-432e-90bb-af2bc6da880e",
-    "identifier" : "Se562mGAvSrUc15Cg",
+    "source" : "https://www.example.org/e8c2853c-89c6-4ab9-84bf-b6a5f0756884",
+    "id" : "https://www.example.org/54e938af-004c-45f9-bc6a-4b83fce27214",
+    "identifier" : "YXUwAHfnyhXr0",
     "labels" : {
-      "zh" : "xdSWxdvU02uSje"
+      "ca" : "R9vWDOcuOd03"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 924153937
+      "amount" : 564968056
     },
-    "activeFrom" : "1978-08-13T15:23:15.154Z",
-    "activeTo" : "1984-06-27T15:03:51.562Z"
+    "activeFrom" : "2013-08-27T18:39:59.897Z",
+    "activeTo" : "2020-06-17T16:34:59.282Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3915c58a-3a6e-4675-9d56-a9703e5c53f9" ],
+  "subjects" : [ "https://www.example.org/bad83edd-92d3-4ef3-b82e-1ad6808a1b60" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "264c03b9-2377-41a9-a53d-e5e7f3be4ae3",
-    "name" : "WZgnnvJnb2",
-    "mimeType" : "7EjZnp7hdVMCioEL8RO",
-    "size" : 828327873,
-    "license" : "https://www.example.com/bxlnnbuapaiz",
+    "identifier" : "b3aaf8e0-74f6-4e50-822f-9e81691dc497",
+    "name" : "tQXbqPNqp8Bpf0s",
+    "mimeType" : "kZSwkFauYi10",
+    "size" : 1614355275,
+    "license" : "https://www.example.com/474ohp5wjt",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "3MO267ySp8FT"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "DfNgSeOwg6kl5rQh",
-    "publishedDate" : "1993-03-03T06:42:11.133Z",
+    "legalNote" : "t1G9glwEVWP",
+    "publishedDate" : "2008-01-24T19:10:02.340Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/d95LJgBOcvPhTLLC",
-    "name" : "eqPhs8YGLZ7tF",
-    "description" : "1vgUPL0sNZaSF"
+    "id" : "https://www.example.com/PJfm6QlNryf8WtBK0",
+    "name" : "WTmuoAdRoOVx",
+    "description" : "QoflCy6wRecRNdTRg"
   } ],
-  "rightsHolder" : "OZGFw5OtTFq4",
-  "duplicateOf" : "https://www.example.org/a656675c-2185-4b42-8516-cabe998afec4",
+  "rightsHolder" : "LyT6zNlI0EkP0iP",
+  "duplicateOf" : "https://www.example.org/8fef58ca-c40e-4028-8634-22c9334bca6a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "57gZe0dVVNHS56v5iP"
+    "note" : "ZPwccDxYUkUN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "o0cI7wm5GzJu",
-    "createdBy" : "cLE8WQGHYDteu",
-    "createdDate" : "2016-11-01T18:55:08.807Z"
+    "note" : "vT1FEheYgHLPK",
+    "createdBy" : "rqztfrlV3bMztspU",
+    "createdDate" : "1980-06-28T14:54:28.060Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dbc645f6-a34a-4b16-b885-98f8c764c374" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/a771e0b2-8ad3-415b-93d9-83a46b19427e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Architecture.json
+++ b/documentation/Architecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "XLL9pwGvqLEA",
-    "ownerAffiliation" : "https://www.example.org/44b28f16-7f8d-40d7-b37c-86a1132a832e"
+    "owner" : "HdNzb0bAtSp",
+    "ownerAffiliation" : "https://www.example.org/1aa6aa54-f98d-4c32-85be-87aa9d2e823d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ce1534ec-dde3-4ecb-9b6d-d405b9b58e79"
+    "id" : "https://www.example.org/31056c59-4063-489d-8c17-50edf0d20734"
   },
-  "createdDate" : "2016-08-26T13:13:35.620Z",
-  "modifiedDate" : "1989-08-13T14:19:37.599Z",
-  "publishedDate" : "2008-04-23T12:52:05.458Z",
-  "indexedDate" : "1983-03-07T21:27:29.439Z",
-  "handle" : "https://www.example.org/80aaaae5-1b86-487e-bbb8-753cdeb3e8d4",
-  "doi" : "https://doi.org/10.1234/animi",
-  "link" : "https://www.example.org/af55b015-d928-40ca-824d-9dd719b3bdfd",
+  "createdDate" : "2022-10-15T04:34:38.016Z",
+  "modifiedDate" : "2006-07-27T10:03:28.947Z",
+  "publishedDate" : "2003-02-21T19:28:13.251Z",
+  "indexedDate" : "2016-03-11T14:28:53.756Z",
+  "handle" : "https://www.example.org/9ebb4fdf-e420-45a0-879b-fe0310566346",
+  "doi" : "https://doi.org/10.1234/eos",
+  "link" : "https://www.example.org/0bb6bb72-96c7-412b-a30f-7e284474efef",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bV6LGvBfnVmq2",
+    "mainTitle" : "Ap69WHSVVrg9KZjT",
     "alternativeTitles" : {
-      "nb" : "Ckp94y6MCaZu"
+      "ca" : "UwW9fOOal2"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "EVjff23QDz3",
-      "month" : "ZhIbOXmwzfweTLpOWm",
-      "day" : "eihH6l1IuqvZ"
+      "year" : "xPRpNGlaiT9xiSr",
+      "month" : "kbO3v3uCtRKq1j",
+      "day" : "bBivKytZrUC"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/32f25ad9-e714-4784-894a-e3015aecd603",
-        "name" : "q5lKT9lFxbVyAiFH",
-        "nameType" : "Organizational",
-        "orcId" : "14klWvIll1Of6uVDhrG",
+        "id" : "https://www.example.org/9c532f5d-0f72-4b9d-8ad8-fadfce6de405",
+        "name" : "TbHYE28aOwO5kiDMx4",
+        "nameType" : "Personal",
+        "orcId" : "6nSdGLY5zCA3QHu",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ct4PioKesMv2D",
-          "value" : "ragElWhTD6l264vFXV"
+          "sourceName" : "JUvTAY0aJOWVtYwwDQ",
+          "value" : "VwtlKJQp7tkXthfwtjn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Kj7PswE6fTOMcrtG7",
-          "value" : "asshxY95mEcTtQWP0X"
+          "sourceName" : "VV8Rjcx8Pjw0",
+          "value" : "5PVrCTbU5fr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2aad2791-6eb5-4709-91e6-4dd747a40523"
+        "id" : "https://www.example.org/d8908599-75da-436e-a52f-0e490d972718"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "DataCurator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,184 +62,190 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a9961b64-9369-443d-910f-c983261b1702",
-        "name" : "51rNXBpBOw964",
-        "nameType" : "Organizational",
-        "orcId" : "V4G0vEpudV4nSC8S",
+        "id" : "https://www.example.org/21b48528-1cde-46aa-8f57-a624ecfed927",
+        "name" : "wexOaoJoMIjM9",
+        "nameType" : "Personal",
+        "orcId" : "PgrXDuuJ4njcnFq4",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U755GrBBNjbIhnnhPE",
-          "value" : "ZJjZAwUDx7"
+          "sourceName" : "xe9cCCEdKTFcDjOEGTn",
+          "value" : "EtcWBCMX4dNhe5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qQi7k4bA6dpu3DOGnw",
-          "value" : "hWn53PXKaf9YOKXY"
+          "sourceName" : "oNY47poJWf1F",
+          "value" : "7Cq1NUQNBLNOfrba"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b7401651-a8a7-4807-a522-b9d49febdf06"
+        "id" : "https://www.example.org/61bb21d8-cf21-4225-8148-8e38fd3893ed"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "45arTtxxhV"
+      "da" : "erbDT9zl44QH"
     },
-    "npiSubjectHeading" : "ECOyXbV1lKFWYzNhTtS",
-    "tags" : [ "jfLPm7wmYQJBqZ" ],
-    "description" : "JNDNkQFQ1D6oGf7hUSq",
+    "npiSubjectHeading" : "yJyBSewjLY",
+    "tags" : [ "kn8lEq7SC6cV" ],
+    "description" : "3Oek7yXm5bJmxZM2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/f64a4597-65ef-4ea7-b0ed-7da6ce2e7ff5",
+      "doi" : "https://www.example.org/d8979d59-bc5b-43ac-a09e-5e3619fe0fd1",
       "publicationInstance" : {
         "type" : "Architecture",
         "subtype" : {
-          "type" : "PlanningProposal"
+          "type" : "Interior"
         },
-        "description" : "zQBUWItuo7UEISm",
+        "description" : "e5ZHCgM4gn6vb",
         "architectureOutput" : [ {
           "type" : "Competition",
-          "name" : "m9X1Wy1oucuSEK8AXk",
-          "description" : "AlqTfvCpQ8T9q1zV2x",
+          "name" : "KBZyEgkpKZfCxwn8ry",
+          "description" : "Hh0kUEsFZq",
           "date" : {
             "type" : "Instant",
-            "value" : "2012-03-28T04:29:10.058Z"
+            "value" : "2001-07-05T16:42:00.501Z"
           },
-          "sequence" : 1532607142
+          "sequence" : 1196090166
         }, {
           "type" : "MentionInPublication",
-          "title" : "ugVOrgsIfaXgOi3f0",
-          "issue" : "23Gdi881DfI0fnFEG",
+          "title" : "xfIhBOgb7ljG3k0MOo",
+          "issue" : "wSdjrgw37B",
           "date" : {
             "type" : "Instant",
-            "value" : "1999-02-20T18:21:27.255Z"
+            "value" : "2005-08-30T10:32:47.913Z"
           },
-          "otherInformation" : "eNNh0WePWzr",
-          "sequence" : 672353991
+          "otherInformation" : "11hAxDEHK3",
+          "sequence" : 1773819425
         }, {
           "type" : "Award",
-          "name" : "ScpKnGO55g",
-          "organizer" : "vlYqqwyCFYPUomF",
+          "name" : "wUKyQoLcn6REqATA",
+          "organizer" : "661EEY98yu7K7Ip",
           "date" : {
             "type" : "Instant",
-            "value" : "2001-10-15T18:42:26.983Z"
+            "value" : "2005-02-07T14:18:11.607Z"
           },
-          "ranking" : 2014503331,
-          "otherInformation" : "0L5Nzau2CarM",
-          "sequence" : 1422646603
+          "ranking" : 787645661,
+          "otherInformation" : "uyxqiyJ63HVUgKHK",
+          "sequence" : 429946945
         }, {
           "type" : "Exhibition",
-          "name" : "E1ovq7DjoDFS",
+          "name" : "AhWcDLFYys",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "EJBkv6Op6AZi",
-            "country" : "v5M7eu28OvC"
+            "label" : "J0yh5oTeGQZaMKSgC",
+            "country" : "Y5UgwRsMfGYmOv02"
           },
-          "organizer" : "It7WukKCY7Ggt",
+          "organizer" : "UfPI1fR8Ye0jCOKwYn",
           "date" : {
             "type" : "Period",
-            "from" : "1971-12-31T10:29:55.413Z",
-            "to" : "1995-03-20T14:13:18.765Z"
+            "from" : "2009-07-29T11:58:57.716Z",
+            "to" : "2016-09-10T04:23:41.050Z"
           },
-          "otherInformation" : "LUufu9k4sq5",
-          "sequence" : 2010377492
+          "otherInformation" : "fi0GJgvUq2",
+          "sequence" : 2122552596
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/089b039a-bbfa-431a-935b-d8fa95e8606b",
-    "abstract" : "m2SrAa7afD3dF"
+    "metadataSource" : "https://www.example.org/d602dd7b-8a0a-4b55-91ac-8af9053b258e",
+    "abstract" : "LsV9L3cnIq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/953b0601-c602-4d78-befd-c1c551eec93b",
-    "name" : "eXc3bhJbHOEL2nRi",
+    "id" : "https://www.example.org/81b8addb-713f-491c-b2dd-efa208e20f6a",
+    "name" : "D0jWYZCmnq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-02-13T03:40:55.295Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "OBbKvBZAnqXpJbWqn"
+      "approvalDate" : "1995-06-28T08:23:57.821Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "HqC3944Vk9tl2JdC1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7de73245-2ff4-48ab-97b5-4b9dffcbcdf5",
-    "identifier" : "Ezl5zfOd1e",
+    "source" : "https://www.example.org/2a0516ee-1bde-4434-b190-64402a40204f",
+    "identifier" : "gBjK1FJuXGTkuX0G",
     "labels" : {
-      "es" : "WqduJ5YXCzT"
+      "el" : "yYWqFXRTyRgU1CmMkm"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1818659983
+      "amount" : 208537353
     },
-    "activeFrom" : "1991-10-27T03:37:11.503Z",
-    "activeTo" : "2011-07-22T16:29:03.875Z"
+    "activeFrom" : "2019-03-28T15:36:13.897Z",
+    "activeTo" : "2023-11-25T19:42:26.231Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e8c2853c-89c6-4ab9-84bf-b6a5f0756884",
-    "id" : "https://www.example.org/54e938af-004c-45f9-bc6a-4b83fce27214",
-    "identifier" : "YXUwAHfnyhXr0",
+    "source" : "https://www.example.org/424feb81-699e-4c09-913f-7e298b52dabc",
+    "id" : "https://www.example.org/01af0606-8543-4b7a-8a51-bf53c9737bae",
+    "identifier" : "YscJzI4Htq9f",
     "labels" : {
-      "ca" : "R9vWDOcuOd03"
+      "af" : "Pf5nAsK0UDPROYh6G2"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 564968056
+      "currency" : "USD",
+      "amount" : 113420243
     },
-    "activeFrom" : "2013-08-27T18:39:59.897Z",
-    "activeTo" : "2020-06-17T16:34:59.282Z"
+    "activeFrom" : "1998-04-01T16:08:24.739Z",
+    "activeTo" : "2019-11-21T16:02:12.068Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bad83edd-92d3-4ef3-b82e-1ad6808a1b60" ],
+  "subjects" : [ "https://www.example.org/eb394cbe-5499-4374-9e7d-54789d2a22fc" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b3aaf8e0-74f6-4e50-822f-9e81691dc497",
-    "name" : "tQXbqPNqp8Bpf0s",
-    "mimeType" : "kZSwkFauYi10",
-    "size" : 1614355275,
-    "license" : "https://www.example.com/474ohp5wjt",
+    "identifier" : "0cf8203b-c210-4130-b81d-77d0e4658c50",
+    "name" : "HfMiCvbS8AthNC",
+    "mimeType" : "SYAylbMg0GQVR7KbjjA",
+    "size" : 1047542762,
+    "license" : "https://www.example.com/cwwzlp4vglulll22",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Cxo4hMpUU2jGl"
     },
-    "legalNote" : "t1G9glwEVWP",
-    "publishedDate" : "2008-01-24T19:10:02.340Z",
+    "legalNote" : "zxwdZBgp62l1zDa1N",
+    "publishedDate" : "1999-12-05T21:59:36.720Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "8r1MCDEmeathe",
+      "uploadedDate" : "1989-06-19T13:09:30.185Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PJfm6QlNryf8WtBK0",
-    "name" : "WTmuoAdRoOVx",
-    "description" : "QoflCy6wRecRNdTRg"
+    "id" : "https://www.example.com/bwYnOHEZE4Abz",
+    "name" : "0iSVRPR2vUcKvJAM",
+    "description" : "LZIo41K8uYl8gJAGEFu"
   } ],
-  "rightsHolder" : "LyT6zNlI0EkP0iP",
-  "duplicateOf" : "https://www.example.org/8fef58ca-c40e-4028-8634-22c9334bca6a",
+  "rightsHolder" : "FyPVMiX5BHfWAp6WqM7",
+  "duplicateOf" : "https://www.example.org/0acd37c7-3cf1-4da7-9d6c-1ebf677e908c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZPwccDxYUkUN"
+    "note" : "L6x4vNbNQRDb8MHnT5b"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vT1FEheYgHLPK",
-    "createdBy" : "rqztfrlV3bMztspU",
-    "createdDate" : "1980-06-28T14:54:28.060Z"
+    "note" : "6W3t6uxqiyDLwKiEHdC",
+    "createdBy" : "ydDOda8rvNhkb6t0hm",
+    "createdDate" : "2020-11-06T08:07:02.253Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a771e0b2-8ad3-415b-93d9-83a46b19427e" ],
+  "curatingInstitutions" : [ "https://www.example.org/dba89fe6-654b-4e74-99e2-9369d70b24ef" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "BFSVJq4IEsbMM8LUc",
-    "ownerAffiliation" : "https://www.example.org/022f785b-13e9-4665-ad35-5f158b2c0c18"
+    "owner" : "3WsyKo377p3lVcXB",
+    "ownerAffiliation" : "https://www.example.org/944c9592-7bee-4f62-89db-b8b6f7cb20f9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4c49121f-7d5f-409d-8b34-67a15eecc0f1"
+    "id" : "https://www.example.org/50effbe8-939b-4677-9d41-1d9e114bddf9"
   },
-  "createdDate" : "2007-09-03T04:22:44.136Z",
-  "modifiedDate" : "1974-05-04T09:08:17.454Z",
-  "publishedDate" : "1977-10-07T07:54:03.923Z",
-  "indexedDate" : "2000-06-21T10:05:19.581Z",
-  "handle" : "https://www.example.org/acd58d27-b197-4742-ae09-07dd8269b3c5",
-  "doi" : "https://doi.org/10.1234/dolor",
-  "link" : "https://www.example.org/d9ace2a8-58e6-4715-a7b9-11e54d007f33",
+  "createdDate" : "1976-04-01T04:34:05.431Z",
+  "modifiedDate" : "2014-06-05T09:33:27.691Z",
+  "publishedDate" : "1989-12-09T14:06:03.756Z",
+  "indexedDate" : "1974-03-30T04:38:55.410Z",
+  "handle" : "https://www.example.org/16492349-d245-4faa-9d99-b922746152ba",
+  "doi" : "https://doi.org/10.1234/soluta",
+  "link" : "https://www.example.org/efe570d9-9a59-4e8f-b179-563243b01fcb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "qQuxHInFvQ6v6",
+    "mainTitle" : "bwrvapR0fzzee",
     "alternativeTitles" : {
-      "ru" : "fupCLGfb8LlK"
+      "it" : "GCbHQfmenYXYOGIQC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "s2yNlOhDTFlru",
-      "month" : "lESH7A5wLwefh",
-      "day" : "1ZiSEhls3gFKSgS8mXo"
+      "year" : "PfW8SCND1XNUIg1",
+      "month" : "jFShVOAakwtoLMOY3z",
+      "day" : "6wudlykgbAn13aI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ee96b25d-e6bd-4dcd-9110-ea437d37bbf6",
-        "name" : "YMyPCFw7drCav0Gr",
-        "nameType" : "Personal",
-        "orcId" : "m68rbuZVQGXlaDN",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/394822e0-f99d-4070-9f8e-09936da47f6b",
+        "name" : "LFn5vYMYR7N5",
+        "nameType" : "Organizational",
+        "orcId" : "C5w39Lx19xi9PZ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AIZFjeibQXbV5qDc52E",
-          "value" : "mwtDxuyWfdJ1"
+          "sourceName" : "61BFaxDkww1BwzhWuxm",
+          "value" : "Uw4Uz7b5fOrR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3ArUFo76bu",
-          "value" : "DMEQkl9LD7xt8MwF7Ib"
+          "sourceName" : "WCzlhbVCsKpeNJh",
+          "value" : "eCiBfTtsBGAZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/41b2ea67-9744-40f2-8dae-845c3f931a17"
+        "id" : "https://www.example.org/4b5938b8-5808-4e36-a9dc-8d23db3b7277"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "DataCollector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,163 +62,165 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1812b193-97a4-498c-a096-74933528d15e",
-        "name" : "Kf172lPiMPoz",
-        "nameType" : "Organizational",
-        "orcId" : "iUoFzSgv2tSE1q",
+        "id" : "https://www.example.org/8759f69e-daa7-4639-8b76-89f563b7faf0",
+        "name" : "sTbfSOJYRIO",
+        "nameType" : "Personal",
+        "orcId" : "RyDey7vMDckR2464o9",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SD9pOFK7MICb6zF",
-          "value" : "YfGZBtsz9T"
+          "sourceName" : "yqlmgwbrGatDYI7FXtR",
+          "value" : "ZL1U2uEZfx3zxueVpB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6sYIJZpG8wId",
-          "value" : "mOGDGyhyxGCDEsF"
+          "sourceName" : "WIPy0W8NIVKyt59r",
+          "value" : "ArY4kGlWbbiOQ8YDGqA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f0c04376-784e-4a37-8829-7061f5c3c490"
+        "id" : "https://www.example.org/4c4c43d3-508a-47ab-98b7-ff271c641169"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "ci4CrmXGLXr"
+      "el" : "Tus3Mr04Tqc"
     },
-    "npiSubjectHeading" : "ByiSVRyxo2G",
-    "tags" : [ "BQv6YIw4cc51" ],
-    "description" : "eiYF5KW1E7ODM094",
+    "npiSubjectHeading" : "yCoGQuAUQuNtwMO",
+    "tags" : [ "YnLYJJ6mKj" ],
+    "description" : "cEeVqNVxaenTZP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/1281dc93-e561-4cc9-a5f4-f499fda3c21c",
+      "doi" : "https://www.example.org/792298a0-63a4-41db-bb66-4fcaf21a260a",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "Exhibition"
+          "type" : "ArtisticDesignOther",
+          "description" : "7Ro32JmxqFl"
         },
-        "description" : "uVv5odiMKW2cPt",
+        "description" : "h4apo76PYn7q",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "sv1xUnqyDkDkW",
-            "country" : "OboIPD4MTrn2J6ChV"
+            "label" : "GKu0oHGrRvgtDs94pvm",
+            "country" : "upBqGruX7UMYrDJqG"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1993-02-08T05:25:48.392Z",
-            "to" : "2016-03-15T13:35:46.102Z"
+            "from" : "2012-10-05T12:10:20.197Z",
+            "to" : "2017-10-16T02:51:48.685Z"
           },
-          "sequence" : 355189027
+          "sequence" : 1699876573
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "bCxazc76QbPRcMwXs",
-            "country" : "FU8XyPHunUvn1691"
+            "label" : "XloflcnhFQ",
+            "country" : "OqrNOlSUmznXMQNMGk"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1988-02-17T07:19:21.923Z",
-            "to" : "2020-02-14T06:20:35.649Z"
+            "from" : "2001-06-07T01:45:19.288Z",
+            "to" : "2016-03-10T11:34:03.555Z"
           },
-          "sequence" : 285080765
+          "sequence" : 1083592295
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7772d0fd-9c0e-489d-ac80-eb6a0ceedffd",
-    "abstract" : "6Cj90Z1OapyvTmj6x"
+    "metadataSource" : "https://www.example.org/f2e6c54f-e731-456f-b441-8bf3e48bf419",
+    "abstract" : "zbLvjRKFyd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8bf3b76a-eff8-4d6e-9dfd-eeceef57c567",
-    "name" : "2vMCBKjt5eFN",
+    "id" : "https://www.example.org/3d6541e5-14b3-4a4c-9a6e-413985395362",
+    "name" : "VpesoIb64inj",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-12-10T19:20:00.842Z",
+      "approvalDate" : "2021-01-19T09:44:07.219Z",
       "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "M5V0CRW8bTRs8Z"
+      "applicationCode" : "nLZSwQpuE8xpYZWx6jP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/a1de856c-3518-487b-b2de-179061b0a89a",
-    "identifier" : "SWi0kHJKG6",
+    "source" : "https://www.example.org/ff052b82-2fa2-4ae8-aa84-fef04102fbb4",
+    "identifier" : "l7IrrArTwmlBL1",
     "labels" : {
-      "bg" : "BPFwtgurRPYC"
+      "nl" : "fAiXWRS1kRBsnSPKW"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1765942168
+      "currency" : "EUR",
+      "amount" : 1343946977
     },
-    "activeFrom" : "2022-09-07T01:26:55.301Z",
-    "activeTo" : "2022-11-07T16:52:42.627Z"
+    "activeFrom" : "2000-05-20T09:17:56.248Z",
+    "activeTo" : "2006-10-12T10:10:00.806Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c36fa994-0d45-48f5-b726-d6a302b49e35",
-    "id" : "https://www.example.org/784d6702-54f4-410f-b16b-f68b00f06229",
-    "identifier" : "cgxcbjoVOCLmfLCCPn",
+    "source" : "https://www.example.org/ba45db73-833b-48be-853e-f962028dd546",
+    "id" : "https://www.example.org/07e8c344-f01a-4275-89e2-7aacdbb127d0",
+    "identifier" : "XUJoq5EtYw51HzLrI",
     "labels" : {
-      "fi" : "RMnwzgwKvnzjqX"
+      "pl" : "XpMOJW8cXO"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 524777746
+      "currency" : "NOK",
+      "amount" : 985954279
     },
-    "activeFrom" : "2005-06-23T20:00:26.755Z",
-    "activeTo" : "2010-07-08T01:17:41.361Z"
+    "activeFrom" : "2013-07-05T22:15:13.902Z",
+    "activeTo" : "2023-12-11T18:29:54.378Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f9e20705-1d62-4c5f-a8b2-406a6bdc224c" ],
+  "subjects" : [ "https://www.example.org/6df223cb-e0c7-42ed-9067-efc60da7a711" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "cae2c906-e31f-4de0-a86c-63c227074036",
-    "name" : "8Q2dMbxhR8etIZ",
-    "mimeType" : "SLVwD3l5GzGq",
-    "size" : 343972276,
-    "license" : "https://www.example.com/tozbjcp0pakigrunyy",
+    "identifier" : "03caa81b-069b-4667-9d1a-80ba2a7d78bf",
+    "name" : "rvhWSieqnFik4iqIgsj",
+    "mimeType" : "GaSFqWsq8nuYM",
+    "size" : 135692772,
+    "license" : "https://www.example.com/cjvsdfw9du6p",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "rCp0rv8KRqXf",
-    "publishedDate" : "1987-07-18T18:51:50.048Z",
+    "legalNote" : "931osArzeF",
+    "publishedDate" : "2002-08-12T17:56:30.629Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/UmMEWthZVbZU6zL",
-    "name" : "zkjtogMOgh13LZa39",
-    "description" : "hahB2lOpweyRuLCu"
+    "id" : "https://www.example.com/J89F1lxaUo",
+    "name" : "hC9xAIjjoQCPHIQQjJ",
+    "description" : "X6ybiZHOmK55Oqbg"
   } ],
-  "rightsHolder" : "HqnivCZG1uAEm",
-  "duplicateOf" : "https://www.example.org/327cfc33-57ad-43b9-a025-682abdd2ebf0",
+  "rightsHolder" : "KLhwloKlcf938d",
+  "duplicateOf" : "https://www.example.org/01110835-d686-400b-9aa9-d7b7457f5202",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "u8rk5vQeMMTOGJ"
+    "note" : "aam2bViXiLPpAElh3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "KuAiMNSmQj",
-    "createdBy" : "p7DlKajd2Qg",
-    "createdDate" : "2005-11-01T18:17:50.438Z"
+    "note" : "T8tKW0rajLMEsrxMx8",
+    "createdBy" : "CgpBCPs08Nnq",
+    "createdDate" : "1977-03-11T05:10:44.340Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/cf328e19-65e1-43c4-9252-33ecbcb96114" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/be17c7fd-c941-4ea8-a4f7-a0b11d88fdc1" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ArtisticDesign.json
+++ b/documentation/ArtisticDesign.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "3WsyKo377p3lVcXB",
-    "ownerAffiliation" : "https://www.example.org/944c9592-7bee-4f62-89db-b8b6f7cb20f9"
+    "owner" : "abEi9LCee8JWclML",
+    "ownerAffiliation" : "https://www.example.org/0a98f0a8-4e86-404b-9058-4ac17f9ed29f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/50effbe8-939b-4677-9d41-1d9e114bddf9"
+    "id" : "https://www.example.org/4133dba6-375c-412a-b63c-092161b0211d"
   },
-  "createdDate" : "1976-04-01T04:34:05.431Z",
-  "modifiedDate" : "2014-06-05T09:33:27.691Z",
-  "publishedDate" : "1989-12-09T14:06:03.756Z",
-  "indexedDate" : "1974-03-30T04:38:55.410Z",
-  "handle" : "https://www.example.org/16492349-d245-4faa-9d99-b922746152ba",
-  "doi" : "https://doi.org/10.1234/soluta",
-  "link" : "https://www.example.org/efe570d9-9a59-4e8f-b179-563243b01fcb",
+  "createdDate" : "1975-10-02T07:31:33.971Z",
+  "modifiedDate" : "2011-02-28T16:16:28.062Z",
+  "publishedDate" : "1982-08-12T20:12:29.411Z",
+  "indexedDate" : "1991-03-13T22:06:21.411Z",
+  "handle" : "https://www.example.org/75c0d401-165f-4684-bb4e-a9f9b900946a",
+  "doi" : "https://doi.org/10.1234/earum",
+  "link" : "https://www.example.org/464a222a-1a92-4df1-94d1-e56e5efd7bd6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bwrvapR0fzzee",
+    "mainTitle" : "5Ukt01Pr8RZe",
     "alternativeTitles" : {
-      "it" : "GCbHQfmenYXYOGIQC"
+      "pl" : "w7XrV2eN1Q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PfW8SCND1XNUIg1",
-      "month" : "jFShVOAakwtoLMOY3z",
-      "day" : "6wudlykgbAn13aI"
+      "year" : "eDyciArYHV7gc",
+      "month" : "p9bGIS4CyD",
+      "day" : "3nKQ4xzB0HXNB26"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/394822e0-f99d-4070-9f8e-09936da47f6b",
-        "name" : "LFn5vYMYR7N5",
+        "id" : "https://www.example.org/0b70b241-8b2d-4544-8fe9-de1a7ad46bbd",
+        "name" : "jgI0m4HBIujtVw5L",
         "nameType" : "Organizational",
-        "orcId" : "C5w39Lx19xi9PZ",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "mY7zt4aApuLMuTW",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "61BFaxDkww1BwzhWuxm",
-          "value" : "Uw4Uz7b5fOrR"
+          "sourceName" : "p43rOQgjd1fzkT",
+          "value" : "LxWEuD6l9sspwP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WCzlhbVCsKpeNJh",
-          "value" : "eCiBfTtsBGAZ"
+          "sourceName" : "cOgN2yVA4COIH",
+          "value" : "1a8jOztSHH9pIsMu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4b5938b8-5808-4e36-a9dc-8d23db3b7277"
+        "id" : "https://www.example.org/d760b679-2271-4dbc-922e-6051a977736e"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "RoleOther",
+        "description" : "bofxbakJLXnhDDzQ"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,165 +63,170 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8759f69e-daa7-4639-8b76-89f563b7faf0",
-        "name" : "sTbfSOJYRIO",
+        "id" : "https://www.example.org/8ff05591-1332-4276-9ca0-d8478dd723a3",
+        "name" : "xxyGID67i4VbJ9idMFj",
         "nameType" : "Personal",
-        "orcId" : "RyDey7vMDckR2464o9",
+        "orcId" : "BSlapF00rhYKKWS",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yqlmgwbrGatDYI7FXtR",
-          "value" : "ZL1U2uEZfx3zxueVpB"
+          "sourceName" : "9oQSYpledYA",
+          "value" : "ePYj3XSqqxJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WIPy0W8NIVKyt59r",
-          "value" : "ArY4kGlWbbiOQ8YDGqA"
+          "sourceName" : "LZKiX8YbXLbvdd5SrY8",
+          "value" : "ZxYdZDyTDI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4c4c43d3-508a-47ab-98b7-ff271c641169"
+        "id" : "https://www.example.org/bda8acab-ff29-483e-be66-a948f9dc23f4"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "Tus3Mr04Tqc"
+      "zh" : "vie9nK8OkKxcoj"
     },
-    "npiSubjectHeading" : "yCoGQuAUQuNtwMO",
-    "tags" : [ "YnLYJJ6mKj" ],
-    "description" : "cEeVqNVxaenTZP",
+    "npiSubjectHeading" : "fsZXs5xC6l4bzUgpdR",
+    "tags" : [ "jrmn3RbVCq" ],
+    "description" : "Jw3Lrm4TNsZ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/792298a0-63a4-41db-bb66-4fcaf21a260a",
+      "doi" : "https://www.example.org/2d32811d-58e9-4d11-ab6d-f5c81cb8918b",
       "publicationInstance" : {
         "type" : "ArtisticDesign",
         "subtype" : {
-          "type" : "ArtisticDesignOther",
-          "description" : "7Ro32JmxqFl"
+          "type" : "Exhibition"
         },
-        "description" : "h4apo76PYn7q",
+        "description" : "aln9bZAs556Iga18",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "GKu0oHGrRvgtDs94pvm",
-            "country" : "upBqGruX7UMYrDJqG"
+            "label" : "biG1FVULxD",
+            "country" : "Wj0ujRyVUdRl1Xhe9e"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2012-10-05T12:10:20.197Z",
-            "to" : "2017-10-16T02:51:48.685Z"
+            "from" : "2020-01-12T17:37:28.696Z",
+            "to" : "2023-09-22T09:17:49.788Z"
           },
-          "sequence" : 1699876573
+          "sequence" : 698508260
         }, {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XloflcnhFQ",
-            "country" : "OqrNOlSUmznXMQNMGk"
+            "label" : "8VzcI13MTT0f",
+            "country" : "qMefC4tPH2JdxNwL"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2001-06-07T01:45:19.288Z",
-            "to" : "2016-03-10T11:34:03.555Z"
+            "from" : "2020-05-22T21:24:07.552Z",
+            "to" : "2021-09-21T07:14:54.841Z"
           },
-          "sequence" : 1083592295
+          "sequence" : 58635364
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f2e6c54f-e731-456f-b441-8bf3e48bf419",
-    "abstract" : "zbLvjRKFyd"
+    "metadataSource" : "https://www.example.org/0be6a52f-b782-401a-81ae-d22295a1e51b",
+    "abstract" : "IvCzirT4nZRn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3d6541e5-14b3-4a4c-9a6e-413985395362",
-    "name" : "VpesoIb64inj",
+    "id" : "https://www.example.org/f6451b0b-f404-42e1-b5da-557cd0f2a532",
+    "name" : "gciZk88zoS2Jp",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-01-19T09:44:07.219Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "nLZSwQpuE8xpYZWx6jP"
+      "approvalDate" : "2009-01-09T08:10:07.292Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "VelLhTAIzGSHLXBS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ff052b82-2fa2-4ae8-aa84-fef04102fbb4",
-    "identifier" : "l7IrrArTwmlBL1",
+    "source" : "https://www.example.org/3fb4d8da-c5ad-4169-af77-0d2ebde8de4b",
+    "identifier" : "SZ1l3qpFAv",
     "labels" : {
-      "nl" : "fAiXWRS1kRBsnSPKW"
+      "zh" : "sg66NTGt93Fsxm5U"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1343946977
+      "amount" : 109502334
     },
-    "activeFrom" : "2000-05-20T09:17:56.248Z",
-    "activeTo" : "2006-10-12T10:10:00.806Z"
+    "activeFrom" : "1979-11-14T11:57:07.611Z",
+    "activeTo" : "1990-10-07T13:10:20.990Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ba45db73-833b-48be-853e-f962028dd546",
-    "id" : "https://www.example.org/07e8c344-f01a-4275-89e2-7aacdbb127d0",
-    "identifier" : "XUJoq5EtYw51HzLrI",
+    "source" : "https://www.example.org/50c7f872-6f00-49de-a7d4-ede7f0088700",
+    "id" : "https://www.example.org/11205446-54f7-48d6-b3c7-5382894a5ec4",
+    "identifier" : "tlC8UW94QSz4FY",
     "labels" : {
-      "pl" : "XpMOJW8cXO"
+      "fi" : "M61zV3oBgBmlUxX"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 985954279
+      "amount" : 2065525379
     },
-    "activeFrom" : "2013-07-05T22:15:13.902Z",
-    "activeTo" : "2023-12-11T18:29:54.378Z"
+    "activeFrom" : "2017-04-06T23:18:31.825Z",
+    "activeTo" : "2019-07-26T01:52:03.686Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6df223cb-e0c7-42ed-9067-efc60da7a711" ],
+  "subjects" : [ "https://www.example.org/21699332-50f0-445d-8591-595c0f44321a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "03caa81b-069b-4667-9d1a-80ba2a7d78bf",
-    "name" : "rvhWSieqnFik4iqIgsj",
-    "mimeType" : "GaSFqWsq8nuYM",
-    "size" : 135692772,
-    "license" : "https://www.example.com/cjvsdfw9du6p",
+    "identifier" : "d040ee75-b48a-415b-9e9e-d3b61d534706",
+    "name" : "HXNDpOgwZT",
+    "mimeType" : "N0986htyGMLj58la",
+    "size" : 2105230044,
+    "license" : "https://www.example.com/9grz4scubni5",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "1TW8IfAAEDRU2c5aD"
     },
-    "legalNote" : "931osArzeF",
-    "publishedDate" : "2002-08-12T17:56:30.629Z",
+    "legalNote" : "QDVTKZlvwIOHN",
+    "publishedDate" : "2009-10-06T19:05:56.879Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "9OvW133cPf",
+      "uploadedDate" : "1984-08-18T19:58:27.125Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/J89F1lxaUo",
-    "name" : "hC9xAIjjoQCPHIQQjJ",
-    "description" : "X6ybiZHOmK55Oqbg"
+    "id" : "https://www.example.com/02agFTeVmlW",
+    "name" : "gC86Qa7CXLgfvfZwpvk",
+    "description" : "QL8u3dArVgjn"
   } ],
-  "rightsHolder" : "KLhwloKlcf938d",
-  "duplicateOf" : "https://www.example.org/01110835-d686-400b-9aa9-d7b7457f5202",
+  "rightsHolder" : "w50Bg8F4XmE",
+  "duplicateOf" : "https://www.example.org/e53fc8f0-feed-4188-854a-ffa8f99e2ba0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "aam2bViXiLPpAElh3"
+    "note" : "6MX8cEEuXdRf0z2s"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "T8tKW0rajLMEsrxMx8",
-    "createdBy" : "CgpBCPs08Nnq",
-    "createdDate" : "1977-03-11T05:10:44.340Z"
+    "note" : "ER9KPj5ArNgtCwC",
+    "createdBy" : "HExqFHs5a6NFHH",
+    "createdDate" : "1971-07-24T18:42:26.244Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/be17c7fd-c941-4ea8-a4f7-a0b11d88fdc1" ],
+  "curatingInstitutions" : [ "https://www.example.org/b960a730-9abc-4597-a5dd-e81a26411336" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "bXWVhTney4HeVsi",
-    "ownerAffiliation" : "https://www.example.org/1afea693-04d4-4cba-9c71-ade55140e210"
+    "owner" : "DoSmig0CU5bk5EAL",
+    "ownerAffiliation" : "https://www.example.org/542ea6ef-9b9e-4ce6-a02b-d76da2701704"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/160290f6-e0e5-4218-842f-ff15a48dc5d1"
+    "id" : "https://www.example.org/941b74f0-c7ca-406c-b9f5-af1bc98656e7"
   },
-  "createdDate" : "1995-10-31T07:57:00.197Z",
-  "modifiedDate" : "1985-10-21T23:15:05.238Z",
-  "publishedDate" : "1991-03-19T07:42:34.368Z",
-  "indexedDate" : "1995-09-17T09:49:58.525Z",
-  "handle" : "https://www.example.org/e4a8ae16-cacf-4696-99ea-f181aaa33388",
-  "doi" : "https://doi.org/10.1234/reprehenderit",
-  "link" : "https://www.example.org/765e0f49-fdde-4f1d-a369-2ec6598fe72e",
+  "createdDate" : "1992-12-25T05:26:06.590Z",
+  "modifiedDate" : "1995-02-07T13:21:52.964Z",
+  "publishedDate" : "1985-11-20T14:38:34.286Z",
+  "indexedDate" : "1995-03-19T00:36:08.919Z",
+  "handle" : "https://www.example.org/ddd5cecc-b571-4d7e-bc47-a085c1894957",
+  "doi" : "https://doi.org/10.1234/in",
+  "link" : "https://www.example.org/cf691fb3-1c6a-4f26-8e88-07fa70c19d08",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "krvmnXXFTCDH8aXR3L",
+    "mainTitle" : "g87kjxRwzMJLpgqTS",
     "alternativeTitles" : {
-      "af" : "3eA1cLOi5A8foZ"
+      "is" : "g3c2X5cmmzDX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "15QryJURMkdu",
-      "month" : "DnfEC1z3l72Uxcl6ux",
-      "day" : "SOzcC3ICYxdUMUoW"
+      "year" : "RWTPQMQ63x",
+      "month" : "KwGuZDpl8LAXl",
+      "day" : "HuH66dfSGNy0JS"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/89d423c8-6141-4cbb-b996-3e93f6253222",
-        "name" : "eQCR4NhVJTW",
-        "nameType" : "Organizational",
-        "orcId" : "nrEe8f3400hq",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/4b1e1e25-ba4d-48a5-8c1f-debb3d64e9fc",
+        "name" : "VLB0RjQfn8SLQj",
+        "nameType" : "Personal",
+        "orcId" : "zN1qHI2zHysAwBRXQJR",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uJvtMoHgZQ",
-          "value" : "nARBc03T2mDMjflDNjl"
+          "sourceName" : "Y0T0nHS49kN8k",
+          "value" : "vfviur9knQwOo2MN0hF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "63qbmfnZ1aX0vmQBX",
-          "value" : "jKvmWkAfYk6upfhH"
+          "sourceName" : "YHAs0rzv38z",
+          "value" : "14RvaxFOY1FzUZe"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/de14109c-6416-44af-8601-496cd82fd172"
+        "id" : "https://www.example.org/58f5c6ee-aa03-4f4e-b058-606ae1a72c35"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Choreographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/917803a6-34f6-430d-9717-1cb5d8c5a498",
-        "name" : "sgd7IacNjBukq6t",
+        "id" : "https://www.example.org/d2f85661-5da2-4843-8ab4-cd572c724785",
+        "name" : "80kwYCnDpCLz4qa",
         "nameType" : "Personal",
-        "orcId" : "IPjqu6YugQeC",
-        "verificationStatus" : "Verified",
+        "orcId" : "eRd9cEQD3f",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wmCDJycWFE5",
-          "value" : "Q0N26LByj8uWMOhof"
+          "sourceName" : "bUyownOBacqPT",
+          "value" : "jq46T0yc4PnPUqzWXW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hhI6ZSab6D3Pea",
-          "value" : "i1Fjz8T1GMz"
+          "sourceName" : "t3qPcrRJIYoMAALuGy5",
+          "value" : "eUJrpUd0x4IVVIKv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f0c1ed9a-3e8d-4d74-bbd8-58a61eb9f506"
+        "id" : "https://www.example.org/8a44a1d9-b617-487a-8f3f-b86ab1e97b71"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "ProgrammeParticipant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "qJ9mTG72QPilQ"
+      "nl" : "7UUJpPoGB6yZetqNTvU"
     },
-    "npiSubjectHeading" : "FDSrXj1xfCV3HDL",
-    "tags" : [ "fIUgi0lpqXIZxfV" ],
-    "description" : "6h68NBnQl8re",
+    "npiSubjectHeading" : "3n2mntoZPSRAgCBLA",
+    "tags" : [ "vZKBeHqWVbXH5uFVej" ],
+    "description" : "CV4BKuMwQTnxF8Krg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4a0ce3c8-e174-4438-bba4-57d148bcdd37"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a620b34e-647b-4b88-974f-8acac71aa082"
         },
-        "seriesNumber" : "oDfg90dFHn5UiTBKSD",
+        "seriesNumber" : "Pmv63svgMzGO7MG",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dc92b3cd-1b0b-42dc-8bab-92509c17f406",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/26c8e3c5-06b7-4c21-a274-95fb2a220420",
           "valid" : true
         },
-        "isbnList" : [ "9791934238829" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781990197710", "9780793556724" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "FuR8i869V6dxqnoZu"
+          "value" : "0793556724"
         } ]
       },
-      "doi" : "https://www.example.org/45b16371-44ca-45be-88ef-4ad34f6608ae",
+      "doi" : "https://www.example.org/a83f25d8-c17b-47f8-bc54-5262d5ad407a",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "1RVKkEAtRANRj5gPm",
-            "end" : "MHBhvHItT6mcruAs3c"
+            "begin" : "vqOoOshpHLCW286",
+            "end" : "CEW7ChmfSHVt3RXK"
           },
-          "pages" : "XhGbsMwMPQbTot",
-          "illustrated" : true
+          "pages" : "78Ph06sZXlThNd6Y9",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3799e102-0b60-404e-a64e-08a0cced270e",
-    "abstract" : "rVaZSXSiVi8is"
+    "metadataSource" : "https://www.example.org/2ef0491e-af66-4a26-ab63-6a491fd40ba1",
+    "abstract" : "pLKuPQyJ4Jocq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b63c070e-8fe3-487e-98fd-a93dd5ed5df7",
-    "name" : "oA27baI1442",
+    "id" : "https://www.example.org/c4008940-210b-4b7c-ac23-efb4dfd08dae",
+    "name" : "SYLphaCSFM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-12-16T18:52:21.868Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "URjcg3SVmZD8epZ9C"
+      "approvalDate" : "1998-02-16T04:50:40.543Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "cO3I33W9se"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/eea004ac-bd55-465b-bbc3-ea435065d609",
-    "identifier" : "JlCqOLuSCq",
+    "source" : "https://www.example.org/c94d7368-1622-471f-83c9-528999da4bd1",
+    "identifier" : "BHvSniu4ssPMM3rzInh",
     "labels" : {
-      "es" : "UPV7MD42F1G5j"
+      "zh" : "7HYKsXXx04hWuUwj"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 351901810
+      "currency" : "USD",
+      "amount" : 353934729
     },
-    "activeFrom" : "2008-05-10T06:09:57.876Z",
-    "activeTo" : "2011-01-10T04:07:07.778Z"
+    "activeFrom" : "2023-07-01T10:22:35.098Z",
+    "activeTo" : "2023-12-07T05:34:57.919Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c4af8cd6-97bf-4b71-8474-b411ab3bbbbf",
-    "id" : "https://www.example.org/914bbd05-c32b-4b23-9e52-346a34595cb6",
-    "identifier" : "uEOTYGUrlak0bQkiiV",
+    "source" : "https://www.example.org/fb8faa51-4017-4db0-ba30-a16b40c52bba",
+    "id" : "https://www.example.org/96bba4a9-a3c1-457b-a379-d2d25a972f8f",
+    "identifier" : "gUy6KaKDqhjSPFNh",
     "labels" : {
-      "el" : "uQOPPtON3j7CXD"
+      "ca" : "et7n07qbFdrNcFUtFr"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1571398234
+      "amount" : 1742252274
     },
-    "activeFrom" : "2021-07-24T01:58:41.750Z",
-    "activeTo" : "2021-12-15T21:39:56.362Z"
+    "activeFrom" : "1999-01-07T23:29:45.112Z",
+    "activeTo" : "2023-02-22T12:33:26.457Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f9c2dd98-8c89-48a2-9cdc-cb8bdea6cc61" ],
+  "subjects" : [ "https://www.example.org/4e8f3bd4-8d42-42d7-a70e-90da4d9ea7a3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b3e93dcb-f4cd-452b-be1e-fdb710e1cded",
-    "name" : "wTRHP15dHOmAgXjum0",
-    "mimeType" : "zLPoiDNm6k89II3Jvs",
-    "size" : 1883752022,
-    "license" : "https://www.example.com/t8uoufgjrenm3",
+    "identifier" : "d93ba4eb-839d-4105-bb44-aaeab15bd7f1",
+    "name" : "WfGPwzxBWdmtAVhKyEX",
+    "mimeType" : "f8gAOPxTkUgh58NB5mr",
+    "size" : 1819148322,
+    "license" : "https://www.example.com/qwmxe8yypa6zg61qerm",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "V80L3K4waSDwJIzk",
-    "publishedDate" : "2015-08-15T07:44:25.298Z",
+    "legalNote" : "BE0UXiyQfxGHCxOLfAh",
+    "publishedDate" : "2011-07-07T14:14:06.771Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "eqPwEtNC8ZhEb",
+      "uploadedDate" : "1982-11-23T17:49:30.586Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/5igIUMeJIPGc8tlTDJh",
-    "name" : "KVOZBxrVswzp",
-    "description" : "HED5sSSPflR"
+    "id" : "https://www.example.com/EakHKc4iLiK32",
+    "name" : "zn5T1Gi8Ygp0PLXuc",
+    "description" : "5QRBRru1DVdKxtAEi"
   } ],
-  "rightsHolder" : "qwdLdjz5k4PQaqNrhGj",
-  "duplicateOf" : "https://www.example.org/3ff2e590-a509-4bbc-a8e4-b17723e1023a",
+  "rightsHolder" : "ZQY4TTqeKI",
+  "duplicateOf" : "https://www.example.org/08d87e70-2202-44eb-876e-ddfa06e8b50b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FV0OrGlVunJIvF"
+    "note" : "5fMB0sJL7spE"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sXPVCMJRvIFWzSd9",
-    "createdBy" : "GKK28IwWKr3",
-    "createdDate" : "2001-08-24T16:06:12.783Z"
+    "note" : "NUygSYhc86",
+    "createdBy" : "KL6IkxoGvREeYJ",
+    "createdDate" : "1972-02-11T01:47:14.766Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c958a105-3b1b-4003-959c-5670a30e0ce0" ],
+  "curatingInstitutions" : [ "https://www.example.org/361f8e37-a2f4-40aa-9613-b5fd79abb708" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/BookAnthology.json
+++ b/documentation/BookAnthology.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "IEN81cubSjPV",
-    "ownerAffiliation" : "https://www.example.org/0b01da4c-c8ed-46d4-902f-eb5cfa684b47"
+    "owner" : "bXWVhTney4HeVsi",
+    "ownerAffiliation" : "https://www.example.org/1afea693-04d4-4cba-9c71-ade55140e210"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b11035b7-3237-4a49-858e-c10e55691dcf"
+    "id" : "https://www.example.org/160290f6-e0e5-4218-842f-ff15a48dc5d1"
   },
-  "createdDate" : "1984-11-07T13:26:38.624Z",
-  "modifiedDate" : "2019-06-07T23:34:33.594Z",
-  "publishedDate" : "1982-09-28T16:41:57.106Z",
-  "indexedDate" : "2001-09-12T02:25:24.915Z",
-  "handle" : "https://www.example.org/d3407c4d-4ff6-4097-af1b-edd79ffd7dde",
-  "doi" : "https://doi.org/10.1234/autem",
-  "link" : "https://www.example.org/e67fedb7-5105-4e7f-b4f6-b3251db6dbd8",
+  "createdDate" : "1995-10-31T07:57:00.197Z",
+  "modifiedDate" : "1985-10-21T23:15:05.238Z",
+  "publishedDate" : "1991-03-19T07:42:34.368Z",
+  "indexedDate" : "1995-09-17T09:49:58.525Z",
+  "handle" : "https://www.example.org/e4a8ae16-cacf-4696-99ea-f181aaa33388",
+  "doi" : "https://doi.org/10.1234/reprehenderit",
+  "link" : "https://www.example.org/765e0f49-fdde-4f1d-a369-2ec6598fe72e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "eVMYB1F3Ddr6VOk",
+    "mainTitle" : "krvmnXXFTCDH8aXR3L",
     "alternativeTitles" : {
-      "hu" : "EaN6UkUBHTWAg"
+      "af" : "3eA1cLOi5A8foZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "FUvZA4t6H7Owv7On",
-      "month" : "3isKUNAhaJ1PAE6XA",
-      "day" : "XRdIufrK973Ny5yOU"
+      "year" : "15QryJURMkdu",
+      "month" : "DnfEC1z3l72Uxcl6ux",
+      "day" : "SOzcC3ICYxdUMUoW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ec8c253a-63f8-4b7c-a9dc-1f34e05dca76",
-        "name" : "b6uFEAeIqhp",
-        "nameType" : "Personal",
-        "orcId" : "IbUAxJTTSUaV387",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/89d423c8-6141-4cbb-b996-3e93f6253222",
+        "name" : "eQCR4NhVJTW",
+        "nameType" : "Organizational",
+        "orcId" : "nrEe8f3400hq",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "S0KMvNFhH8HXN",
-          "value" : "DfXFDt9wkUXtzzJBv0D"
+          "sourceName" : "uJvtMoHgZQ",
+          "value" : "nARBc03T2mDMjflDNjl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0ovoJ6UD1yJg1sh",
-          "value" : "dovN7GXbkAyqwuQ"
+          "sourceName" : "63qbmfnZ1aX0vmQBX",
+          "value" : "jKvmWkAfYk6upfhH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/78d9797b-80e9-4075-9d25-20b09c95c376"
+        "id" : "https://www.example.org/de14109c-6416-44af-8601-496cd82fd172"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3aa52533-16c5-4521-baa0-8e5039f326b1",
-        "name" : "5FhI1M6blZWGtDV8BiT",
+        "id" : "https://www.example.org/917803a6-34f6-430d-9717-1cb5d8c5a498",
+        "name" : "sgd7IacNjBukq6t",
         "nameType" : "Personal",
-        "orcId" : "NPUq8M0EBJfEeLG0",
+        "orcId" : "IPjqu6YugQeC",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gfj1DepLLUMVchfm",
-          "value" : "xLgDjVqELbpW8N"
+          "sourceName" : "wmCDJycWFE5",
+          "value" : "Q0N26LByj8uWMOhof"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0bVSG0qIecOnBwe",
-          "value" : "QB49BhpVhs"
+          "sourceName" : "hhI6ZSab6D3Pea",
+          "value" : "i1Fjz8T1GMz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b6398a3f-3702-47cc-ad04-59c4f89e5050"
+        "id" : "https://www.example.org/f0c1ed9a-3e8d-4d74-bbd8-58a61eb9f506"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "pGHbkY1vubTmxX"
+      "ca" : "qJ9mTG72QPilQ"
     },
-    "npiSubjectHeading" : "lUq9dzJJTEBAh8DmG",
-    "tags" : [ "OiPz1xvb3rK99" ],
-    "description" : "I8MFVvm1sGMVA5kjz",
+    "npiSubjectHeading" : "FDSrXj1xfCV3HDL",
+    "tags" : [ "fIUgi0lpqXIZxfV" ],
+    "description" : "6h68NBnQl8re",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/af393111-304d-4a09-8536-e2b2284f7805"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4a0ce3c8-e174-4438-bba4-57d148bcdd37"
         },
-        "seriesNumber" : "ZFZV38WXudFy",
+        "seriesNumber" : "oDfg90dFHn5UiTBKSD",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c8e1bd7d-3e2a-48fc-a20d-49f840c002e6",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/dc92b3cd-1b0b-42dc-8bab-92509c17f406",
           "valid" : true
         },
-        "isbnList" : [ "9791030683417" ],
+        "isbnList" : [ "9791934238829" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "oddFx8bqZP"
+          "value" : "FuR8i869V6dxqnoZu"
         } ]
       },
-      "doi" : "https://www.example.org/50db6653-2feb-427c-bd35-9c98710dab2a",
+      "doi" : "https://www.example.org/45b16371-44ca-45be-88ef-4ad34f6608ae",
       "publicationInstance" : {
         "type" : "BookAnthology",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "qCcd5hQIpo",
-            "end" : "osYbL8oWPbXyVbquLVz"
+            "begin" : "1RVKkEAtRANRj5gPm",
+            "end" : "MHBhvHItT6mcruAs3c"
           },
-          "pages" : "b5SN8BEdpOnU8bY0",
-          "illustrated" : false
+          "pages" : "XhGbsMwMPQbTot",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e0dd99c9-c514-4e51-b157-834e1476b2ed",
-    "abstract" : "eIKJZ8ragu"
+    "metadataSource" : "https://www.example.org/3799e102-0b60-404e-a64e-08a0cced270e",
+    "abstract" : "rVaZSXSiVi8is"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0d152af2-797a-40bf-8711-325f3ee9dedb",
-    "name" : "4hxI2Lp81JNPEJnsW2",
+    "id" : "https://www.example.org/b63c070e-8fe3-487e-98fd-a93dd5ed5df7",
+    "name" : "oA27baI1442",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-01-20T20:27:23.676Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2021-12-16T18:52:21.868Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "kwNbNmbEB7"
+      "applicationCode" : "URjcg3SVmZD8epZ9C"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/bd7304cb-d316-4d12-8928-1ee5f0cc15f3",
-    "identifier" : "nWMv6SuTaDjx90zmmsW",
+    "source" : "https://www.example.org/eea004ac-bd55-465b-bbc3-ea435065d609",
+    "identifier" : "JlCqOLuSCq",
     "labels" : {
-      "it" : "Wi8SGSsndjLfhdl"
+      "es" : "UPV7MD42F1G5j"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2070797819
+      "currency" : "NOK",
+      "amount" : 351901810
     },
-    "activeFrom" : "1976-08-15T09:18:32.957Z",
-    "activeTo" : "1990-02-28T01:57:58.483Z"
+    "activeFrom" : "2008-05-10T06:09:57.876Z",
+    "activeTo" : "2011-01-10T04:07:07.778Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9127677d-39db-4779-9234-52cc3b8ea51d",
-    "id" : "https://www.example.org/d8041fcb-6914-43a5-8b0f-d5ea45ee998f",
-    "identifier" : "lWoeUkXipK9Hp27Yzz",
+    "source" : "https://www.example.org/c4af8cd6-97bf-4b71-8474-b411ab3bbbbf",
+    "id" : "https://www.example.org/914bbd05-c32b-4b23-9e52-346a34595cb6",
+    "identifier" : "uEOTYGUrlak0bQkiiV",
     "labels" : {
-      "pt" : "QSrseQYaIzfGU"
+      "el" : "uQOPPtON3j7CXD"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1822314912
+      "currency" : "NOK",
+      "amount" : 1571398234
     },
-    "activeFrom" : "2002-04-23T02:45:05.839Z",
-    "activeTo" : "2022-07-15T09:22:47.712Z"
+    "activeFrom" : "2021-07-24T01:58:41.750Z",
+    "activeTo" : "2021-12-15T21:39:56.362Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/79670fe5-caa1-4081-8c1c-f44dd2b53d5a" ],
+  "subjects" : [ "https://www.example.org/f9c2dd98-8c89-48a2-9cdc-cb8bdea6cc61" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d52a1175-625e-40c1-af18-7d3c8d51c687",
-    "name" : "CSET7OSZzEj0m5VPGLf",
-    "mimeType" : "jlnlTKC1A4PBl9pqPF",
-    "size" : 1986585305,
-    "license" : "https://www.example.com/igvz840mlstk",
+    "identifier" : "b3e93dcb-f4cd-452b-be1e-fdb710e1cded",
+    "name" : "wTRHP15dHOmAgXjum0",
+    "mimeType" : "zLPoiDNm6k89II3Jvs",
+    "size" : 1883752022,
+    "license" : "https://www.example.com/t8uoufgjrenm3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "4f4svGai1SLx8u",
-    "publishedDate" : "1989-08-22T01:07:18.818Z",
+    "legalNote" : "V80L3K4waSDwJIzk",
+    "publishedDate" : "2015-08-15T07:44:25.298Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2YJOTr8aE12gf2vz1a2",
-    "name" : "xe218STcyb",
-    "description" : "bBKKZ3qLWH2CjRczhYU"
+    "id" : "https://www.example.com/5igIUMeJIPGc8tlTDJh",
+    "name" : "KVOZBxrVswzp",
+    "description" : "HED5sSSPflR"
   } ],
-  "rightsHolder" : "9lb8nbXdVFbXZFRy",
-  "duplicateOf" : "https://www.example.org/544a9ead-94b3-4612-93ba-065f8bc1d320",
+  "rightsHolder" : "qwdLdjz5k4PQaqNrhGj",
+  "duplicateOf" : "https://www.example.org/3ff2e590-a509-4bbc-a8e4-b17723e1023a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "XsRI5nqpjm"
+    "note" : "FV0OrGlVunJIvF"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "rfuoklogQaoaha",
-    "createdBy" : "Uzvfy5mb5pI5SUU",
-    "createdDate" : "1980-01-12T07:52:11.081Z"
+    "note" : "sXPVCMJRvIFWzSd9",
+    "createdBy" : "GKK28IwWKr3",
+    "createdDate" : "2001-08-24T16:06:12.783Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5dd2c616-9357-4610-ac1f-2f1799b0b81a" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/c958a105-3b1b-4003-959c-5670a30e0ce0" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "TjBZllRrR8Eusl",
-    "ownerAffiliation" : "https://www.example.org/6ad5d995-e9ce-4d32-be8c-d18ebab7495f"
+    "owner" : "341Vn3LtgelZLpfpYW",
+    "ownerAffiliation" : "https://www.example.org/407fbaf5-b433-4138-a5dd-96eeca85b85b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/55d8f0f4-b375-446c-b5e6-e55181d024a0"
+    "id" : "https://www.example.org/bad99e6c-322b-42ef-a6f4-8b4829ba6424"
   },
-  "createdDate" : "2006-06-09T19:55:50.977Z",
-  "modifiedDate" : "2014-02-17T10:49:16.749Z",
-  "publishedDate" : "2022-02-10T04:20:10.120Z",
-  "indexedDate" : "2012-08-25T03:38:49.435Z",
-  "handle" : "https://www.example.org/88d3f062-745c-4308-ad0f-505b170c238f",
-  "doi" : "https://doi.org/10.1234/minus",
-  "link" : "https://www.example.org/eb89604f-01ec-45dc-b01a-c497ac0a8cec",
+  "createdDate" : "1994-06-12T06:38:25.422Z",
+  "modifiedDate" : "2006-07-08T10:24:44.678Z",
+  "publishedDate" : "1997-12-27T07:43:47.025Z",
+  "indexedDate" : "2018-12-30T20:23:35.467Z",
+  "handle" : "https://www.example.org/6c2f61f5-7237-419f-bbfa-4b015b27c9e6",
+  "doi" : "https://doi.org/10.1234/unde",
+  "link" : "https://www.example.org/2736d113-4dfd-463f-99ca-cdcdaeb02d25",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IRpbrfD7dbLXlD4bq",
+    "mainTitle" : "kkVhUoQApcT",
     "alternativeTitles" : {
-      "pl" : "78FMYVXwk36IywVn"
+      "en" : "n7toM6WuUy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "9gDAzAPJw1hWLVcL6",
-      "month" : "4VhV8QRyxU",
-      "day" : "HC3doFdY5zWFJ8Hl"
+      "year" : "DxxrvK1aXghp",
+      "month" : "ZZ8H0iFzQK",
+      "day" : "cjsJ85n3Kk10SJ9RmUE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d312c004-4a85-41c5-86c4-97dd425d308e",
-        "name" : "cgElmwK0QI7wgCyK",
+        "id" : "https://www.example.org/0e113136-294a-43b2-9319-91fc9bc411db",
+        "name" : "bE70iotNdHD5wFaQOsN",
         "nameType" : "Organizational",
-        "orcId" : "6ehWwlPRkop5N",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "MZdB9bcvya639",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LFj9X3qq50Cq",
-          "value" : "TcvSvjOc9LDLvXaeb"
+          "sourceName" : "R1CfaWo1XwEjhoec",
+          "value" : "vK6EIk4Gxu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rlAnVw1u8dykKVxT6DZ",
-          "value" : "xkolh4wwxGo"
+          "sourceName" : "fkXBpN3La7d2Nm6xg",
+          "value" : "yOg5v90GPicMUMpOB4D"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e72b7e36-b9e8-47b4-9b76-92b92a8ec8ef"
+        "id" : "https://www.example.org/6b25b77b-eada-4de5-b188-0506b1313933"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e73e1bb8-0022-4279-b8c0-7ed25d1bf17c",
-        "name" : "jwOx3sQlnxi9",
+        "id" : "https://www.example.org/be39c58c-b712-4e6a-91b8-0e1f4ab241c7",
+        "name" : "Xcytfx5LHdvYu",
         "nameType" : "Personal",
-        "orcId" : "i8TX8eFTgOxc0i0EHcE",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "PT1z7UiQLwlvNVi",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9qxnWBnrmglU",
-          "value" : "To7VMFUEvnSDNlMU3z"
+          "sourceName" : "xt1U4bguXhaeY",
+          "value" : "uJplmsUX2a1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6QeAffffDmHJaF2n",
-          "value" : "X8BzcVi3xUPGIbbP"
+          "sourceName" : "HetWg7EU0hh",
+          "value" : "TDSnedwwmMfA3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4a4bf39-44fe-43b1-895c-91a887fc78ba"
+        "id" : "https://www.example.org/8228198c-9b13-4741-9ce3-ae46717eb2e8"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "RoleOther",
+        "description" : "rBtdylsfNTqIRo"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "CkuWn9L6ZYtYyUom1r"
+      "sv" : "bAwm6Ufp6q3hIE"
     },
-    "npiSubjectHeading" : "2W9UPvzrrRE5uTvL3nT",
-    "tags" : [ "DJx8KvGOIurt8qN4nuk" ],
-    "description" : "pXKNF3ZnytyPdFVBqS",
+    "npiSubjectHeading" : "0dGw0V4JQDXCk1",
+    "tags" : [ "FwZXL44ysoUoAp" ],
+    "description" : "KlbAeMf4IAZd3j7f",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/883ad9e7-137d-4bf8-ad5d-abd8163e0240"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e4806b12-5068-48bf-b727-e2bd90215de1"
       },
-      "doi" : "https://www.example.org/a77627a5-1bfd-47d9-83e9-9179a62a3a9d",
+      "doi" : "https://www.example.org/1e0c6b12-d851-44d2-b6d1-52bf5e3e2840",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "U7RumsDpA5MDRFh0",
-          "end" : "z9IPY1EFwwfncXxx"
+          "begin" : "p1KkxTIMxuDTA",
+          "end" : "RW8n7WicnxEr6yVD2y0"
         },
-        "volume" : "1ExvlqEw5xGBl",
-        "issue" : "mWuGYyrLEYX98DZmnt",
-        "articleNumber" : "wBnjiTYYhMIaf69K2"
+        "volume" : "UIdb7oHBD9Upi7DGO",
+        "issue" : "3gBw0E3zRwK",
+        "articleNumber" : "JpnY0Q9JOEsR"
       }
     },
-    "metadataSource" : "https://www.example.org/165b35ce-61b1-4326-9874-d389d98aec8f",
-    "abstract" : "fa3BkORrgZ7"
+    "metadataSource" : "https://www.example.org/0aad3447-ea24-482a-bbb5-c04f16c14ac8",
+    "abstract" : "lvoYPOdbZSBh2V2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/041d4d4e-b076-424d-b851-5efb22cdc82e",
-    "name" : "EcjMLlgQfowGRM",
+    "id" : "https://www.example.org/5ae8a1ba-3899-41e4-b51b-0870b906c432",
+    "name" : "lQurUTNp5FeyQhl7g3w",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-09-27T04:11:15.012Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "uf3lbsgD2Z3gGrNnKag"
+      "approvalDate" : "1997-02-19T21:12:28.793Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "sML4zQ8pkL04Ujunx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c12b29a0-50d1-4d60-9542-0d16206b2c9a",
-    "identifier" : "vSyYvrewpixYh",
+    "source" : "https://www.example.org/0809659b-0339-4012-a43d-6b54b6ef1057",
+    "identifier" : "WV4YATjYgJ",
     "labels" : {
-      "es" : "zoTynLbjmD"
+      "nl" : "dUEFVmvXTyRtnOqB"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2143741145
+      "currency" : "EUR",
+      "amount" : 1393267208
     },
-    "activeFrom" : "2023-04-22T08:32:44.620Z",
-    "activeTo" : "2024-02-18T10:44:54.260Z"
+    "activeFrom" : "2020-09-30T15:38:05.975Z",
+    "activeTo" : "2022-01-17T21:56:53.937Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1c05cdcd-d157-4727-bbfa-dc87168986c7",
-    "id" : "https://www.example.org/89e3c29e-efbe-48d3-ba97-e81bab8cb0d9",
-    "identifier" : "Zgfk2xJP0iI3JnzDHz",
+    "source" : "https://www.example.org/a1759937-fe3c-4646-8a14-4675ed9e34ca",
+    "id" : "https://www.example.org/695e567a-b4a7-4c88-82aa-5b052f550deb",
+    "identifier" : "JqIBUjc7r8VHzEM",
     "labels" : {
-      "nb" : "mEO0BkWQENqYh3UhOrQ"
+      "nl" : "HuCktgSTaRKWMy6EMH"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 978555359
+      "amount" : 1521260279
     },
-    "activeFrom" : "1975-07-24T04:15:12.633Z",
-    "activeTo" : "1989-06-12T02:02:39.915Z"
+    "activeFrom" : "2015-03-09T17:08:56.472Z",
+    "activeTo" : "2018-12-16T19:57:27.071Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4a7cae2e-58ba-4f75-b15d-d8ba2659b705" ],
+  "subjects" : [ "https://www.example.org/84563913-8666-46a0-97b8-e9485f38e329" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f01b33d2-dfd8-45fb-82e2-7e32199728c5",
-    "name" : "ExjOw0uRZtx1TJ5",
-    "mimeType" : "UAkOIy2DXLSCQQR",
-    "size" : 420377620,
-    "license" : "https://www.example.com/odd7vdjbrzjxzcyh",
+    "identifier" : "a2665e47-7b2b-4fe7-9f10-6a60bd51c2de",
+    "name" : "X1UhkEDJ2oq",
+    "mimeType" : "WbQhpWGc0KXC",
+    "size" : 1729775690,
+    "license" : "https://www.example.com/qqe2mebdlz4oxoai8ud",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "OeoO6qXj9VgD"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "EKDCMFT7OOtZKDUaS6",
-    "publishedDate" : "1972-11-28T03:58:38.668Z",
+    "legalNote" : "dzrtfFzIrE",
+    "publishedDate" : "1979-08-22T06:01:08.762Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "7h2PlShKatq9zdXm",
+      "uploadedDate" : "1971-02-04T00:59:32.369Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/I9NpSeLQPOS4xj7rm7S",
-    "name" : "fRKpcXAwe6keN",
-    "description" : "Mj3YMu5kx4nM"
+    "id" : "https://www.example.com/sKo0Zc7hNg8Haru3S",
+    "name" : "vWAJdGFqEnTli44TN",
+    "description" : "d2AphHOXaXoIWslT"
   } ],
-  "rightsHolder" : "k56NkV9MZqaQBZa2",
-  "duplicateOf" : "https://www.example.org/dffec0cf-8b06-4efa-ae37-5dd37efb320b",
+  "rightsHolder" : "yv00htca6PfLsGotVlu",
+  "duplicateOf" : "https://www.example.org/5aa171de-23c3-4f34-810d-e65697f8a652",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FSM0yyokM4XqVlS"
+    "note" : "GRwoNqPDenPYy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CrD531m0SFNO7",
-    "createdBy" : "usHvqhNGYrFxKhr",
-    "createdDate" : "2010-09-21T22:24:09.997Z"
+    "note" : "ehZfxS5f4Hqzr",
+    "createdBy" : "tClpb37soimp",
+    "createdDate" : "2023-09-27T21:01:44.558Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/464d7495-5c0a-424d-93b2-7171316be820" ],
+  "curatingInstitutions" : [ "https://www.example.org/b8c8126a-1ef8-4bfd-a945-87419f491e07" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/CaseReport.json
+++ b/documentation/CaseReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "LRLSKGVrUiO4fXkL",
-    "ownerAffiliation" : "https://www.example.org/1ab77f48-0892-4191-8ae2-bc335fb0aa4c"
+    "owner" : "TjBZllRrR8Eusl",
+    "ownerAffiliation" : "https://www.example.org/6ad5d995-e9ce-4d32-be8c-d18ebab7495f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/be759c68-c8ea-4339-a573-0ee00376ee5f"
+    "id" : "https://www.example.org/55d8f0f4-b375-446c-b5e6-e55181d024a0"
   },
-  "createdDate" : "1997-12-11T08:33:58.261Z",
-  "modifiedDate" : "1995-12-17T04:16:17.405Z",
-  "publishedDate" : "1980-03-08T11:17:57.917Z",
-  "indexedDate" : "2004-10-07T15:13:36.600Z",
-  "handle" : "https://www.example.org/3183e1df-fd14-4082-94ed-66250a3afab8",
-  "doi" : "https://doi.org/10.1234/dolores",
-  "link" : "https://www.example.org/83d55291-2789-4c88-a404-c792bdd1e486",
+  "createdDate" : "2006-06-09T19:55:50.977Z",
+  "modifiedDate" : "2014-02-17T10:49:16.749Z",
+  "publishedDate" : "2022-02-10T04:20:10.120Z",
+  "indexedDate" : "2012-08-25T03:38:49.435Z",
+  "handle" : "https://www.example.org/88d3f062-745c-4308-ad0f-505b170c238f",
+  "doi" : "https://doi.org/10.1234/minus",
+  "link" : "https://www.example.org/eb89604f-01ec-45dc-b01a-c497ac0a8cec",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "l2rU8A4wKJu4uV9",
+    "mainTitle" : "IRpbrfD7dbLXlD4bq",
     "alternativeTitles" : {
-      "hu" : "RddOZUFbFhoglEOIlC"
+      "pl" : "78FMYVXwk36IywVn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "7QdVjDC6LcnOITI4",
-      "month" : "4XvCnQKNKffo9l",
-      "day" : "OxlEXFvZ3z"
+      "year" : "9gDAzAPJw1hWLVcL6",
+      "month" : "4VhV8QRyxU",
+      "day" : "HC3doFdY5zWFJ8Hl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fd58f475-f3d0-4c61-8460-77f395d216a3",
-        "name" : "nyTuQj4Ga15J",
+        "id" : "https://www.example.org/d312c004-4a85-41c5-86c4-97dd425d308e",
+        "name" : "cgElmwK0QI7wgCyK",
         "nameType" : "Organizational",
-        "orcId" : "wOr7iSkSWSpt",
-        "verificationStatus" : "Verified",
+        "orcId" : "6ehWwlPRkop5N",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Fk1C6BWEPbGXn0hxz",
-          "value" : "M54xKReGxlPafXL"
+          "sourceName" : "LFj9X3qq50Cq",
+          "value" : "TcvSvjOc9LDLvXaeb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6o9bHeKX0JxLPRl",
-          "value" : "ajbn5FsHgbmUppw"
+          "sourceName" : "rlAnVw1u8dykKVxT6DZ",
+          "value" : "xkolh4wwxGo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bab91054-8564-44e0-996c-5a6042363d04"
+        "id" : "https://www.example.org/e72b7e36-b9e8-47b4-9b76-92b92a8ec8ef"
       } ],
       "role" : {
-        "type" : "AudioVisualContributor"
+        "type" : "Librettist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/373d6fb4-29c9-44c3-8190-41467b68abb4",
-        "name" : "NVuSa3WF4cIOF65oyNW",
-        "nameType" : "Organizational",
-        "orcId" : "tbGoFuAkhTG",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/e73e1bb8-0022-4279-b8c0-7ed25d1bf17c",
+        "name" : "jwOx3sQlnxi9",
+        "nameType" : "Personal",
+        "orcId" : "i8TX8eFTgOxc0i0EHcE",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KnWClX1NNouJ",
-          "value" : "TMO4RLYIagONRpdFTs"
+          "sourceName" : "9qxnWBnrmglU",
+          "value" : "To7VMFUEvnSDNlMU3z"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uiVeMbRkxLVFm1B",
-          "value" : "pNyTBuveGJmXg"
+          "sourceName" : "6QeAffffDmHJaF2n",
+          "value" : "X8BzcVi3xUPGIbbP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/66d72ce8-5a23-453c-8779-a9250642e659"
+        "id" : "https://www.example.org/b4a4bf39-44fe-43b1-895c-91a887fc78ba"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "UhEp5rQ2nzjO4D02ype"
+      "zh" : "CkuWn9L6ZYtYyUom1r"
     },
-    "npiSubjectHeading" : "wg1OIBi9Po2TKWCpMUf",
-    "tags" : [ "LBBZ3kgsAN7" ],
-    "description" : "eX0tgjt3LAFcaLIcz7",
+    "npiSubjectHeading" : "2W9UPvzrrRE5uTvL3nT",
+    "tags" : [ "DJx8KvGOIurt8qN4nuk" ],
+    "description" : "pXKNF3ZnytyPdFVBqS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/87d59ac7-fda1-433c-ab8a-135920df16bf"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/883ad9e7-137d-4bf8-ad5d-abd8163e0240"
       },
-      "doi" : "https://www.example.org/1f0d9764-ae10-4dfa-b4cc-c9f84bf94867",
+      "doi" : "https://www.example.org/a77627a5-1bfd-47d9-83e9-9179a62a3a9d",
       "publicationInstance" : {
         "type" : "CaseReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "lRw7fi2tqWdCIS",
-          "end" : "7jUOHupHoa9gbeqL1v"
+          "begin" : "U7RumsDpA5MDRFh0",
+          "end" : "z9IPY1EFwwfncXxx"
         },
-        "volume" : "jKACnN1HVHmZqn7dqgd",
-        "issue" : "87DaQwtL7cIeN",
-        "articleNumber" : "5al0tlTd4gxpRqHMCI"
+        "volume" : "1ExvlqEw5xGBl",
+        "issue" : "mWuGYyrLEYX98DZmnt",
+        "articleNumber" : "wBnjiTYYhMIaf69K2"
       }
     },
-    "metadataSource" : "https://www.example.org/5f9fe8be-8a30-4652-af41-d7842d3a5eb8",
-    "abstract" : "SrKIrPDiptOo1y3"
+    "metadataSource" : "https://www.example.org/165b35ce-61b1-4326-9874-d389d98aec8f",
+    "abstract" : "fa3BkORrgZ7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5df90065-b70e-4f47-a866-17d19fcd9db5",
-    "name" : "jT9km1Evp9o9vP4",
+    "id" : "https://www.example.org/041d4d4e-b076-424d-b851-5efb22cdc82e",
+    "name" : "EcjMLlgQfowGRM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-10-08T18:31:49.902Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "UEZDVlpmUhl"
+      "approvalDate" : "2002-09-27T04:11:15.012Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "uf3lbsgD2Z3gGrNnKag"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/509f86e1-f340-41f6-a178-1d4dabd89bd3",
-    "identifier" : "3nPozEEE7wDkb3P",
+    "source" : "https://www.example.org/c12b29a0-50d1-4d60-9542-0d16206b2c9a",
+    "identifier" : "vSyYvrewpixYh",
     "labels" : {
-      "de" : "tvjnZnfSzKm83yzu"
+      "es" : "zoTynLbjmD"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1478773638
+      "amount" : 2143741145
     },
-    "activeFrom" : "2001-07-28T06:44:22.602Z",
-    "activeTo" : "2015-09-05T03:00:31.152Z"
+    "activeFrom" : "2023-04-22T08:32:44.620Z",
+    "activeTo" : "2024-02-18T10:44:54.260Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/f079ae3e-56a1-418c-a100-eb691bde6a75",
-    "id" : "https://www.example.org/aa218bcd-3cba-46a0-a371-164810555457",
-    "identifier" : "gBRvs941sBQF",
+    "source" : "https://www.example.org/1c05cdcd-d157-4727-bbfa-dc87168986c7",
+    "id" : "https://www.example.org/89e3c29e-efbe-48d3-ba97-e81bab8cb0d9",
+    "identifier" : "Zgfk2xJP0iI3JnzDHz",
     "labels" : {
-      "es" : "eBPtd2e1oUD"
+      "nb" : "mEO0BkWQENqYh3UhOrQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 306800504
+      "currency" : "USD",
+      "amount" : 978555359
     },
-    "activeFrom" : "1994-02-23T19:43:58.156Z",
-    "activeTo" : "2014-04-25T10:29:59.420Z"
+    "activeFrom" : "1975-07-24T04:15:12.633Z",
+    "activeTo" : "1989-06-12T02:02:39.915Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c3b5a39e-e4b8-473b-97f2-3ed5098c8f4c" ],
+  "subjects" : [ "https://www.example.org/4a7cae2e-58ba-4f75-b15d-d8ba2659b705" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "570cc98e-b3d9-4278-87e1-681248136a5e",
-    "name" : "ewjsPhiaVSp",
-    "mimeType" : "bCX1rwLjMTr67L0aQx4",
-    "size" : 1809623897,
-    "license" : "https://www.example.com/xzaxqgwwh5w9o",
+    "identifier" : "f01b33d2-dfd8-45fb-82e2-7e32199728c5",
+    "name" : "ExjOw0uRZtx1TJ5",
+    "mimeType" : "UAkOIy2DXLSCQQR",
+    "size" : 420377620,
+    "license" : "https://www.example.com/odd7vdjbrzjxzcyh",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "TNQih34Ng5gyV9f69G"
+      "overriddenBy" : "OeoO6qXj9VgD"
     },
-    "legalNote" : "NTGfEOP6h1ema",
-    "publishedDate" : "2004-09-08T09:33:07.185Z",
+    "legalNote" : "EKDCMFT7OOtZKDUaS6",
+    "publishedDate" : "1972-11-28T03:58:38.668Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TMwg4Ys2SBcvnAF1o",
-    "name" : "PulP7Dpvnnjw7au60rG",
-    "description" : "e0sdqRkZcbvpi"
+    "id" : "https://www.example.com/I9NpSeLQPOS4xj7rm7S",
+    "name" : "fRKpcXAwe6keN",
+    "description" : "Mj3YMu5kx4nM"
   } ],
-  "rightsHolder" : "jzxPPe2Jwq9EmfPsIIs",
-  "duplicateOf" : "https://www.example.org/9ce9cc3c-8daf-4fc1-a107-fb1ecf8343c1",
+  "rightsHolder" : "k56NkV9MZqaQBZa2",
+  "duplicateOf" : "https://www.example.org/dffec0cf-8b06-4efa-ae37-5dd37efb320b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pFb8wVEpYxQxUEF"
+    "note" : "FSM0yyokM4XqVlS"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fdECOXWlGQsWUxP",
-    "createdBy" : "gVjThatfzvsFrwIbHQO",
-    "createdDate" : "2006-04-04T10:53:07.969Z"
+    "note" : "CrD531m0SFNO7",
+    "createdBy" : "usHvqhNGYrFxKhr",
+    "createdDate" : "2010-09-21T22:24:09.997Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a1eeff34-9662-4f66-968b-a62dcdf31c62" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/464d7495-5c0a-424d-93b2-7171316be820" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "uPBBybgASgi1",
-    "ownerAffiliation" : "https://www.example.org/e18feb00-795b-4666-a2f6-d4bb7d6a6b63"
+    "owner" : "5pETWRGaSO",
+    "ownerAffiliation" : "https://www.example.org/73485963-24ea-4f0c-b7ba-e6ea775633ce"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2a61e67a-55de-4821-aa93-8d70113b5a4f"
+    "id" : "https://www.example.org/7dcbae62-4c8a-43b4-9118-e976e2d7cb0d"
   },
-  "createdDate" : "2003-05-18T03:35:23.456Z",
-  "modifiedDate" : "1978-03-25T10:11:29.451Z",
-  "publishedDate" : "2014-02-23T04:53:52.241Z",
-  "indexedDate" : "1997-05-21T09:57:05.581Z",
-  "handle" : "https://www.example.org/53eac64a-ca42-4059-a810-e130dab94e3a",
-  "doi" : "https://doi.org/10.1234/neque",
-  "link" : "https://www.example.org/7b2142f4-e6bb-4436-b561-d65153a3e114",
+  "createdDate" : "2006-08-30T07:31:27.343Z",
+  "modifiedDate" : "1995-08-04T00:25:00.016Z",
+  "publishedDate" : "1992-11-02T01:23:06.691Z",
+  "indexedDate" : "2013-08-01T14:36:30.963Z",
+  "handle" : "https://www.example.org/dd66ef4d-a4ff-4c05-bb72-118fba09044e",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/09c336e7-f560-4ca0-9313-9fa2321da6d1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "l83eyV4Xy3FA4y1F",
+    "mainTitle" : "W1R5ouRBX7A",
     "alternativeTitles" : {
-      "en" : "V12vFIOblT"
+      "es" : "6YdXBKZLul"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "2HrSFjhCgI",
-      "month" : "GnGJHZXT05JYRxfXQg3",
-      "day" : "UKVVajfhrkD2UDzStOl"
+      "year" : "XdWRhnNCID817P3g",
+      "month" : "nlQhmCpJXLE",
+      "day" : "KZQo6HpfPV8Omz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/60091467-9ac9-455f-9c02-d0e1cedf2c0c",
-        "name" : "DtgD8PJsAEqqB",
+        "id" : "https://www.example.org/727cadc1-0085-4d70-88e2-66e5edbfaa9b",
+        "name" : "STsH4UL6Joxj3a",
         "nameType" : "Organizational",
-        "orcId" : "Of3RasrTMRgG",
+        "orcId" : "35dmA0U2u3mJKnXy9R",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RokDC4ntUUskrmMtX6",
-          "value" : "pImsDKaPJt"
+          "sourceName" : "rthotb5G7kyQhIqRhq",
+          "value" : "wuXRZSjzhrYNW9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1BeLgY0G60foXJXXiZ",
-          "value" : "MCXLHVljY0tXrb5H"
+          "sourceName" : "XdiFUqnoLehlJl6QduZ",
+          "value" : "r9E0bURkxsi0Liz54Ge"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fff5f13a-4d7d-44a0-83c2-cb960fff2970"
+        "id" : "https://www.example.org/8bc6ae9c-e795-4dfe-98dc-c9b6a728f711"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "HostingInstitution"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,137 +62,142 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/14adabde-2395-4739-8fdc-d12cdd11e72b",
-        "name" : "BxckXMLkQB",
+        "id" : "https://www.example.org/894e5998-7de1-455d-970c-254f4225a857",
+        "name" : "TAUKa2G4HtZTD",
         "nameType" : "Personal",
-        "orcId" : "b0aJnxWIVP6",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "j5yGHBzSpDcmgDTLmI",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pCi0bVNDDlvM1z",
-          "value" : "XNvFA6qOrnvkBX"
+          "sourceName" : "XHZNEZxSHf",
+          "value" : "iRuYfRY5E6lUVu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T31lCFD46lBwxt3OEYb",
-          "value" : "5RWAiddTNjJ"
+          "sourceName" : "9YnBi9vTTLMQ1JDla",
+          "value" : "MtwbFFox11XlzoJyY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bb773666-18a7-4041-802c-b52fd8c54d6d"
+        "id" : "https://www.example.org/5c5d350a-a65c-4147-81c2-3efd29c7d73e"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "xYeB75BS5gn"
+      "se" : "xMxvn3HFoOhXyOAquW"
     },
-    "npiSubjectHeading" : "80lS9T2oSw",
-    "tags" : [ "ZoAhBKn6qblByZhky" ],
-    "description" : "tdS1CtItAwS",
+    "npiSubjectHeading" : "vIgYSuXAGCwC",
+    "tags" : [ "osKcjNStBsNe" ],
+    "description" : "H1Ncky4onn8aytW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/K2A0x3mBqMU0Cz4o"
+        "id" : "https://www.example.com/AxyY1Q64DEwr"
       },
-      "doi" : "https://www.example.org/2b6758b9-fe5a-4bec-95f3-184ea1739959",
+      "doi" : "https://www.example.org/4c6e92d5-3e97-4590-bf2f-281fe34a45b6",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "43pU8ZxgwOIPWijMT",
-          "end" : "Y9sJ57vRnEbtA"
+          "begin" : "0MaDTHDRONqd",
+          "end" : "gwbJ4Z2vxiBqbucgi"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4c3844e0-8e84-4308-a93d-ce739b7dd36d",
-    "abstract" : "ofOcr2u2HIHjW5wzONw"
+    "metadataSource" : "https://www.example.org/c0695125-efda-481f-8c80-59ae735a3e9a",
+    "abstract" : "WqtoJg4v0ytQzaohfEI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6538ddd8-1e18-4a1c-96df-9a8d3f6ce5de",
-    "name" : "xvjDLWIPikqkzke1vyq",
+    "id" : "https://www.example.org/e48210aa-9e7a-4b04-97b8-b1518fdc83ad",
+    "name" : "BehU2ybBRh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-08-06T13:51:45.095Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "lqFx3fvtVHfj"
+      "approvalDate" : "1993-07-23T21:24:53.904Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "GLiLyuwIPRnm"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/14da4e72-6c0c-4ded-b96a-8623dbf6bca0",
-    "identifier" : "aEq0JoIu2hgS32S4F",
+    "source" : "https://www.example.org/7186847f-10d1-4f98-a774-f77ce2bd1631",
+    "identifier" : "szrXdxFIIBplZrFR",
     "labels" : {
-      "ru" : "9abRTBcv43cXzSKi"
+      "nn" : "4YGjUGDsd5UGBntyc98"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1952733902
+      "currency" : "USD",
+      "amount" : 538977491
     },
-    "activeFrom" : "2017-01-27T05:45:58.208Z",
-    "activeTo" : "2019-04-19T18:40:21.903Z"
+    "activeFrom" : "1973-02-06T20:27:35.226Z",
+    "activeTo" : "1980-02-29T14:20:05.453Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a4ccf0c2-229a-424d-8578-3308b524101f",
-    "id" : "https://www.example.org/68e4cc2a-2a84-4957-9aa1-d2ca46356d1b",
-    "identifier" : "XqmnF30VSob",
+    "source" : "https://www.example.org/b7af1a1c-b7fe-417e-8844-63574d5390c1",
+    "id" : "https://www.example.org/81e4356e-c3cc-4820-b6cf-09f1560154f6",
+    "identifier" : "E0agLQqQNDh",
     "labels" : {
-      "it" : "xFizF0xrcscF5"
+      "nn" : "qCSvNk9ZTZVu7BQ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 255430693
+      "currency" : "USD",
+      "amount" : 1665984630
     },
-    "activeFrom" : "1993-11-14T06:26:51.330Z",
-    "activeTo" : "2012-04-11T20:10:42.458Z"
+    "activeFrom" : "2001-07-12T23:51:50.258Z",
+    "activeTo" : "2015-07-24T00:19:46.915Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/01e7ba88-90ec-4e40-bc68-f2f935380392" ],
+  "subjects" : [ "https://www.example.org/66798ee3-c3db-4761-a30e-c4c58a81c17d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9ff4540e-95ef-46e9-aa04-2a3bee332a8a",
-    "name" : "k2uRyeASPFNjtQuF0w",
-    "mimeType" : "s74EG7dpFmISNQkVbA",
-    "size" : 1789878135,
-    "license" : "https://www.example.com/1hgrbllgza0xxxro",
+    "identifier" : "20fafeaf-c3b0-4541-8565-38917a8c1846",
+    "name" : "sWC0sjP6wGDW50soRG",
+    "mimeType" : "HeqapqoUtK8Y",
+    "size" : 209785964,
+    "license" : "https://www.example.com/u31gtqogpm2wgchdswc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "aBb4P3POx7vaiZO9n"
+      "overriddenBy" : "dOpq1fJupVxPNq5"
     },
-    "legalNote" : "wQAfQSU0afuU",
-    "publishedDate" : "2015-03-13T15:16:58.888Z",
+    "legalNote" : "ZXs7rcexlRn2QYT",
+    "publishedDate" : "1984-04-24T22:11:06.902Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "M0i9T6lJNLQ0WFd8SBD",
+      "uploadedDate" : "1985-11-28T18:42:07.139Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/XG14mbPpAvo",
-    "name" : "EjFLVCntZUp7",
-    "description" : "h1rHqRUeuDxhH0R679"
+    "id" : "https://www.example.com/hCRctkpzRiX",
+    "name" : "yNgsArDk06wsjT",
+    "description" : "5jPQUTde9qITFkiu"
   } ],
-  "rightsHolder" : "u6suNN6Uzs4WuDOBs",
-  "duplicateOf" : "https://www.example.org/3a29f56d-ae84-4ce1-8a3a-cefe408ac4d3",
+  "rightsHolder" : "zg9WkqVfbZTKedGuai",
+  "duplicateOf" : "https://www.example.org/2c0cf7bb-5d23-48c2-ad74-5cd029e26fb3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "k0QLqAdFHb2V"
+    "note" : "wczl84l0c7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "4aG7jW6XKbQgnV",
-    "createdBy" : "grIeXQ6pgg8wvyETh",
-    "createdDate" : "2001-12-20T18:45:30.745Z"
+    "note" : "j7s2WxC8e53dj",
+    "createdBy" : "D3gMu27pMR",
+    "createdDate" : "2018-11-08T02:37:36.352Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c6c5e5ea-9256-4573-8929-88e7d23f4fc0" ],
+  "curatingInstitutions" : [ "https://www.example.org/1c154ab5-1263-45da-93c3-dcfe426441de" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ChapterConferenceAbstract.json
+++ b/documentation/ChapterConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "UOVKT65TaNpPSzs",
-    "ownerAffiliation" : "https://www.example.org/5231f1c4-6d86-4d42-8b65-3ac8608dd88d"
+    "owner" : "uPBBybgASgi1",
+    "ownerAffiliation" : "https://www.example.org/e18feb00-795b-4666-a2f6-d4bb7d6a6b63"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c38a2d37-67e2-4cb7-aa9f-d86186326da2"
+    "id" : "https://www.example.org/2a61e67a-55de-4821-aa93-8d70113b5a4f"
   },
-  "createdDate" : "1997-01-07T02:21:33.013Z",
-  "modifiedDate" : "1998-12-30T06:47:33.152Z",
-  "publishedDate" : "2021-09-28T09:24:42.143Z",
-  "indexedDate" : "1983-12-17T04:30:58.201Z",
-  "handle" : "https://www.example.org/0a0b1c75-e451-40f6-9d41-f346039cd024",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/76f3ded3-c5f0-413b-8e4e-77cff9edfd6f",
+  "createdDate" : "2003-05-18T03:35:23.456Z",
+  "modifiedDate" : "1978-03-25T10:11:29.451Z",
+  "publishedDate" : "2014-02-23T04:53:52.241Z",
+  "indexedDate" : "1997-05-21T09:57:05.581Z",
+  "handle" : "https://www.example.org/53eac64a-ca42-4059-a810-e130dab94e3a",
+  "doi" : "https://doi.org/10.1234/neque",
+  "link" : "https://www.example.org/7b2142f4-e6bb-4436-b561-d65153a3e114",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "yNRmqRkQK9RNHsp6Jp",
+    "mainTitle" : "l83eyV4Xy3FA4y1F",
     "alternativeTitles" : {
-      "ca" : "hNt8399klk8B"
+      "en" : "V12vFIOblT"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "aGySvnab8loH",
-      "month" : "KVRu3LBy3Wz0bAQWHQy",
-      "day" : "w0JpQhNzpKbu2JeEr"
+      "year" : "2HrSFjhCgI",
+      "month" : "GnGJHZXT05JYRxfXQg3",
+      "day" : "UKVVajfhrkD2UDzStOl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/43936bb6-6784-4933-8570-7fa7f653dfd3",
-        "name" : "GB93xbdVE6Q",
+        "id" : "https://www.example.org/60091467-9ac9-455f-9c02-d0e1cedf2c0c",
+        "name" : "DtgD8PJsAEqqB",
         "nameType" : "Organizational",
-        "orcId" : "I6qFascwvceyM",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Of3RasrTMRgG",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2B3KQMIKjt",
-          "value" : "TtfCfOOYUwKE8"
+          "sourceName" : "RokDC4ntUUskrmMtX6",
+          "value" : "pImsDKaPJt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BeacCvMwF4o9TvAL",
-          "value" : "smZhejqPiWwm"
+          "sourceName" : "1BeLgY0G60foXJXXiZ",
+          "value" : "MCXLHVljY0tXrb5H"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/66cd5ec4-7d08-490a-ab73-cf8f2605df60"
+        "id" : "https://www.example.org/fff5f13a-4d7d-44a0-83c2-cb960fff2970"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "Photographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,137 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d465ef0c-caf6-43f3-abcd-9f0c52e0495c",
-        "name" : "UYWqnGl2JKWMTB",
-        "nameType" : "Organizational",
-        "orcId" : "biB2iZdWpy3uAX",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/14adabde-2395-4739-8fdc-d12cdd11e72b",
+        "name" : "BxckXMLkQB",
+        "nameType" : "Personal",
+        "orcId" : "b0aJnxWIVP6",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YnpMSitvArZWC61Y",
-          "value" : "7V2iMM72MhwDitq"
+          "sourceName" : "pCi0bVNDDlvM1z",
+          "value" : "XNvFA6qOrnvkBX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GVtaMC1q4KDypDS",
-          "value" : "CzLig3GE7AIBW1XA"
+          "sourceName" : "T31lCFD46lBwxt3OEYb",
+          "value" : "5RWAiddTNjJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/df57c818-ea77-4944-ae67-bc8a4d828dbf"
+        "id" : "https://www.example.org/bb773666-18a7-4041-802c-b52fd8c54d6d"
       } ],
       "role" : {
-        "type" : "CuratorOrganizer"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "118JPLIz4t"
+      "sv" : "xYeB75BS5gn"
     },
-    "npiSubjectHeading" : "OKjcMmkdaDs1LnHQbzM",
-    "tags" : [ "Eaul8oA69dL9h8" ],
-    "description" : "jA1NrZuAtaCD8ox",
+    "npiSubjectHeading" : "80lS9T2oSw",
+    "tags" : [ "ZoAhBKn6qblByZhky" ],
+    "description" : "tdS1CtItAwS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/F8pWiUSe18UrS8"
+        "id" : "https://www.example.com/K2A0x3mBqMU0Cz4o"
       },
-      "doi" : "https://www.example.org/bb0f4ea3-1c2c-46f8-80ed-ceba88702687",
+      "doi" : "https://www.example.org/2b6758b9-fe5a-4bec-95f3-184ea1739959",
       "publicationInstance" : {
         "type" : "ChapterConferenceAbstract",
         "pages" : {
           "type" : "Range",
-          "begin" : "FG6ixBj9MzUiq1y",
-          "end" : "libJJfINRgOMc4zW"
+          "begin" : "43pU8ZxgwOIPWijMT",
+          "end" : "Y9sJ57vRnEbtA"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/81ff9ed8-170e-40fa-a715-cc971b041be5",
-    "abstract" : "oZndXDEqLMViK6wYLS"
+    "metadataSource" : "https://www.example.org/4c3844e0-8e84-4308-a93d-ce739b7dd36d",
+    "abstract" : "ofOcr2u2HIHjW5wzONw"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0d17dffc-e4ff-49cb-b335-563eeff914b5",
-    "name" : "5YEQq8Ne6Cz9V",
+    "id" : "https://www.example.org/6538ddd8-1e18-4a1c-96df-9a8d3f6ce5de",
+    "name" : "xvjDLWIPikqkzke1vyq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-12-27T18:25:12.257Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "lmtr20LEy8AMG"
+      "approvalDate" : "1998-08-06T13:51:45.095Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "lqFx3fvtVHfj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7759b713-b8f5-4d42-90a7-c03bfaf2aaa4",
-    "identifier" : "yR069pfv2z",
+    "source" : "https://www.example.org/14da4e72-6c0c-4ded-b96a-8623dbf6bca0",
+    "identifier" : "aEq0JoIu2hgS32S4F",
     "labels" : {
-      "ru" : "Hmd0aUPT2JE0DQGye5G"
+      "ru" : "9abRTBcv43cXzSKi"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1182626044
+      "amount" : 1952733902
     },
-    "activeFrom" : "1977-09-05T07:44:35.127Z",
-    "activeTo" : "2003-12-19T13:02:44.329Z"
+    "activeFrom" : "2017-01-27T05:45:58.208Z",
+    "activeTo" : "2019-04-19T18:40:21.903Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e173951c-7455-48a8-9f19-58e9fe1fd0f8",
-    "id" : "https://www.example.org/58187298-c1ff-4fff-a7da-cbab6a54ac57",
-    "identifier" : "ol6Qd0gULh9T",
+    "source" : "https://www.example.org/a4ccf0c2-229a-424d-8578-3308b524101f",
+    "id" : "https://www.example.org/68e4cc2a-2a84-4957-9aa1-d2ca46356d1b",
+    "identifier" : "XqmnF30VSob",
     "labels" : {
-      "it" : "hPYjUQ6TRplhnGY0pQc"
+      "it" : "xFizF0xrcscF5"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 974223498
+      "amount" : 255430693
     },
-    "activeFrom" : "2012-02-24T16:43:09.156Z",
-    "activeTo" : "2019-01-22T06:18:49.112Z"
+    "activeFrom" : "1993-11-14T06:26:51.330Z",
+    "activeTo" : "2012-04-11T20:10:42.458Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a59cda8a-47f1-44e1-9558-ef047ef734ab" ],
+  "subjects" : [ "https://www.example.org/01e7ba88-90ec-4e40-bc68-f2f935380392" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f71ffa01-5369-4b51-8f5b-75418d9c0d67",
-    "name" : "gy6yxGsYfy",
-    "mimeType" : "mL42rsLxZ7s5ky",
-    "size" : 1192357806,
-    "license" : "https://www.example.com/hpsmf8lctbvn",
+    "identifier" : "9ff4540e-95ef-46e9-aa04-2a3bee332a8a",
+    "name" : "k2uRyeASPFNjtQuF0w",
+    "mimeType" : "s74EG7dpFmISNQkVbA",
+    "size" : 1789878135,
+    "license" : "https://www.example.com/1hgrbllgza0xxxro",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "YcMAzbMF9vhZyWze"
+      "overriddenBy" : "aBb4P3POx7vaiZO9n"
     },
-    "legalNote" : "uBHlc82Lzb7",
-    "publishedDate" : "2010-02-27T21:19:01.215Z",
+    "legalNote" : "wQAfQSU0afuU",
+    "publishedDate" : "2015-03-13T15:16:58.888Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qgloaHYvBSrBODbu",
-    "name" : "GEVHDDS0blA",
-    "description" : "1ft5lY6enS"
+    "id" : "https://www.example.com/XG14mbPpAvo",
+    "name" : "EjFLVCntZUp7",
+    "description" : "h1rHqRUeuDxhH0R679"
   } ],
-  "rightsHolder" : "CIABLJeCmmx",
-  "duplicateOf" : "https://www.example.org/f5993e9c-bf5c-45a9-a4fe-ef56d169c4fd",
+  "rightsHolder" : "u6suNN6Uzs4WuDOBs",
+  "duplicateOf" : "https://www.example.org/3a29f56d-ae84-4ce1-8a3a-cefe408ac4d3",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "QOELUVmuwRVkL7jJxN"
+    "note" : "k0QLqAdFHb2V"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Ia8oPPvFNV7d3unzE",
-    "createdBy" : "6YZAzKa6nyFD5FNv3",
-    "createdDate" : "1987-09-21T04:59:22.231Z"
+    "note" : "4aG7jW6XKbQgnV",
+    "createdBy" : "grIeXQ6pgg8wvyETh",
+    "createdDate" : "2001-12-20T18:45:30.745Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d8f8237b-8f04-4957-b0b5-0019f3d9c9df" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/c6c5e5ea-9256-4573-8929-88e7d23f4fc0" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "038WSzAEmX0x",
-    "ownerAffiliation" : "https://www.example.org/a4bce3ee-70ac-4817-9817-874ef037cb95"
+    "owner" : "5A7bEyRCuKA",
+    "ownerAffiliation" : "https://www.example.org/fa3b5206-9e4e-4b88-b2e2-0d604acf913c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3c735a2c-6345-4e13-aa50-516b9ac39390"
+    "id" : "https://www.example.org/771c94fc-84c9-48cf-8973-63d3dfb1a14f"
   },
-  "createdDate" : "1993-11-06T13:22:29.701Z",
-  "modifiedDate" : "1972-05-27T06:10:25.842Z",
-  "publishedDate" : "1989-09-14T09:39:43.107Z",
-  "indexedDate" : "1996-03-02T05:29:07.953Z",
-  "handle" : "https://www.example.org/c352e68b-ba34-4230-8152-2e5e3f93d907",
-  "doi" : "https://doi.org/10.1234/culpa",
-  "link" : "https://www.example.org/32e98db9-5b1e-4260-a567-4e650f8b4238",
+  "createdDate" : "2022-07-16T01:26:36.449Z",
+  "modifiedDate" : "1988-10-17T20:21:25.744Z",
+  "publishedDate" : "1975-04-28T12:15:08.096Z",
+  "indexedDate" : "2006-02-21T21:18:21.762Z",
+  "handle" : "https://www.example.org/ebe402d7-0db7-4225-943f-1bb7b00c3d6f",
+  "doi" : "https://doi.org/10.1234/quasi",
+  "link" : "https://www.example.org/9f259327-e9b6-4f24-acd8-ec879a1e50a6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Dc2AY3meyYcfycsJHnL",
+    "mainTitle" : "mZ4oAOqqjBoUP2Hh",
     "alternativeTitles" : {
-      "nl" : "pxVvNeyk03Li8qAI"
+      "en" : "47zoUQzn1DvSog"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zyq3KqciDkqxrTN1",
-      "month" : "BklDQbT2sTLcc",
-      "day" : "5AAq3YimKIhBbGW8"
+      "year" : "nWXPGbvLC9exrkDlwB",
+      "month" : "XWUR4vIF8how3KyVCq",
+      "day" : "ybzeTjFlPTFIaHGYH3d"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/644c4451-1265-4278-95bb-6172816e3030",
-        "name" : "jgzbjV5UHCUgDmw5",
-        "nameType" : "Organizational",
-        "orcId" : "AfM6U55dXIyUK",
+        "id" : "https://www.example.org/dcae1193-d71a-47f6-a28b-8c3fcd883c5b",
+        "name" : "2VVlXNEfop3t",
+        "nameType" : "Personal",
+        "orcId" : "taXJg6l0rHdjZq7gPUO",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tiBKTG3KUW9tBM",
-          "value" : "PULGNTWNQ7UJ"
+          "sourceName" : "l6MBnmRy9XRg5Kk",
+          "value" : "mXEFhXrs66Ai8Q6nvY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hm1aVuqHUBFf9L5",
-          "value" : "udxhI4NgW3"
+          "sourceName" : "QdsdoUjwjE",
+          "value" : "IdiRY863YC5Z3LnaM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ceb59941-00be-42ee-975b-a28b725380c1"
+        "id" : "https://www.example.org/28c27174-b5c7-466d-880c-ef20de58301f"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Organizer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a0c5b337-f8cf-40df-a68f-add35824d0bc",
-        "name" : "NGGpQY0pcc3K51x",
+        "id" : "https://www.example.org/2a15300e-fe86-4db6-8f4a-c12eb79212fa",
+        "name" : "aa8FflS7c0",
         "nameType" : "Organizational",
-        "orcId" : "7Kqdmo0IeSAtun",
-        "verificationStatus" : "Verified",
+        "orcId" : "hxncf2bLEtKmzKkpy",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bFDOmxG6p1",
-          "value" : "WZiMGjrUwraI2yk"
+          "sourceName" : "l5T6mOkv49bXEatZ",
+          "value" : "6sAe5xSazljxpxpXwnx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AXEkmgQcRMoHrs",
-          "value" : "PmFfjymalW70f4CaUm"
+          "sourceName" : "dhCoyCQbppzG2iB",
+          "value" : "Fo9tHw0Ibokc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/94458413-26fd-4c9e-b221-af289c6427b8"
+        "id" : "https://www.example.org/f25d7b67-c0fd-48b9-b3fb-d2d245f510fb"
       } ],
       "role" : {
-        "type" : "Librettist"
+        "type" : "Distributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "l3GWzbObkStX"
+      "pt" : "GeCA9TsPBHQuCc12lOr"
     },
-    "npiSubjectHeading" : "TZNULRkZJO",
-    "tags" : [ "EuZeAN6Z9kqHl" ],
-    "description" : "fSVAx9TReL7OnYFxSVc",
+    "npiSubjectHeading" : "5lxfY4Odc0Tik",
+    "tags" : [ "gxv2HUdoNn4q9MvAsmb" ],
+    "description" : "73z59gcdeQeqvrZNxQ9",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/ZvbOVuv4GQN"
+        "id" : "https://www.example.com/YjXoOxbF1OqLFS"
       },
-      "doi" : "https://www.example.org/6d767508-eb76-4764-852a-dc5f69fb670d",
+      "doi" : "https://www.example.org/eab4bd37-1e9f-45e2-86da-5180b0ed9f76",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "uy6zAQ5yCEEpx5zNF",
-          "end" : "o58sgKds7F"
+          "begin" : "HnSI7Jxlskf",
+          "end" : "yEoeQFBqv6K"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/46416f1c-516c-4561-b9e9-2fb19f07f37b",
-    "abstract" : "RGwaObuQvKstYNz"
+    "metadataSource" : "https://www.example.org/ce7aa310-83c8-4169-a3d7-8e5a027db5a5",
+    "abstract" : "dRsCHf1RnHvXx6BDoU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/72dcaed8-355b-4db1-98cc-a79d6611ee49",
-    "name" : "qqMQWzCdXCXAJz",
+    "id" : "https://www.example.org/9bdc4528-2157-449a-b52d-8bc7877d5372",
+    "name" : "79a74p2sxqo",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-01-13T16:58:37.469Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2001-05-14T18:28:32.357Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "StB7LLDh8jAh8fSEYC9"
+      "applicationCode" : "MADMwjvLM1ewsrl8"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/716c879d-d18f-4460-bf8f-2a8bb74e8dfa",
-    "identifier" : "kjHZknW1Gwx3225XB9",
+    "source" : "https://www.example.org/1e3a31e7-642a-4221-a3d3-d0baee70b31a",
+    "identifier" : "Dd48nUhFN8f",
     "labels" : {
-      "fr" : "oJ8QE48MQzocK6f6w"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1024407887
-    },
-    "activeFrom" : "2007-09-29T06:30:17.994Z",
-    "activeTo" : "2010-09-02T22:14:15.218Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/487bcecb-b4b1-462f-96a9-d4e7b1f27a8e",
-    "id" : "https://www.example.org/0fcd28d8-e7ef-4b2d-929c-1293c6cbe44c",
-    "identifier" : "pIKB8yOY3uDXTC2PxL",
-    "labels" : {
-      "zh" : "OsX0Czo95kwMM6W0"
+      "se" : "9g34Z0EvgVQ"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1051112802
+      "amount" : 530822978
     },
-    "activeFrom" : "1989-03-02T22:48:22.613Z",
-    "activeTo" : "2006-09-17T12:45:54.634Z"
+    "activeFrom" : "1986-01-13T21:28:10.769Z",
+    "activeTo" : "1995-02-15T15:15:02.951Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/60d1dc2f-445c-4f4e-ab15-33f9974947bc",
+    "id" : "https://www.example.org/c4ca1b0d-a82e-4ca9-ab45-c203c962b080",
+    "identifier" : "de9aqhLNekCAp",
+    "labels" : {
+      "ru" : "2rtLm1E9B7NvSBUw"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1711992589
+    },
+    "activeFrom" : "1998-10-03T01:09:55.518Z",
+    "activeTo" : "2002-06-12T03:18:44.234Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6f7ee93a-5e06-4b7e-9933-51bfd1549d7a" ],
+  "subjects" : [ "https://www.example.org/7b2d2f62-7024-45e0-8bbd-c99f2174129f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7b576da7-928d-4aff-bde3-3e190e883da8",
-    "name" : "z1MpiuGUtNzwtf0W3",
-    "mimeType" : "f5Gi6ENUZmmuDWgFm",
-    "size" : 543245288,
-    "license" : "https://www.example.com/0hrodj3plhb4rdcqk",
+    "identifier" : "92888b6c-3c10-4c57-9e59-0d739f2510cd",
+    "name" : "ghOEmt2tqaI",
+    "mimeType" : "Wb31PM8yH24LkQSSpT",
+    "size" : 2096578298,
+    "license" : "https://www.example.com/50vnerhiufv75g97mme",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vnZaIDaKDDLg68OwRh",
-    "publishedDate" : "2020-08-14T11:26:28.240Z",
+    "legalNote" : "WkGYmS35zTka",
+    "publishedDate" : "1975-01-03T00:06:00.430Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/LAQHtuuLArvo87HXo",
-    "name" : "LlhckKYou1hp6c",
-    "description" : "RplU8CSfMy"
+    "id" : "https://www.example.com/6up8Nzr4POrrG",
+    "name" : "uwxz81kSWJdzyC",
+    "description" : "Z27FPYyzHVof5nfI"
   } ],
-  "rightsHolder" : "sbcomL5ditX21uALp",
-  "duplicateOf" : "https://www.example.org/bce9aaa3-2e34-4196-bd85-087799a812dd",
+  "rightsHolder" : "pmPZVgqTOSKUw9v0q5",
+  "duplicateOf" : "https://www.example.org/1ee3a2df-6877-4e39-bcb8-fb96644b189b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vr8VITOC1t545OX"
+    "note" : "FEZ3H3vRM6D"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WkfzcuBi6xJC",
-    "createdBy" : "dEHSXbi7eYG",
-    "createdDate" : "2014-01-25T05:12:52.148Z"
+    "note" : "Mxmm47ylsFSr",
+    "createdBy" : "LY1cH2ilmJpefpp",
+    "createdDate" : "1971-06-28T16:43:07.631Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/add3a4dc-98f3-4840-8ec6-fefd194b9663" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/21184176-edfe-4443-a4c0-67b6c2a3d66c" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ChapterInReport.json
+++ b/documentation/ChapterInReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "5A7bEyRCuKA",
-    "ownerAffiliation" : "https://www.example.org/fa3b5206-9e4e-4b88-b2e2-0d604acf913c"
+    "owner" : "FiruyCLtMG1kNVUrp",
+    "ownerAffiliation" : "https://www.example.org/cb0fc8eb-1933-4342-ba92-3c1569767831"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/771c94fc-84c9-48cf-8973-63d3dfb1a14f"
+    "id" : "https://www.example.org/6ccfa9b4-2d38-4977-a782-6d52b69c2920"
   },
-  "createdDate" : "2022-07-16T01:26:36.449Z",
-  "modifiedDate" : "1988-10-17T20:21:25.744Z",
-  "publishedDate" : "1975-04-28T12:15:08.096Z",
-  "indexedDate" : "2006-02-21T21:18:21.762Z",
-  "handle" : "https://www.example.org/ebe402d7-0db7-4225-943f-1bb7b00c3d6f",
-  "doi" : "https://doi.org/10.1234/quasi",
-  "link" : "https://www.example.org/9f259327-e9b6-4f24-acd8-ec879a1e50a6",
+  "createdDate" : "1977-03-20T17:50:35.919Z",
+  "modifiedDate" : "1973-02-03T10:17:36.521Z",
+  "publishedDate" : "1972-04-30T08:50:10.676Z",
+  "indexedDate" : "2012-10-30T20:36:17.451Z",
+  "handle" : "https://www.example.org/6a21da8a-5ddb-4eab-aea9-970a5ebdd272",
+  "doi" : "https://doi.org/10.1234/modi",
+  "link" : "https://www.example.org/6ec9e40d-bb36-4159-9850-6a7bc8dda522",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "mZ4oAOqqjBoUP2Hh",
+    "mainTitle" : "NGkfLDalTUSsTMs5Hq",
     "alternativeTitles" : {
-      "en" : "47zoUQzn1DvSog"
+      "ca" : "swkWcShX5J1srbXZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "nWXPGbvLC9exrkDlwB",
-      "month" : "XWUR4vIF8how3KyVCq",
-      "day" : "ybzeTjFlPTFIaHGYH3d"
+      "year" : "A2VYkd8rQ6gu8yPnU5l",
+      "month" : "vfYvCRCCrtXPeIiq",
+      "day" : "jGL5zveHiP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dcae1193-d71a-47f6-a28b-8c3fcd883c5b",
-        "name" : "2VVlXNEfop3t",
-        "nameType" : "Personal",
-        "orcId" : "taXJg6l0rHdjZq7gPUO",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/700667a9-bb12-4c0b-806c-84ce9eab5fa2",
+        "name" : "jGqmahoEmBqWER",
+        "nameType" : "Organizational",
+        "orcId" : "pac61hXQypWJWOd",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l6MBnmRy9XRg5Kk",
-          "value" : "mXEFhXrs66Ai8Q6nvY"
+          "sourceName" : "hreCuWBXtPSpnz0",
+          "value" : "y7yGK2cU5xMM3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QdsdoUjwjE",
-          "value" : "IdiRY863YC5Z3LnaM"
+          "sourceName" : "S8yk6Uq3gCGLo7xHD1",
+          "value" : "jYtBPXROHXoh0wbg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/28c27174-b5c7-466d-880c-ef20de58301f"
+        "id" : "https://www.example.org/7df72464-b704-453e-91c4-8618b3b886f3"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2a15300e-fe86-4db6-8f4a-c12eb79212fa",
-        "name" : "aa8FflS7c0",
-        "nameType" : "Organizational",
-        "orcId" : "hxncf2bLEtKmzKkpy",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/d4fa830b-2034-4bb2-9c98-a84ce7fe30f3",
+        "name" : "F5qCzjj5BFS7eQWW2",
+        "nameType" : "Personal",
+        "orcId" : "TVmPOpZAeWGgDb8nzw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l5T6mOkv49bXEatZ",
-          "value" : "6sAe5xSazljxpxpXwnx"
+          "sourceName" : "K7hkUUTvUjWnPpm",
+          "value" : "xZni1XpHy4KHe7FBK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dhCoyCQbppzG2iB",
-          "value" : "Fo9tHw0Ibokc"
+          "sourceName" : "1o6qBArzG1Kow9",
+          "value" : "0yqiVgMcKRtJT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f25d7b67-c0fd-48b9-b3fb-d2d245f510fb"
+        "id" : "https://www.example.org/fb2b2e97-0adf-451f-839b-eb5e300c7913"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "DataManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "GeCA9TsPBHQuCc12lOr"
+      "hu" : "2bT3oGdJs69txW"
     },
-    "npiSubjectHeading" : "5lxfY4Odc0Tik",
-    "tags" : [ "gxv2HUdoNn4q9MvAsmb" ],
-    "description" : "73z59gcdeQeqvrZNxQ9",
+    "npiSubjectHeading" : "7U6AbQaZuU7M5UckzzI",
+    "tags" : [ "xnWgothj6TAen2UAk" ],
+    "description" : "wBL74EYXcKIYk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/YjXoOxbF1OqLFS"
+        "id" : "https://www.example.com/qKkvZiHILvMsdI"
       },
-      "doi" : "https://www.example.org/eab4bd37-1e9f-45e2-86da-5180b0ed9f76",
+      "doi" : "https://www.example.org/71ed241f-f201-4dec-8c90-bee8c768aa39",
       "publicationInstance" : {
         "type" : "ChapterInReport",
         "pages" : {
           "type" : "Range",
-          "begin" : "HnSI7Jxlskf",
-          "end" : "yEoeQFBqv6K"
+          "begin" : "n7wIGPg1yNneL",
+          "end" : "AxDIvWjc9FFu6v4eWAe"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ce7aa310-83c8-4169-a3d7-8e5a027db5a5",
-    "abstract" : "dRsCHf1RnHvXx6BDoU"
+    "metadataSource" : "https://www.example.org/c8b63e99-0eb1-4111-8fcf-efbd89d43a3c",
+    "abstract" : "vuYdR3S2rDyqOa"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9bdc4528-2157-449a-b52d-8bc7877d5372",
-    "name" : "79a74p2sxqo",
+    "id" : "https://www.example.org/cf305685-c287-4907-9a8e-5d22a0031e60",
+    "name" : "tQ4CS4g2oPLfDwysKUJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-05-14T18:28:32.357Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "MADMwjvLM1ewsrl8"
+      "approvalDate" : "2023-12-27T03:06:19.876Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "tlXOcqi3cUzu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1e3a31e7-642a-4221-a3d3-d0baee70b31a",
-    "identifier" : "Dd48nUhFN8f",
+    "source" : "https://www.example.org/b94ea4d7-c64b-4816-af65-9ab6186edae6",
+    "identifier" : "ExWgph9pILbH8X7",
     "labels" : {
-      "se" : "9g34Z0EvgVQ"
+      "sv" : "RenjlXCs8M"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 530822978
+      "currency" : "NOK",
+      "amount" : 1183181812
     },
-    "activeFrom" : "1986-01-13T21:28:10.769Z",
-    "activeTo" : "1995-02-15T15:15:02.951Z"
+    "activeFrom" : "1980-04-30T22:22:37.420Z",
+    "activeTo" : "1995-03-08T06:36:53.519Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/60d1dc2f-445c-4f4e-ab15-33f9974947bc",
-    "id" : "https://www.example.org/c4ca1b0d-a82e-4ca9-ab45-c203c962b080",
-    "identifier" : "de9aqhLNekCAp",
+    "source" : "https://www.example.org/a3276511-f8ff-4d91-a370-7beb25eafbfe",
+    "id" : "https://www.example.org/25687259-797b-4a09-8ed6-8bfada2d5089",
+    "identifier" : "HVktUrPcSPkLCz",
     "labels" : {
-      "ru" : "2rtLm1E9B7NvSBUw"
+      "en" : "EVxutkj9t1cpM4D5"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1711992589
+      "currency" : "GBP",
+      "amount" : 1895793722
     },
-    "activeFrom" : "1998-10-03T01:09:55.518Z",
-    "activeTo" : "2002-06-12T03:18:44.234Z"
+    "activeFrom" : "2017-08-18T22:49:26.353Z",
+    "activeTo" : "2024-01-24T19:11:08.180Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7b2d2f62-7024-45e0-8bbd-c99f2174129f" ],
+  "subjects" : [ "https://www.example.org/b0307134-0afc-4b2d-b3f9-80179005e239" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "92888b6c-3c10-4c57-9e59-0d739f2510cd",
-    "name" : "ghOEmt2tqaI",
-    "mimeType" : "Wb31PM8yH24LkQSSpT",
-    "size" : 2096578298,
-    "license" : "https://www.example.com/50vnerhiufv75g97mme",
+    "identifier" : "93e521ec-ae54-4641-be0f-37c875307218",
+    "name" : "HQRrd0j6TFTxf8tHx0",
+    "mimeType" : "LIjvxnp4idj",
+    "size" : 1040072493,
+    "license" : "https://www.example.com/lpufl90y2ualkrbimqc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "WkGYmS35zTka",
-    "publishedDate" : "1975-01-03T00:06:00.430Z",
+    "legalNote" : "csSQYXCUI2uss",
+    "publishedDate" : "1997-03-24T18:57:59.805Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "jtqZ4X3KIGQywP105Zd",
+      "uploadedDate" : "2014-01-25T04:05:10.486Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/6up8Nzr4POrrG",
-    "name" : "uwxz81kSWJdzyC",
-    "description" : "Z27FPYyzHVof5nfI"
+    "id" : "https://www.example.com/IRTO4SzAjwcij1",
+    "name" : "8NpPw9LvUzTJVBOa",
+    "description" : "PutbwycIB2EulX0lg"
   } ],
-  "rightsHolder" : "pmPZVgqTOSKUw9v0q5",
-  "duplicateOf" : "https://www.example.org/1ee3a2df-6877-4e39-bcb8-fb96644b189b",
+  "rightsHolder" : "C45LdlSjzbKWTZZfmvH",
+  "duplicateOf" : "https://www.example.org/4ce5ce0f-2bc7-4858-902b-557559265b64",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FEZ3H3vRM6D"
+    "note" : "997liRNoQwgjx"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Mxmm47ylsFSr",
-    "createdBy" : "LY1cH2ilmJpefpp",
-    "createdDate" : "1971-06-28T16:43:07.631Z"
+    "note" : "U2spFXOwEYP7FVsafQ",
+    "createdBy" : "Rl61CHQUqzrI3Zq",
+    "createdDate" : "2003-01-26T05:35:05.706Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/21184176-edfe-4443-a4c0-67b6c2a3d66c" ],
+  "curatingInstitutions" : [ "https://www.example.org/740743ad-cf4d-4f13-8bac-a7c7aa9fe62f" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "M2PgpkXabbB4pRYH",
-    "ownerAffiliation" : "https://www.example.org/1c54a09a-37e8-4cfc-8851-561f8ff03103"
+    "owner" : "PC8EO5UTE0KhzSRv",
+    "ownerAffiliation" : "https://www.example.org/a56522a8-e9af-432a-8cd9-cb9b022c75e8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/597a975b-c3ac-4b79-8aed-47b0e409306c"
+    "id" : "https://www.example.org/a18e02c0-be4a-4264-b8ee-d53ac9bde47b"
   },
-  "createdDate" : "1979-10-29T00:44:19.502Z",
-  "modifiedDate" : "2015-01-19T07:03:59.325Z",
-  "publishedDate" : "2020-05-08T02:54:20.276Z",
-  "indexedDate" : "1984-09-18T00:17:58.323Z",
-  "handle" : "https://www.example.org/ccc4b66f-719d-4009-8615-917823a20956",
-  "doi" : "https://doi.org/10.1234/tempore",
-  "link" : "https://www.example.org/65346c85-209a-448f-993f-12d4f537c8a6",
+  "createdDate" : "2020-10-20T11:59:11.692Z",
+  "modifiedDate" : "1983-07-27T17:06:57.842Z",
+  "publishedDate" : "1981-11-13T11:56:00.197Z",
+  "indexedDate" : "2008-06-16T16:11:21.055Z",
+  "handle" : "https://www.example.org/0ea04e69-f9e9-40c2-a12c-87df8fb99643",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/31f76890-3c24-41e6-b195-98ecc7a59288",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RqBynlXTuVM69wxaeDv",
+    "mainTitle" : "jjrJfUkeMnUi89A63aR",
     "alternativeTitles" : {
-      "is" : "T7aftazktv1DVLaHNC"
+      "nb" : "iDffIUkXQKd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Usj1yuxJWVT",
-      "month" : "xM3yhZryO9jVu8m",
-      "day" : "gOoPUPYBb7K"
+      "year" : "fStFys6DBod7ckNnMYb",
+      "month" : "Fu1zxED27t",
+      "day" : "wJAu3uAQncw4yg5N"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/37dc3400-1b5b-46d6-871b-3ff80ba23d89",
-        "name" : "tywrtca3sky",
+        "id" : "https://www.example.org/05063bde-788a-4d10-8952-b465922fd4d3",
+        "name" : "e5em6Gl2Fa8DFBC7OjC",
         "nameType" : "Personal",
-        "orcId" : "HbVgKlFRvCcvVut8F",
+        "orcId" : "8JSI3CmkAFVwv3",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FgkfyFehXQul5aAnX",
-          "value" : "ZI1FU0Nj6nFPHJrFR4b"
+          "sourceName" : "GgItjJvWUege9",
+          "value" : "G6bsEXzyH4c6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0wF75aBOZlAgC",
-          "value" : "X0Ikfyg7Dc"
+          "sourceName" : "Vm6zuTT7pkQ70mHFMZ",
+          "value" : "d2n1ye6uoKjSJAc05"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a41e3300-188a-45bc-99fd-7363f689a6f8"
+        "id" : "https://www.example.org/09ebe72d-3e28-4147-9a5b-ca5c4a40f4b7"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7fe7fdc8-35e1-404e-a14c-4dc14353d40b",
-        "name" : "1tPWOONP4mIr",
-        "nameType" : "Personal",
-        "orcId" : "222zo3qeTAw",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/eddb3b37-55e3-435d-b85c-719c1419c4d2",
+        "name" : "mT9PLk6I97eAnCbv7u",
+        "nameType" : "Organizational",
+        "orcId" : "HSK8gJXFjZ",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1Xk0S6EVt2m",
-          "value" : "WCpBpySHX4Y4jLIhXtp"
+          "sourceName" : "RgYKtb8gpqEUsw",
+          "value" : "5VWhDcItgM5VAJ5cxm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1EFXb1v21UZ93F",
-          "value" : "IpM5Lz0E3Ecs8i4A6Hh"
+          "sourceName" : "HtbxmXdAE23a0Gp",
+          "value" : "8Fp8sdTfisy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a9b42177-e2ad-475b-a47f-2e5d498ab61f"
+        "id" : "https://www.example.org/d0829017-9ac1-497f-b611-84dd838fb1db"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Artist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "iEkpwNfleiLRzh9DuXp"
+      "ca" : "128JP0Po35CPsPmS9"
     },
-    "npiSubjectHeading" : "U4mbVxeu75M",
-    "tags" : [ "vJ01DncyUYAuALHPj" ],
-    "description" : "wtvemHzUQzL9ZpvzGsF",
+    "npiSubjectHeading" : "CkbwZFRlEp1I8HObOY",
+    "tags" : [ "kwrx6AKBwMw" ],
+    "description" : "kx1FRggkwQcq09c",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/780c2120-3ded-459f-acb6-0f23c26cd894"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c69c2626-f890-41e0-8d6b-057735439289"
       },
-      "doi" : "https://www.example.org/1f85b05c-7e83-470c-86ac-cd4313451eda",
+      "doi" : "https://www.example.org/7e051789-20b6-411d-9182-9b8989e81b96",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "Mnq8UBAARmIkkgqFvpo",
-        "issue" : "NFtWg98mcLI6L",
-        "articleNumber" : "RMw6IhWFcoNpIOXlLC",
+        "volume" : "Ac0jqbQ1FrrOyubO0E",
+        "issue" : "qt1XcPShQxL",
+        "articleNumber" : "1oDj3nf9KqwRcjMBDm",
         "pages" : {
           "type" : "Range",
-          "begin" : "5WYfDGSEf6lwzTys3e",
-          "end" : "6hRjH8KgAhcvA0NFXM"
+          "begin" : "3k9stWVCeXVmW106roR",
+          "end" : "hd3wq2tBvxaqeLtuA"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/269818d0-0c38-4768-b192-25ad06fa1bc8",
-    "abstract" : "BTcb5lIFF0HWKvZd"
+    "metadataSource" : "https://www.example.org/149ee21d-d27f-4fd7-9db2-e70a79d681b1",
+    "abstract" : "72iGdHTbpA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a7b81685-bbf9-4afb-880b-49449921ba19",
-    "name" : "hRCaK2KxGS2iNXGcvE",
+    "id" : "https://www.example.org/0e67838d-39a1-4b1d-a6b2-e5629c58eef8",
+    "name" : "lcWTIpsDV9i",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1985-07-10T01:30:13.248Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "YNqhaug1T4T"
+      "approvalDate" : "1997-11-06T11:15:51.078Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "ADybg8YiZUJcQ3fQw"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/728ca96f-7f05-484e-94f3-0e95d8ed7b21",
-    "identifier" : "8aXbb8nTvttvnAiIOsd",
+    "source" : "https://www.example.org/6ea3daf1-c8d6-460c-92bb-fbcdd4c2b9fa",
+    "identifier" : "rfqHcjhjBMTQF7o",
     "labels" : {
-      "pl" : "xUrHrivqRig2IzH6aXf"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 456947694
-    },
-    "activeFrom" : "1999-05-15T22:53:44.046Z",
-    "activeTo" : "2022-07-14T20:44:29.611Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/67bbcd48-192d-4106-a7bb-a129056110e6",
-    "id" : "https://www.example.org/eeb01e42-aeab-4588-99ff-1ec40d593e22",
-    "identifier" : "n7j0taZgHkIsR1qRk",
-    "labels" : {
-      "el" : "tReT3hjmvIxH"
+      "nb" : "heYRF78VHB4SL6KurQP"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1040575969
+      "amount" : 1500660931
     },
-    "activeFrom" : "1978-07-22T21:10:40.453Z",
-    "activeTo" : "2003-03-06T03:35:11.225Z"
+    "activeFrom" : "2004-08-25T17:35:22.161Z",
+    "activeTo" : "2017-08-18T09:30:32.044Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/e76ea8c3-da7f-4e8b-a107-a58f01a12038",
+    "id" : "https://www.example.org/f3303d46-9e57-409b-a53f-2fc977624f3e",
+    "identifier" : "7pBkfHHu6Sga9hpk4CT",
+    "labels" : {
+      "bg" : "0eyP4PW6BrgyU"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 675306499
+    },
+    "activeFrom" : "1987-07-24T00:43:47.675Z",
+    "activeTo" : "2021-08-08T08:05:12.202Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b2417203-fec3-4367-aa43-61ece7174a83" ],
+  "subjects" : [ "https://www.example.org/0df274d4-eddc-4770-a71a-0446df3f2ec2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d13bdf28-bd8b-4add-aefa-1fb3f9d427be",
-    "name" : "cVXR30wjtknnNQ5f87",
-    "mimeType" : "mWgkcUX686uO1ZsMqLU",
-    "size" : 1420244696,
-    "license" : "https://www.example.com/n8sbexvwyv",
+    "identifier" : "dce50395-f16e-4402-8590-885c2c46835a",
+    "name" : "QZWQWoWz5rOgGomf2v",
+    "mimeType" : "BWu3ePYdZo",
+    "size" : 1281752206,
+    "license" : "https://www.example.com/juyxp0eril",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ShVOf2BIBhP0P4ob2f",
-    "publishedDate" : "1975-11-30T02:59:06.988Z",
+    "legalNote" : "Thk0gS9gfRdSlIsh",
+    "publishedDate" : "2009-04-11T02:17:25.662Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8Q9Pdm1mFTOavuRS",
-    "name" : "4EqJ5qtLuFhnqf",
-    "description" : "nOWiv5xpHCm5R7DSY"
+    "id" : "https://www.example.com/YPTMuJaET5fvVxv",
+    "name" : "zObOBBBgS7nLwu",
+    "description" : "hWT8dsKkvw1rC"
   } ],
-  "rightsHolder" : "c8eJGcDH3r7yNkceN",
-  "duplicateOf" : "https://www.example.org/13e0d905-2fdb-4ee4-9d2e-3b57fa713b37",
+  "rightsHolder" : "m18M633rB0zbdsqhTk",
+  "duplicateOf" : "https://www.example.org/c415e4e4-a8f6-47df-8b54-66122723560b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "S5iJKXAKr90ledvC"
+    "note" : "zmRGn8Ipk4F"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sfZ4N3tGAT",
-    "createdBy" : "eYe4aUi4GXbO0Dyq",
-    "createdDate" : "2013-07-08T05:15:16.914Z"
+    "note" : "piKWtcim01nGs",
+    "createdBy" : "dAQMrfpGmKL",
+    "createdDate" : "1980-01-29T07:27:14.432Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/79b60c2e-5a35-4e66-b05a-7553181c9688" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/4c958f14-cc72-4643-baa2-6cea5952c3bf" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ConferenceAbstract.json
+++ b/documentation/ConferenceAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "PC8EO5UTE0KhzSRv",
-    "ownerAffiliation" : "https://www.example.org/a56522a8-e9af-432a-8cd9-cb9b022c75e8"
+    "owner" : "ETJcRr2Ajhzjr4",
+    "ownerAffiliation" : "https://www.example.org/fb4a2f40-2559-449c-a383-2acb16f9a5ac"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a18e02c0-be4a-4264-b8ee-d53ac9bde47b"
+    "id" : "https://www.example.org/677d2969-acd9-48a6-ab51-e0f115ed5b4a"
   },
-  "createdDate" : "2020-10-20T11:59:11.692Z",
-  "modifiedDate" : "1983-07-27T17:06:57.842Z",
-  "publishedDate" : "1981-11-13T11:56:00.197Z",
-  "indexedDate" : "2008-06-16T16:11:21.055Z",
-  "handle" : "https://www.example.org/0ea04e69-f9e9-40c2-a12c-87df8fb99643",
-  "doi" : "https://doi.org/10.1234/vel",
-  "link" : "https://www.example.org/31f76890-3c24-41e6-b195-98ecc7a59288",
+  "createdDate" : "2014-02-26T07:19:35.392Z",
+  "modifiedDate" : "2022-06-24T04:03:46.441Z",
+  "publishedDate" : "2022-03-04T10:04:13.789Z",
+  "indexedDate" : "1988-04-12T01:06:41.108Z",
+  "handle" : "https://www.example.org/0e5863f5-6072-484e-abf1-54f3ca94696c",
+  "doi" : "https://doi.org/10.1234/occaecati",
+  "link" : "https://www.example.org/50c06637-05d1-4f39-8cfd-c5d79f48bebe",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jjrJfUkeMnUi89A63aR",
+    "mainTitle" : "nMfgA1xhfjM0nCZ",
     "alternativeTitles" : {
-      "nb" : "iDffIUkXQKd"
+      "fi" : "pC1UMiDD94vRm1BE1E"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "fStFys6DBod7ckNnMYb",
-      "month" : "Fu1zxED27t",
-      "day" : "wJAu3uAQncw4yg5N"
+      "year" : "4SSHS7Gu6hgZYzgMiKd",
+      "month" : "dy5MmAuhkwNjn8349R",
+      "day" : "FQ5gqIEZhaiZptp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/05063bde-788a-4d10-8952-b465922fd4d3",
-        "name" : "e5em6Gl2Fa8DFBC7OjC",
+        "id" : "https://www.example.org/06be0bd6-de32-4a64-aec1-99f7d4a6c6c9",
+        "name" : "jLjLcd9V53Apx",
         "nameType" : "Personal",
-        "orcId" : "8JSI3CmkAFVwv3",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Non0uGKmvLSw5P",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GgItjJvWUege9",
-          "value" : "G6bsEXzyH4c6"
+          "sourceName" : "SqG1d5vYk67X",
+          "value" : "GoWC1Y7ATqqL2pANaL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Vm6zuTT7pkQ70mHFMZ",
-          "value" : "d2n1ye6uoKjSJAc05"
+          "sourceName" : "NcS4FnRAZz",
+          "value" : "xigjnA3FWBbs3ZTBW1j"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/09ebe72d-3e28-4147-9a5b-ca5c4a40f4b7"
+        "id" : "https://www.example.org/e993aa63-56df-46a6-823b-57e4c51e58ef"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "Producer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eddb3b37-55e3-435d-b85c-719c1419c4d2",
-        "name" : "mT9PLk6I97eAnCbv7u",
-        "nameType" : "Organizational",
-        "orcId" : "HSK8gJXFjZ",
+        "id" : "https://www.example.org/e355ebaf-288b-441d-95eb-54f9153b77a6",
+        "name" : "woKW2HgZFa",
+        "nameType" : "Personal",
+        "orcId" : "wbWgWCPKY6tg5LIVVwh",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RgYKtb8gpqEUsw",
-          "value" : "5VWhDcItgM5VAJ5cxm"
+          "sourceName" : "eTbWw6lYmMMlYDdedca",
+          "value" : "Q1h1tMzbnjr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HtbxmXdAE23a0Gp",
-          "value" : "8Fp8sdTfisy"
+          "sourceName" : "BxkGKodqvki9vc6",
+          "value" : "IxWb7G1qwACVfD6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d0829017-9ac1-497f-b611-84dd838fb1db"
+        "id" : "https://www.example.org/6d4bdf20-55f4-4792-bc9b-53bb7d5fe629"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "RoleOther",
+        "description" : "Q2oDFH4e4F2UE"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "128JP0Po35CPsPmS9"
+      "nl" : "qzzxyQGRf3St0Jf4Mtn"
     },
-    "npiSubjectHeading" : "CkbwZFRlEp1I8HObOY",
-    "tags" : [ "kwrx6AKBwMw" ],
-    "description" : "kx1FRggkwQcq09c",
+    "npiSubjectHeading" : "WEqfoKfLSfUZ8px6aMu",
+    "tags" : [ "luBklC089ETL" ],
+    "description" : "vrOUB5m8cbs009",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c69c2626-f890-41e0-8d6b-057735439289"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2cd1bac2-a943-4970-8962-738d6184ef46"
       },
-      "doi" : "https://www.example.org/7e051789-20b6-411d-9182-9b8989e81b96",
+      "doi" : "https://www.example.org/d67de607-db9c-428c-af1a-41385d741625",
       "publicationInstance" : {
         "type" : "ConferenceAbstract",
-        "volume" : "Ac0jqbQ1FrrOyubO0E",
-        "issue" : "qt1XcPShQxL",
-        "articleNumber" : "1oDj3nf9KqwRcjMBDm",
+        "volume" : "E8WK8mEunIWUGl",
+        "issue" : "TDfBLUAcsN",
+        "articleNumber" : "THygrJyUaEGcIUkE9",
         "pages" : {
           "type" : "Range",
-          "begin" : "3k9stWVCeXVmW106roR",
-          "end" : "hd3wq2tBvxaqeLtuA"
+          "begin" : "gEpzfPDACVPC",
+          "end" : "lOu2DBRdMJytSc6Wn"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/149ee21d-d27f-4fd7-9db2-e70a79d681b1",
-    "abstract" : "72iGdHTbpA"
+    "metadataSource" : "https://www.example.org/a0c59b1f-9a9b-48c8-9ab5-8d1b832062fa",
+    "abstract" : "l04DeleUgM2m"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0e67838d-39a1-4b1d-a6b2-e5629c58eef8",
-    "name" : "lcWTIpsDV9i",
+    "id" : "https://www.example.org/e2e9807b-4f67-425e-809b-18e836792eeb",
+    "name" : "TwGLb9orovO",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1997-11-06T11:15:51.078Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "ADybg8YiZUJcQ3fQw"
+      "approvalDate" : "2006-03-18T19:55:26.304Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "Vqn0sdbzxSz8y"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6ea3daf1-c8d6-460c-92bb-fbcdd4c2b9fa",
-    "identifier" : "rfqHcjhjBMTQF7o",
+    "source" : "https://www.example.org/757e68d6-396d-4843-b3cc-6d79ccff572e",
+    "identifier" : "wEBwF7ep5Irq6PCZ16",
     "labels" : {
-      "nb" : "heYRF78VHB4SL6KurQP"
+      "it" : "d3fhOP05nOYOik"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1500660931
+      "amount" : 1463124560
     },
-    "activeFrom" : "2004-08-25T17:35:22.161Z",
-    "activeTo" : "2017-08-18T09:30:32.044Z"
+    "activeFrom" : "2010-02-22T00:27:47.308Z",
+    "activeTo" : "2015-02-12T13:27:01.979Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e76ea8c3-da7f-4e8b-a107-a58f01a12038",
-    "id" : "https://www.example.org/f3303d46-9e57-409b-a53f-2fc977624f3e",
-    "identifier" : "7pBkfHHu6Sga9hpk4CT",
+    "source" : "https://www.example.org/1bf7459d-ba92-4fcd-9e66-856b861c2421",
+    "id" : "https://www.example.org/5397a2f6-6496-4e78-b864-e2ed60febdd4",
+    "identifier" : "M7wksZqnvkR6WzBw79",
     "labels" : {
-      "bg" : "0eyP4PW6BrgyU"
+      "af" : "fZgVN1e66G"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 675306499
+      "amount" : 1036537111
     },
-    "activeFrom" : "1987-07-24T00:43:47.675Z",
-    "activeTo" : "2021-08-08T08:05:12.202Z"
+    "activeFrom" : "2006-03-05T03:35:42.382Z",
+    "activeTo" : "2014-10-22T06:03:16.023Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0df274d4-eddc-4770-a71a-0446df3f2ec2" ],
+  "subjects" : [ "https://www.example.org/fbb0b4ee-20c2-456c-8e5a-cc6daac61722" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dce50395-f16e-4402-8590-885c2c46835a",
-    "name" : "QZWQWoWz5rOgGomf2v",
-    "mimeType" : "BWu3ePYdZo",
-    "size" : 1281752206,
-    "license" : "https://www.example.com/juyxp0eril",
+    "identifier" : "0f7e07f1-3e46-4d8a-a70b-218bd30ce416",
+    "name" : "PxhGe8wKXOzT0xFKV3q",
+    "mimeType" : "qYBLTLEXCne",
+    "size" : 508418152,
+    "license" : "https://www.example.com/qkusaux0im86srian",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Thk0gS9gfRdSlIsh",
-    "publishedDate" : "2009-04-11T02:17:25.662Z",
+    "legalNote" : "z5CiepIeeS",
+    "publishedDate" : "2007-01-20T21:27:50.142Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "9BkEntJIzLI",
+      "uploadedDate" : "2014-07-02T05:30:58.276Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YPTMuJaET5fvVxv",
-    "name" : "zObOBBBgS7nLwu",
-    "description" : "hWT8dsKkvw1rC"
+    "id" : "https://www.example.com/Pp5ElEK7BMcYr",
+    "name" : "nQ9mZ1Nw6Qhc6aM",
+    "description" : "X3Ww9Lor9KDbE5HS96Q"
   } ],
-  "rightsHolder" : "m18M633rB0zbdsqhTk",
-  "duplicateOf" : "https://www.example.org/c415e4e4-a8f6-47df-8b54-66122723560b",
+  "rightsHolder" : "lXzKEYj1n5",
+  "duplicateOf" : "https://www.example.org/6676271f-b605-4974-b2b1-96bb700ad57b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zmRGn8Ipk4F"
+    "note" : "gfiS8gFgF7XQnP"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "piKWtcim01nGs",
-    "createdBy" : "dAQMrfpGmKL",
-    "createdDate" : "1980-01-29T07:27:14.432Z"
+    "note" : "0wklbXXC5mT0h6lu",
+    "createdBy" : "W9SubWKooNB",
+    "createdDate" : "2019-01-24T07:35:36.842Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4c958f14-cc72-4643-baa2-6cea5952c3bf" ],
+  "curatingInstitutions" : [ "https://www.example.org/068d8061-781f-453d-afd4-ffd20a7bfabe" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "PcfNkplJ0fauB1l0",
-    "ownerAffiliation" : "https://www.example.org/ce1d21a7-b60a-43e1-aefe-62e8e682302d"
+    "owner" : "sjemY2LPsurjEWEKM",
+    "ownerAffiliation" : "https://www.example.org/149e8850-4b5d-4bdb-b32d-3a7d23b42da8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/af58c8aa-fef9-4618-90d2-e6e97e175a94"
+    "id" : "https://www.example.org/c0f1234c-939d-4b9d-90b1-bdbf8ad0b7b4"
   },
-  "createdDate" : "2005-09-22T15:28:08.145Z",
-  "modifiedDate" : "1999-12-05T07:19:43.696Z",
-  "publishedDate" : "1983-02-07T18:15:52.187Z",
-  "indexedDate" : "2012-09-13T10:23:47.878Z",
-  "handle" : "https://www.example.org/fc40be19-f74b-4307-857d-e4bf66af6bf1",
-  "doi" : "https://doi.org/10.1234/voluptatum",
-  "link" : "https://www.example.org/c73a282d-9824-40ed-a27f-3ae48ee46605",
+  "createdDate" : "1979-06-18T12:23:20.845Z",
+  "modifiedDate" : "2009-10-31T23:41:36.399Z",
+  "publishedDate" : "1978-08-08T09:38:19.514Z",
+  "indexedDate" : "2002-01-08T21:10:46.464Z",
+  "handle" : "https://www.example.org/2520ce43-4d17-4eaf-a966-d230c7f821f6",
+  "doi" : "https://doi.org/10.1234/reiciendis",
+  "link" : "https://www.example.org/cc2566a7-f929-4069-8da2-b981ad4b4513",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Wmylv5ARuY89G7",
+    "mainTitle" : "z2GzvKHcrj0vILFc",
     "alternativeTitles" : {
-      "de" : "nAJ8FWczQB5"
+      "fi" : "nmSKL97PVxkK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "gkBRRblCTjawX2rYud",
-      "month" : "KBr2g7q8UVGUU2h",
-      "day" : "SShnkDO9Cl0iQX5A04"
+      "year" : "AtVomSVBiA7u3bNV",
+      "month" : "WlRxpg7FfAvPi9jQVh",
+      "day" : "BfZoS1qDNjvkEX6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b19eea8f-7c79-4d16-85c2-1ae2e5fae3b6",
-        "name" : "fUP610IBInx",
+        "id" : "https://www.example.org/64a22950-e197-4a16-8cd0-2a1f5b78506f",
+        "name" : "EadNbNTOpOPkNGc9WBn",
         "nameType" : "Organizational",
-        "orcId" : "xbzLYhrzNBE",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "tKb1jksz0L",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KkuZrslaDl",
-          "value" : "kHBeB09gpuWqIa7"
+          "sourceName" : "gCGgChfmmHQX7ASag",
+          "value" : "NZ0OGpnVim4NW1KgX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ptxK3piNuQMPl",
-          "value" : "o5T6B1EmtA87lag"
+          "sourceName" : "JYTsV9uQ10Egf1",
+          "value" : "VhLM1yaQ47IaZH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/57490b07-5d9d-4eb6-bea2-050d6c619c7e"
+        "id" : "https://www.example.org/e7be3bbe-ffdf-4753-9229-7bd03b0bc614"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Researcher"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bf2a3761-ce27-4283-9b31-b5def6595b52",
-        "name" : "kakUy2mid2xMlL9x",
-        "nameType" : "Personal",
-        "orcId" : "Yfgz25c35E",
+        "id" : "https://www.example.org/7db480e8-c2a7-4744-b6fe-ac901fa20c22",
+        "name" : "g4cvvN8OxWDetobg",
+        "nameType" : "Organizational",
+        "orcId" : "4ORZ5wLOWnb",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zVLPKGpE6uuglFh",
-          "value" : "zjtYd3Dz51z7LBG"
+          "sourceName" : "Mw9PJ6WpopdCW",
+          "value" : "ZaDAce4hDQ3z"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fmFA0ZJevnr",
-          "value" : "nKKLlAjJ2Epn7j9"
+          "sourceName" : "L8GFqlaXeSXbgRipMp",
+          "value" : "7AckCHA7mn9ShCu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/89768a3e-bdeb-451a-943f-62d9b7274d97"
+        "id" : "https://www.example.org/6f5ea044-4359-426a-a5e0-c2986a95e4db"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "00jMOsmTB4bh"
+      "nb" : "Kwo2KaqvTonywx4EX"
     },
-    "npiSubjectHeading" : "hEjB8gfBmz5hx8Vp",
-    "tags" : [ "E8HPqz68PusR8ovkdb" ],
-    "description" : "FG1s0sDIK3Ppn",
+    "npiSubjectHeading" : "39buU4RGBihWMXqgPGl",
+    "tags" : [ "muSVaxvXlCG41" ],
+    "description" : "YsYdGiNNdE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "zAzGpraEUsvwH",
+        "label" : "5x4ZMIB4GDaUTe6FFX",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "lcSjabyCiff0",
-          "country" : "agdD5VwA83yJ"
+          "label" : "EFHHMGkDID",
+          "country" : "MM0bBa4s4Mnt2pUojSL"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1977-12-25T23:05:25.431Z",
-          "to" : "1980-04-22T00:20:51.895Z"
+          "from" : "1979-08-09T00:10:49.076Z",
+          "to" : "2003-02-23T21:51:17.305Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/uRi6DhViXHvTJZVyM9"
+          "id" : "https://www.example.com/5WBpw235YZv0"
         },
-        "product" : "https://www.example.com/Z7xL5ovxjs57rmrbX5i"
+        "product" : "https://www.example.com/JBDHPgg34q8"
       },
-      "doi" : "https://www.example.org/6e50eacf-71e0-41f8-8d3a-fb0483fbae15",
+      "doi" : "https://www.example.org/a7d4ee17-f221-413a-b68d-40f83010b7bd",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -122,88 +122,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5f8f93b9-f21e-42e8-ae4c-4d992a56f9db",
-    "abstract" : "DBgaXyOLg9SM72t"
+    "metadataSource" : "https://www.example.org/5a496a59-a736-48e6-86a4-2c5e9c16a5e8",
+    "abstract" : "uUogtJnFBPE7rIUvRHc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a3080afa-3876-48d1-8cef-f095e518e542",
-    "name" : "Yo1XzYDd8CF6q",
+    "id" : "https://www.example.org/5fc91b1e-540c-4a90-a300-38bdae1c3da9",
+    "name" : "sYcAfFtGsHor",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-01-11T21:40:06.993Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "dkMGkADn0JyJ"
+      "approvalDate" : "1996-12-23T09:52:05.002Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "YPy4h5h2Zej0ZcvNb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1d369f5d-e8f7-4d32-af5f-83521853d653",
-    "identifier" : "hRnelCjDcs8NxH",
+    "source" : "https://www.example.org/7cb2cee6-9fda-412a-a62d-342273f60f9a",
+    "identifier" : "d1ymJZhuKlRK3",
     "labels" : {
-      "pt" : "dlUqREBeku7mv"
+      "nl" : "uCfUAWn9w9VodOaQ"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 344860949
+      "currency" : "EUR",
+      "amount" : 438681884
     },
-    "activeFrom" : "1972-11-19T18:53:44.222Z",
-    "activeTo" : "2016-09-17T01:22:10.780Z"
+    "activeFrom" : "1998-08-10T05:07:51.055Z",
+    "activeTo" : "2013-10-04T16:21:26.199Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/88b9f705-4b1c-46a5-825f-eeea61be2650",
-    "id" : "https://www.example.org/3aa3e093-d906-4b9c-b47f-8eb5a4b76331",
-    "identifier" : "nwS8gzkQiy7UuO",
+    "source" : "https://www.example.org/eda19b3b-dc6c-43b9-bf6e-acf962abfe92",
+    "id" : "https://www.example.org/0177d010-bd27-40dc-b963-d6db6c7226ce",
+    "identifier" : "HoD67PD1fVkD5sG",
     "labels" : {
-      "el" : "Y0MgfzW8wwb"
+      "nn" : "6NatuRReYK3XiQy"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2113061331
+      "amount" : 1426995751
     },
-    "activeFrom" : "1993-09-03T08:34:07.633Z",
-    "activeTo" : "2024-02-18T05:04:07.596Z"
+    "activeFrom" : "2000-02-11T11:50:27.697Z",
+    "activeTo" : "2003-07-26T09:18:21.772Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7c591848-b296-43f4-b322-a5b53e5b3ac6" ],
+  "subjects" : [ "https://www.example.org/df5fb030-33d3-411a-84e9-297c523ad412" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6062c5b6-10fd-496b-b6b9-ed92f0ffce84",
-    "name" : "i1q1AeETEbBX",
-    "mimeType" : "VrjAsSHdcK",
-    "size" : 357687293,
-    "license" : "https://www.example.com/kchwmysmziy",
+    "identifier" : "8ec346ad-ea6d-4f64-ae74-ee5925e8afdd",
+    "name" : "qCgtXr4RPMNO9h",
+    "mimeType" : "DO2E9U1BSDU",
+    "size" : 1285273284,
+    "license" : "https://www.example.com/2vqdgyqcanjgo",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "e9nwibNIyDwf3Eu64Ak",
-    "publishedDate" : "1981-09-09T14:25:26.081Z",
+    "legalNote" : "mu9kxHLNwZ",
+    "publishedDate" : "1998-08-10T05:55:35.314Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HStutWPywRbB",
-    "name" : "wwVCSN49TC39H",
-    "description" : "UZcn9MvFgWaom9iljE"
+    "id" : "https://www.example.com/pc4kQukkgl5",
+    "name" : "8BzlhgrqzO5k",
+    "description" : "t08SnDT8lfkQZK"
   } ],
-  "rightsHolder" : "hlI2xkkL2mU",
-  "duplicateOf" : "https://www.example.org/15589e43-4c97-44e0-8480-e28ff216c714",
+  "rightsHolder" : "EsZT2kErvSq9dcm",
+  "duplicateOf" : "https://www.example.org/e7384a02-39c5-4752-8da8-cefc57e44737",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "nnbX7n5DTpCdXVSVo"
+    "note" : "KLD3vv1OOOrI8URLoh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "4wOTZvQfphUxi1RsyE5",
-    "createdBy" : "RklEmWf1OawTb",
-    "createdDate" : "1988-09-15T05:33:40.886Z"
+    "note" : "hh0rYb2QWhXCFLqu",
+    "createdBy" : "93MnNExOWyyGB",
+    "createdDate" : "1992-03-18T10:11:07.251Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9b84b3d6-657d-4c62-ac57-35b537b443f6" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/b8ef72fc-da29-4a72-b807-da6a9df8cfc0" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ConferenceLecture.json
+++ b/documentation/ConferenceLecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "sjemY2LPsurjEWEKM",
-    "ownerAffiliation" : "https://www.example.org/149e8850-4b5d-4bdb-b32d-3a7d23b42da8"
+    "owner" : "99eIAlk6n7v",
+    "ownerAffiliation" : "https://www.example.org/bf62b07b-6e82-4c26-9cbc-381322babd02"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c0f1234c-939d-4b9d-90b1-bdbf8ad0b7b4"
+    "id" : "https://www.example.org/cc6a17d5-b2de-42ea-89ea-79d159fb9d0e"
   },
-  "createdDate" : "1979-06-18T12:23:20.845Z",
-  "modifiedDate" : "2009-10-31T23:41:36.399Z",
-  "publishedDate" : "1978-08-08T09:38:19.514Z",
-  "indexedDate" : "2002-01-08T21:10:46.464Z",
-  "handle" : "https://www.example.org/2520ce43-4d17-4eaf-a966-d230c7f821f6",
-  "doi" : "https://doi.org/10.1234/reiciendis",
-  "link" : "https://www.example.org/cc2566a7-f929-4069-8da2-b981ad4b4513",
+  "createdDate" : "2014-08-23T19:01:04.016Z",
+  "modifiedDate" : "2021-10-04T00:46:35.404Z",
+  "publishedDate" : "1982-09-26T16:59:27.906Z",
+  "indexedDate" : "2018-11-23T14:04:27.586Z",
+  "handle" : "https://www.example.org/e45c2971-afa9-4e87-88e4-1f4fdf500d4f",
+  "doi" : "https://doi.org/10.1234/ab",
+  "link" : "https://www.example.org/dda20988-d2ce-4546-adf0-d11ddaac99db",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "z2GzvKHcrj0vILFc",
+    "mainTitle" : "Cm1maPp2lawT72hAsLl",
     "alternativeTitles" : {
-      "fi" : "nmSKL97PVxkK"
+      "da" : "LIsc1gm4t4ic"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "AtVomSVBiA7u3bNV",
-      "month" : "WlRxpg7FfAvPi9jQVh",
-      "day" : "BfZoS1qDNjvkEX6"
+      "year" : "foBLfNqeZiu7",
+      "month" : "l26vgeXFqXP5nx",
+      "day" : "wJ4wH0F6HAH6bYNDE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/64a22950-e197-4a16-8cd0-2a1f5b78506f",
-        "name" : "EadNbNTOpOPkNGc9WBn",
-        "nameType" : "Organizational",
-        "orcId" : "tKb1jksz0L",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/76194284-2059-4532-a8fe-a5a1def752fe",
+        "name" : "VnBeSdIDZfqU",
+        "nameType" : "Personal",
+        "orcId" : "tZLNPAEoAr",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gCGgChfmmHQX7ASag",
-          "value" : "NZ0OGpnVim4NW1KgX"
+          "sourceName" : "H4J7HVBABgXBwz5GxcA",
+          "value" : "xqmLUFEy6uyF1hstz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JYTsV9uQ10Egf1",
-          "value" : "VhLM1yaQ47IaZH"
+          "sourceName" : "k6PGIO7FHjGFRL3U",
+          "value" : "WwaCedtY3l"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e7be3bbe-ffdf-4753-9229-7bd03b0bc614"
+        "id" : "https://www.example.org/bbdf77bf-8792-4c65-a4f1-3ab6da89c1a8"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7db480e8-c2a7-4744-b6fe-ac901fa20c22",
-        "name" : "g4cvvN8OxWDetobg",
-        "nameType" : "Organizational",
-        "orcId" : "4ORZ5wLOWnb",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/2ad6826e-8c67-4311-9c70-5d7b9a1c1d31",
+        "name" : "d5SV6gR3q0",
+        "nameType" : "Personal",
+        "orcId" : "sEkj8cmScutOV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Mw9PJ6WpopdCW",
-          "value" : "ZaDAce4hDQ3z"
+          "sourceName" : "LVnWxhwyPGeDR",
+          "value" : "2ff5fQp69sROWoJxkI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "L8GFqlaXeSXbgRipMp",
-          "value" : "7AckCHA7mn9ShCu"
+          "sourceName" : "UBJe1yYldoafYWXDo",
+          "value" : "08R387l0ffjm9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6f5ea044-4359-426a-a5e0-c2986a95e4db"
+        "id" : "https://www.example.org/b89565ad-4358-4a15-9f6a-1813f75d2d54"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "Choreographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "Kwo2KaqvTonywx4EX"
+      "fi" : "0SD8IR38Tyw"
     },
-    "npiSubjectHeading" : "39buU4RGBihWMXqgPGl",
-    "tags" : [ "muSVaxvXlCG41" ],
-    "description" : "YsYdGiNNdE",
+    "npiSubjectHeading" : "tzCyZtdBD4H6PZAJR",
+    "tags" : [ "UOxyz7zDVk" ],
+    "description" : "YvHFoob3i5nzLaC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "5x4ZMIB4GDaUTe6FFX",
+        "label" : "xwJAZz82lsPg3",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "EFHHMGkDID",
-          "country" : "MM0bBa4s4Mnt2pUojSL"
+          "label" : "24rSz3W0Qo2e",
+          "country" : "127JRdCX1pcna"
         },
         "time" : {
           "type" : "Period",
-          "from" : "1979-08-09T00:10:49.076Z",
-          "to" : "2003-02-23T21:51:17.305Z"
+          "from" : "2006-06-17T21:28:20.803Z",
+          "to" : "2014-08-13T10:07:13.584Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/5WBpw235YZv0"
+          "id" : "https://www.example.com/CYcD0qOvtOba"
         },
-        "product" : "https://www.example.com/JBDHPgg34q8"
+        "product" : "https://www.example.com/GC7aXQTHxX3brS0"
       },
-      "doi" : "https://www.example.org/a7d4ee17-f221-413a-b68d-40f83010b7bd",
+      "doi" : "https://www.example.org/ee5b937d-0ad8-45d0-a314-2dedee83b9ff",
       "publicationInstance" : {
         "type" : "ConferenceLecture",
         "pages" : {
@@ -122,89 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5a496a59-a736-48e6-86a4-2c5e9c16a5e8",
-    "abstract" : "uUogtJnFBPE7rIUvRHc"
+    "metadataSource" : "https://www.example.org/55c9ecca-3bc4-4f1e-8fab-5ae15c7bae6b",
+    "abstract" : "tYraEzMflmuT2exsx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/5fc91b1e-540c-4a90-a300-38bdae1c3da9",
-    "name" : "sYcAfFtGsHor",
+    "id" : "https://www.example.org/5a331e67-7658-45f2-b3cf-02ae96127dd8",
+    "name" : "GM4SzlrTeXSu7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-12-23T09:52:05.002Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "YPy4h5h2Zej0ZcvNb"
+      "approvalDate" : "1980-04-20T01:24:28.486Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "NgSrlGEZP2M3IAbyp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7cb2cee6-9fda-412a-a62d-342273f60f9a",
-    "identifier" : "d1ymJZhuKlRK3",
+    "source" : "https://www.example.org/6c07f5bc-1bdb-40ff-8067-81dd14977f2b",
+    "identifier" : "epn9g2RSAtlX",
     "labels" : {
-      "nl" : "uCfUAWn9w9VodOaQ"
+      "nb" : "jNalOLm40ynsxaRVT"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 438681884
+      "currency" : "USD",
+      "amount" : 190038531
     },
-    "activeFrom" : "1998-08-10T05:07:51.055Z",
-    "activeTo" : "2013-10-04T16:21:26.199Z"
+    "activeFrom" : "1985-04-28T13:05:06.065Z",
+    "activeTo" : "1985-08-04T05:33:22.754Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eda19b3b-dc6c-43b9-bf6e-acf962abfe92",
-    "id" : "https://www.example.org/0177d010-bd27-40dc-b963-d6db6c7226ce",
-    "identifier" : "HoD67PD1fVkD5sG",
+    "source" : "https://www.example.org/1caf34f1-8f59-4e2e-8b6d-b7459ddf4094",
+    "id" : "https://www.example.org/82f64095-cc64-43f7-b0c5-8f602887ef79",
+    "identifier" : "mLY8kxsTvTyX",
     "labels" : {
-      "nn" : "6NatuRReYK3XiQy"
+      "nn" : "dKg480hqEV1bw4jR9wp"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1426995751
+      "currency" : "USD",
+      "amount" : 1310684742
     },
-    "activeFrom" : "2000-02-11T11:50:27.697Z",
-    "activeTo" : "2003-07-26T09:18:21.772Z"
+    "activeFrom" : "1988-02-07T15:56:30.208Z",
+    "activeTo" : "2024-04-30T05:54:48.759Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/df5fb030-33d3-411a-84e9-297c523ad412" ],
+  "subjects" : [ "https://www.example.org/6bd5a705-f573-4a96-8e98-c20dcf869a44" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8ec346ad-ea6d-4f64-ae74-ee5925e8afdd",
-    "name" : "qCgtXr4RPMNO9h",
-    "mimeType" : "DO2E9U1BSDU",
-    "size" : 1285273284,
-    "license" : "https://www.example.com/2vqdgyqcanjgo",
+    "identifier" : "4943fc99-c927-44c8-b20e-33de7b5e05da",
+    "name" : "inB2P4h45xa2loEUzX",
+    "mimeType" : "MI1gWZ2ULBLBTBfBd",
+    "size" : 1923434216,
+    "license" : "https://www.example.com/adjgq7r1xm",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mu9kxHLNwZ",
-    "publishedDate" : "1998-08-10T05:55:35.314Z",
+    "legalNote" : "fy5OoKyvU5",
+    "publishedDate" : "1995-12-24T07:11:05.558Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "NVFsgX0yZv5",
+      "uploadedDate" : "2022-03-29T14:37:09.167Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/pc4kQukkgl5",
-    "name" : "8BzlhgrqzO5k",
-    "description" : "t08SnDT8lfkQZK"
+    "id" : "https://www.example.com/VKePEgxr4c436",
+    "name" : "qmiG85PJCiwqMZc",
+    "description" : "aY2gmHWEzUxbIOlFI"
   } ],
-  "rightsHolder" : "EsZT2kErvSq9dcm",
-  "duplicateOf" : "https://www.example.org/e7384a02-39c5-4752-8da8-cefc57e44737",
+  "rightsHolder" : "xRJ39brmXZz6kdX",
+  "duplicateOf" : "https://www.example.org/bf5dad6c-8468-44c4-b2e3-aabb90f61f70",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KLD3vv1OOOrI8URLoh"
+    "note" : "JjA0UGchXlydM"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hh0rYb2QWhXCFLqu",
-    "createdBy" : "93MnNExOWyyGB",
-    "createdDate" : "1992-03-18T10:11:07.251Z"
+    "note" : "rRgD4HhUpJeL50jm",
+    "createdBy" : "rKoDbahBfB7dEH8hvA",
+    "createdDate" : "2001-07-08T00:57:40.833Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b8ef72fc-da29-4a72-b807-da6a9df8cfc0" ],
+  "curatingInstitutions" : [ "https://www.example.org/1ad6ec62-243a-4009-a535-b033107a151b" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "oiGLFxdvjV1F3fvxA",
-    "ownerAffiliation" : "https://www.example.org/a7202100-f2ad-4d05-8dbb-9cca370d313d"
+    "owner" : "UcDZil34eqy1",
+    "ownerAffiliation" : "https://www.example.org/a4fb708f-691c-4075-bbc1-c612844fc786"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f9c69793-7398-4bc1-8f4e-b911fedf9dbc"
+    "id" : "https://www.example.org/f82da773-f27a-465d-b0c9-36fb1bde602b"
   },
-  "createdDate" : "1973-09-05T11:05:28.395Z",
-  "modifiedDate" : "2006-10-30T12:56:41.413Z",
-  "publishedDate" : "2005-10-27T19:59:15.632Z",
-  "indexedDate" : "2019-03-14T08:48:44.470Z",
-  "handle" : "https://www.example.org/0ae61640-c4db-47d6-b859-96688ab8963c",
-  "doi" : "https://doi.org/10.1234/quis",
-  "link" : "https://www.example.org/4f5d6b84-5485-4ff6-b30a-0af4cf19d4d0",
+  "createdDate" : "1978-08-11T12:30:30.995Z",
+  "modifiedDate" : "1984-10-04T12:48:39.665Z",
+  "publishedDate" : "1973-01-20T04:35:13.227Z",
+  "indexedDate" : "1983-09-06T20:48:12.564Z",
+  "handle" : "https://www.example.org/337afdc1-d44d-45f9-be22-e1cc3906b7b0",
+  "doi" : "https://doi.org/10.1234/quo",
+  "link" : "https://www.example.org/a3e9c23b-07ae-4b94-97d8-514dc3c83a99",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "CN9vMGQ8zh1BYy2eRj",
+    "mainTitle" : "5YPFMbWLCYb",
     "alternativeTitles" : {
-      "is" : "eRBCRqHvV5y"
+      "it" : "6IlgjX5qyAhS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XMAtDcFvbKVQ45NLG8a",
-      "month" : "I7VREicQVjcCZcHzR",
-      "day" : "9ZogsEoSgEGAk"
+      "year" : "pMYwWdrYT1P",
+      "month" : "1b4ZjXCenKq22brnn5",
+      "day" : "YGYqaBWBzYCdFrl"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2cfe1a5d-9b98-437d-a1b3-407f08e81b3c",
-        "name" : "8qToudL5d3",
+        "id" : "https://www.example.org/e4522cdd-9df9-4759-a128-722e00fe1531",
+        "name" : "MwlfpjlsBl9lDTx9r",
         "nameType" : "Personal",
-        "orcId" : "3Dvwo1ngDYiQ5",
+        "orcId" : "esimD7BhYmb6",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cF16nFHla5",
-          "value" : "B43tgilIUhIWaAf"
+          "sourceName" : "80rBwYW4TDhhszcudd",
+          "value" : "CELFHRrLaDUMSN"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Q76lNUm9l9",
-          "value" : "EYZzdjcDDb2hn8T3bOW"
+          "sourceName" : "8UgIUn3EBsCqjK0yUg",
+          "value" : "nxY5I4H1AdUpDio"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c5b65291-a604-42a0-823a-d89b97f434b1"
+        "id" : "https://www.example.org/49d97775-6b79-4469-86c7-3e57025a1aaa"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/848ea6ee-aaf9-4d69-bd3b-ca4addc11de1",
-        "name" : "otRWLLgz7Mwfq4wzF9A",
-        "nameType" : "Personal",
-        "orcId" : "zviGiqRfuT",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/56130f05-062b-42a6-9cd9-6fc12568318f",
+        "name" : "ckERw46sH0",
+        "nameType" : "Organizational",
+        "orcId" : "jLuzzpPbln",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "m591XZweKz16h2L",
-          "value" : "4C4NzRboHm"
+          "sourceName" : "97fEaAdA9iKJP1y",
+          "value" : "P6b69inDUZH4RY1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LvX1N6skRS1x",
-          "value" : "f67sdAcPdIb8i"
+          "sourceName" : "z0TMJuKBXdU",
+          "value" : "zLInxej49jLLLrb8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1ef1bfe0-2203-4ea9-b70d-b42df382211c"
+        "id" : "https://www.example.org/052d4634-e9a1-4b94-9092-b77246ce1353"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "waohLSvOMMr0c6"
+      "se" : "TLPUWeIrq19fGjhK8"
     },
-    "npiSubjectHeading" : "OfTxDMcTtTXitDw",
-    "tags" : [ "R7elvJjJRQ8QdeSxP" ],
-    "description" : "u9UaNNScqbuk8dq",
+    "npiSubjectHeading" : "RHSjxJwq27snAl7q",
+    "tags" : [ "E11BO33N1c" ],
+    "description" : "CvBDuf9W56l3jld1Pxo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "VBbbUyx4Wkj4",
+        "label" : "DSqUGudpC4axyVBo6g",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "hgmCX7OAa3q",
-          "country" : "RXEeKdwUeT4"
+          "label" : "4j7PzBA7OK52x",
+          "country" : "SEAUmhqo6ZR68ujR27"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "2008-11-14T12:51:03.160Z",
-          "to" : "2013-07-07T11:22:53.093Z"
+          "type" : "Instant",
+          "value" : "2020-07-12T11:34:27.546Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/UVnJSiZcnLn6"
+          "id" : "https://www.example.com/QKbDxxHArPcMDYP"
         },
-        "product" : "https://www.example.com/812lezt5boh"
+        "product" : "https://www.example.com/RrdGt0flyUoxz3og7g"
       },
-      "doi" : "https://www.example.org/3d2f5972-2d4f-4bd2-987a-5f113f1693c8",
+      "doi" : "https://www.example.org/cae2c0bf-2423-4d96-9f88-f8b23e570af9",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -122,88 +121,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7ca6c6fb-0bb6-4c58-88ae-a23ea7fa1a5f",
-    "abstract" : "WkrfGJ6oDQ5YRX6"
+    "metadataSource" : "https://www.example.org/1f9fccbf-d34d-454c-9fa9-bffca30b3b4f",
+    "abstract" : "RvoKKYs3mBNe4P6oUj"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a162c68c-6a2d-4e75-864d-6fef928479cd",
-    "name" : "gH4EqVFDCnb7V",
+    "id" : "https://www.example.org/cb7e5f66-9c79-4e07-ab1d-b2ee5c1b8537",
+    "name" : "lTc7G81h49T6p",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-01-07T16:50:01.322Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "RKJj9G9ApQU"
+      "approvalDate" : "2008-06-21T03:06:31.115Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "t7XM0dakFS0SAA"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cf19cf0f-e98a-4767-8128-9bef7e17631f",
-    "identifier" : "mCG8HEcK0LeuhM",
+    "source" : "https://www.example.org/8b87a3f6-7d73-40e7-93de-d8e34192450e",
+    "identifier" : "Kog491G9Q58ou",
     "labels" : {
-      "ru" : "CKjT1L9jdv5cZNHY"
+      "zh" : "ZMZYD60RlVJf"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1348622755
+      "amount" : 1224125468
     },
-    "activeFrom" : "1988-10-28T05:12:52.594Z",
-    "activeTo" : "2002-06-05T21:33:54.594Z"
+    "activeFrom" : "2010-12-16T02:11:52.288Z",
+    "activeTo" : "2015-04-14T04:09:42.894Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b966a8f5-add2-4d9e-acf7-a4b4dee03099",
-    "id" : "https://www.example.org/427fd9d2-2f83-4243-8364-e0a08988f59d",
-    "identifier" : "LwBU8W92W8FL3w9f",
+    "source" : "https://www.example.org/4e2c7a07-6bb1-4cd1-b623-41573c3faffe",
+    "id" : "https://www.example.org/800e5c65-dd35-471a-b921-3b2a4fde8f18",
+    "identifier" : "YLtBkNt1rBG42klxgnm",
     "labels" : {
-      "da" : "I6rVvXsY9DSf5DGokv"
+      "en" : "yccvh53zYvbOK"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 513638014
+      "currency" : "GBP",
+      "amount" : 243979556
     },
-    "activeFrom" : "2018-12-27T03:14:57.566Z",
-    "activeTo" : "2022-09-03T18:23:55.355Z"
+    "activeFrom" : "2018-12-25T03:13:16.944Z",
+    "activeTo" : "2021-07-27T21:44:08.106Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ae9563d6-bda3-4fc5-8f62-a98738d73782" ],
+  "subjects" : [ "https://www.example.org/c76f0409-8250-4804-9fb9-ab061c5972aa" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8de60cf8-c849-4c96-9ec6-13ec2e4aa287",
-    "name" : "wXlCiIwltt006chim",
-    "mimeType" : "ZN5RRBQuCGcMLoX",
-    "size" : 968433524,
-    "license" : "https://www.example.com/rmxtv4ocaq",
+    "identifier" : "fa08941e-bc2e-4a84-927e-cc6b87449c1a",
+    "name" : "J5v1vueTPcHG",
+    "mimeType" : "UX1H2x8x3NYfMhpid",
+    "size" : 804311045,
+    "license" : "https://www.example.com/5k8tllcb7h8s",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "wfBgZ8tCJl8rk6O3",
-    "publishedDate" : "1982-03-17T09:11:29.941Z",
+    "legalNote" : "GJfEzFMYGyKOWFJfLky",
+    "publishedDate" : "2007-04-27T08:51:48.917Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/mlRwF2mJcWHQP",
-    "name" : "j6md941XS5SyRjDtVB",
-    "description" : "0AtQIeNIgbjFMG"
+    "id" : "https://www.example.com/khQAdzji6fHzleEOxR",
+    "name" : "JoBtGIqH296OH6DpN5",
+    "description" : "h8MNVACPX5teI9Ms"
   } ],
-  "rightsHolder" : "MHKflkJJfIw6eA5c",
-  "duplicateOf" : "https://www.example.org/50e32b1d-7313-4e21-ae79-7badd3b6597c",
+  "rightsHolder" : "xPdSsUgmPO77lEkdJH",
+  "duplicateOf" : "https://www.example.org/0724fa79-036a-4821-b40b-03e525898679",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZfXnFkZ8JrG9"
+    "note" : "LjLc9mKKJR16G"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DvBC1rpsvab",
-    "createdBy" : "2zQ95qptwblDmvZ",
-    "createdDate" : "1972-07-23T01:53:57.736Z"
+    "note" : "xcsh6UN70Z2O1Csp",
+    "createdBy" : "RhmO0CRvDWeTk5nN",
+    "createdDate" : "2004-07-21T01:36:01.245Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/afc3d694-30e5-4c73-b053-e8887c0c305a" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/fd959ab0-0344-4f0d-b0fe-e91648f00953" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ConferencePoster.json
+++ b/documentation/ConferencePoster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "UcDZil34eqy1",
-    "ownerAffiliation" : "https://www.example.org/a4fb708f-691c-4075-bbc1-c612844fc786"
+    "owner" : "Dj2OksNK2lfI0Du",
+    "ownerAffiliation" : "https://www.example.org/7aad0b1f-a651-4ed2-b7ab-ab8433e97d7d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f82da773-f27a-465d-b0c9-36fb1bde602b"
+    "id" : "https://www.example.org/fe7121a1-0fe2-4785-8eb6-41de63e40ea3"
   },
-  "createdDate" : "1978-08-11T12:30:30.995Z",
-  "modifiedDate" : "1984-10-04T12:48:39.665Z",
-  "publishedDate" : "1973-01-20T04:35:13.227Z",
-  "indexedDate" : "1983-09-06T20:48:12.564Z",
-  "handle" : "https://www.example.org/337afdc1-d44d-45f9-be22-e1cc3906b7b0",
-  "doi" : "https://doi.org/10.1234/quo",
-  "link" : "https://www.example.org/a3e9c23b-07ae-4b94-97d8-514dc3c83a99",
+  "createdDate" : "2021-07-04T15:37:53.401Z",
+  "modifiedDate" : "2016-11-22T14:46:19.986Z",
+  "publishedDate" : "1979-12-07T02:43:02.311Z",
+  "indexedDate" : "2002-01-24T01:00:21.405Z",
+  "handle" : "https://www.example.org/735c660b-97f9-41fe-926c-e64fff6ac69e",
+  "doi" : "https://doi.org/10.1234/ab",
+  "link" : "https://www.example.org/f8a52023-0fb1-4d05-bc64-c82fa38da17e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5YPFMbWLCYb",
+    "mainTitle" : "CZ5tn41X3pWCDzLWbXB",
     "alternativeTitles" : {
-      "it" : "6IlgjX5qyAhS"
+      "ca" : "CYdHzSdZWxCmNfzT2k"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "pMYwWdrYT1P",
-      "month" : "1b4ZjXCenKq22brnn5",
-      "day" : "YGYqaBWBzYCdFrl"
+      "year" : "kacz0VGfCME",
+      "month" : "652HrYp8VSF",
+      "day" : "loDqlRx3fw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e4522cdd-9df9-4759-a128-722e00fe1531",
-        "name" : "MwlfpjlsBl9lDTx9r",
+        "id" : "https://www.example.org/ef1e348b-27e4-4b2e-ad17-f58813c4b6eb",
+        "name" : "9pkoxqXVozwZyfVeZ",
         "nameType" : "Personal",
-        "orcId" : "esimD7BhYmb6",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "SnrRjuObiJMVPDTq",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "80rBwYW4TDhhszcudd",
-          "value" : "CELFHRrLaDUMSN"
+          "sourceName" : "4dozu5OLadXCRSk8m",
+          "value" : "J0QCk7zPFHm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8UgIUn3EBsCqjK0yUg",
-          "value" : "nxY5I4H1AdUpDio"
+          "sourceName" : "KA1nULMP6sJWolD4",
+          "value" : "z5jWkDmmfkC0MuTX"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/49d97775-6b79-4469-86c7-3e57025a1aaa"
+        "id" : "https://www.example.org/9179d437-2896-4f10-a280-22dc4473b96c"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/56130f05-062b-42a6-9cd9-6fc12568318f",
-        "name" : "ckERw46sH0",
-        "nameType" : "Organizational",
-        "orcId" : "jLuzzpPbln",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/8883a10e-0688-47dd-aa66-73ddf4218f65",
+        "name" : "Rqbw8BEFWoo1y707",
+        "nameType" : "Personal",
+        "orcId" : "TMPx3538owhi72Y",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "97fEaAdA9iKJP1y",
-          "value" : "P6b69inDUZH4RY1"
+          "sourceName" : "bmrJewS8qUow8",
+          "value" : "7wKwLEe7Epqus1eRUr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z0TMJuKBXdU",
-          "value" : "zLInxej49jLLLrb8"
+          "sourceName" : "aM2C5MKqKaBVB",
+          "value" : "FmNXKSTI5mRJIFzYup"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/052d4634-e9a1-4b94-9092-b77246ce1353"
+        "id" : "https://www.example.org/3dfb8914-3bed-448a-b6a2-3103c1de8f1a"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "TLPUWeIrq19fGjhK8"
+      "da" : "i6j2Bk4OkDqei"
     },
-    "npiSubjectHeading" : "RHSjxJwq27snAl7q",
-    "tags" : [ "E11BO33N1c" ],
-    "description" : "CvBDuf9W56l3jld1Pxo",
+    "npiSubjectHeading" : "el0GyjQhAChCV",
+    "tags" : [ "mzuytQbojmPnU" ],
+    "description" : "D8jd3qqcKwn",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "DSqUGudpC4axyVBo6g",
+        "label" : "lNNb0h8bniq",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "4j7PzBA7OK52x",
-          "country" : "SEAUmhqo6ZR68ujR27"
+          "label" : "eoRAO4yYCcZWcnTy",
+          "country" : "GwM86ipUVy"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2020-07-12T11:34:27.546Z"
+          "type" : "Period",
+          "from" : "2019-06-15T21:25:47.080Z",
+          "to" : "2020-12-12T10:16:11.333Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/QKbDxxHArPcMDYP"
+          "id" : "https://www.example.com/b6z1u4JaxcEO"
         },
-        "product" : "https://www.example.com/RrdGt0flyUoxz3og7g"
+        "product" : "https://www.example.com/k4ZcLZNSXaySv4WtY8"
       },
-      "doi" : "https://www.example.org/cae2c0bf-2423-4d96-9f88-f8b23e570af9",
+      "doi" : "https://www.example.org/a44f218a-7aae-421d-bd04-cfb07c24a978",
       "publicationInstance" : {
         "type" : "ConferencePoster",
         "pages" : {
@@ -121,89 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/1f9fccbf-d34d-454c-9fa9-bffca30b3b4f",
-    "abstract" : "RvoKKYs3mBNe4P6oUj"
+    "metadataSource" : "https://www.example.org/426c1d4b-59cc-4ac9-acc0-00ecddfaf82e",
+    "abstract" : "hAr9Qdbwgu6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cb7e5f66-9c79-4e07-ab1d-b2ee5c1b8537",
-    "name" : "lTc7G81h49T6p",
+    "id" : "https://www.example.org/16b40d51-27b2-4893-91f0-749ad4815d85",
+    "name" : "VD675zcCJkSTLALAo0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-06-21T03:06:31.115Z",
+      "approvalDate" : "1983-10-18T02:36:32.950Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "t7XM0dakFS0SAA"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "C0fiI7H61QUZT"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8b87a3f6-7d73-40e7-93de-d8e34192450e",
-    "identifier" : "Kog491G9Q58ou",
+    "source" : "https://www.example.org/29a3e3d2-ce16-427f-8631-a6b8437fecf4",
+    "identifier" : "gScOS953FJFD0JBrj",
     "labels" : {
-      "zh" : "ZMZYD60RlVJf"
+      "nl" : "GeYTTgGgkhFhfWkOG"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1224125468
+      "currency" : "NOK",
+      "amount" : 1175174613
     },
-    "activeFrom" : "2010-12-16T02:11:52.288Z",
-    "activeTo" : "2015-04-14T04:09:42.894Z"
+    "activeFrom" : "1984-02-02T05:28:39.368Z",
+    "activeTo" : "2002-09-25T21:26:40.477Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4e2c7a07-6bb1-4cd1-b623-41573c3faffe",
-    "id" : "https://www.example.org/800e5c65-dd35-471a-b921-3b2a4fde8f18",
-    "identifier" : "YLtBkNt1rBG42klxgnm",
+    "source" : "https://www.example.org/c9585296-82a2-4ed6-bb58-772c6ec5770f",
+    "id" : "https://www.example.org/395fc047-0795-489e-acc4-69fb126c5b84",
+    "identifier" : "B8lXcvuzWk7XU",
     "labels" : {
-      "en" : "yccvh53zYvbOK"
+      "el" : "DpubCFOnumgIL6hGB"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 243979556
+      "currency" : "USD",
+      "amount" : 2119292363
     },
-    "activeFrom" : "2018-12-25T03:13:16.944Z",
-    "activeTo" : "2021-07-27T21:44:08.106Z"
+    "activeFrom" : "1999-09-14T04:05:47.607Z",
+    "activeTo" : "2000-10-24T20:58:31.755Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c76f0409-8250-4804-9fb9-ab061c5972aa" ],
+  "subjects" : [ "https://www.example.org/64f4495a-8a51-4fe8-9617-d299129b32cd" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "fa08941e-bc2e-4a84-927e-cc6b87449c1a",
-    "name" : "J5v1vueTPcHG",
-    "mimeType" : "UX1H2x8x3NYfMhpid",
-    "size" : 804311045,
-    "license" : "https://www.example.com/5k8tllcb7h8s",
+    "identifier" : "141e46c7-1fa9-465c-9129-11bb0c42c7ca",
+    "name" : "iqpx8g0IlI",
+    "mimeType" : "hzRzzoJqmFvV",
+    "size" : 314606222,
+    "license" : "https://www.example.com/c38vc7mstbcpm",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "GJfEzFMYGyKOWFJfLky",
-    "publishedDate" : "2007-04-27T08:51:48.917Z",
+    "legalNote" : "BBlZJ5oGBTO0FhtRP",
+    "publishedDate" : "1983-04-03T21:53:40.634Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "JNF06GRv7bh8Q",
+      "uploadedDate" : "1981-08-20T06:35:47.834Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/khQAdzji6fHzleEOxR",
-    "name" : "JoBtGIqH296OH6DpN5",
-    "description" : "h8MNVACPX5teI9Ms"
+    "id" : "https://www.example.com/WcFxlhP353VAf7bcie",
+    "name" : "6KlQUS1NTQNAnKLtg",
+    "description" : "17YAoK6rAnGvOQMFam"
   } ],
-  "rightsHolder" : "xPdSsUgmPO77lEkdJH",
-  "duplicateOf" : "https://www.example.org/0724fa79-036a-4821-b40b-03e525898679",
+  "rightsHolder" : "FtkxxCHzvYRys",
+  "duplicateOf" : "https://www.example.org/5767e7b7-2749-47f7-98fa-41cceb81677e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "LjLc9mKKJR16G"
+    "note" : "qs6HHb4mnmsttloQ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xcsh6UN70Z2O1Csp",
-    "createdBy" : "RhmO0CRvDWeTk5nN",
-    "createdDate" : "2004-07-21T01:36:01.245Z"
+    "note" : "MfJDCSEr7Gp1q7",
+    "createdBy" : "XBDpWweInSAZFB",
+    "createdDate" : "2003-10-07T06:46:44.211Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fd959ab0-0344-4f0d-b0fe-e91648f00953" ],
+  "curatingInstitutions" : [ "https://www.example.org/f41c5068-d0e1-4a07-b8cf-34b4a7b39386" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Zx1eziL3hawMHP",
-    "ownerAffiliation" : "https://www.example.org/2cdd6be3-24bf-42f5-b3fc-c7fb31a7e435"
+    "owner" : "WDoD5knTmiDyb",
+    "ownerAffiliation" : "https://www.example.org/d11f25b1-4ad1-44a2-9d18-2153b9d69209"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b5ee86cf-f732-47c0-8e5c-5aa91d592c39"
+    "id" : "https://www.example.org/30a73dc1-3a5c-4aa3-98e0-3f81f961d646"
   },
-  "createdDate" : "1998-08-16T22:12:23.102Z",
-  "modifiedDate" : "1996-12-08T17:49:09.399Z",
-  "publishedDate" : "2007-08-29T03:30:02.339Z",
-  "indexedDate" : "1976-01-27T06:18:29.804Z",
-  "handle" : "https://www.example.org/5bb23e48-1d80-40b1-8b46-e393d6451326",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/ec2560bd-3b06-415b-ab6c-2894d74712d3",
+  "createdDate" : "2006-12-12T07:58:59.078Z",
+  "modifiedDate" : "2023-07-22T20:42:42.620Z",
+  "publishedDate" : "1989-10-14T18:15:57.670Z",
+  "indexedDate" : "2017-03-04T08:52:32.715Z",
+  "handle" : "https://www.example.org/7bcdd7b8-942b-4543-8efd-39d8279ce078",
+  "doi" : "https://doi.org/10.1234/cum",
+  "link" : "https://www.example.org/a75411c0-a22c-4d68-afa4-61d7bcccb7ef",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "klPaMCEclUKS6aDX",
+    "mainTitle" : "AWS1iy8lDAQXdaK1",
     "alternativeTitles" : {
-      "nb" : "vOW3wYPBnDjHzcAF"
+      "se" : "CdOa42DCqn0ifMX8ls"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "nZnqt77Ce54qVxonHdw",
-      "month" : "asHV3r3RRlM1GIH",
-      "day" : "cxJo9vbr3dUk"
+      "year" : "YUBS9IJCQSjJyfyUB",
+      "month" : "cy7SvBDkuZ4P65Kp95L",
+      "day" : "3nNa3cADLZ6B9G"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ec28bfbe-5f89-4bed-a4ed-7b892ec100f2",
-        "name" : "kHY0AOw76r",
+        "id" : "https://www.example.org/7d4b9c33-e664-46e2-9a8d-57863fd8c92f",
+        "name" : "pX5DTo5NVrfls",
         "nameType" : "Organizational",
-        "orcId" : "7QUE6xyX1VziOSyLy",
-        "verificationStatus" : "Verified",
+        "orcId" : "ECuuE5rsGaC",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7oNKehwKZGuyX",
-          "value" : "ShLVv7HCOP"
+          "sourceName" : "QoVQd20YlQbM8IP5v",
+          "value" : "E3m6suQxKZhvsodd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GSx2qjV2j9",
-          "value" : "hoo5ElxdLVlet4"
+          "sourceName" : "agILj97zJFLwy",
+          "value" : "mBfKJRrbmW4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/04843d5d-cd2e-4f5b-b022-debc5c43e61b"
+        "id" : "https://www.example.org/bd09c89b-9cba-458b-85be-35cbd2b78abe"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c38715d3-7779-433e-9af6-44d758d0cd6b",
-        "name" : "pwSj3QWsHeCwGJ",
+        "id" : "https://www.example.org/14f210db-cf5e-4560-887b-6b2d20796608",
+        "name" : "ALCAfHyNpkXL",
         "nameType" : "Personal",
-        "orcId" : "K0jGLjDAdbFAa4AL",
+        "orcId" : "f0S4Jaja7OuI",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CVP8z8kuarz",
-          "value" : "dZOF2og2yLMh"
+          "sourceName" : "8Qg6nh0OJb80Gi7hLk",
+          "value" : "DfAsfI8hHmvfY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ceh7jJr3gCCk",
-          "value" : "UCtxEm4ycBJ6"
+          "sourceName" : "YiHAIl1APXtOGgzD",
+          "value" : "TADP6xGRoue8hs55udt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e1d00bcf-1684-47f3-92bb-388547cea09a"
+        "id" : "https://www.example.org/d16e5008-c162-4413-94d6-16d17d669f44"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "t9s1O4ZzTM"
+      "ca" : "IbOEFzyYrFk"
     },
-    "npiSubjectHeading" : "64tdg4qyBeVbdU",
-    "tags" : [ "BUoWvKDaYEsyo" ],
-    "description" : "kUegN4amR4MHZY",
+    "npiSubjectHeading" : "EfybjCTuHw0GV",
+    "tags" : [ "HOxp66N3SH7dM" ],
+    "description" : "q4Sr0CCM9M8OeZQF",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/462765c3-31d5-4581-8004-d7e5cca349cf"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9e26f917-465b-4c81-817d-bd25e574cd93"
         },
-        "seriesNumber" : "iz2A2cDh1Ny",
+        "seriesNumber" : "bq10j5Qx9aZsH6OwnzA",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d3ad7192-cc21-4b91-b75a-5044bfd2b475",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5c6f3e3a-8d03-4f1c-8eb7-ae8221be8734",
           "valid" : true
         },
-        "isbnList" : [ "9791050953590" ],
+        "isbnList" : [ "9780987930293", "9780921258599" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "iTJdAhOiBEr"
+          "value" : "0921258593"
         } ]
       },
-      "doi" : "https://www.example.org/30ab90fc-f468-4ead-98d9-ab665f0b10d8",
+      "doi" : "https://www.example.org/1b900507-930d-4f0f-9347-096f8d964e19",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "uiAz6AcJVZz0xDgpPt",
-            "end" : "0A3psSNprRAu89"
+            "begin" : "0TxJS4pnRKh",
+            "end" : "Xft8EkUXUk2"
           },
-          "pages" : "XtRNFMQt0BL",
+          "pages" : "CKDYFegB4z0LGpVQ",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/acebe227-98c8-42e4-9d70-480f95102ab7",
-    "abstract" : "wR6wiEzEKKVlHE5OAwg"
+    "metadataSource" : "https://www.example.org/6595a573-fdc4-4e56-b297-e9e5fd887c37",
+    "abstract" : "36Xy6Aysgv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3720c7e6-dfcd-4aee-a608-03dbfeda4b9e",
-    "name" : "4TdkExW73yontfIiz",
+    "id" : "https://www.example.org/9b9fbe46-c998-4abf-a72d-c1d61ac97761",
+    "name" : "W4PHq75AxM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-04-25T04:21:21.130Z",
+      "approvalDate" : "1972-08-17T08:21:09.270Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "h1cJJbE6qf8KR5nd2kb"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "W0skiur3v6gi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/86611510-0e1f-412f-bbce-ba0ebc372e4a",
-    "identifier" : "c4Xukh4rcJdQ27cq4U8",
+    "source" : "https://www.example.org/d302c6c7-ba94-4c7a-bb83-dff68937318d",
+    "identifier" : "WWeczilkCVG",
     "labels" : {
-      "pt" : "t9YhB4gLUEbainGw8JZ"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 412903241
-    },
-    "activeFrom" : "2021-11-14T06:31:57.299Z",
-    "activeTo" : "2024-01-04T08:44:09.235Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/79f73310-2943-4b67-84e1-d0f1ba21bbe5",
-    "id" : "https://www.example.org/72dcb1fa-8d7b-42a6-af5f-e23d131908b9",
-    "identifier" : "TsONVMC2tfVtpnPVUSw",
-    "labels" : {
-      "fi" : "9mdpcvUJD5Yw"
+      "en" : "cbduR9DkfW5"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 556644260
+      "amount" : 1126041591
     },
-    "activeFrom" : "1978-11-24T07:24:23.045Z",
-    "activeTo" : "1996-10-22T15:05:25.745Z"
+    "activeFrom" : "2004-10-08T08:35:25.211Z",
+    "activeTo" : "2013-12-06T14:04:38.343Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/ba96200d-b79c-4eb1-a616-ceed8356d15b",
+    "id" : "https://www.example.org/e6770b34-be8a-4c9e-b0e7-dce4299ec80b",
+    "identifier" : "8VJi57Yd2Xux4BnpUcu",
+    "labels" : {
+      "it" : "lq87EOBWoYUTYye9"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1762662500
+    },
+    "activeFrom" : "2009-07-19T08:11:55.154Z",
+    "activeTo" : "2011-06-15T00:54:37.449Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c327b251-2ccd-4d6b-9363-8aa69ee71a89" ],
+  "subjects" : [ "https://www.example.org/5e2bbf7f-a046-4639-8073-e659fcaa2552" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b29bc177-ca78-452f-afe7-b4b4475b87cd",
-    "name" : "wdWjgAIxaLXdCQsI",
-    "mimeType" : "QjPFiRrNNBr26",
-    "size" : 808860656,
-    "license" : "https://www.example.com/klpecr4ga2f",
+    "identifier" : "d6ee4513-d5d3-4586-a038-97877853b507",
+    "name" : "JI3SiSaRGgH",
+    "mimeType" : "YlrBxVCNQokI7EloXw4",
+    "size" : 334345175,
+    "license" : "https://www.example.com/tuqatzmxt2qrr2210rp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "vfEezaqnlJ5X"
     },
-    "legalNote" : "9tVf84RxoFu8IDy",
-    "publishedDate" : "1995-07-08T16:50:11.252Z",
+    "legalNote" : "YGaNK85o19cDYlPPM3",
+    "publishedDate" : "2011-11-30T14:36:09.268Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "E00X7IH6BUVCqgHs",
+      "uploadedDate" : "1982-03-23T19:13:28.612Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/omfz2tILbxQrm",
-    "name" : "U50QGA9ulSuME",
-    "description" : "rslCSIUt9gOV94NF"
+    "id" : "https://www.example.com/0TLkBRXBPlZf",
+    "name" : "9NTUq2nwqOQIx",
+    "description" : "QYJZC4epPavaCqSMH"
   } ],
-  "rightsHolder" : "PiPKiJ4AT89qD",
-  "duplicateOf" : "https://www.example.org/a657d5b6-9998-4c3a-9712-f5ee0f16c010",
+  "rightsHolder" : "kcaXxypntbnnqrzd8O",
+  "duplicateOf" : "https://www.example.org/b40216fe-0e69-4ad2-b3e8-b61635f112fd",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FqNj8kH8tBMlWi"
+    "note" : "v35b6GAumI2wkmJ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8eb6DVxYVH6RAMv07",
-    "createdBy" : "niPR6sTXooI",
-    "createdDate" : "1989-01-27T17:15:37.705Z"
+    "note" : "zPdEy7NvWQM717ujbm",
+    "createdBy" : "pVW7ge00Hj",
+    "createdDate" : "1978-04-30T00:29:00.065Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/19db1b02-77c4-4039-902b-c3c0b5d4073f" ],
+  "curatingInstitutions" : [ "https://www.example.org/48beea0a-622b-49c4-b91a-236cfcd9d00a" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ConferenceReport.json
+++ b/documentation/ConferenceReport.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "FnJUWscXwmKliPoATi",
-    "ownerAffiliation" : "https://www.example.org/33e5d5d4-bf1d-422b-8d5f-00a496bf6648"
+    "owner" : "Zx1eziL3hawMHP",
+    "ownerAffiliation" : "https://www.example.org/2cdd6be3-24bf-42f5-b3fc-c7fb31a7e435"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1c3c6a37-f5dd-4c5e-83a2-b8ba8b6cb8e9"
+    "id" : "https://www.example.org/b5ee86cf-f732-47c0-8e5c-5aa91d592c39"
   },
-  "createdDate" : "1977-01-12T08:10:39.331Z",
-  "modifiedDate" : "1975-09-11T17:01:25.555Z",
-  "publishedDate" : "2001-02-28T13:10:35.733Z",
-  "indexedDate" : "2014-12-16T10:40:22.872Z",
-  "handle" : "https://www.example.org/88db1617-80ce-43c4-93e2-4c512cc2b155",
-  "doi" : "https://doi.org/10.1234/voluptatibus",
-  "link" : "https://www.example.org/45cffa77-c9af-4740-a167-52c572da20a8",
+  "createdDate" : "1998-08-16T22:12:23.102Z",
+  "modifiedDate" : "1996-12-08T17:49:09.399Z",
+  "publishedDate" : "2007-08-29T03:30:02.339Z",
+  "indexedDate" : "1976-01-27T06:18:29.804Z",
+  "handle" : "https://www.example.org/5bb23e48-1d80-40b1-8b46-e393d6451326",
+  "doi" : "https://doi.org/10.1234/molestiae",
+  "link" : "https://www.example.org/ec2560bd-3b06-415b-ab6c-2894d74712d3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uvHAQccaxy29z1BFG5",
+    "mainTitle" : "klPaMCEclUKS6aDX",
     "alternativeTitles" : {
-      "zh" : "iqNZyzsDbFJ1lgQ"
+      "nb" : "vOW3wYPBnDjHzcAF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "sNBvMT6EKZ8fPsKSW0r",
-      "month" : "lUwtiTJAqCaPQ2W",
-      "day" : "dNM0AYHJLFLKlg9"
+      "year" : "nZnqt77Ce54qVxonHdw",
+      "month" : "asHV3r3RRlM1GIH",
+      "day" : "cxJo9vbr3dUk"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4a1dcf43-7843-499c-add2-4feda5da221d",
-        "name" : "dWOPg8XgE2meGzdDAmO",
+        "id" : "https://www.example.org/ec28bfbe-5f89-4bed-a4ed-7b892ec100f2",
+        "name" : "kHY0AOw76r",
         "nameType" : "Organizational",
-        "orcId" : "ZP8c7UpJkJC2rIVLwk",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "7QUE6xyX1VziOSyLy",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "irwecTuyOYjL",
-          "value" : "EIUD9aaev1kKIFHlX"
+          "sourceName" : "7oNKehwKZGuyX",
+          "value" : "ShLVv7HCOP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "XmuqVjda1GHilIuJl",
-          "value" : "PRNPhr3TzHj1a38"
+          "sourceName" : "GSx2qjV2j9",
+          "value" : "hoo5ElxdLVlet4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2d6b2aad-7b55-4c47-836a-cd3e406feb6c"
+        "id" : "https://www.example.org/04843d5d-cd2e-4f5b-b022-debc5c43e61b"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b2acb788-a474-4372-9eca-506522fccae5",
-        "name" : "RoKsAq0YhIU9lCOMGya",
+        "id" : "https://www.example.org/c38715d3-7779-433e-9af6-44d758d0cd6b",
+        "name" : "pwSj3QWsHeCwGJ",
         "nameType" : "Personal",
-        "orcId" : "Kg6lUYXIC091KLMVI",
-        "verificationStatus" : "Verified",
+        "orcId" : "K0jGLjDAdbFAa4AL",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mOGBMOUYcIQ",
-          "value" : "0Fl1GwAiJCLtjuefWxh"
+          "sourceName" : "CVP8z8kuarz",
+          "value" : "dZOF2og2yLMh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IVtU9amxlXILCS8o",
-          "value" : "i3DZUSeYTk"
+          "sourceName" : "Ceh7jJr3gCCk",
+          "value" : "UCtxEm4ycBJ6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d2f804a4-72ea-4cda-bd18-403497a547fd"
+        "id" : "https://www.example.org/e1d00bcf-1684-47f3-92bb-388547cea09a"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "jaTG1Evkotww"
+      "cs" : "t9s1O4ZzTM"
     },
-    "npiSubjectHeading" : "gDjgiEdxZYMePejL4",
-    "tags" : [ "1LMHGFl6XzH" ],
-    "description" : "XwZBveD5rb",
+    "npiSubjectHeading" : "64tdg4qyBeVbdU",
+    "tags" : [ "BUoWvKDaYEsyo" ],
+    "description" : "kUegN4amR4MHZY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b233e9af-f174-4a09-a06a-c8da43cb862d"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/462765c3-31d5-4581-8004-d7e5cca349cf"
         },
-        "seriesNumber" : "jHWfyXxy6H",
+        "seriesNumber" : "iz2A2cDh1Ny",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f51447e8-8975-4d33-abef-d9c24f0ed380",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d3ad7192-cc21-4b91-b75a-5044bfd2b475",
           "valid" : true
         },
-        "isbnList" : [ "9791794980944" ],
+        "isbnList" : [ "9791050953590" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "lV2UQd9nuxc3yoR6vM"
+          "value" : "iTJdAhOiBEr"
         } ]
       },
-      "doi" : "https://www.example.org/8100b72c-66d5-41f1-b491-9dbd48651366",
+      "doi" : "https://www.example.org/30ab90fc-f468-4ead-98d9-ab665f0b10d8",
       "publicationInstance" : {
         "type" : "ConferenceReport",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "nRhYYnmTpJju9XPKw6",
-            "end" : "YYSTHebmS0LubZM"
+            "begin" : "uiAz6AcJVZz0xDgpPt",
+            "end" : "0A3psSNprRAu89"
           },
-          "pages" : "Mz6D3tQeLCiQR",
+          "pages" : "XtRNFMQt0BL",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b9b68cb9-2f93-481e-87c6-e764cb8cd58e",
-    "abstract" : "LzqQEhAVmcm"
+    "metadataSource" : "https://www.example.org/acebe227-98c8-42e4-9d70-480f95102ab7",
+    "abstract" : "wR6wiEzEKKVlHE5OAwg"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4a33bae8-fd00-423d-aa2f-71d6b63fbf42",
-    "name" : "ZOnmjXZEn86",
+    "id" : "https://www.example.org/3720c7e6-dfcd-4aee-a608-03dbfeda4b9e",
+    "name" : "4TdkExW73yontfIiz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-09-16T01:40:55.711Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "1972-04-25T04:21:21.130Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "Ncf6W2Srl6FnJu5"
+      "applicationCode" : "h1cJJbE6qf8KR5nd2kb"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e3b2aabe-eac8-46cd-a154-c02bff2859b1",
-    "identifier" : "K0WmPBJ5iFWyEgWEnqq",
+    "source" : "https://www.example.org/86611510-0e1f-412f-bbce-ba0ebc372e4a",
+    "identifier" : "c4Xukh4rcJdQ27cq4U8",
     "labels" : {
-      "ca" : "gHLFAOCtxMgKxi2VE"
+      "pt" : "t9YhB4gLUEbainGw8JZ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1167387284
+      "currency" : "USD",
+      "amount" : 412903241
     },
-    "activeFrom" : "2014-06-25T11:55:50.054Z",
-    "activeTo" : "2018-08-28T17:11:11.840Z"
+    "activeFrom" : "2021-11-14T06:31:57.299Z",
+    "activeTo" : "2024-01-04T08:44:09.235Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8053d882-c54e-4f5c-8add-1ba1bb49be33",
-    "id" : "https://www.example.org/12ed72f6-1ad5-4650-948c-1dcb4ad92c98",
-    "identifier" : "Tocp9Iund2aCE",
+    "source" : "https://www.example.org/79f73310-2943-4b67-84e1-d0f1ba21bbe5",
+    "id" : "https://www.example.org/72dcb1fa-8d7b-42a6-af5f-e23d131908b9",
+    "identifier" : "TsONVMC2tfVtpnPVUSw",
     "labels" : {
-      "es" : "Rgyk9kyU6KED"
+      "fi" : "9mdpcvUJD5Yw"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 366726625
+      "amount" : 556644260
     },
-    "activeFrom" : "1979-03-24T07:07:46.422Z",
-    "activeTo" : "2020-10-15T22:16:47.910Z"
+    "activeFrom" : "1978-11-24T07:24:23.045Z",
+    "activeTo" : "1996-10-22T15:05:25.745Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d13af9d0-c4ac-45fc-a889-ac2e6a86ea8e" ],
+  "subjects" : [ "https://www.example.org/c327b251-2ccd-4d6b-9363-8aa69ee71a89" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0fb262a9-9106-4313-8d91-f4a47ef01147",
-    "name" : "Mx63tqKl1mVk6",
-    "mimeType" : "lhp8Y1loMDkvrL0kl",
-    "size" : 1910613989,
-    "license" : "https://www.example.com/sqex1h3l2n42",
+    "identifier" : "b29bc177-ca78-452f-afe7-b4b4475b87cd",
+    "name" : "wdWjgAIxaLXdCQsI",
+    "mimeType" : "QjPFiRrNNBr26",
+    "size" : 808860656,
+    "license" : "https://www.example.com/klpecr4ga2f",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "r06Si8cbMIyMW3F",
-    "publishedDate" : "2020-06-14T16:26:44.920Z",
+    "legalNote" : "9tVf84RxoFu8IDy",
+    "publishedDate" : "1995-07-08T16:50:11.252Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/1X5dSUwz72oLW60AJ",
-    "name" : "uiREAvBdd5N3jBCAj",
-    "description" : "k9gO2fmdHWUTnwyFy"
+    "id" : "https://www.example.com/omfz2tILbxQrm",
+    "name" : "U50QGA9ulSuME",
+    "description" : "rslCSIUt9gOV94NF"
   } ],
-  "rightsHolder" : "an1GbcWFalT",
-  "duplicateOf" : "https://www.example.org/35178ad6-953b-466d-b796-80c8e1ab035e",
+  "rightsHolder" : "PiPKiJ4AT89qD",
+  "duplicateOf" : "https://www.example.org/a657d5b6-9998-4c3a-9712-f5ee0f16c010",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tVlpjBR6C7OFISRbIA"
+    "note" : "FqNj8kH8tBMlWi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "UYFcZr4D5IbZ7Nh",
-    "createdBy" : "fwx3scKVL1QlB88",
-    "createdDate" : "1997-01-06T22:51:24.917Z"
+    "note" : "8eb6DVxYVH6RAMv07",
+    "createdBy" : "niPR6sTXooI",
+    "createdDate" : "1989-01-27T17:15:37.705Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7da4ffe0-5712-4bbd-9440-781f5cc94889" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/19db1b02-77c4-4039-902b-c3c0b5d4073f" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "sftnGYBZFzPcrI",
-    "ownerAffiliation" : "https://www.example.org/931e24b6-ecc0-4897-a7c7-cedf7b25bf52"
+    "owner" : "NUugfyQPBZXN",
+    "ownerAffiliation" : "https://www.example.org/a35407b8-aa83-43eb-b4fe-89374278692e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/00c7a7d6-82a5-4d78-8b56-7ae2c7fec851"
+    "id" : "https://www.example.org/688dca83-13d7-458b-97d4-c01cd795eb04"
   },
-  "createdDate" : "1984-10-12T05:01:26.576Z",
-  "modifiedDate" : "1993-01-22T11:39:19.321Z",
-  "publishedDate" : "1989-08-10T13:29:47.571Z",
-  "indexedDate" : "2000-09-13T12:27:52.990Z",
-  "handle" : "https://www.example.org/abfcec8b-31a1-4390-b6bd-ded3ab16b18e",
-  "doi" : "https://doi.org/10.1234/laboriosam",
-  "link" : "https://www.example.org/03dd3afc-b9a1-4793-9265-fe61d7c8cbc3",
+  "createdDate" : "2001-05-22T03:44:46.151Z",
+  "modifiedDate" : "1995-02-19T02:56:26.503Z",
+  "publishedDate" : "1988-01-29T21:38:45.989Z",
+  "indexedDate" : "1997-08-05T11:59:53.605Z",
+  "handle" : "https://www.example.org/631d46bf-7c99-4cc0-8d84-185ed95591a9",
+  "doi" : "https://doi.org/10.1234/doloremque",
+  "link" : "https://www.example.org/d6a1effa-e389-45f1-a879-dd71e3d84145",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "lYvOaQr9SANuecGFhE",
+    "mainTitle" : "q4bHgaEYxhZyGBMFr",
     "alternativeTitles" : {
-      "it" : "Jqs3darvH5xn"
+      "cs" : "VF46pi3R0ce"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uuWmYoSWjB7q4FcDd",
-      "month" : "1U5yw4OVSUyiaNfew",
-      "day" : "1laIiynip9"
+      "year" : "ARSE46Y8iPmFa",
+      "month" : "gxR5eS1qnkrBmWr4VBp",
+      "day" : "ae8uJMtOlGX"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eb6d93fe-891e-4220-a833-086d8b58ae82",
-        "name" : "mNzAuNLcQ69Ik3zv",
-        "nameType" : "Personal",
-        "orcId" : "gSxK7qPHVM7lTXoyzpL",
+        "id" : "https://www.example.org/b399e6a7-97cc-4955-a5da-2b993c032967",
+        "name" : "4ieOop2T187YzpX",
+        "nameType" : "Organizational",
+        "orcId" : "sGWOzfEQBomasMW",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rIujHfOZOEoTfOT",
-          "value" : "2VvbDLZz6Dr3mNIjd9n"
+          "sourceName" : "3Tx8EwtFNt",
+          "value" : "GqlP3iDVWO2J"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "44Xa89RMYpUR8lHIoP",
-          "value" : "6JSsqPJV5iT0Jp"
+          "sourceName" : "Qm6ANIA3dPwOwAp0",
+          "value" : "U1wrh4yeS8tfdaujM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1848eb6f-40af-4d24-aab5-e86c97e3b6fc"
+        "id" : "https://www.example.org/06e75ab3-9ab7-423d-8a9a-8d07f0552044"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "ContactPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,148 +62,149 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/91f00ac3-fdc1-4a2b-9fbb-ecb36a466a92",
-        "name" : "W1wpTDiYLuGMV2KG10b",
-        "nameType" : "Personal",
-        "orcId" : "c9HWEYYpfxZnC",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/fdae70fa-8511-4889-be86-abf761204a1f",
+        "name" : "YrKgoRrCBl3",
+        "nameType" : "Organizational",
+        "orcId" : "sI2RPaRR0TC1bUw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mJe5psY1UJDaAil4pX",
-          "value" : "QqAqqUwhQVihpn"
+          "sourceName" : "ag8y7LRUkVq0m",
+          "value" : "ZVSdooTcqPyMRS5kPgu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yPvbGDDpLhiYw43p",
-          "value" : "kOxeRQxYaj9p"
+          "sourceName" : "dyLYjl1afEXw95iu",
+          "value" : "a48R8TNuIWV1Xth2SIT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b74aed4f-e9a3-4b25-ba69-df3980244595"
+        "id" : "https://www.example.org/242f070e-4acc-44a0-b65b-fe51548d4e17"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "kC4QeezPcrSYhDdW"
+      "ru" : "VGtHvtNgdQzkOK3dd"
     },
-    "npiSubjectHeading" : "zXovQi9T8xYGIR4s4x",
-    "tags" : [ "c6dwN5VAVwZR" ],
-    "description" : "HScyQns1E4Qa",
+    "npiSubjectHeading" : "tgYF5koUMLb",
+    "tags" : [ "fG6XgWdeQGDJnSE" ],
+    "description" : "8kWFr7qL4kxk",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/26da86c3-7c1b-4f76-bd2b-91aeaa1add1c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/11e6b9ce-2915-467b-9dff-c4f0499f4f54",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/75840a59-2b22-4a78-a3a4-d77af5b47714",
+      "doi" : "https://www.example.org/2da5c046-3fcb-42de-91ca-e145c191a76f",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "MwLrGuPEIWRqG"
+          "text" : "MlpKCc5V1t3Q9XQ"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "jqeUKd2cUeEMb1",
-            "end" : "V8iPnTDGW401INz9"
+            "begin" : "le3sztSedpLX2GRyd6",
+            "end" : "99EU3g5q5f"
           },
-          "pages" : "UTlTUBCaeWN0mMe1qw2",
-          "illustrated" : false
+          "pages" : "vhcxVJfKjK2ZAM8re6",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7bf9e620-9cc9-4ee0-a4b2-6673afa3d4ec",
-    "abstract" : "6QT9qaMk5xHaRgK"
+    "metadataSource" : "https://www.example.org/ed601074-ea9b-4b77-86a1-8f5e0906430b",
+    "abstract" : "0l32any9zdezY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0e0f9340-c793-4a7b-b0a4-69b71b28c361",
-    "name" : "tV2R5HN7XYFFO",
+    "id" : "https://www.example.org/e965cfe9-fd64-4c36-863c-acd9ab8e90af",
+    "name" : "cDDIipcYZJ9dW1OfyM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-12-16T17:45:25.012Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "4khPiCvP09EbiCHhDYZ"
+      "approvalDate" : "2020-01-28T01:48:01.688Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "ADHZfLtz3CO7Ld8Jr"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/264429a0-65f8-4f45-a9f7-973715aa5b3d",
-    "identifier" : "BaIvzpW8RQHy",
+    "source" : "https://www.example.org/ef930547-202e-4b39-a262-a5cef9b2f65e",
+    "identifier" : "Vmfr97eVyDACwX0D",
     "labels" : {
-      "nl" : "Rf60UyGyUWnEXQcV40u"
+      "fi" : "5JjqBT78JHkJcIp"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1312823232
+      "amount" : 1235998687
     },
-    "activeFrom" : "2002-07-24T01:08:34.401Z",
-    "activeTo" : "2014-01-16T17:37:04.416Z"
+    "activeFrom" : "1972-02-26T07:12:49.712Z",
+    "activeTo" : "1975-12-01T17:40:05.035Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a150c29b-7499-46ae-901f-7ece13f5d069",
-    "id" : "https://www.example.org/8a25c51f-7aab-48b5-b087-d578d02c2966",
-    "identifier" : "itdv1eB0y3ueGMxIVL",
+    "source" : "https://www.example.org/40d2b4c1-b5c8-4913-9422-59c6d3c7a6c8",
+    "id" : "https://www.example.org/c4bef93d-2a0d-4fae-af46-a1d429a9029f",
+    "identifier" : "QuBECnmsQY9W8T",
     "labels" : {
-      "sv" : "ZPHHh7dHn26RMXu"
+      "pl" : "pGDtyRcZPKuOLmY"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 629379758
+      "currency" : "USD",
+      "amount" : 1189146879
     },
-    "activeFrom" : "2014-08-18T04:01:26.028Z",
-    "activeTo" : "2020-11-01T22:36:04.738Z"
+    "activeFrom" : "2003-05-05T19:39:28.704Z",
+    "activeTo" : "2003-11-24T13:53:03.628Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a60ebea8-0a29-4f91-a6dd-fa526d4ab083" ],
+  "subjects" : [ "https://www.example.org/416026dd-5f30-4268-ad68-c144cb6e8fb9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4a7e8e50-331c-470d-bff4-0fdf11794826",
-    "name" : "s1BOFxJ8YBFcodmVWJ",
-    "mimeType" : "atRkfXqibcaXRIAZD8",
-    "size" : 2001736779,
-    "license" : "https://www.example.com/hc7uqabyww",
+    "identifier" : "8ce7fc26-7acf-433e-b4fe-b063ef0a004e",
+    "name" : "tvxpQW18uKoqLfs",
+    "mimeType" : "RIkpusl8vc93OVQKeG",
+    "size" : 1360941275,
+    "license" : "https://www.example.com/pssrvswde5mvyvwbul",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kBFsmuPDTuRXFX",
-    "publishedDate" : "2017-10-29T11:03:13.805Z",
+    "legalNote" : "P13Jc3sT1F",
+    "publishedDate" : "1997-05-16T08:37:18.602Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tM9JBZraOPj",
-    "name" : "dVetiqaQQCUK",
-    "description" : "Z1aoxiQLuQ"
+    "id" : "https://www.example.com/wQHT9FT59u45w0",
+    "name" : "yn01K7NoKX",
+    "description" : "PUfwCV5mK7ripmBT"
   } ],
-  "rightsHolder" : "gFMQ7ks3PqyiX0HzGS",
-  "duplicateOf" : "https://www.example.org/38ce497c-e78b-4d21-9b00-425fb9df7914",
+  "rightsHolder" : "wlV9x5jqK3",
+  "duplicateOf" : "https://www.example.org/79b02c82-28c6-4d41-995d-4867424c5f1e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9TE9Oys7GhbRLvKM"
+    "note" : "6bLNbtjWhReJ3iZp8"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ebSQIomCRb",
-    "createdBy" : "dsEBAzWmBthsNp",
-    "createdDate" : "2014-12-03T08:08:10.005Z"
+    "note" : "ABbe1U7qWhAW",
+    "createdBy" : "3zL9GD6u8B95",
+    "createdDate" : "1982-05-28T01:40:10.382Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c577b2e9-ea4f-4a30-887f-ea346a057934" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/e8f6907a-82e7-4eeb-a851-3ee19f47ff2e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DataManagementPlan.json
+++ b/documentation/DataManagementPlan.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "NUugfyQPBZXN",
-    "ownerAffiliation" : "https://www.example.org/a35407b8-aa83-43eb-b4fe-89374278692e"
+    "owner" : "E7PV1PwcuHR",
+    "ownerAffiliation" : "https://www.example.org/40326cb5-3958-4c7f-9083-75346c30adba"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/688dca83-13d7-458b-97d4-c01cd795eb04"
+    "id" : "https://www.example.org/250bd84c-3f81-48bf-a751-fc0bcfc542ae"
   },
-  "createdDate" : "2001-05-22T03:44:46.151Z",
-  "modifiedDate" : "1995-02-19T02:56:26.503Z",
-  "publishedDate" : "1988-01-29T21:38:45.989Z",
-  "indexedDate" : "1997-08-05T11:59:53.605Z",
-  "handle" : "https://www.example.org/631d46bf-7c99-4cc0-8d84-185ed95591a9",
-  "doi" : "https://doi.org/10.1234/doloremque",
-  "link" : "https://www.example.org/d6a1effa-e389-45f1-a879-dd71e3d84145",
+  "createdDate" : "1980-05-03T03:25:03.342Z",
+  "modifiedDate" : "2007-12-19T19:33:57.856Z",
+  "publishedDate" : "2006-11-16T01:19:42.558Z",
+  "indexedDate" : "2006-01-08T00:15:41.155Z",
+  "handle" : "https://www.example.org/fd2d6097-c1ee-46ed-8a44-bacaa9de6fc8",
+  "doi" : "https://doi.org/10.1234/necessitatibus",
+  "link" : "https://www.example.org/d8edfc07-f607-423a-956d-0b2e83edf9e0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "q4bHgaEYxhZyGBMFr",
+    "mainTitle" : "RCcTgDsPWy",
     "alternativeTitles" : {
-      "cs" : "VF46pi3R0ce"
+      "el" : "UEKkiBRhmc1abhLc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ARSE46Y8iPmFa",
-      "month" : "gxR5eS1qnkrBmWr4VBp",
-      "day" : "ae8uJMtOlGX"
+      "year" : "U504qR55mY1",
+      "month" : "cpx4Bz3tKMEee9",
+      "day" : "bH2TWfsQ2WYNj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b399e6a7-97cc-4955-a5da-2b993c032967",
-        "name" : "4ieOop2T187YzpX",
+        "id" : "https://www.example.org/3d28797d-68e3-42c5-a181-55783d5a0da3",
+        "name" : "TINHVKwA06Tu20E",
         "nameType" : "Organizational",
-        "orcId" : "sGWOzfEQBomasMW",
+        "orcId" : "MOkvCjQt7uILX",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3Tx8EwtFNt",
-          "value" : "GqlP3iDVWO2J"
+          "sourceName" : "2qy1NckY6OsLbv2zL",
+          "value" : "wFmuF1Ct9g61Ggk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Qm6ANIA3dPwOwAp0",
-          "value" : "U1wrh4yeS8tfdaujM"
+          "sourceName" : "pmjkzNbvh4SJKH1KKk",
+          "value" : "1WkwMMrpiENAqi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/06e75ab3-9ab7-423d-8a9a-8d07f0552044"
+        "id" : "https://www.example.org/b73990ec-a639-441e-9733-21dd065020a5"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Librettist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,149 +62,154 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fdae70fa-8511-4889-be86-abf761204a1f",
-        "name" : "YrKgoRrCBl3",
+        "id" : "https://www.example.org/485aea9d-885d-4593-b9d2-62bb2d70bfa8",
+        "name" : "RZKFGgXCnWKf",
         "nameType" : "Organizational",
-        "orcId" : "sI2RPaRR0TC1bUw",
+        "orcId" : "7rnRW7kc2NQYV1gNG",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ag8y7LRUkVq0m",
-          "value" : "ZVSdooTcqPyMRS5kPgu"
+          "sourceName" : "KKyKIO2yIByXVb7zc0v",
+          "value" : "rFv0f39E62wdUK0B"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dyLYjl1afEXw95iu",
-          "value" : "a48R8TNuIWV1Xth2SIT"
+          "sourceName" : "aFFqhteR5b0NiDjh",
+          "value" : "VXyGkBO8XOeZVAghlv1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/242f070e-4acc-44a0-b65b-fe51548d4e17"
+        "id" : "https://www.example.org/5723f51a-968f-4da0-8437-b923b4648924"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "VGtHvtNgdQzkOK3dd"
+      "ca" : "h9iBuvzLqH1NE"
     },
-    "npiSubjectHeading" : "tgYF5koUMLb",
-    "tags" : [ "fG6XgWdeQGDJnSE" ],
-    "description" : "8kWFr7qL4kxk",
+    "npiSubjectHeading" : "kpJaRsHy5M3i0MLpdoe",
+    "tags" : [ "c37DphueeWeEN4" ],
+    "description" : "xoROLfQ04Cg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/11e6b9ce-2915-467b-9dff-c4f0499f4f54",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d9699b87-2e63-4271-93ad-e3daaf4e4113",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/2da5c046-3fcb-42de-91ca-e145c191a76f",
+      "doi" : "https://www.example.org/012944b8-8b0a-4fdf-bdc5-a8d44b4e1261",
       "publicationInstance" : {
         "type" : "DataManagementPlan",
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "MlpKCc5V1t3Q9XQ"
+          "text" : "vDrolY5IL86W"
         } ],
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "le3sztSedpLX2GRyd6",
-            "end" : "99EU3g5q5f"
+            "begin" : "zJrtBZSQoHsQDYWy",
+            "end" : "EZVI5rsgemtWMiq"
           },
-          "pages" : "vhcxVJfKjK2ZAM8re6",
+          "pages" : "0657iR6fZLyA3",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ed601074-ea9b-4b77-86a1-8f5e0906430b",
-    "abstract" : "0l32any9zdezY"
+    "metadataSource" : "https://www.example.org/ca8f18ad-707f-4861-96a8-f58c6525de49",
+    "abstract" : "jmXJ9wd49NG6v4k"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e965cfe9-fd64-4c36-863c-acd9ab8e90af",
-    "name" : "cDDIipcYZJ9dW1OfyM",
+    "id" : "https://www.example.org/f263bd91-d73f-4151-9072-4003cc8862f3",
+    "name" : "3F8CEuy8MtDuD",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-01-28T01:48:01.688Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "ADHZfLtz3CO7Ld8Jr"
+      "approvalDate" : "2018-02-10T19:40:59.215Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "YWrDO3bPmWOD0ORo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ef930547-202e-4b39-a262-a5cef9b2f65e",
-    "identifier" : "Vmfr97eVyDACwX0D",
+    "source" : "https://www.example.org/d591de27-1a2a-4a40-ad32-77007515f06b",
+    "identifier" : "XbLnPmf6Abt2",
     "labels" : {
-      "fi" : "5JjqBT78JHkJcIp"
+      "se" : "KsRv39qZCO5h"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1235998687
+      "currency" : "EUR",
+      "amount" : 2136576258
     },
-    "activeFrom" : "1972-02-26T07:12:49.712Z",
-    "activeTo" : "1975-12-01T17:40:05.035Z"
+    "activeFrom" : "1995-02-03T06:58:56.204Z",
+    "activeTo" : "2010-07-08T00:09:53.540Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/40d2b4c1-b5c8-4913-9422-59c6d3c7a6c8",
-    "id" : "https://www.example.org/c4bef93d-2a0d-4fae-af46-a1d429a9029f",
-    "identifier" : "QuBECnmsQY9W8T",
+    "source" : "https://www.example.org/75bc5599-f520-488a-b367-9455facfcf40",
+    "id" : "https://www.example.org/4dec2050-9c59-416a-9dba-e6d01ea3cd81",
+    "identifier" : "eZdz5kBLaqx0QzpN7",
     "labels" : {
-      "pl" : "pGDtyRcZPKuOLmY"
+      "da" : "DGhC226yJ7KwvkM7Yd"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1189146879
+      "currency" : "GBP",
+      "amount" : 1404032944
     },
-    "activeFrom" : "2003-05-05T19:39:28.704Z",
-    "activeTo" : "2003-11-24T13:53:03.628Z"
+    "activeFrom" : "1981-10-16T01:02:39.806Z",
+    "activeTo" : "1996-11-20T16:36:08.021Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/416026dd-5f30-4268-ad68-c144cb6e8fb9" ],
+  "subjects" : [ "https://www.example.org/13de64b1-c2f6-4b17-895d-aec8cf024a36" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8ce7fc26-7acf-433e-b4fe-b063ef0a004e",
-    "name" : "tvxpQW18uKoqLfs",
-    "mimeType" : "RIkpusl8vc93OVQKeG",
-    "size" : 1360941275,
-    "license" : "https://www.example.com/pssrvswde5mvyvwbul",
+    "identifier" : "2b678fff-c112-4e80-853c-ec0651e8d8c7",
+    "name" : "myFZv31aDoR1Otxyg0",
+    "mimeType" : "RZjT1sWixp",
+    "size" : 1703420736,
+    "license" : "https://www.example.com/bhnryyberwl",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "P13Jc3sT1F",
-    "publishedDate" : "1997-05-16T08:37:18.602Z",
+    "legalNote" : "U2IsMFyfDmH8z",
+    "publishedDate" : "2018-03-20T23:54:39.627Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "AtDy6vcfPc35i7p",
+      "uploadedDate" : "2018-10-06T07:05:59.437Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wQHT9FT59u45w0",
-    "name" : "yn01K7NoKX",
-    "description" : "PUfwCV5mK7ripmBT"
+    "id" : "https://www.example.com/0KYj5OMVdLGCgf55z",
+    "name" : "ebybUN8yeJ0wI",
+    "description" : "oeng3Hk9Tx"
   } ],
-  "rightsHolder" : "wlV9x5jqK3",
-  "duplicateOf" : "https://www.example.org/79b02c82-28c6-4d41-995d-4867424c5f1e",
+  "rightsHolder" : "gR7SvRStGEodZd2H8F3",
+  "duplicateOf" : "https://www.example.org/34e4e567-8a6c-4a76-b333-69e122d933a6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "6bLNbtjWhReJ3iZp8"
+    "note" : "yzBMwEcChWwVzbJj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ABbe1U7qWhAW",
-    "createdBy" : "3zL9GD6u8B95",
-    "createdDate" : "1982-05-28T01:40:10.382Z"
+    "note" : "p5rOlcQa4YRNyKQpnk",
+    "createdBy" : "YQGtNAB18PPbpbbN",
+    "createdDate" : "1997-11-28T16:37:10.118Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e8f6907a-82e7-4eeb-a851-3ee19f47ff2e" ],
+  "curatingInstitutions" : [ "https://www.example.org/4331c33c-41ad-4c44-937c-eea89ef81de3" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "Z1RPdJP4X3PNcvltGC",
-    "ownerAffiliation" : "https://www.example.org/93f4774e-0a49-4783-8ddb-247e289aed34"
+    "owner" : "U30hjRI7jxXghTnfmG",
+    "ownerAffiliation" : "https://www.example.org/8d385f59-c7c3-4342-be8c-c88471cad523"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/139f323d-ddb4-4408-8572-2d5568e90eeb"
+    "id" : "https://www.example.org/ffd755b6-6957-4948-a2fc-32d84a626b57"
   },
-  "createdDate" : "1981-06-24T18:11:48.557Z",
-  "modifiedDate" : "1999-04-14T23:37:40.352Z",
-  "publishedDate" : "1972-12-23T12:04:22.865Z",
-  "indexedDate" : "1981-04-22T05:05:25.954Z",
-  "handle" : "https://www.example.org/42b50d0f-67bd-49a8-ac33-5c2bd14c434c",
-  "doi" : "https://doi.org/10.1234/tempora",
-  "link" : "https://www.example.org/b0cc3af2-5cfb-47c4-87d3-b4a7e9380889",
+  "createdDate" : "1973-10-03T12:27:36.830Z",
+  "modifiedDate" : "2023-07-11T12:27:03.106Z",
+  "publishedDate" : "1997-09-26T15:53:47.184Z",
+  "indexedDate" : "2017-06-09T18:06:11.509Z",
+  "handle" : "https://www.example.org/54bbe7da-40df-43c4-9c1d-41e20835c856",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/bd9473c4-49d2-45ad-936a-b77791746280",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "jmU8zaXpRyU5l7okTD",
+    "mainTitle" : "T6teHlb8bwNcR1UZ8g",
     "alternativeTitles" : {
-      "fr" : "y3UhDmGmGR1qAE"
+      "zh" : "fB0NtLMTw6COMq05g"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TUDYZ0ajClHQQJvaEs3",
-      "month" : "bdNFywXHUWo",
-      "day" : "oTW6J3PZETNH"
+      "year" : "H8saPZ1GYJ7C",
+      "month" : "Q1MvZp4KhGSirtU",
+      "day" : "Q4q8KsMmof8CxJUr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0828e91b-bd85-4594-aec8-b513eb4f207a",
-        "name" : "JCkc4EJgzMlhi54",
-        "nameType" : "Organizational",
-        "orcId" : "jV9YRbLAeG",
+        "id" : "https://www.example.org/c2c5e703-70a8-46d2-9ba4-ba3066a90d6f",
+        "name" : "E0Qa6i751B22s7o45kh",
+        "nameType" : "Personal",
+        "orcId" : "HTKIpI7l8zmPUvWc",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VpUpfNMpt9Q",
-          "value" : "D8Enk2nyDIP"
+          "sourceName" : "Ebw6IftnvQlTE1tHqG7",
+          "value" : "Rc5TVQhpSZUgAONgr5"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KpZdISDZv3i",
-          "value" : "zz4Jw5nQOpu7"
+          "sourceName" : "dzB0qmV3jz4Mcc",
+          "value" : "eBYrpAYbmDC3Xn1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/51be219b-e824-4c99-acba-f49d36bfe596"
+        "id" : "https://www.example.org/22dd47ba-81de-4feb-b293-f2a138113b57"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,24 +62,24 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/50404a4f-af87-443b-aab1-ea0996d03aa4",
-        "name" : "7K8HVsgHFLuYpK9",
+        "id" : "https://www.example.org/a39518a4-86d9-48e1-ad93-98ed0a71c9af",
+        "name" : "LnHC0Cj2fqwcmO",
         "nameType" : "Personal",
-        "orcId" : "Yt2v3g6eoYqtNl",
+        "orcId" : "WX4JpxKOSpsJB2mzw",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "D2LCdv5CtNFP1I",
-          "value" : "y59lfCzwkVIj"
+          "sourceName" : "p7jrY72UPXoTp",
+          "value" : "h259JQqutEiTX5XGU"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t7zQJUHUr94u",
-          "value" : "82jQCpbEfX1jjwluK"
+          "sourceName" : "FLomY5vqCuWb3A",
+          "value" : "s9YZAsAH6DcnCfK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ae06196b-dc4f-44fb-8e4e-c782d1e785fa"
+        "id" : "https://www.example.org/64243cd2-a77c-4c06-94a3-c83312955ef1"
       } ],
       "role" : {
         "type" : "AcademicCoordinator"
@@ -88,123 +88,129 @@
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "ryc8xUTnETuWp"
+      "hu" : "yBSXV9qH5Kd3peMNZ1J"
     },
-    "npiSubjectHeading" : "Nc3DVXICOQ1p",
-    "tags" : [ "UKabFZKBQAg" ],
-    "description" : "JD79vJXO0jFjBp",
+    "npiSubjectHeading" : "v5MUzlEWokv5nyG7cH",
+    "tags" : [ "wjl8cUI7pOeiTw8" ],
+    "description" : "C9LfsTYGl2EJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0d9e0a6e-53ef-42c6-a418-ef751166e097",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e5b9b141-5500-4ecb-bb4c-e86a01eb5be3",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/8ea579f2-9776-48f2-b8ff-ecd4de271d1c",
+      "doi" : "https://www.example.org/216ed66e-32fd-498d-8bab-c74b025a63ba",
       "publicationInstance" : {
         "type" : "DataSet",
         "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "HXRF0cpIvxB1IjuzB"
+          "description" : "IAoQkj4Aa20tb7zYyYQ"
         },
-        "referencedBy" : [ "https://www.example.com/8yjkGuUW3ns943W0UoD" ],
+        "referencedBy" : [ "https://www.example.com/5ZgLROyo4YAzyWC" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "7kkXrvbbVLN2a"
+          "text" : "d1gi3OjYydMgwXb"
         } ],
-        "compliesWith" : [ "https://www.example.com/gbEDwr7PsFL" ],
+        "compliesWith" : [ "https://www.example.com/ZBkcW1h2EJf" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a814d1b7-2835-46d2-91ac-76bb0497004b",
-    "abstract" : "5BigZFwDokcFZqx7"
+    "metadataSource" : "https://www.example.org/d47144c2-f5d1-4034-9084-33926039c5e2",
+    "abstract" : "SKuzHxT4BvJ933o"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/15c4f7b0-768c-4312-a56f-6dc9ced42431",
-    "name" : "H0mEiJvUCR",
+    "id" : "https://www.example.org/29d4ec04-4a8c-4f02-ba95-e2c66cd03d53",
+    "name" : "6osG4kuPkjBKeyMs",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-05-27T22:54:41.549Z",
+      "approvalDate" : "2019-11-19T12:28:49.585Z",
       "approvedBy" : "NMA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "TwbZKLLKHL"
+      "applicationCode" : "u51PesJD1C2mMk"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/0fd83971-205f-4127-957e-4496226f2876",
-    "identifier" : "oWIHluEZPpEfDma4mQA",
+    "source" : "https://www.example.org/b54d5e05-14e7-4be2-a7b6-9d4984d61b92",
+    "identifier" : "ZRWI8n2OWTtk",
     "labels" : {
-      "af" : "FdlidZn29TsMXC0YIJT"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2069104868
-    },
-    "activeFrom" : "2008-07-08T20:48:23.476Z",
-    "activeTo" : "2017-11-06T23:42:31.340Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1f64f424-bf49-42a2-b24f-c86adbd3e423",
-    "id" : "https://www.example.org/a0103aa6-a903-40d0-bd77-201fc1372245",
-    "identifier" : "jDitES5cUB3",
-    "labels" : {
-      "pl" : "MXVV7hCowaI0nZQr"
+      "ca" : "yV5JFl3LMu"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2002128501
+      "amount" : 1496437908
     },
-    "activeFrom" : "2013-01-31T15:54:42.964Z",
-    "activeTo" : "2023-06-29T22:11:36.576Z"
+    "activeFrom" : "2020-10-09T21:19:54.159Z",
+    "activeTo" : "2023-11-09T23:04:16.709Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/1e20b82c-732c-4cf0-9954-2cb26617c69d",
+    "id" : "https://www.example.org/d4422a24-2cce-4fef-9b79-fe489c5e412a",
+    "identifier" : "noDcarpS8i",
+    "labels" : {
+      "fr" : "LKlkULo5tXpQjC5wE78"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1735175123
+    },
+    "activeFrom" : "2000-12-08T13:45:40.564Z",
+    "activeTo" : "2014-05-11T19:59:38.082Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4303bbe8-12d9-4fb1-b082-03f947f18f0c" ],
+  "subjects" : [ "https://www.example.org/7ae4bc50-23d2-45fc-a3f8-838932165430" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0e36534d-7982-4446-a034-bfe931adc541",
-    "name" : "OwCFE2uXsS94VrX",
-    "mimeType" : "4HGmvI7ABF2tp",
-    "size" : 2206982,
-    "license" : "https://www.example.com/iscyea1zjqoura",
+    "identifier" : "c4be57cb-2f9c-4859-b4ee-bd05e08f9acf",
+    "name" : "rea7ADuS7OZV",
+    "mimeType" : "rjplKJEHjJNapbghHd",
+    "size" : 568768786,
+    "license" : "https://www.example.com/gdnkarbnojhv",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "xhowGKPMaaR"
     },
-    "legalNote" : "zzs5Ifs6rZvUq",
-    "publishedDate" : "1973-03-30T06:44:25.982Z",
+    "legalNote" : "UsA3gKCq3Zpj",
+    "publishedDate" : "1975-07-11T14:55:16.254Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "zBTlMnH29AdcjLOhi0",
+      "uploadedDate" : "2018-11-15T12:13:16.373Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/g4oDFayC6oVPwV0",
-    "name" : "XBGqo4NtSN8RXN6SBF",
-    "description" : "VDobtgNpOj7umT"
+    "id" : "https://www.example.com/ECrLzcxssv9odH1Gm",
+    "name" : "bsCsnbqLReo3OGyCouN",
+    "description" : "YHvbqTfwQHa10oUQgER"
   } ],
-  "rightsHolder" : "ETWCFygb8B7",
-  "duplicateOf" : "https://www.example.org/5d3e1a55-1c3e-459a-b5c2-b0e78c2c11da",
+  "rightsHolder" : "RrCCfIkgbZBUW",
+  "duplicateOf" : "https://www.example.org/2a67f1cc-89cb-450d-9c1e-a90d8b5b9232",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "RdNzBeW2SMq3w"
+    "note" : "uk5gi4hm8A8hv4"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oFUDofLMjQBYkP0AFh",
-    "createdBy" : "avSispcjxkh4cWUSq",
-    "createdDate" : "1977-01-27T20:33:38.187Z"
+    "note" : "w4kyYBb1PprBV0Z",
+    "createdBy" : "jbxUcEtVmRtaePxQsV",
+    "createdDate" : "1997-11-24T18:26:45.175Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/21a96c60-8fa7-4e1e-9caf-c1f99132c73d" ],
+  "curatingInstitutions" : [ "https://www.example.org/158d2087-103d-4135-ada2-7d4589e3931c" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/DataSet.json
+++ b/documentation/DataSet.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "y4ShZ1L59K",
-    "ownerAffiliation" : "https://www.example.org/22b1b6db-4d7d-4334-acbd-ea25f1d23271"
+    "owner" : "Z1RPdJP4X3PNcvltGC",
+    "ownerAffiliation" : "https://www.example.org/93f4774e-0a49-4783-8ddb-247e289aed34"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b6704df5-b4e1-4819-a5eb-d58907fa17e6"
+    "id" : "https://www.example.org/139f323d-ddb4-4408-8572-2d5568e90eeb"
   },
-  "createdDate" : "2005-12-28T21:10:03.160Z",
-  "modifiedDate" : "1977-10-05T08:58:09.888Z",
-  "publishedDate" : "1978-10-07T08:39:52.535Z",
-  "indexedDate" : "2007-11-23T11:10:30.361Z",
-  "handle" : "https://www.example.org/ba5fb6bb-5e01-45af-9e3f-525e110c2f47",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/3ace3f9a-3d64-43f6-a50a-36a1bfba138e",
+  "createdDate" : "1981-06-24T18:11:48.557Z",
+  "modifiedDate" : "1999-04-14T23:37:40.352Z",
+  "publishedDate" : "1972-12-23T12:04:22.865Z",
+  "indexedDate" : "1981-04-22T05:05:25.954Z",
+  "handle" : "https://www.example.org/42b50d0f-67bd-49a8-ac33-5c2bd14c434c",
+  "doi" : "https://doi.org/10.1234/tempora",
+  "link" : "https://www.example.org/b0cc3af2-5cfb-47c4-87d3-b4a7e9380889",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "t1DbzMVoOTAvEUQ",
+    "mainTitle" : "jmU8zaXpRyU5l7okTD",
     "alternativeTitles" : {
-      "fi" : "e5dk8CVEW23VQK0FcOx"
+      "fr" : "y3UhDmGmGR1qAE"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "2ylg9II817K",
-      "month" : "wxHSEAp02x2e6Jsw",
-      "day" : "ZV3FmOMrhm"
+      "year" : "TUDYZ0ajClHQQJvaEs3",
+      "month" : "bdNFywXHUWo",
+      "day" : "oTW6J3PZETNH"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4f2a40ef-d74b-4904-91b1-3b001c0250cd",
-        "name" : "usriMO7mGMMW",
-        "nameType" : "Personal",
-        "orcId" : "QmnfzaDtJFd3V",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/0828e91b-bd85-4594-aec8-b513eb4f207a",
+        "name" : "JCkc4EJgzMlhi54",
+        "nameType" : "Organizational",
+        "orcId" : "jV9YRbLAeG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Pji5Yddh8JfSEL",
-          "value" : "GyWWavozFNxvTqyHEe5"
+          "sourceName" : "VpUpfNMpt9Q",
+          "value" : "D8Enk2nyDIP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NywrATsM5M1xZtr5s",
-          "value" : "d09BhDUP8eoA2wsSs"
+          "sourceName" : "KpZdISDZv3i",
+          "value" : "zz4Jw5nQOpu7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/50cc5168-9c1e-46e8-930f-bae3e54f8cce"
+        "id" : "https://www.example.org/51be219b-e824-4c99-acba-f49d36bfe596"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "SoundDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,148 +62,149 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e5b16a39-14ec-4903-8ffb-d408b61ecb42",
-        "name" : "RRIrPSgspDJ",
-        "nameType" : "Organizational",
-        "orcId" : "Eh7hKryhMhfbw16",
+        "id" : "https://www.example.org/50404a4f-af87-443b-aab1-ea0996d03aa4",
+        "name" : "7K8HVsgHFLuYpK9",
+        "nameType" : "Personal",
+        "orcId" : "Yt2v3g6eoYqtNl",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "P7fxSi3T7MV",
-          "value" : "vSur4LqCfbWwLhGQ1k"
+          "sourceName" : "D2LCdv5CtNFP1I",
+          "value" : "y59lfCzwkVIj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aAa6Ewcae8lgWHef",
-          "value" : "TkgxORlKa7f"
+          "sourceName" : "t7zQJUHUr94u",
+          "value" : "82jQCpbEfX1jjwluK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c0993ebf-da11-4659-8829-c2de3d4c2b28"
+        "id" : "https://www.example.org/ae06196b-dc4f-44fb-8e4e-c782d1e785fa"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "PUhoMIKuiGWtsSJ"
+      "bg" : "ryc8xUTnETuWp"
     },
-    "npiSubjectHeading" : "BBqMnutjD5ls",
-    "tags" : [ "y344biKioFmKS6rS" ],
-    "description" : "K7GZav3BiyCo5Ogtm",
+    "npiSubjectHeading" : "Nc3DVXICOQ1p",
+    "tags" : [ "UKabFZKBQAg" ],
+    "description" : "JD79vJXO0jFjBp",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ResearchData",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f0337d7b-c893-4d14-8d75-d9ed4eb648e0",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0d9e0a6e-53ef-42c6-a418-ef751166e097",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/a44fdfd4-6b03-4cda-b8a5-a773c7471eea",
+      "doi" : "https://www.example.org/8ea579f2-9776-48f2-b8ff-ecd4de271d1c",
       "publicationInstance" : {
         "type" : "DataSet",
         "userAgreesToTermsAndConditions" : false,
         "geographicalCoverage" : {
           "type" : "GeographicalDescription",
-          "description" : "xlVBq2pIxCj"
+          "description" : "HXRF0cpIvxB1IjuzB"
         },
-        "referencedBy" : [ "https://www.example.com/sSxBAx8Y7TG3CX8Ql3z" ],
+        "referencedBy" : [ "https://www.example.com/8yjkGuUW3ns943W0UoD" ],
         "related" : [ {
           "type" : "UnconfirmedDocument",
-          "text" : "sVIdlEyZ46Qxmh"
+          "text" : "7kkXrvbbVLN2a"
         } ],
-        "compliesWith" : [ "https://www.example.com/Yw7VGLYNnM" ],
+        "compliesWith" : [ "https://www.example.com/gbEDwr7PsFL" ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/97bd57bc-32a9-4d80-83a7-79a0536d3bbf",
-    "abstract" : "F921RaX3Z5gAc"
+    "metadataSource" : "https://www.example.org/a814d1b7-2835-46d2-91ac-76bb0497004b",
+    "abstract" : "5BigZFwDokcFZqx7"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/653b3d0e-fc17-4d0e-9bb7-f26a92a4547a",
-    "name" : "y64vscc9Vpl",
+    "id" : "https://www.example.org/15c4f7b0-768c-4312-a56f-6dc9ced42431",
+    "name" : "H0mEiJvUCR",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-02-09T15:56:17.063Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "C76ejb4NOobuy7I0"
+      "approvalDate" : "1996-05-27T22:54:41.549Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "TwbZKLLKHL"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f3e5cbbf-eebe-4ec5-a04f-07f277732c3a",
-    "identifier" : "mNFBw3PJQA0CSM",
+    "source" : "https://www.example.org/0fd83971-205f-4127-957e-4496226f2876",
+    "identifier" : "oWIHluEZPpEfDma4mQA",
     "labels" : {
-      "bg" : "unUovnGuNS62bdvQcR"
+      "af" : "FdlidZn29TsMXC0YIJT"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 149400272
+      "currency" : "USD",
+      "amount" : 2069104868
     },
-    "activeFrom" : "1993-12-27T02:53:47.553Z",
-    "activeTo" : "1996-01-20T03:22:59.502Z"
+    "activeFrom" : "2008-07-08T20:48:23.476Z",
+    "activeTo" : "2017-11-06T23:42:31.340Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/759b5393-cd0e-4336-89cc-fd10c753d11f",
-    "id" : "https://www.example.org/9f7d6609-2c99-4272-8b6e-b5305e986c09",
-    "identifier" : "ixWfrXuCzYX5",
+    "source" : "https://www.example.org/1f64f424-bf49-42a2-b24f-c86adbd3e423",
+    "id" : "https://www.example.org/a0103aa6-a903-40d0-bd77-201fc1372245",
+    "identifier" : "jDitES5cUB3",
     "labels" : {
-      "pt" : "jBB05pGjy9WxfYQw1"
+      "pl" : "MXVV7hCowaI0nZQr"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1894755901
+      "currency" : "EUR",
+      "amount" : 2002128501
     },
-    "activeFrom" : "1997-10-06T20:46:50.236Z",
-    "activeTo" : "2007-07-18T19:48:12.915Z"
+    "activeFrom" : "2013-01-31T15:54:42.964Z",
+    "activeTo" : "2023-06-29T22:11:36.576Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e79a4f73-c495-4879-acaa-899f4cc2a5ff" ],
+  "subjects" : [ "https://www.example.org/4303bbe8-12d9-4fb1-b082-03f947f18f0c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "638c1986-059e-4369-898d-96df4097dcf7",
-    "name" : "so89zV9oIIqM",
-    "mimeType" : "B6y7pKHEqSW",
-    "size" : 223200916,
-    "license" : "https://www.example.com/cikqrpauybe6gmxqwj",
+    "identifier" : "0e36534d-7982-4446-a034-bfe931adc541",
+    "name" : "OwCFE2uXsS94VrX",
+    "mimeType" : "4HGmvI7ABF2tp",
+    "size" : 2206982,
+    "license" : "https://www.example.com/iscyea1zjqoura",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "vptqEK2eob",
-    "publishedDate" : "2007-05-02T17:19:07.315Z",
+    "legalNote" : "zzs5Ifs6rZvUq",
+    "publishedDate" : "1973-03-30T06:44:25.982Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/iiXoE50VXUODuD",
-    "name" : "1IrZvH3t7BsQgijrxA",
-    "description" : "PMvDxiJA2W1Ffmeinv"
+    "id" : "https://www.example.com/g4oDFayC6oVPwV0",
+    "name" : "XBGqo4NtSN8RXN6SBF",
+    "description" : "VDobtgNpOj7umT"
   } ],
-  "rightsHolder" : "ynGhhFrl82idN1lM",
-  "duplicateOf" : "https://www.example.org/8c6c76d2-6a7d-4ea9-945e-fc766132fd89",
+  "rightsHolder" : "ETWCFygb8B7",
+  "duplicateOf" : "https://www.example.org/5d3e1a55-1c3e-459a-b5c2-b0e78c2c11da",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "juNLFoirxJyQWZ0DG"
+    "note" : "RdNzBeW2SMq3w"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "YOxnoqKVoYXhSGhZjDV",
-    "createdBy" : "rJ9GNYrcRT6Psduf",
-    "createdDate" : "1979-02-28T04:32:04.447Z"
+    "note" : "oFUDofLMjQBYkP0AFh",
+    "createdBy" : "avSispcjxkh4cWUSq",
+    "createdDate" : "1977-01-27T20:33:38.187Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1892389a-3425-454c-9ec2-267a024bf46f" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/21a96c60-8fa7-4e1e-9caf-c1f99132c73d" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "CUc2lzhwwymPk",
-    "ownerAffiliation" : "https://www.example.org/087f85e9-9d01-4fe8-a6db-19baf835c96c"
+    "owner" : "viujNJ0EJ4nb",
+    "ownerAffiliation" : "https://www.example.org/1013a746-2e88-448b-9a70-d4bc727a3550"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c32ac933-073f-461e-a911-abb1c1733da0"
+    "id" : "https://www.example.org/8e48497a-6a29-4b4e-bda9-f9bcae1e4e11"
   },
-  "createdDate" : "2011-09-19T04:47:22.788Z",
-  "modifiedDate" : "1982-12-05T18:29:21.891Z",
-  "publishedDate" : "1993-02-18T23:46:37.378Z",
-  "indexedDate" : "2000-03-16T20:35:53.473Z",
-  "handle" : "https://www.example.org/bf35cb60-64d9-4a64-ae9c-167c6a80c119",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/7ad6778d-c291-4556-8bcd-6ffe03a255cf",
+  "createdDate" : "2015-02-13T20:33:30.226Z",
+  "modifiedDate" : "2004-12-17T16:31:36.433Z",
+  "publishedDate" : "1990-05-26T13:02:09.099Z",
+  "indexedDate" : "2021-12-21T11:08:52.542Z",
+  "handle" : "https://www.example.org/5bfdf32b-1096-4017-9321-87bc791fb8ec",
+  "doi" : "https://doi.org/10.1234/suscipit",
+  "link" : "https://www.example.org/8498a95c-8db2-4d54-b703-9dc94b452d1c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "IaWzlYJBY09f4Bu",
+    "mainTitle" : "F7qaK5wE708n",
     "alternativeTitles" : {
-      "el" : "R8zIx1rGky8XhfKRLB"
+      "bg" : "08TCV1iLnuC8m"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iLfTnAuyCWp",
-      "month" : "n4ssYicJm0rlFUVLtk",
-      "day" : "bxyoxwXah6MyEcBxT"
+      "year" : "iU2BmyvqAnvKTD2s",
+      "month" : "gm2h8pDoF9hdB",
+      "day" : "5CFsMzVLGLRW5CeP2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c91d3752-fcfe-429f-bdd6-9ba073260fa4",
-        "name" : "kjCoptUtrhX",
-        "nameType" : "Organizational",
-        "orcId" : "UyGC8IEmDe3GMr0",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/205d13e5-f51d-49fd-898e-3fb1af704c38",
+        "name" : "8XYD7EMPhVACj5aqHsf",
+        "nameType" : "Personal",
+        "orcId" : "wtC5OwKkAGW7ha",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "72CKfne0zNynVbLH7i",
-          "value" : "0n8MIb8WRjDUg8"
+          "sourceName" : "KytnYbTmFyAYPi",
+          "value" : "fQm25WzJnlHi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4UD0biemHIAtS8",
-          "value" : "SQonIjFE9T2Sp"
+          "sourceName" : "K6F5D7YSSWMd",
+          "value" : "HAV4ZzoDm9r"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fc09ec1b-ce6f-4e0e-9035-cf15f7b5ecd3"
+        "id" : "https://www.example.org/6bf33085-de10-4913-92b3-754918986db6"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,166 +62,171 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a2621383-3a5b-4e54-8b83-7ba01db1814f",
-        "name" : "S5xUPvbEGux",
-        "nameType" : "Organizational",
-        "orcId" : "xYMsDhwoDd",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/5eb3e1e1-0494-4efc-be4c-b0819a47228d",
+        "name" : "CK6SxnhdArpQH4Fsget",
+        "nameType" : "Personal",
+        "orcId" : "2MAQXG62qJatcK0JH8X",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sBf4UiqHPpqx2E",
-          "value" : "iEn9poaFrsLwSPcX"
+          "sourceName" : "zbDzyYQfyO8Nmo5RWxF",
+          "value" : "K9MJiHlr5QERH8uKUZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hJTGRCaDGlhk1KLsvK",
-          "value" : "tSDxjXqyv1rB3"
+          "sourceName" : "Eoob6x1tzbmvlX",
+          "value" : "3g8QaDp2rHkmGQxP"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dd91019c-6128-4235-86d7-ff7177c1f200"
+        "id" : "https://www.example.org/5b470b63-b92e-49aa-9ba1-2c83f06e7dbb"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "rD3ZBX2y9V4zxXd6"
+      "fi" : "bzGhhuoKwNXxp"
     },
-    "npiSubjectHeading" : "448EzMCAXRcoc",
-    "tags" : [ "X2DPRV8BdMGMmRis1gv" ],
-    "description" : "O5JAFoBxC5ZWg",
+    "npiSubjectHeading" : "IiiiRzs0VcbTw",
+    "tags" : [ "uuSc4C7oEg47JE0" ],
+    "description" : "9GQw1WsIJ3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bee57022-4755-4c58-870f-304fe158b010"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/08bec17e-3363-477e-98bc-1cc279d5d478"
         },
-        "seriesNumber" : "jyOkrgTUoALrymxzIXS",
+        "seriesNumber" : "sM3EjsqJKo",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f4ea0a88-ed22-47b3-99e6-c67bf1539b10",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/652a40a3-92d9-447a-80e1-54c4e1b0d6bc",
           "valid" : true
         },
-        "isbnList" : [ "9781076602275" ],
+        "isbnList" : [ "9780739238929", "9780032768109" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "DJR4JaNtfbqoPfZKl"
+          "code" : "W4GVGX9jYxueQkPq"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "jphaQ4u0bzNU0In7"
+          "value" : "0032768109"
         } ]
       },
-      "doi" : "https://www.example.org/7505bb86-65d7-4c0d-bcdf-3efc99508c16",
+      "doi" : "https://www.example.org/c6d91c18-f825-42c9-ab55-c363ee7f5926",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "hRNxDhfEMN0Z27c",
-            "end" : "gOVEMYyKqRg29bFE0S"
+            "begin" : "oXQVyPuUPTZzq5Tw",
+            "end" : "Gj8hMGQ09yz0AywQ1"
           },
-          "pages" : "xcTqylu1kwp",
+          "pages" : "9aCb1Ek2c46Up",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "JuNAaHQXmiOlNV",
-          "month" : "Af1UtSVtqMx",
-          "day" : "vTxS7cg6jLiTidy"
+          "year" : "dQIuSqyAV6",
+          "month" : "crev3BO09W43FY",
+          "day" : "X19k3CRJ3rxMX"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3f814cf6-5ed3-4617-8acb-aa45c6022271",
-    "abstract" : "01gAWEovBrecajXFI"
+    "metadataSource" : "https://www.example.org/175fea36-14f2-4216-b987-3df0b63109f1",
+    "abstract" : "CpLVR3PxcRk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0c150a7e-0fde-4b58-83a3-04abcc46b9db",
-    "name" : "Up2ihrWDyq2qOOA7H",
+    "id" : "https://www.example.org/3a68f9b2-3fca-48a7-a794-6861d5793124",
+    "name" : "yq7ByXuzy4CshlE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-11-08T05:20:31.814Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "NSkiAqPelnewxSa2"
+      "approvalDate" : "1989-01-19T00:48:42.525Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "7FttYD1yCTpel3DXqqG"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/630adaa5-4580-42be-9872-2006014cbf77",
-    "identifier" : "UJiBcMHYQG",
+    "source" : "https://www.example.org/6b55e978-45c2-4eee-b29d-d8e7a5cc4737",
+    "identifier" : "dze2I0rokShW9dDpHu",
     "labels" : {
-      "ca" : "oVIlqnbyM0"
+      "it" : "U2pg9J921CINHeopMYc"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1967015486
+      "currency" : "USD",
+      "amount" : 1998092208
     },
-    "activeFrom" : "2009-10-07T16:44:39.860Z",
-    "activeTo" : "2021-02-24T23:05:36.805Z"
+    "activeFrom" : "2009-10-19T06:12:37.907Z",
+    "activeTo" : "2010-10-04T14:20:00.817Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/16cc7a35-cb21-45e0-bb4c-1fce26de7d97",
-    "id" : "https://www.example.org/6d009698-b04b-4d26-8a98-0875002518cc",
-    "identifier" : "CjoPGCsYX9OZy1",
+    "source" : "https://www.example.org/4cd9528a-2280-4e8e-91c6-03d79380503f",
+    "id" : "https://www.example.org/6dddad81-c967-462a-acf1-6b10de468e39",
+    "identifier" : "En8bgr6ZrWk",
     "labels" : {
-      "is" : "XptxUZPmdR7HB5"
+      "nn" : "DeI94mzHgp"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1193814162
+      "currency" : "USD",
+      "amount" : 987305966
     },
-    "activeFrom" : "2003-05-14T06:06:48.611Z",
-    "activeTo" : "2009-12-01T14:48:17.823Z"
+    "activeFrom" : "2014-10-19T18:09:20.456Z",
+    "activeTo" : "2015-07-11T19:03:10.693Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4f65ec93-2be0-4de7-821b-c6ccc851489a" ],
+  "subjects" : [ "https://www.example.org/b24309f3-837e-4281-b390-24a47ecebbc6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6a67872e-8913-4865-acd4-2cf0168d5493",
-    "name" : "jKsuoGOSFxYr34m",
-    "mimeType" : "UCPiFR0NZrZwqk4kE8e",
-    "size" : 1596265122,
-    "license" : "https://www.example.com/rsr7xu924nxf69o",
+    "identifier" : "ac6f6c65-c93a-46c2-9205-9c29f9759b82",
+    "name" : "fgiDrWyO2uX06NHWL1t",
+    "mimeType" : "sjHrDLDra2AOQPPPZak",
+    "size" : 1676642590,
+    "license" : "https://www.example.com/oupytxjazwzzsz0pzpn",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "PWCWg7hKxxHLHyokW",
-    "publishedDate" : "1986-05-01T19:00:22.654Z",
+    "legalNote" : "yqpi4PvU38w1l7Gs",
+    "publishedDate" : "2017-01-31T03:12:26.204Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "jZQyJPmjxfOo4y",
+      "uploadedDate" : "1997-11-05T22:22:49.102Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/T61aJwGLFXgU5",
-    "name" : "D5YTqMuUO83A72w",
-    "description" : "radiqfw4XYJreV"
+    "id" : "https://www.example.com/uAjq0BgrOR62V",
+    "name" : "GjMoUTXNmKcXB9A",
+    "description" : "KipyT9g5NHkvP"
   } ],
-  "rightsHolder" : "wI9BZcQG3j",
-  "duplicateOf" : "https://www.example.org/fcbe55a8-f999-4401-8490-6f004455846d",
+  "rightsHolder" : "FBYVzQHmN2aiR4MUG",
+  "duplicateOf" : "https://www.example.org/a505a8e3-fa4e-4901-aa16-8017900d799d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vIKnRVNai7pJnA"
+    "note" : "8MONhL9qpZV7Wt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "IbZgLO16uHaS4",
-    "createdBy" : "RONVp2eaDYv3Q7izy6",
-    "createdDate" : "1990-07-12T11:51:38.282Z"
+    "note" : "aRJDsG4PkQ",
+    "createdBy" : "b0VOUGC1S183I3z",
+    "createdDate" : "1989-11-10T15:23:54.208Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/25030996-0d6c-4907-8135-4547ed3f50c0" ],
+  "curatingInstitutions" : [ "https://www.example.org/f4902653-edc8-4e9f-81ed-9590b4b24c42" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/DegreeBachelor.json
+++ b/documentation/DegreeBachelor.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "TB2QBNkzgwsePE7Bf",
-    "ownerAffiliation" : "https://www.example.org/018eff7a-40bf-4a3a-897d-eff0a1c3a46f"
+    "owner" : "CUc2lzhwwymPk",
+    "ownerAffiliation" : "https://www.example.org/087f85e9-9d01-4fe8-a6db-19baf835c96c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/63de8c17-9f17-4731-9d0d-dc56bf55b8d5"
+    "id" : "https://www.example.org/c32ac933-073f-461e-a911-abb1c1733da0"
   },
-  "createdDate" : "1981-03-04T01:09:54.725Z",
-  "modifiedDate" : "1992-04-27T14:49:40.390Z",
-  "publishedDate" : "1971-01-07T10:21:22.148Z",
-  "indexedDate" : "2003-03-27T14:12:00.416Z",
-  "handle" : "https://www.example.org/41267982-ead9-407c-9322-97a44b580de6",
-  "doi" : "https://doi.org/10.1234/ab",
-  "link" : "https://www.example.org/78f9bc90-a65e-4c7d-ad1e-bb25b71ed023",
+  "createdDate" : "2011-09-19T04:47:22.788Z",
+  "modifiedDate" : "1982-12-05T18:29:21.891Z",
+  "publishedDate" : "1993-02-18T23:46:37.378Z",
+  "indexedDate" : "2000-03-16T20:35:53.473Z",
+  "handle" : "https://www.example.org/bf35cb60-64d9-4a64-ae9c-167c6a80c119",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/7ad6778d-c291-4556-8bcd-6ffe03a255cf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "oYMnx7WSJW",
+    "mainTitle" : "IaWzlYJBY09f4Bu",
     "alternativeTitles" : {
-      "fr" : "pDKWk8nmWkLiw8xqBM"
+      "el" : "R8zIx1rGky8XhfKRLB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uEcidypO9pZ6LOfORG",
-      "month" : "j5ojd2Jd1s0UJj2",
-      "day" : "Iuwi1Mn20ndbselyvF"
+      "year" : "iLfTnAuyCWp",
+      "month" : "n4ssYicJm0rlFUVLtk",
+      "day" : "bxyoxwXah6MyEcBxT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ffbf244e-d8f8-4c57-acf4-c4c1da6d0973",
-        "name" : "Xdkg9gsS6UMqZYfo2b",
+        "id" : "https://www.example.org/c91d3752-fcfe-429f-bdd6-9ba073260fa4",
+        "name" : "kjCoptUtrhX",
         "nameType" : "Organizational",
-        "orcId" : "h7E39cLr5TFVj",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "UyGC8IEmDe3GMr0",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZuEqW9tyiW6l",
-          "value" : "CQSrEHzhte5BJZy652Q"
+          "sourceName" : "72CKfne0zNynVbLH7i",
+          "value" : "0n8MIb8WRjDUg8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hmYna9LycjJ",
-          "value" : "BzD6gVTS266Ar"
+          "sourceName" : "4UD0biemHIAtS8",
+          "value" : "SQonIjFE9T2Sp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d5706056-00a2-433a-b667-90986d528315"
+        "id" : "https://www.example.org/fc09ec1b-ce6f-4e0e-9035-cf15f7b5ecd3"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,166 +62,166 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/91e254af-4730-4279-9c31-32b2b73f65bb",
-        "name" : "7GkjEiyXDU4",
-        "nameType" : "Personal",
-        "orcId" : "q5nbWW6YMFf1ZwV",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a2621383-3a5b-4e54-8b83-7ba01db1814f",
+        "name" : "S5xUPvbEGux",
+        "nameType" : "Organizational",
+        "orcId" : "xYMsDhwoDd",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lsuaiQSpuKhD9e",
-          "value" : "W7D0W9iW0ewPep"
+          "sourceName" : "sBf4UiqHPpqx2E",
+          "value" : "iEn9poaFrsLwSPcX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OvFoyz8bzP39vUnwojm",
-          "value" : "HGwc8N3o3d"
+          "sourceName" : "hJTGRCaDGlhk1KLsvK",
+          "value" : "tSDxjXqyv1rB3"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fcc2899d-c0e8-4c8b-8c17-877d578a1d3c"
+        "id" : "https://www.example.org/dd91019c-6128-4235-86d7-ff7177c1f200"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "hyC5XvYeaZwckhskq3"
+      "pt" : "rD3ZBX2y9V4zxXd6"
     },
-    "npiSubjectHeading" : "HQNaJV77jNquPJ3g",
-    "tags" : [ "dPkBWk4e8IhEDWC2XJ" ],
-    "description" : "v0UCoIphX6",
+    "npiSubjectHeading" : "448EzMCAXRcoc",
+    "tags" : [ "X2DPRV8BdMGMmRis1gv" ],
+    "description" : "O5JAFoBxC5ZWg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0643ebb8-3ba8-4185-b271-b629f51dbde5"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bee57022-4755-4c58-870f-304fe158b010"
         },
-        "seriesNumber" : "AZXzBsm14C",
+        "seriesNumber" : "jyOkrgTUoALrymxzIXS",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c45d0f1c-3659-49e4-a203-54d08ab8e355",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f4ea0a88-ed22-47b3-99e6-c67bf1539b10",
           "valid" : true
         },
-        "isbnList" : [ "9780547195872" ],
+        "isbnList" : [ "9781076602275" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "Bnmt6P45x8ggf2"
+          "code" : "DJR4JaNtfbqoPfZKl"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "1UArKw9nZr2"
+          "value" : "jphaQ4u0bzNU0In7"
         } ]
       },
-      "doi" : "https://www.example.org/e958d0b4-75ff-4008-9967-3e5836cbc088",
+      "doi" : "https://www.example.org/7505bb86-65d7-4c0d-bcdf-3efc99508c16",
       "publicationInstance" : {
         "type" : "DegreeBachelor",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "uQBAgCG4I6Mc1R3rWN9",
-            "end" : "QLJNZWXCwbAuqtP"
+            "begin" : "hRNxDhfEMN0Z27c",
+            "end" : "gOVEMYyKqRg29bFE0S"
           },
-          "pages" : "z62uk8oC3zvvLY35H",
+          "pages" : "xcTqylu1kwp",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "TXzVhP89dzPJK17H26R",
-          "month" : "z64F0DIZTGUM",
-          "day" : "U8zyurRcucn"
+          "year" : "JuNAaHQXmiOlNV",
+          "month" : "Af1UtSVtqMx",
+          "day" : "vTxS7cg6jLiTidy"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/78fe2c39-04c9-4fea-b355-fd088897ae5b",
-    "abstract" : "QqXx0gf2yPZkHncLF"
+    "metadataSource" : "https://www.example.org/3f814cf6-5ed3-4617-8acb-aa45c6022271",
+    "abstract" : "01gAWEovBrecajXFI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/84a825a2-3bd7-46cb-b274-30f84d6600a0",
-    "name" : "jyVtPEtFeb7RboIDo",
+    "id" : "https://www.example.org/0c150a7e-0fde-4b58-83a3-04abcc46b9db",
+    "name" : "Up2ihrWDyq2qOOA7H",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-03-02T04:55:10.025Z",
+      "approvalDate" : "1994-11-08T05:20:31.814Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "soJjG63oag"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "NSkiAqPelnewxSa2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/37f54d8a-6cf5-4b7a-99e9-174a735ff38a",
-    "identifier" : "RVedKMhLnMmA1Fw",
+    "source" : "https://www.example.org/630adaa5-4580-42be-9872-2006014cbf77",
+    "identifier" : "UJiBcMHYQG",
     "labels" : {
-      "ca" : "EGdw8QDynO"
+      "ca" : "oVIlqnbyM0"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 17233737
+      "currency" : "NOK",
+      "amount" : 1967015486
     },
-    "activeFrom" : "1983-03-23T21:44:41.680Z",
-    "activeTo" : "2001-06-20T21:19:02.814Z"
+    "activeFrom" : "2009-10-07T16:44:39.860Z",
+    "activeTo" : "2021-02-24T23:05:36.805Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9f722b85-cc35-4bf4-a5b1-e1e71ff92d89",
-    "id" : "https://www.example.org/759283f9-7a83-49b7-96f0-b0d7ca971397",
-    "identifier" : "qws4rSucJxMzD0AU",
+    "source" : "https://www.example.org/16cc7a35-cb21-45e0-bb4c-1fce26de7d97",
+    "id" : "https://www.example.org/6d009698-b04b-4d26-8a98-0875002518cc",
+    "identifier" : "CjoPGCsYX9OZy1",
     "labels" : {
-      "is" : "fVqrFJggUmSXc534M"
+      "is" : "XptxUZPmdR7HB5"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1626001325
+      "currency" : "GBP",
+      "amount" : 1193814162
     },
-    "activeFrom" : "1982-04-27T11:53:56.243Z",
-    "activeTo" : "1988-12-02T16:49:45.187Z"
+    "activeFrom" : "2003-05-14T06:06:48.611Z",
+    "activeTo" : "2009-12-01T14:48:17.823Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/daced0ba-0667-492b-a809-484b4269ceae" ],
+  "subjects" : [ "https://www.example.org/4f65ec93-2be0-4de7-821b-c6ccc851489a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "13ee40bb-6b68-4c16-9d88-02574240bde5",
-    "name" : "Sf5vVU69149s7",
-    "mimeType" : "SoX1B4M6RKOzq2",
-    "size" : 1617485669,
-    "license" : "https://www.example.com/nqok9206g9erew1psy",
+    "identifier" : "6a67872e-8913-4865-acd4-2cf0168d5493",
+    "name" : "jKsuoGOSFxYr34m",
+    "mimeType" : "UCPiFR0NZrZwqk4kE8e",
+    "size" : 1596265122,
+    "license" : "https://www.example.com/rsr7xu924nxf69o",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "kxNHM9DDjcj0EpsURRV"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "oaXBZGUcaLb",
-    "publishedDate" : "2002-07-02T02:30:11.936Z",
+    "legalNote" : "PWCWg7hKxxHLHyokW",
+    "publishedDate" : "1986-05-01T19:00:22.654Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gBAsZVRd0fu4o",
-    "name" : "az5yDVxQZiqcmjOfgoZ",
-    "description" : "xWDqPQcT3IPIleA5uW"
+    "id" : "https://www.example.com/T61aJwGLFXgU5",
+    "name" : "D5YTqMuUO83A72w",
+    "description" : "radiqfw4XYJreV"
   } ],
-  "rightsHolder" : "gH4IYsJ95Pa89",
-  "duplicateOf" : "https://www.example.org/e4868272-9752-40c1-8989-a0865a255ea4",
+  "rightsHolder" : "wI9BZcQG3j",
+  "duplicateOf" : "https://www.example.org/fcbe55a8-f999-4401-8490-6f004455846d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "beh1kv9r999B96f"
+    "note" : "vIKnRVNai7pJnA"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8BJ1fazsF2F298j",
-    "createdBy" : "CER1CWOe8ibEjmu",
-    "createdDate" : "2016-05-01T23:20:41.602Z"
+    "note" : "IbZgLO16uHaS4",
+    "createdBy" : "RONVp2eaDYv3Q7izy6",
+    "createdDate" : "1990-07-12T11:51:38.282Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5066ab65-db89-4ec7-83b8-7f5df46b20de" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/25030996-0d6c-4907-8135-4547ed3f50c0" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "TuRfqPF70Lb",
-    "ownerAffiliation" : "https://www.example.org/fd859a80-7058-4da7-a4de-2d98d3424f04"
+    "owner" : "YjB8v3CkqG8qcSY",
+    "ownerAffiliation" : "https://www.example.org/c2c0924d-56a0-4809-9130-6d2605034568"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ee9701b7-91cd-4197-a832-affae6d70145"
+    "id" : "https://www.example.org/3b41b64e-ddb9-4f09-a42f-651e6824e4a3"
   },
-  "createdDate" : "2010-12-13T07:46:25.050Z",
-  "modifiedDate" : "1975-03-13T07:32:06.705Z",
-  "publishedDate" : "2003-05-03T04:22:11.412Z",
-  "indexedDate" : "2012-12-31T01:03:28.224Z",
-  "handle" : "https://www.example.org/03042743-54f7-4d9b-a74a-1b541e85b6e6",
-  "doi" : "https://doi.org/10.1234/earum",
-  "link" : "https://www.example.org/eadbedfc-a782-4153-b6dc-ff1e0b4ecbc1",
+  "createdDate" : "2009-02-09T01:18:58.292Z",
+  "modifiedDate" : "1971-12-14T07:53:49.960Z",
+  "publishedDate" : "1979-09-08T01:34:27.329Z",
+  "indexedDate" : "2011-08-16T04:05:34.100Z",
+  "handle" : "https://www.example.org/c9d7ab7c-f651-4c6d-9461-a057f2e4777f",
+  "doi" : "https://doi.org/10.1234/debitis",
+  "link" : "https://www.example.org/a39970c9-befa-49fa-a328-cfa64b40e100",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VvwPHqJTpim4MAzx",
+    "mainTitle" : "4trHx5V4OV858Zy",
     "alternativeTitles" : {
-      "ru" : "wnDDtBEau0103zZWE"
+      "pl" : "hpMhlRvkxVbex"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qiKW1Nw6FpvoKIOOJ",
-      "month" : "96ldGx5LNKx",
-      "day" : "AuRpdit7pugUJ"
+      "year" : "Vdc6czQPic5jZSUlOiA",
+      "month" : "UG2LmqZoFqECxIVjT",
+      "day" : "z7qbgRMJn8Tvo7WRhQi"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a1f442e4-0872-45c8-aa6d-2dceaad2d06d",
-        "name" : "ARqfszHlZSz",
-        "nameType" : "Organizational",
-        "orcId" : "HluDQ5RvjDMfjIUwfw",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/9052a5ec-8b28-44ae-a64e-bc86807efd17",
+        "name" : "SOPfBIpf1VewZmB6",
+        "nameType" : "Personal",
+        "orcId" : "72J0VvgIleNj",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MPzu0VzCfty",
-          "value" : "dwFGNXcFYo1xdXY"
+          "sourceName" : "PopjAhqXqdqzxgZ620",
+          "value" : "NcgrILlgEAi875VlR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Pfmnhg7q6Jaij9",
-          "value" : "muZ0c04MAD0k1q"
+          "sourceName" : "PvIBbviD6iLYC8tal",
+          "value" : "k3YShp40tgVBcyGT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a2e3737a-cc7a-42e8-8a7f-3cdf934fb20d"
+        "id" : "https://www.example.org/f9cf7f8d-9908-457a-a704-d4cf78dda90a"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,165 +62,166 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8f35f242-6af8-478e-aaae-356ad52e326e",
-        "name" : "Q9zdtdaMCHN5",
-        "nameType" : "Organizational",
-        "orcId" : "CUp1QalU4nxe",
+        "id" : "https://www.example.org/0757d398-39ae-4d9f-9e8f-d765d8fc81f9",
+        "name" : "dSmzdSO4dUl5mOp",
+        "nameType" : "Personal",
+        "orcId" : "C4mDi39FdVSZLRYP",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "O9f8bAsBBw4VuG",
-          "value" : "ISWfKYj9r0"
+          "sourceName" : "LRJ0fs8YJkc95C7AL",
+          "value" : "G3FCnFXgasZaSNBJQbW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "557vW5kDkz6is",
-          "value" : "NrRNLjXVDuUyRjY9"
+          "sourceName" : "dDhnjtxm7JXprQiqem",
+          "value" : "RVVQr196RPQB89"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/470df839-6ae6-4f94-a9e9-983dc117a9af"
+        "id" : "https://www.example.org/499ce6c8-2eaf-4e5d-ba54-520d5f0f2f61"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "Choreographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "GgFrG74M6IVb1R1CZ"
+      "es" : "JQNkcPHnlDrRThPGdr"
     },
-    "npiSubjectHeading" : "rlP9pcS8K2Xpuug",
-    "tags" : [ "we5LNuTSjQI5WLXb15D" ],
-    "description" : "8I0op5ERjSQi",
+    "npiSubjectHeading" : "NpXG9PNwZ9",
+    "tags" : [ "6Gd4IGMR53" ],
+    "description" : "mw6CypSUTvvd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/28a462b1-39cf-4926-80e9-23545ce613eb"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5edb366d-ff2e-46bb-90e3-5b411402619b"
         },
-        "seriesNumber" : "VftKjKqyqCrw9V76xE",
+        "seriesNumber" : "0LTmmxYV8m",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e3814297-f137-4ab6-8ace-b2137b2da90c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3492deab-23cd-4cea-ad53-87c87620481d",
           "valid" : true
         },
-        "isbnList" : [ "9790400921548" ],
+        "isbnList" : [ "9780011529806" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "BtuOvy874Kkti3JT"
+          "code" : "vjFNl4LeGrtXA50Z"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "s7ab7CI0iKvYuFY"
+          "value" : "sYu5kH2OlaH26UEl3k"
         } ]
       },
-      "doi" : "https://www.example.org/d89fed0c-f0d0-46ba-ab1f-ae3938ba161c",
+      "doi" : "https://www.example.org/2f074f27-4942-4f6e-9a78-b5d91a5e0cdb",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "JFWn0X3ZyHGz7A531",
-            "end" : "avcvKp3cNqs3RfaV"
+            "begin" : "y0jEwQT4rSXna5i5D",
+            "end" : "D9ZvBmfnYwU54HaMM"
           },
-          "pages" : "hkuOlWZDi2aQecb1",
+          "pages" : "wG7NO8sKWHspjQ",
           "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "VupL3C5kaLYviEjq5",
-          "month" : "uryREob8v5lan",
-          "day" : "YqWFicoaqm"
+          "year" : "X1dy7bULpERiuhh",
+          "month" : "RMIeSjAxKUlevNLC5uS",
+          "day" : "rhkQnVU5LJISKCp"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f8536b53-c5d4-4a9e-893c-f87a8eccdbef",
-    "abstract" : "xIebj6bUI4"
+    "metadataSource" : "https://www.example.org/58f060b2-27c1-4d40-89bd-fdfe49754eff",
+    "abstract" : "tWSLkECdhc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3b160b81-fe71-40d5-b60d-d6e9bd433f93",
-    "name" : "DtOVRyJ2CFHtrT",
+    "id" : "https://www.example.org/76574542-714a-4864-91c9-4294f3347db5",
+    "name" : "pwF7fwT099Dt9s",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-08-23T07:51:08.761Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "4nsdSPyb1o"
+      "approvalDate" : "2018-01-06T13:13:37.079Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "pncMPgoMLGKEs0176"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f12621c7-098a-4238-abc3-b90a15176f10",
-    "identifier" : "8TQ6xjqiolw",
+    "source" : "https://www.example.org/7b687ae2-be78-4c34-8fbb-f2aecfc2aaf3",
+    "identifier" : "dBjAz5eQqABekRhH",
     "labels" : {
-      "cs" : "U9YwRyLCunzVrak"
+      "da" : "pGRiFCOJAjv3BUn6x"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1933230812
+      "currency" : "USD",
+      "amount" : 2117252837
     },
-    "activeFrom" : "1989-08-07T19:22:47.464Z",
-    "activeTo" : "1993-12-29T21:37:21.298Z"
+    "activeFrom" : "2008-11-02T23:29:10.663Z",
+    "activeTo" : "2020-04-18T02:20:00.518Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cd5a458f-d03a-4cf9-84aa-e0901f27f5ad",
-    "id" : "https://www.example.org/1027edc7-6fd0-4c78-a5f0-ab78c6bcf248",
-    "identifier" : "1MgdFlmumBFk4WFVfb",
+    "source" : "https://www.example.org/70e7a0f4-fa04-478f-bd23-b33ab44eb4db",
+    "id" : "https://www.example.org/556ad78d-590d-453a-9a1a-a513ddf76535",
+    "identifier" : "nx07JNyyxCN",
     "labels" : {
-      "is" : "z81FTFRI8Ph"
+      "nb" : "kWZEJLHfmjOfq2"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1748201459
+      "currency" : "USD",
+      "amount" : 540417330
     },
-    "activeFrom" : "1979-07-09T07:22:33.448Z",
-    "activeTo" : "2011-08-14T13:31:39.404Z"
+    "activeFrom" : "2005-11-12T20:38:27.982Z",
+    "activeTo" : "2021-02-16T03:31:45.153Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/212d76ac-fe68-414e-824e-2d3a8eeead41" ],
+  "subjects" : [ "https://www.example.org/284d0aa1-7feb-4696-ab40-9a7204e3eea2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c02e35c7-5bc1-4b52-8982-b060256bc840",
-    "name" : "i7bUSBDXmk1",
-    "mimeType" : "f5Psxw9jZW",
-    "size" : 1049472757,
-    "license" : "https://www.example.com/kaudm5mc82",
+    "identifier" : "19c1a507-7c9a-4fcd-9203-369f8d0d4d7d",
+    "name" : "ZFQIdl22DIOrM",
+    "mimeType" : "qXWU7yJ4oHAWONlNg",
+    "size" : 2015093904,
+    "license" : "https://www.example.com/gvmxwrg3khx9wmyudoe",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "GGvh1PDvfum9",
-    "publishedDate" : "2021-05-14T23:38:33.323Z",
+    "legalNote" : "7wGNsVoUTy",
+    "publishedDate" : "2019-07-04T00:39:05.561Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/jW2wpmgCZFPh",
-    "name" : "3iYzfd1Jybp9Dh",
-    "description" : "go1OPrT8pO6"
+    "id" : "https://www.example.com/Jb6q0o23pK7hAUm",
+    "name" : "ONU0khX7Ziv",
+    "description" : "boA4JtJ1N9px"
   } ],
-  "rightsHolder" : "oHyevHS01bzl9bTLPN",
-  "duplicateOf" : "https://www.example.org/51c8cd08-a047-4a93-b186-678f634363b8",
+  "rightsHolder" : "bRQCldSToCIgRNox",
+  "duplicateOf" : "https://www.example.org/4287992a-dde7-42e0-bda1-37571bec1ac5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gbArNVkxTES7c0T"
+    "note" : "kFwfUk4d33jhAugPHZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "xTPukNAQetf1YtLWZ6G",
-    "createdBy" : "izhMgd1V4wNrZ3iKoZ",
-    "createdDate" : "1984-03-02T07:16:18.298Z"
+    "note" : "OqkNwpoEyJPJpwH",
+    "createdBy" : "rTdkmyFAKxDypFPg",
+    "createdDate" : "1975-01-28T12:59:15.397Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e70a3e0b-30c7-4e9f-9792-01d5e1c0e334" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/28aa469e-7a86-4c80-8a6c-29279394d208" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DegreeLicentiate.json
+++ b/documentation/DegreeLicentiate.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "YjB8v3CkqG8qcSY",
-    "ownerAffiliation" : "https://www.example.org/c2c0924d-56a0-4809-9130-6d2605034568"
+    "owner" : "yPrROPwLTM4iBlA4Xha",
+    "ownerAffiliation" : "https://www.example.org/12fe97f6-fc0b-40bd-bc9a-e743b5d1de8e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3b41b64e-ddb9-4f09-a42f-651e6824e4a3"
+    "id" : "https://www.example.org/5f21c777-688b-4ba8-b6c7-4c1948fadfdf"
   },
-  "createdDate" : "2009-02-09T01:18:58.292Z",
-  "modifiedDate" : "1971-12-14T07:53:49.960Z",
-  "publishedDate" : "1979-09-08T01:34:27.329Z",
-  "indexedDate" : "2011-08-16T04:05:34.100Z",
-  "handle" : "https://www.example.org/c9d7ab7c-f651-4c6d-9461-a057f2e4777f",
-  "doi" : "https://doi.org/10.1234/debitis",
-  "link" : "https://www.example.org/a39970c9-befa-49fa-a328-cfa64b40e100",
+  "createdDate" : "2006-03-30T11:38:12.798Z",
+  "modifiedDate" : "2011-06-20T11:54:33.498Z",
+  "publishedDate" : "2007-06-16T09:16:51.437Z",
+  "indexedDate" : "2017-07-18T14:27:04.904Z",
+  "handle" : "https://www.example.org/126a5361-2461-4cce-a275-3898aca711b2",
+  "doi" : "https://doi.org/10.1234/eos",
+  "link" : "https://www.example.org/2a4ce903-240d-41ed-a25c-7f7c4c28e514",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "4trHx5V4OV858Zy",
+    "mainTitle" : "nCgif6DO6mH",
     "alternativeTitles" : {
-      "pl" : "hpMhlRvkxVbex"
+      "it" : "1XoPIepRO8qEWs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Vdc6czQPic5jZSUlOiA",
-      "month" : "UG2LmqZoFqECxIVjT",
-      "day" : "z7qbgRMJn8Tvo7WRhQi"
+      "year" : "fcmlifP2oY1x",
+      "month" : "y8KkaJzDUyZ",
+      "day" : "LQfL77k9S3lGpYYt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9052a5ec-8b28-44ae-a64e-bc86807efd17",
-        "name" : "SOPfBIpf1VewZmB6",
-        "nameType" : "Personal",
-        "orcId" : "72J0VvgIleNj",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/1127fbf6-e860-4919-b068-352b06f9fc30",
+        "name" : "5ZLK428HqkDE8uhOx",
+        "nameType" : "Organizational",
+        "orcId" : "GYAnEPmPgx7w6tw7H",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PopjAhqXqdqzxgZ620",
-          "value" : "NcgrILlgEAi875VlR"
+          "sourceName" : "sd7I5TjQs4Dh",
+          "value" : "AR2h2VY84Q8Hdbc4u"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PvIBbviD6iLYC8tal",
-          "value" : "k3YShp40tgVBcyGT"
+          "sourceName" : "ckib0N5RLBk6Nddyx",
+          "value" : "quThzLvXGO47EwX8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f9cf7f8d-9908-457a-a704-d4cf78dda90a"
+        "id" : "https://www.example.org/f469034f-81e2-4997-9f6b-968e248a275c"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,166 +62,171 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0757d398-39ae-4d9f-9e8f-d765d8fc81f9",
-        "name" : "dSmzdSO4dUl5mOp",
-        "nameType" : "Personal",
-        "orcId" : "C4mDi39FdVSZLRYP",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/cac6aed6-cd82-487a-a787-2b4fbfd8c161",
+        "name" : "0MM4pk4KWpEt",
+        "nameType" : "Organizational",
+        "orcId" : "h9FcnyVNSO5oluOzRRx",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LRJ0fs8YJkc95C7AL",
-          "value" : "G3FCnFXgasZaSNBJQbW"
+          "sourceName" : "QR2IGixBmc0Pf4NFlZ",
+          "value" : "27v3pUHnRY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dDhnjtxm7JXprQiqem",
-          "value" : "RVVQr196RPQB89"
+          "sourceName" : "cLc0yoQT4Hr",
+          "value" : "aOOyuCQ3Mp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/499ce6c8-2eaf-4e5d-ba54-520d5f0f2f61"
+        "id" : "https://www.example.org/d5f97b8b-5646-4508-97cf-ccc3ec3d57f6"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "JQNkcPHnlDrRThPGdr"
+      "fi" : "jpoGgA7o8QSAo8y"
     },
-    "npiSubjectHeading" : "NpXG9PNwZ9",
-    "tags" : [ "6Gd4IGMR53" ],
-    "description" : "mw6CypSUTvvd",
+    "npiSubjectHeading" : "N9drIl57Y55Xez59JO",
+    "tags" : [ "NL23tC3yIaPHE" ],
+    "description" : "MAgFCTiNPZeztmmT",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5edb366d-ff2e-46bb-90e3-5b411402619b"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f0945c0a-d46b-46c3-a243-07b3f89aa74b"
         },
-        "seriesNumber" : "0LTmmxYV8m",
+        "seriesNumber" : "wF1qm7MK4lFLbRdj",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3492deab-23cd-4cea-ad53-87c87620481d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f12c9bf8-4266-435a-a0bf-d9e74673a605",
           "valid" : true
         },
-        "isbnList" : [ "9780011529806" ],
+        "isbnList" : [ "9781968046750", "9781984937971" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "vjFNl4LeGrtXA50Z"
+          "code" : "xmF1BSWxOD41T"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "sYu5kH2OlaH26UEl3k"
+          "value" : "1984937979"
         } ]
       },
-      "doi" : "https://www.example.org/2f074f27-4942-4f6e-9a78-b5d91a5e0cdb",
+      "doi" : "https://www.example.org/0e495f0e-cc3d-440a-9dda-8e00238b584a",
       "publicationInstance" : {
         "type" : "DegreeLicentiate",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "y0jEwQT4rSXna5i5D",
-            "end" : "D9ZvBmfnYwU54HaMM"
+            "begin" : "tiqr7j99r1z",
+            "end" : "bvNqCatZeV7YM"
           },
-          "pages" : "wG7NO8sKWHspjQ",
-          "illustrated" : false
+          "pages" : "jgaHmp4QTHkJNrsAu",
+          "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "X1dy7bULpERiuhh",
-          "month" : "RMIeSjAxKUlevNLC5uS",
-          "day" : "rhkQnVU5LJISKCp"
+          "year" : "lb1WglxwQTQHWMjj",
+          "month" : "CRfLXnxqyRA",
+          "day" : "VJrACaRXuf"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/58f060b2-27c1-4d40-89bd-fdfe49754eff",
-    "abstract" : "tWSLkECdhc"
+    "metadataSource" : "https://www.example.org/d5ab28c8-4847-4ed9-9455-035b46e959c0",
+    "abstract" : "QvKrP5yIp2Lq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/76574542-714a-4864-91c9-4294f3347db5",
-    "name" : "pwF7fwT099Dt9s",
+    "id" : "https://www.example.org/a1b7b716-2e5c-4dc1-8a1e-359ae20e151e",
+    "name" : "aAleLG9gs964n0cn",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-01-06T13:13:37.079Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "pncMPgoMLGKEs0176"
+      "approvalDate" : "1971-08-17T04:34:37.425Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "sc3PAul3AmUd2R4jMl"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/7b687ae2-be78-4c34-8fbb-f2aecfc2aaf3",
-    "identifier" : "dBjAz5eQqABekRhH",
+    "source" : "https://www.example.org/f0af739e-c797-4574-8039-a48b18c46915",
+    "identifier" : "WiwJFF9Lg7",
     "labels" : {
-      "da" : "pGRiFCOJAjv3BUn6x"
+      "bg" : "E8oHhqPg0xtl8V8WAF"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2117252837
+      "amount" : 44264280
     },
-    "activeFrom" : "2008-11-02T23:29:10.663Z",
-    "activeTo" : "2020-04-18T02:20:00.518Z"
+    "activeFrom" : "2003-02-18T01:10:51.909Z",
+    "activeTo" : "2020-04-12T22:59:43.259Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/70e7a0f4-fa04-478f-bd23-b33ab44eb4db",
-    "id" : "https://www.example.org/556ad78d-590d-453a-9a1a-a513ddf76535",
-    "identifier" : "nx07JNyyxCN",
+    "source" : "https://www.example.org/eaad4856-2e4e-4369-8cb3-ad0b90ef1430",
+    "id" : "https://www.example.org/b179aea4-7a6f-4ca7-a4bf-2bdbcf74fd60",
+    "identifier" : "WWppOkkxxUkEnbR",
     "labels" : {
-      "nb" : "kWZEJLHfmjOfq2"
+      "it" : "vp8eJEvBNH1S"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 540417330
+      "amount" : 1315880815
     },
-    "activeFrom" : "2005-11-12T20:38:27.982Z",
-    "activeTo" : "2021-02-16T03:31:45.153Z"
+    "activeFrom" : "1971-01-26T12:42:33.489Z",
+    "activeTo" : "2006-03-19T13:11:49.702Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/284d0aa1-7feb-4696-ab40-9a7204e3eea2" ],
+  "subjects" : [ "https://www.example.org/70ecc5d2-1ac4-4f89-b003-396ca5eb7d62" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "19c1a507-7c9a-4fcd-9203-369f8d0d4d7d",
-    "name" : "ZFQIdl22DIOrM",
-    "mimeType" : "qXWU7yJ4oHAWONlNg",
-    "size" : 2015093904,
-    "license" : "https://www.example.com/gvmxwrg3khx9wmyudoe",
+    "identifier" : "602e86e3-c4db-4d52-898f-8d1426593b00",
+    "name" : "1N4cqVWe6LDU",
+    "mimeType" : "PF22TyzLu61HsHI",
+    "size" : 411940616,
+    "license" : "https://www.example.com/5prdirbayx4j",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "7wGNsVoUTy",
-    "publishedDate" : "2019-07-04T00:39:05.561Z",
+    "legalNote" : "l9J10PulttJxGuf5K",
+    "publishedDate" : "2016-11-28T15:34:56.168Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "sTSXAc5wy12C4",
+      "uploadedDate" : "1989-03-24T08:00:10.055Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Jb6q0o23pK7hAUm",
-    "name" : "ONU0khX7Ziv",
-    "description" : "boA4JtJ1N9px"
+    "id" : "https://www.example.com/VPiaahbD00KTbZNW",
+    "name" : "2IWwRYoF7ungnWWCGIS",
+    "description" : "870ZdqQGNX"
   } ],
-  "rightsHolder" : "bRQCldSToCIgRNox",
-  "duplicateOf" : "https://www.example.org/4287992a-dde7-42e0-bda1-37571bec1ac5",
+  "rightsHolder" : "bOVBKTn1vDNQ9k",
+  "duplicateOf" : "https://www.example.org/f9c1a149-3920-4892-96f7-37acfde53a9a",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kFwfUk4d33jhAugPHZ"
+    "note" : "rXVooTB8pHKb3f"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "OqkNwpoEyJPJpwH",
-    "createdBy" : "rTdkmyFAKxDypFPg",
-    "createdDate" : "1975-01-28T12:59:15.397Z"
+    "note" : "zx9uaSTPuJKkSHtl4",
+    "createdBy" : "tvOMIFhMxRYLuPZ8H1",
+    "createdDate" : "2000-07-15T23:25:34.670Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/28aa469e-7a86-4c80-8a6c-29279394d208" ],
+  "curatingInstitutions" : [ "https://www.example.org/aea2e223-65d9-45e2-be74-6a116053c782" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "yr4r0hqzBFo7MHIMd",
-    "ownerAffiliation" : "https://www.example.org/d3d25e99-b33c-4361-8d24-69778c35e63f"
+    "owner" : "HAReXoGLyD6",
+    "ownerAffiliation" : "https://www.example.org/e4a0664a-563e-46c8-912d-233c27f1ce31"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0468322d-4daf-4385-af4a-0172c42451e5"
+    "id" : "https://www.example.org/02fb8cf3-d72b-4206-9825-457e5de1a6fb"
   },
-  "createdDate" : "1984-03-22T18:20:11.896Z",
-  "modifiedDate" : "2007-03-11T14:14:01.985Z",
-  "publishedDate" : "1992-02-04T14:32:13.134Z",
-  "indexedDate" : "1999-12-16T19:31:10.165Z",
-  "handle" : "https://www.example.org/d786716e-db45-4f01-82ee-06c44bd16ed0",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/1513f93e-2e3f-4c58-b010-27d5beca23ab",
+  "createdDate" : "1980-11-27T09:13:23.341Z",
+  "modifiedDate" : "2008-02-06T22:22:48.741Z",
+  "publishedDate" : "1983-02-17T04:51:37.612Z",
+  "indexedDate" : "1972-01-24T20:07:55.341Z",
+  "handle" : "https://www.example.org/61e0b194-6b43-47a2-ab34-ee8462218bad",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/11c2caac-d335-494d-99d5-fc9536e510c7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JbwdyqfNjyz",
+    "mainTitle" : "JurOgpxk7n6HUHj5",
     "alternativeTitles" : {
-      "hu" : "YctE64JuuM5XgXfLXI"
+      "el" : "5DB8vtzcs99BdsQ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "P629bokQ2G",
-      "month" : "zmVb3mrzRljvQfCR3HB",
-      "day" : "NUfG6bD6uQrsb1"
+      "year" : "0xLs4Y7bxj3z16WLH",
+      "month" : "7htlROgHKQ0o2t",
+      "day" : "CMV0EsjXLcib"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3029587e-0f90-4d84-b095-444f7177b803",
-        "name" : "8QU4M5JNFnc7Xy",
-        "nameType" : "Personal",
-        "orcId" : "Dl6LqX5NGrQ",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/2c49fe92-c702-4551-9186-370ba61188ca",
+        "name" : "PSHYPymSbCvy1",
+        "nameType" : "Organizational",
+        "orcId" : "gI6T69UqGM89xSw",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZDhZWl3UIh4O2q",
-          "value" : "29gc9BW14M3IsVAL"
+          "sourceName" : "q30JavCIP5fcWd5",
+          "value" : "rBKEQKQebDJjIg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sXMMQFA357NsuM",
-          "value" : "og2FAqyIROg"
+          "sourceName" : "JlsR2E5DXx2iKvTAuk",
+          "value" : "v1UUDGxqjZlxdDK"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3d8399c0-286b-451f-aef6-c2912adc65cd"
+        "id" : "https://www.example.org/b317d441-5bdc-4e37-ace7-d0a4081e74a6"
       } ],
       "role" : {
         "type" : "Screenwriter"
@@ -62,166 +62,171 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b2a1ce72-4c0d-4c88-a2a6-58395d276c66",
-        "name" : "K5uXDsobM5h",
-        "nameType" : "Organizational",
-        "orcId" : "1V7pftr3aABXcDwrSx",
+        "id" : "https://www.example.org/4229a0c7-4d5f-44e2-ac25-2ce9928f6b06",
+        "name" : "nwHhVe4KHcYWKiTuikY",
+        "nameType" : "Personal",
+        "orcId" : "JPsU1c2Lhc",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qQ1R87x0PggP",
-          "value" : "w8LibllUhQXz"
+          "sourceName" : "KtA4D6G9eBDz0aTsI",
+          "value" : "FumueQjGHqt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xlCj34OzMauZZWMcman",
-          "value" : "BhZdieqwGYs"
+          "sourceName" : "jjHfW0lfCUKdh9EFrm4",
+          "value" : "opwW9XMuI9Yw0d"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ad56876f-a5aa-4e27-b6b6-31cbf2001bb5"
+        "id" : "https://www.example.org/b60b7128-f320-4cb5-b106-477b6576200d"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "Lws4q7RuULY72rIolq3"
+      "ca" : "lH8FW4KQ1m3JnU7izac"
     },
-    "npiSubjectHeading" : "M8jzF1CyKrU4I",
-    "tags" : [ "0f5tSFjQvOW" ],
-    "description" : "0tNFvbcX4eC7IiDC9Cq",
+    "npiSubjectHeading" : "YlO1590jeDtHZhYDK1",
+    "tags" : [ "J6hSqZ8kCEC9oE7L" ],
+    "description" : "OItrAScZeKo",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f85a6ee3-9a59-44de-971c-8e300c2f3219"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6423b2ea-4290-4306-9de0-198c237fea7f"
         },
-        "seriesNumber" : "Zlj2nHD47Nw2Tsf",
+        "seriesNumber" : "siyPt8zt5UrQn",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b476f302-8628-4edb-9ffa-d466f98e8ed8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/31133975-a2c5-4f04-b214-acb19a2e2639",
           "valid" : true
         },
-        "isbnList" : [ "9790747417940" ],
+        "isbnList" : [ "9791876593925", "9780944018200" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "l8bhKSTdP2pjpWyJ7"
+          "code" : "bfbAQMrRFNq9v"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "VCHyXKUePIq1Gf"
+          "value" : "0944018203"
         } ]
       },
-      "doi" : "https://www.example.org/47e6e9ce-0473-44e0-86ab-281765781cdf",
+      "doi" : "https://www.example.org/ff2a023e-764f-4a7f-931c-dba4f7b01afd",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "tNrMuyWHKUC4j",
-            "end" : "WoeBwVF5AlZ"
+            "begin" : "P6488PVCUEAFP",
+            "end" : "ZpaQksFIaCoJPLukR"
           },
-          "pages" : "KNDmLH0xXUfG1NmAWx",
+          "pages" : "qXktpRD1eueJm0Ueao",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "ml6PyvFg6zJf0F",
-          "month" : "5mzIvPtgcLD",
-          "day" : "mrzlRT8Mv4W7"
+          "year" : "naSBp91rHCplRq8t",
+          "month" : "fxtudYapRUvkUXkyldo",
+          "day" : "OnoNekdqGT"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0ee223be-3892-4b31-831f-779d141f07e0",
-    "abstract" : "8oJk5wZ0k9epTfR"
+    "metadataSource" : "https://www.example.org/83a7b83f-fd19-4bd7-945e-275206a2c0e5",
+    "abstract" : "GOrjiMemEKPgBE3r"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/71819be3-abe4-4885-a9de-ffa7e634f61d",
-    "name" : "X53VKYJ4yZk9svKPH",
+    "id" : "https://www.example.org/87a1a0d1-3259-420f-adc9-b4a89f177f3a",
+    "name" : "Yh5pb8pcAjY9by0dOJ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-05-10T07:13:38.526Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Nj7TObTQsEtI7CbA"
+      "approvalDate" : "2020-10-24T02:22:24.406Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "OwHDQe8XBCx9"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e24ad887-c993-4510-ab0d-59231333f82e",
-    "identifier" : "22EWYprA2TrxMZa",
+    "source" : "https://www.example.org/cc357e9a-0b06-4440-b7bc-7d8522234b92",
+    "identifier" : "fKRhb57WGzih",
     "labels" : {
-      "en" : "ZRMqvKx1zW1r"
+      "nl" : "OyLKSZC7AOajp3"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 805973990
+      "amount" : 1435041244
     },
-    "activeFrom" : "2008-06-07T08:53:34.290Z",
-    "activeTo" : "2024-05-08T23:10:50.307Z"
+    "activeFrom" : "2024-01-30T03:37:38.962Z",
+    "activeTo" : "2024-05-16T03:36:04.633Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a955faa9-5c63-4397-9039-27a9bcb04791",
-    "id" : "https://www.example.org/68965267-59f3-41ce-a690-7a6f2c6c1695",
-    "identifier" : "wCxY6uuCASP",
+    "source" : "https://www.example.org/459d6432-9533-43f0-8d86-eaea96359aa8",
+    "id" : "https://www.example.org/415513e6-bfb1-4ea8-9b9f-124536940b2b",
+    "identifier" : "IHvujogqaKrT",
     "labels" : {
-      "da" : "QBZZFY9c2NHjUM"
+      "se" : "1ThP5IypAppb3V22BT"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1901251985
+      "currency" : "USD",
+      "amount" : 273951519
     },
-    "activeFrom" : "2011-04-04T01:06:37.633Z",
-    "activeTo" : "2022-12-15T03:19:40.344Z"
+    "activeFrom" : "2004-01-12T14:26:29.975Z",
+    "activeTo" : "2022-07-24T14:52:30.891Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/206d5a20-6a89-4aed-add7-caebe2d4650b" ],
+  "subjects" : [ "https://www.example.org/aa08f2ef-4eaa-4554-83cf-1ce215dd4e5e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a964836a-1cc1-45b2-81ce-b526970e0341",
-    "name" : "oYV8IIKfQf8eUPEA",
-    "mimeType" : "X8h6VlU17j",
-    "size" : 1869703269,
-    "license" : "https://www.example.com/fys4hzs630w",
+    "identifier" : "272c5805-58db-4895-a34f-53eaf7190c03",
+    "name" : "M6Q91mnoM2I1eS",
+    "mimeType" : "c2SADaPjB1wcr",
+    "size" : 732467598,
+    "license" : "https://www.example.com/gbrd1gaxinbsi",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "NPgexoUwt7czv4ndP2h",
-    "publishedDate" : "2023-11-24T14:56:48.859Z",
+    "legalNote" : "EbC3SCWjvYpcJi6",
+    "publishedDate" : "1996-05-29T07:03:15.215Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "91v3eM4bMrJxHt4E4",
+      "uploadedDate" : "1987-05-18T20:13:25.382Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/6NIWIEzVv94orhAEmVA",
-    "name" : "EUv5W40wuGvqHaaIpB",
-    "description" : "2uOiTwVi5eT2SJ"
+    "id" : "https://www.example.com/ob1EEsGGxQ",
+    "name" : "B2Jd9q8Z5K",
+    "description" : "5omS9jd40DzClUbM3"
   } ],
-  "rightsHolder" : "hxFcsdru3kms5",
-  "duplicateOf" : "https://www.example.org/656bd584-e430-4055-a1c9-f0c7622dffaa",
+  "rightsHolder" : "RKIk9RGdl10",
+  "duplicateOf" : "https://www.example.org/a05abe44-49c1-40ab-8484-55e41fc7d470",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ptYvyW4oMA"
+    "note" : "XwMaVWqHl8H"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Y8Y6PEVHRAkl",
-    "createdBy" : "3Z5qtrmrbE",
-    "createdDate" : "1979-05-23T13:42:41.915Z"
+    "note" : "8wQo9ZKZZLO59E",
+    "createdBy" : "faYK9fu9jg",
+    "createdDate" : "2001-01-19T23:22:53.727Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5e9e7fcc-fe5c-464a-a239-d6767336fd39" ],
+  "curatingInstitutions" : [ "https://www.example.org/04510c19-640c-4727-b9e2-4c20af1937fd" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/DegreeMaster.json
+++ b/documentation/DegreeMaster.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "FXsx3m5qVg7KOzatf",
-    "ownerAffiliation" : "https://www.example.org/cd5ca6dc-35e9-4331-92cb-808667c4ff7b"
+    "owner" : "yr4r0hqzBFo7MHIMd",
+    "ownerAffiliation" : "https://www.example.org/d3d25e99-b33c-4361-8d24-69778c35e63f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/91357f50-7738-483d-87e9-4fd780cd8fbd"
+    "id" : "https://www.example.org/0468322d-4daf-4385-af4a-0172c42451e5"
   },
-  "createdDate" : "1992-05-08T04:46:29.835Z",
-  "modifiedDate" : "1981-11-22T11:05:44.612Z",
-  "publishedDate" : "1971-04-13T05:08:07.046Z",
-  "indexedDate" : "2021-09-14T12:56:51.837Z",
-  "handle" : "https://www.example.org/a39f04cb-63c8-40c4-9395-fe1349155a76",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/4439a489-b78b-48d5-b21a-f2c4ef4e04d8",
+  "createdDate" : "1984-03-22T18:20:11.896Z",
+  "modifiedDate" : "2007-03-11T14:14:01.985Z",
+  "publishedDate" : "1992-02-04T14:32:13.134Z",
+  "indexedDate" : "1999-12-16T19:31:10.165Z",
+  "handle" : "https://www.example.org/d786716e-db45-4f01-82ee-06c44bd16ed0",
+  "doi" : "https://doi.org/10.1234/dolorem",
+  "link" : "https://www.example.org/1513f93e-2e3f-4c58-b010-27d5beca23ab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3uRUuP85l8c1If",
+    "mainTitle" : "JbwdyqfNjyz",
     "alternativeTitles" : {
-      "sv" : "orQ9ysy82eWzyXT"
+      "hu" : "YctE64JuuM5XgXfLXI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "m0wy673Nhmqy982",
-      "month" : "xBxsiAhvxFwHuSyTL5V",
-      "day" : "jZjK7CWCT3z"
+      "year" : "P629bokQ2G",
+      "month" : "zmVb3mrzRljvQfCR3HB",
+      "day" : "NUfG6bD6uQrsb1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d57958df-5df8-4d31-a300-98ba0b4a8c90",
-        "name" : "8zAFEOFQdgnSdaP9Lg",
+        "id" : "https://www.example.org/3029587e-0f90-4d84-b095-444f7177b803",
+        "name" : "8QU4M5JNFnc7Xy",
         "nameType" : "Personal",
-        "orcId" : "qo0Nn9I1rj",
+        "orcId" : "Dl6LqX5NGrQ",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LZWIsgxFoe",
-          "value" : "3VJ5rSq5U1eW8M"
+          "sourceName" : "ZDhZWl3UIh4O2q",
+          "value" : "29gc9BW14M3IsVAL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6aH7tR2dXTOdjPdd5",
-          "value" : "apS6Wtp8A18vFdOyFl"
+          "sourceName" : "sXMMQFA357NsuM",
+          "value" : "og2FAqyIROg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b783c4f9-3d81-4582-abe0-45dd31868967"
+        "id" : "https://www.example.org/3d8399c0-286b-451f-aef6-c2912adc65cd"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Screenwriter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,165 +62,166 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e92b2a8a-da23-46af-b920-1854dc92f518",
-        "name" : "j22nf8MIq1",
-        "nameType" : "Personal",
-        "orcId" : "CEspzfEWmM",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/b2a1ce72-4c0d-4c88-a2a6-58395d276c66",
+        "name" : "K5uXDsobM5h",
+        "nameType" : "Organizational",
+        "orcId" : "1V7pftr3aABXcDwrSx",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4XPxKqGL1N",
-          "value" : "Hk0RQVgmS74JBh"
+          "sourceName" : "qQ1R87x0PggP",
+          "value" : "w8LibllUhQXz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dLmBQrvqpio",
-          "value" : "Z90ye8X7SbqgrA"
+          "sourceName" : "xlCj34OzMauZZWMcman",
+          "value" : "BhZdieqwGYs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/14897afa-0642-457e-832b-31d1ef89f311"
+        "id" : "https://www.example.org/ad56876f-a5aa-4e27-b6b6-31cbf2001bb5"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "edHBHGeXlfLyl31zDh"
+      "se" : "Lws4q7RuULY72rIolq3"
     },
-    "npiSubjectHeading" : "a1VMpfyB9lCXnbGg6",
-    "tags" : [ "JlSYgJoYUPb1TmyqSoF" ],
-    "description" : "cXilV72cvuwD",
+    "npiSubjectHeading" : "M8jzF1CyKrU4I",
+    "tags" : [ "0f5tSFjQvOW" ],
+    "description" : "0tNFvbcX4eC7IiDC9Cq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5143bbc4-14f6-49d9-b50e-707d144f0df2"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f85a6ee3-9a59-44de-971c-8e300c2f3219"
         },
-        "seriesNumber" : "1BnJ7ePHBbz",
+        "seriesNumber" : "Zlj2nHD47Nw2Tsf",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/2ff9556f-b20d-4397-a3e1-02c160cbebd2",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b476f302-8628-4edb-9ffa-d466f98e8ed8",
           "valid" : true
         },
-        "isbnList" : [ "9781713897729" ],
+        "isbnList" : [ "9790747417940" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "3YhTMWNYUB94cKVAqT"
+          "code" : "l8bhKSTdP2pjpWyJ7"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "UKM0sYJQknwMHSP6yHW"
+          "value" : "VCHyXKUePIq1Gf"
         } ]
       },
-      "doi" : "https://www.example.org/984b2add-dc64-4c60-8774-f2f0580204d6",
+      "doi" : "https://www.example.org/47e6e9ce-0473-44e0-86ab-281765781cdf",
       "publicationInstance" : {
         "type" : "DegreeMaster",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "9DMVtWv4tQr",
-            "end" : "BBtV3Lh3QNqy2gbz2"
+            "begin" : "tNrMuyWHKUC4j",
+            "end" : "WoeBwVF5AlZ"
           },
-          "pages" : "s4ht8iZt8EH01szmTmu",
+          "pages" : "KNDmLH0xXUfG1NmAWx",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "GtIUpa9hlkGGnB",
-          "month" : "MPhJj6tNFkxGIuJCxf",
-          "day" : "brUAUCMa6BY"
+          "year" : "ml6PyvFg6zJf0F",
+          "month" : "5mzIvPtgcLD",
+          "day" : "mrzlRT8Mv4W7"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7506f1b9-7f05-4b60-9d5e-81c7e8f64521",
-    "abstract" : "YWfWrfoKIs5c1Xr"
+    "metadataSource" : "https://www.example.org/0ee223be-3892-4b31-831f-779d141f07e0",
+    "abstract" : "8oJk5wZ0k9epTfR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e68c1e9f-f340-47a4-9221-edd476369df7",
-    "name" : "E2IaKsYEPbGHYXBI",
+    "id" : "https://www.example.org/71819be3-abe4-4885-a9de-ffa7e634f61d",
+    "name" : "X53VKYJ4yZk9svKPH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-06-02T10:40:45.224Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "liLpWbJVpa"
+      "approvalDate" : "1996-05-10T07:13:38.526Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "Nj7TObTQsEtI7CbA"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6155766d-19eb-4a3a-9f20-c992381aac3f",
-    "identifier" : "ebyRSiXS2y6",
+    "source" : "https://www.example.org/e24ad887-c993-4510-ab0d-59231333f82e",
+    "identifier" : "22EWYprA2TrxMZa",
     "labels" : {
-      "is" : "IUjNr0cLIlfG5TY"
+      "en" : "ZRMqvKx1zW1r"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 461513339
+      "currency" : "NOK",
+      "amount" : 805973990
     },
-    "activeFrom" : "2014-12-10T13:19:06.097Z",
-    "activeTo" : "2018-07-26T14:10:21.877Z"
+    "activeFrom" : "2008-06-07T08:53:34.290Z",
+    "activeTo" : "2024-05-08T23:10:50.307Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6dbb5a51-897f-49c4-b2fd-5c5f534c393a",
-    "id" : "https://www.example.org/2800880e-0542-4985-a514-63a778f6c78c",
-    "identifier" : "XquO4SgMYxgD",
+    "source" : "https://www.example.org/a955faa9-5c63-4397-9039-27a9bcb04791",
+    "id" : "https://www.example.org/68965267-59f3-41ce-a690-7a6f2c6c1695",
+    "identifier" : "wCxY6uuCASP",
     "labels" : {
-      "es" : "wTbpa6Tryj5doRuv"
+      "da" : "QBZZFY9c2NHjUM"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1097892258
+      "currency" : "GBP",
+      "amount" : 1901251985
     },
-    "activeFrom" : "2009-07-20T16:54:42.614Z",
-    "activeTo" : "2021-06-23T04:36:59.532Z"
+    "activeFrom" : "2011-04-04T01:06:37.633Z",
+    "activeTo" : "2022-12-15T03:19:40.344Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/407013a3-8f4d-485a-83fd-dedf340d0902" ],
+  "subjects" : [ "https://www.example.org/206d5a20-6a89-4aed-add7-caebe2d4650b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "02631c14-3de1-43fc-ab15-57d8ddc35d5a",
-    "name" : "fDo1SxhKla8zk5v",
-    "mimeType" : "DYdLVAmVebMP",
-    "size" : 1028981299,
-    "license" : "https://www.example.com/ravib7y9kwuo",
+    "identifier" : "a964836a-1cc1-45b2-81ce-b526970e0341",
+    "name" : "oYV8IIKfQf8eUPEA",
+    "mimeType" : "X8h6VlU17j",
+    "size" : 1869703269,
+    "license" : "https://www.example.com/fys4hzs630w",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Yv1PUzjU2oq",
-    "publishedDate" : "2013-01-02T02:08:06.343Z",
+    "legalNote" : "NPgexoUwt7czv4ndP2h",
+    "publishedDate" : "2023-11-24T14:56:48.859Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3L5zTnHAbLzX",
-    "name" : "NkZGE2cycgNPWn",
-    "description" : "KH21ihsBlG8e"
+    "id" : "https://www.example.com/6NIWIEzVv94orhAEmVA",
+    "name" : "EUv5W40wuGvqHaaIpB",
+    "description" : "2uOiTwVi5eT2SJ"
   } ],
-  "rightsHolder" : "xipcgOlPWwXo",
-  "duplicateOf" : "https://www.example.org/7b93349d-d23f-4c2f-afc7-36648ee2de75",
+  "rightsHolder" : "hxFcsdru3kms5",
+  "duplicateOf" : "https://www.example.org/656bd584-e430-4055-a1c9-f0c7622dffaa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ICtFvXU1FmE"
+    "note" : "ptYvyW4oMA"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "YON1tMrxWtSN",
-    "createdBy" : "WPynZmwNqy7AZOsjabA",
-    "createdDate" : "1975-01-29T00:19:14.087Z"
+    "note" : "Y8Y6PEVHRAkl",
+    "createdBy" : "3Z5qtrmrbE",
+    "createdDate" : "1979-05-23T13:42:41.915Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5254f958-3b8e-400e-ad2e-7ebb10f1e5a9" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/5e9e7fcc-fe5c-464a-a239-d6767336fd39" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "cA3TnPYK38",
-    "ownerAffiliation" : "https://www.example.org/ac011ae7-dc27-49c8-9418-de91543acb89"
+    "owner" : "7ZUZFbINyvl24jSb",
+    "ownerAffiliation" : "https://www.example.org/8a4917f3-ef1c-4895-b988-6097de3a7e34"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/89bf7f9b-da5b-47cc-941f-1aa91707c496"
+    "id" : "https://www.example.org/faee78dd-670a-45ea-a6fb-a9ea2033a44b"
   },
-  "createdDate" : "1991-03-09T13:31:03.235Z",
-  "modifiedDate" : "2003-08-12T09:48:54.142Z",
-  "publishedDate" : "1982-03-14T20:25:45.987Z",
-  "indexedDate" : "1979-10-02T13:06:14.427Z",
-  "handle" : "https://www.example.org/58698424-5036-47a7-9eb4-f3a116a359c9",
-  "doi" : "https://doi.org/10.1234/laudantium",
-  "link" : "https://www.example.org/95724745-10d1-4d4b-ab88-444053482b16",
+  "createdDate" : "1987-04-27T09:23:51.433Z",
+  "modifiedDate" : "2016-01-17T05:38:41.245Z",
+  "publishedDate" : "1977-06-23T05:10:11.026Z",
+  "indexedDate" : "1994-02-08T20:57:18.897Z",
+  "handle" : "https://www.example.org/1f229c5a-4165-4533-9731-8560c86fdab2",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/64e02eb5-ae39-42d4-aa10-971dbebce62d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HMAIw7cZ6fUvwzBDgwM",
+    "mainTitle" : "U38nHAP0FblJb2",
     "alternativeTitles" : {
-      "cs" : "dF9hDvUdy4Zq8IF4Y"
+      "bg" : "xMTVrppLCAIKm4wCzBo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KSPSyLDPj13d8",
-      "month" : "b9hJN0hQyco",
-      "day" : "RjrygKthsBYCS"
+      "year" : "NlQ1kMVwrzCjzj6WiN",
+      "month" : "M6PVvnszswX",
+      "day" : "AJSkMdvNYcpVPh"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/99510d4e-76c5-4c49-9ba5-118d70ca38de",
-        "name" : "14ObT7bTAuYB8",
+        "id" : "https://www.example.org/5589181f-348e-439d-b59a-c8a2973589a8",
+        "name" : "bOq0TKVgdZ",
         "nameType" : "Organizational",
-        "orcId" : "DEXNIA1qin79e",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "NHsNmkVrC7A9dtzxsV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "28oNlKluht",
-          "value" : "zVGw4DgLNbaMHiq"
+          "sourceName" : "qvojwBdD0bdCQBz",
+          "value" : "sPULFUVbaagOlfus"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jSyG0zPHMKNM7V1C0a",
-          "value" : "7liNWq9WmvQYB9V"
+          "sourceName" : "4xoaFKPaC8ZtT",
+          "value" : "VyURPpKLV4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c33abfaf-990e-416e-a65c-4b747c413514"
+        "id" : "https://www.example.org/d9cf5855-3593-4d13-bc13-60eb7e6f37b2"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Photographer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,172 +62,173 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c4c94202-38ed-4707-8d80-a983edcd255a",
-        "name" : "3IbyWZVB9i8mmlgZM",
+        "id" : "https://www.example.org/6586dcba-8fb3-4136-99c9-63a40262c8e0",
+        "name" : "sCc26AavSd8lc6",
         "nameType" : "Organizational",
-        "orcId" : "BcSBnpcypuw4rzxt",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "APrEwHWdVf2LP",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KruHrdrs2cURF60",
-          "value" : "P2N9CE7nkVGtcweH"
+          "sourceName" : "cAH6Lp8hlcCzS",
+          "value" : "4Uac5T0YwqoNB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Sd2gHKYLBu8cJw",
-          "value" : "AUBl2Ar7Uvq"
+          "sourceName" : "yBpvt0hrQhN",
+          "value" : "9JJvLpXRVIfWN4kR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d30ad3e6-fd9a-4713-8b6f-6714be20734d"
+        "id" : "https://www.example.org/b2d72f22-ddc8-41c5-90a3-7ab7c82b56d2"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "DL3ZnvIyuYmQIlbu"
+      "en" : "vWvdkga0nSXJ4ZzQkED"
     },
-    "npiSubjectHeading" : "t20TO35742X3zQr",
-    "tags" : [ "VgGoqSccKHu" ],
-    "description" : "vH89Q9qGU6qXGXy6w",
+    "npiSubjectHeading" : "u9cySFOt4Az5WhJM",
+    "tags" : [ "nCuXQL5T5mPN" ],
+    "description" : "b2ITQCeT6XuHWoZ5A",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/86d99347-6504-4267-9a75-aa82a5d40863"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8eb40b1f-cd4f-451a-bc5a-773b7709a1a8"
         },
-        "seriesNumber" : "HtWwS1mMS65g",
+        "seriesNumber" : "mQ2YQSC65nW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8802836b-4cb6-43f3-9269-accd000f910a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7951c8d6-a48c-44e1-8c2e-5fc67f708be2",
           "valid" : true
         },
-        "isbnList" : [ "9790951082934" ],
+        "isbnList" : [ "9790943499955" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "iLGwTtt8fP"
+          "code" : "9Tu2UvcygVs9zfN2OG3"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "tC8iPq6U5W"
+          "value" : "4vwVusW0a8mM"
         } ]
       },
-      "doi" : "https://www.example.org/77145c08-98d6-4718-85d0-4e2e4acb4aae",
+      "doi" : "https://www.example.org/87983068-326e-45b5-85f1-f24c459bec61",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ebjmjbJOGarhRXUBRdq",
-            "end" : "HYu8lp0ls9whfsirq"
+            "begin" : "6YHdzkKDqPyFJM",
+            "end" : "JgSc4DVqTQRWMotoWT3"
           },
-          "pages" : "9Wb1rABPjK",
+          "pages" : "jCd99kTeCt6zX47pD",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "vIPMvuPixnBMKEOZ6c",
-          "month" : "8dVWB5UZXmX",
-          "day" : "xdnZm9hGJu"
+          "year" : "IHivM6Bu9o",
+          "month" : "2dCtudIEoO8zTnCm",
+          "day" : "yxbJtpAbcL1pVgXMsr"
         },
         "related" : [ {
           "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/kFTIdnER8lgomhN"
+          "identifier" : "https://www.example.com/HL0xdeW6oLbeku"
         }, {
           "type" : "UnconfirmedDocument",
-          "text" : "56xqres1LTZ8nWA5yg"
+          "text" : "BQAQaXfF1lnD0"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/7bbb0ed5-60b8-44ee-971b-5a1338ee2173",
-    "abstract" : "vRAi8siXiGK8kz"
+    "metadataSource" : "https://www.example.org/d1714ad9-b5be-4056-aca6-f31c9c0becab",
+    "abstract" : "6ow7e4wOmrSeXxO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c0f5d1d7-bea7-4746-a22b-5647382e79fc",
-    "name" : "TI26TZTshk0",
+    "id" : "https://www.example.org/c5e87946-9aa9-45f3-92c0-dbaaf1b4f886",
+    "name" : "R0uKC5pGQF",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-04-22T16:24:50.190Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "5EvYiBWKK3u0dq"
+      "approvalDate" : "2017-08-15T01:15:33.591Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "ClMKsswidX1f1R"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b80ef67e-da2a-4a57-9c9d-55207d51bf6c",
-    "identifier" : "L5C6mdt7ny",
+    "source" : "https://www.example.org/8be4507b-b127-4527-8903-1fcb01e4566f",
+    "identifier" : "2CmkF8ls4oN",
     "labels" : {
-      "it" : "SQFack1xaZ3"
+      "af" : "X6kX6nsgGMRGMXMRK"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1844192337
+      "amount" : 1553836795
     },
-    "activeFrom" : "1971-04-28T18:56:38.027Z",
-    "activeTo" : "1979-01-20T01:27:11.613Z"
+    "activeFrom" : "1971-08-23T02:05:36.614Z",
+    "activeTo" : "2009-08-31T23:28:14.921Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d114bcdb-6cf2-4580-83d1-83ad4eea0e31",
-    "id" : "https://www.example.org/00149755-11a3-489e-a24c-95edf39b294f",
-    "identifier" : "i5aWYzJYOV",
+    "source" : "https://www.example.org/dc5b0a75-50ef-4e0e-bdf1-63cf1a57288a",
+    "id" : "https://www.example.org/58eb69ad-fb58-4c81-88a5-c7eb3f414502",
+    "identifier" : "fSE3kCpO16mzPX",
     "labels" : {
-      "sv" : "szYFOApn31mWCLQpPbI"
+      "de" : "9ked1D8yGyPg2Zta"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 818542477
+      "currency" : "USD",
+      "amount" : 913421093
     },
-    "activeFrom" : "2018-01-25T22:06:50.445Z",
-    "activeTo" : "2018-04-23T00:34:21.196Z"
+    "activeFrom" : "1997-10-31T14:58:07.126Z",
+    "activeTo" : "2012-09-26T11:20:18.043Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f8e21cfe-1e89-4ee8-9f46-aad2e0539c92" ],
+  "subjects" : [ "https://www.example.org/bf76f077-7510-4dd5-93b6-03b595fdd199" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "64813000-527f-44b8-9a9a-7131e3d1a893",
-    "name" : "iwzEIA4xvFLKTuYV",
-    "mimeType" : "1Pj1NW7AfpGZLT0YwqM",
-    "size" : 1392077668,
-    "license" : "https://www.example.com/br9ehpzz5fwh",
+    "identifier" : "f1a51d6e-166e-4697-a0d2-cd4f964bdd63",
+    "name" : "Wsei40ziffVEd",
+    "mimeType" : "9vj3aGfZ5u4FpU9",
+    "size" : 1900132783,
+    "license" : "https://www.example.com/ngqzb5vqtaudjlfvtx",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "7xqMcrUbxP8",
-    "publishedDate" : "1998-05-29T02:48:52.703Z",
+    "legalNote" : "dkJrLWqCUyBi76oCDk",
+    "publishedDate" : "2018-09-08T17:46:07.762Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/BD4ok7H0Gp1GrEqL",
-    "name" : "eycPscbTOb6sIi",
-    "description" : "tcK1nKmjeY"
+    "id" : "https://www.example.com/dxI68Zo0ir1vxeP06f",
+    "name" : "Dm5sSVsq72TMVgdQd0g",
+    "description" : "iYF9jtGAhgp8OKnwVK"
   } ],
-  "rightsHolder" : "L3hCKsjgc322IyJ6q",
-  "duplicateOf" : "https://www.example.org/8e3bccd8-dd19-41ed-b6bd-a17aae59c441",
+  "rightsHolder" : "JvkaUa0krg9RFz",
+  "duplicateOf" : "https://www.example.org/edeb0f96-0575-4b8d-b502-dd7ecea941bc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "6RTOHwgg7czurbzvJX"
+    "note" : "6MMC9BBmie2"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "k0gOsHBXPFdIZZNzNf",
-    "createdBy" : "KcvQdlBkgj9aRkTxc",
-    "createdDate" : "2004-05-29T15:10:59.797Z"
+    "note" : "QLbAmIR9feFqcNObbi",
+    "createdBy" : "kxmTwU36NmqVEv",
+    "createdDate" : "1981-10-25T00:05:03.076Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fd819f77-1094-454f-a24d-4c54141b885a" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/5cf1fc04-856c-4006-8d21-e7d772457df3" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/DegreePhd.json
+++ b/documentation/DegreePhd.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "7ZUZFbINyvl24jSb",
-    "ownerAffiliation" : "https://www.example.org/8a4917f3-ef1c-4895-b988-6097de3a7e34"
+    "owner" : "ArsZYg9BQHz4YySfxe2",
+    "ownerAffiliation" : "https://www.example.org/19768859-5beb-42f8-9805-406310018c09"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/faee78dd-670a-45ea-a6fb-a9ea2033a44b"
+    "id" : "https://www.example.org/39b05e3c-d82f-4a57-8beb-5e7a1df4b5ac"
   },
-  "createdDate" : "1987-04-27T09:23:51.433Z",
-  "modifiedDate" : "2016-01-17T05:38:41.245Z",
-  "publishedDate" : "1977-06-23T05:10:11.026Z",
-  "indexedDate" : "1994-02-08T20:57:18.897Z",
-  "handle" : "https://www.example.org/1f229c5a-4165-4533-9731-8560c86fdab2",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/64e02eb5-ae39-42d4-aa10-971dbebce62d",
+  "createdDate" : "1982-04-24T02:47:31.330Z",
+  "modifiedDate" : "1988-05-21T22:03:19.513Z",
+  "publishedDate" : "1972-10-13T03:54:31.790Z",
+  "indexedDate" : "1990-04-05T14:24:35.699Z",
+  "handle" : "https://www.example.org/15259fc0-192f-4f09-91d6-fb31a1d30bd1",
+  "doi" : "https://doi.org/10.1234/aspernatur",
+  "link" : "https://www.example.org/9593fbe7-bbea-4c5a-a834-01834c4ba5b1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "U38nHAP0FblJb2",
+    "mainTitle" : "qA8eSWNudlt",
     "alternativeTitles" : {
-      "bg" : "xMTVrppLCAIKm4wCzBo"
+      "fr" : "KHuFCTZURzrvtLJD"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NlQ1kMVwrzCjzj6WiN",
-      "month" : "M6PVvnszswX",
-      "day" : "AJSkMdvNYcpVPh"
+      "year" : "sq6yNV8mhm43E3Q96",
+      "month" : "veBP9wCgf18QNY",
+      "day" : "dyjcVFweiN5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5589181f-348e-439d-b59a-c8a2973589a8",
-        "name" : "bOq0TKVgdZ",
-        "nameType" : "Organizational",
-        "orcId" : "NHsNmkVrC7A9dtzxsV",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/bc5949a2-d539-40d3-8d99-f851373630e9",
+        "name" : "qV9jOQ3DSZs",
+        "nameType" : "Personal",
+        "orcId" : "mYNNQ4MdJFb",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qvojwBdD0bdCQBz",
-          "value" : "sPULFUVbaagOlfus"
+          "sourceName" : "6hDqfaHPrS1Pam",
+          "value" : "2ctNzbrq2E"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4xoaFKPaC8ZtT",
-          "value" : "VyURPpKLV4"
+          "sourceName" : "5TkNg6Otg9q",
+          "value" : "8eHsGj7haDgO1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d9cf5855-3593-4d13-bc13-60eb7e6f37b2"
+        "id" : "https://www.example.org/558e55e8-de72-4107-8ed5-28535097a56c"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,173 +62,178 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6586dcba-8fb3-4136-99c9-63a40262c8e0",
-        "name" : "sCc26AavSd8lc6",
-        "nameType" : "Organizational",
-        "orcId" : "APrEwHWdVf2LP",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/d08f33a3-9cea-4a38-9d02-e6fafa4d1bf9",
+        "name" : "lVP0dQlvGZJRPT",
+        "nameType" : "Personal",
+        "orcId" : "cw0KAIYkyOYwrjHHS",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cAH6Lp8hlcCzS",
-          "value" : "4Uac5T0YwqoNB"
+          "sourceName" : "vTvBXq7W9JMJEsGD",
+          "value" : "oEVotIqygjspEi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yBpvt0hrQhN",
-          "value" : "9JJvLpXRVIfWN4kR"
+          "sourceName" : "t93C2DfE84A5Ktdz",
+          "value" : "qSfBQcvPUBGulFBv"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b2d72f22-ddc8-41c5-90a3-7ab7c82b56d2"
+        "id" : "https://www.example.org/99fc2c3f-5597-4ffd-bd28-a339ec635a9d"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "vWvdkga0nSXJ4ZzQkED"
+      "el" : "OtAbn8TPSw"
     },
-    "npiSubjectHeading" : "u9cySFOt4Az5WhJM",
-    "tags" : [ "nCuXQL5T5mPN" ],
-    "description" : "b2ITQCeT6XuHWoZ5A",
+    "npiSubjectHeading" : "rqaOXMKVJeqcLURK79f",
+    "tags" : [ "FoEOteV8ekEagym73" ],
+    "description" : "ZEaE8VSPTLTipw1A98",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Degree",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8eb40b1f-cd4f-451a-bc5a-773b7709a1a8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4842dad9-6120-4cfe-bd60-f0515169a9d7"
         },
-        "seriesNumber" : "mQ2YQSC65nW",
+        "seriesNumber" : "mwK2n0Sinq",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7951c8d6-a48c-44e1-8c2e-5fc67f708be2",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4f2019c0-2535-41f4-a0ed-00e63e1c95f3",
           "valid" : true
         },
-        "isbnList" : [ "9790943499955" ],
+        "isbnList" : [ "9780277513632", "9780707726168" ],
         "course" : {
           "type" : "UnconfirmedCourse",
-          "code" : "9Tu2UvcygVs9zfN2OG3"
+          "code" : "aos0FER49ZBdu0V9NeI"
         },
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "4vwVusW0a8mM"
+          "value" : "0707726166"
         } ]
       },
-      "doi" : "https://www.example.org/87983068-326e-45b5-85f1-f24c459bec61",
+      "doi" : "https://www.example.org/50761b06-1796-4b06-b3be-73a94638890a",
       "publicationInstance" : {
         "type" : "DegreePhd",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "6YHdzkKDqPyFJM",
-            "end" : "JgSc4DVqTQRWMotoWT3"
+            "begin" : "dclZOcu8ZaldNiO",
+            "end" : "xSaV4KCWG6oQlfh0jV"
           },
-          "pages" : "jCd99kTeCt6zX47pD",
-          "illustrated" : true
+          "pages" : "RzZBBTTTSmhgtohBR0",
+          "illustrated" : false
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "IHivM6Bu9o",
-          "month" : "2dCtudIEoO8zTnCm",
-          "day" : "yxbJtpAbcL1pVgXMsr"
+          "year" : "gwsnpe9FVk",
+          "month" : "oQZPmppFTzUdCa8Ao",
+          "day" : "X66ACUjgwN"
         },
         "related" : [ {
-          "type" : "ConfirmedDocument",
-          "identifier" : "https://www.example.com/HL0xdeW6oLbeku"
-        }, {
           "type" : "UnconfirmedDocument",
-          "text" : "BQAQaXfF1lnD0"
+          "text" : "5C5i6s1mBl4z"
+        }, {
+          "type" : "ConfirmedDocument",
+          "identifier" : "https://www.example.com/jqrsuXVSxbqxjb"
         } ]
       }
     },
-    "metadataSource" : "https://www.example.org/d1714ad9-b5be-4056-aca6-f31c9c0becab",
-    "abstract" : "6ow7e4wOmrSeXxO"
+    "metadataSource" : "https://www.example.org/2e40ae11-66c2-49c1-ac55-429ea5a8b6e8",
+    "abstract" : "oovnG3FSWrAOYfjbe"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c5e87946-9aa9-45f3-92c0-dbaaf1b4f886",
-    "name" : "R0uKC5pGQF",
+    "id" : "https://www.example.org/4bdeea5c-06f5-4d21-af0f-b419ca04a09f",
+    "name" : "YvB86dJ7S63",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-08-15T01:15:33.591Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "1985-10-29T23:30:25.942Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "ClMKsswidX1f1R"
+      "applicationCode" : "xpFOoA5PIUSNe"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8be4507b-b127-4527-8903-1fcb01e4566f",
-    "identifier" : "2CmkF8ls4oN",
+    "source" : "https://www.example.org/91d9200f-be92-4e8e-a45a-9b672c4e55f5",
+    "identifier" : "Rci5CdO1lB",
     "labels" : {
-      "af" : "X6kX6nsgGMRGMXMRK"
+      "ru" : "2XnJu6g0mnOHlgKt"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1553836795
+      "currency" : "GBP",
+      "amount" : 1531639918
     },
-    "activeFrom" : "1971-08-23T02:05:36.614Z",
-    "activeTo" : "2009-08-31T23:28:14.921Z"
+    "activeFrom" : "2001-11-18T06:13:10.204Z",
+    "activeTo" : "2009-01-01T19:26:13.542Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dc5b0a75-50ef-4e0e-bdf1-63cf1a57288a",
-    "id" : "https://www.example.org/58eb69ad-fb58-4c81-88a5-c7eb3f414502",
-    "identifier" : "fSE3kCpO16mzPX",
+    "source" : "https://www.example.org/4111f473-6ddd-4a18-ba76-1f0c3ece010a",
+    "id" : "https://www.example.org/d1d3da05-0b24-4798-986b-2d73628ecac1",
+    "identifier" : "xPccxCTMxAAE29vyWF",
     "labels" : {
-      "de" : "9ked1D8yGyPg2Zta"
+      "hu" : "Jb1OgCw8e0Yc0QYYu"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 913421093
+      "currency" : "EUR",
+      "amount" : 1181800928
     },
-    "activeFrom" : "1997-10-31T14:58:07.126Z",
-    "activeTo" : "2012-09-26T11:20:18.043Z"
+    "activeFrom" : "1972-11-23T18:18:10.322Z",
+    "activeTo" : "1990-02-14T15:46:23.192Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bf76f077-7510-4dd5-93b6-03b595fdd199" ],
+  "subjects" : [ "https://www.example.org/b9cdeb64-6d8d-4f94-a930-43c71ffeb611" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f1a51d6e-166e-4697-a0d2-cd4f964bdd63",
-    "name" : "Wsei40ziffVEd",
-    "mimeType" : "9vj3aGfZ5u4FpU9",
-    "size" : 1900132783,
-    "license" : "https://www.example.com/ngqzb5vqtaudjlfvtx",
+    "identifier" : "5a097906-76e1-4439-8826-5d33f1ff306e",
+    "name" : "EfoTaqamrMOx",
+    "mimeType" : "2rwpxvHtYpIBOMCJxEr",
+    "size" : 2059622676,
+    "license" : "https://www.example.com/omy1bo7r8tzdpzvp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "dkJrLWqCUyBi76oCDk",
-    "publishedDate" : "2018-09-08T17:46:07.762Z",
+    "legalNote" : "koc2AN11vlX4zBB",
+    "publishedDate" : "1975-02-11T13:46:45.905Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "jcSnp07sSkREuCeplTZ",
+      "uploadedDate" : "1987-09-02T11:45:42.164Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/dxI68Zo0ir1vxeP06f",
-    "name" : "Dm5sSVsq72TMVgdQd0g",
-    "description" : "iYF9jtGAhgp8OKnwVK"
+    "id" : "https://www.example.com/fFwJCHQwdK8EzdKrUrX",
+    "name" : "AwhSs5lt1YQEKdCAzN",
+    "description" : "5qhV0sW4rDhVIyYGK"
   } ],
-  "rightsHolder" : "JvkaUa0krg9RFz",
-  "duplicateOf" : "https://www.example.org/edeb0f96-0575-4b8d-b502-dd7ecea941bc",
+  "rightsHolder" : "lPvgjYB50d62M",
+  "duplicateOf" : "https://www.example.org/2cec18bc-c4a3-4a78-a177-7a05d41392cc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "6MMC9BBmie2"
+    "note" : "df9pvaGBnFgcFbB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QLbAmIR9feFqcNObbi",
-    "createdBy" : "kxmTwU36NmqVEv",
-    "createdDate" : "1981-10-25T00:05:03.076Z"
+    "note" : "NtCE04bKd7fZIvOQmQ",
+    "createdBy" : "8Fcf3tBxW5HD2i2",
+    "createdDate" : "1975-01-01T03:22:07.488Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5cf1fc04-856c-4006-8d21-e7d772457df3" ],
+  "curatingInstitutions" : [ "https://www.example.org/8b122a5f-d503-4866-a717-28f230718b35" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "A30ka2Z18fY",
-    "ownerAffiliation" : "https://www.example.org/3629dc82-e619-4bc8-aeef-90202f53150b"
+    "owner" : "IXDardRytkSdv",
+    "ownerAffiliation" : "https://www.example.org/fe09bec7-549b-48a6-91a5-c64c049b89a5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3b2e8f3f-9bfd-4940-86f2-d5aa6ee928fd"
+    "id" : "https://www.example.org/d8b7dc4b-3512-49fc-9bd0-e0f2a6f46d7e"
   },
-  "createdDate" : "1997-03-22T18:52:39.873Z",
-  "modifiedDate" : "1983-06-17T04:50:53.117Z",
-  "publishedDate" : "1972-03-13T00:19:47.979Z",
-  "indexedDate" : "2000-10-08T12:31:46.040Z",
-  "handle" : "https://www.example.org/fb2c1773-2858-42ef-b5b7-41e01a32a4bd",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/f9faa066-b714-4561-a1f9-b34164a9eacb",
+  "createdDate" : "2002-09-26T03:56:26.070Z",
+  "modifiedDate" : "1977-11-24T00:49:22.101Z",
+  "publishedDate" : "1979-05-31T02:18:15.566Z",
+  "indexedDate" : "2007-01-19T06:56:35.920Z",
+  "handle" : "https://www.example.org/8e0fa793-f075-47ab-9d53-467ebb52345a",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/69f08671-e3aa-4ced-955b-787f54eb0f41",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9G0Wmk07FXjB5c8",
+    "mainTitle" : "CLAm6jGgGMDqzLf",
     "alternativeTitles" : {
-      "da" : "wDDwaM6Qg2j8"
+      "nb" : "zSmKP8WMZ6wy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vUk3WsC7TqtwQxWlNqr",
-      "month" : "gg29QU3boTu",
-      "day" : "d3zwOBtRJw"
+      "year" : "pgXxM150uezjd9B2eZ",
+      "month" : "zL0OpWz6Qmq8",
+      "day" : "gbLwDFbqA0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1947219b-c181-46e0-9c96-51549c9e2505",
-        "name" : "SmYp76GDOTDwkviEt2",
+        "id" : "https://www.example.org/38fa6346-6d17-413b-8a0f-aa483b0074c1",
+        "name" : "VAzhw61B2t4juYt",
         "nameType" : "Personal",
-        "orcId" : "6hlGhRDkmotPXWz",
+        "orcId" : "RdbJyerkj6ijvAJU",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0cOcnuA2XEG7rMq8",
-          "value" : "BYG51t3m81F"
+          "sourceName" : "IkjR12dwGISt55",
+          "value" : "JCj283sRYWCIpFmiwI"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uTQRfinM8wcENcl7",
-          "value" : "rO7CTYANVEJ"
+          "sourceName" : "9DUVU4BbMUWsR9",
+          "value" : "PLhSxVsVEBXuYwTqU5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0218ff32-3b26-47aa-a090-f66fa6ee3b66"
+        "id" : "https://www.example.org/0ce3560e-2304-4f7a-b6df-e4b479b3940c"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c1b88770-de75-43b3-ac3a-2508ac8f3409",
-        "name" : "fy00zFu3TAxbNydYG",
-        "nameType" : "Organizational",
-        "orcId" : "tz8apCqTdW",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/7aa3234e-009b-41d5-93da-282c7e0026f2",
+        "name" : "UHX7bVr9KRO9w",
+        "nameType" : "Personal",
+        "orcId" : "zLPpFIwFcyQZwVeFbp",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ftdtVjLTCXQD",
-          "value" : "IyWQmfRyABWTB3thk2"
+          "sourceName" : "axPFQc6c6Mqhrx",
+          "value" : "lm5dQyjdkfGMDSRUA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SAHCkNlU2JlepKPx6",
-          "value" : "UeQuDjXWRzQ7r"
+          "sourceName" : "iJjirB89d4aKkhtYJbH",
+          "value" : "yxg7pn4VieHr20ZZAy"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/162fbeda-cefd-4d76-8e19-244fb6f72045"
+        "id" : "https://www.example.org/6d63c0d6-e8f0-4a7b-be9c-497332c68037"
       } ],
       "role" : {
-        "type" : "Architect"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "VBJYr1JxaTLA"
+      "pt" : "BOk1aS0MXQKH"
     },
-    "npiSubjectHeading" : "Sh4FD0rHMoKY",
-    "tags" : [ "eL1OTefp6LkytcS5sh" ],
-    "description" : "n4WryZvBOTF0DS",
+    "npiSubjectHeading" : "5iAHkoZB5m",
+    "tags" : [ "ABQuembdn6djL" ],
+    "description" : "t6FaSEdFaL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ed3e6caf-5e93-4dbf-97d5-09917cfeee57"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a2baacaa-195e-4937-965f-37199d293aeb"
         },
-        "seriesNumber" : "mUOBkhnqYSGP",
+        "seriesNumber" : "rOyOyP0yp0Tqpifwym",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b54fe5f8-a8c4-4fcb-a902-6865264d729f",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cbc96ade-e2a4-4a42-8beb-c57d91cbaae0",
           "valid" : true
         },
-        "isbnList" : [ "9791392022749" ],
+        "isbnList" : [ "9781950172856", "9781751618713" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "trcdjV6QMPU"
+          "value" : "1751618714"
         } ]
       },
-      "doi" : "https://www.example.org/020d4c50-59f1-4bf1-ac41-02fafa0619b6",
+      "doi" : "https://www.example.org/cdc5f7ea-3f0d-4567-93f9-c54b85992584",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "npvDNk64pW",
-            "end" : "3wv2f0fBaJ8tau1"
+            "begin" : "9t5fvmBA6oIqj",
+            "end" : "Dn1RN1fKhEb5xFcOf"
           },
-          "pages" : "wsGZo0bY1wMgZE4oNI",
+          "pages" : "kzCOoosGLC9EzD",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/cf8cec93-bf1d-4818-8dea-70c406356681",
-    "abstract" : "YEYkeRbcV46Ksahd"
+    "metadataSource" : "https://www.example.org/c0c476f6-f9cd-486e-8d4b-a5f8c20bae7c",
+    "abstract" : "xYAOgEY7eY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8c4f9eed-33cc-4c1f-bf88-8b1057f45731",
-    "name" : "hTdN0y8Z5ObgQ3",
+    "id" : "https://www.example.org/522f0014-4c58-4167-a070-8c37597b3ce8",
+    "name" : "TnoZCyomxl2q8F",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-10-11T04:03:12.438Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "iV9T8Vv2JMj25p"
+      "approvalDate" : "1972-04-19T14:42:07.273Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "CErEvYxAqm5bk"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4639a4dc-050f-4f48-819f-e0861329e577",
-    "identifier" : "qbyClP500J5Q06",
+    "source" : "https://www.example.org/04c5cac5-97dc-47d4-b143-7b3606220ffb",
+    "identifier" : "Xs2YUlIQsuzevNkNQt9",
     "labels" : {
-      "nb" : "TH6dPIfnqFqFT"
+      "en" : "W4CH9hPnM3rGvZdke"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 319187957
+      "currency" : "NOK",
+      "amount" : 1214661794
     },
-    "activeFrom" : "1975-02-04T04:49:43.829Z",
-    "activeTo" : "1976-04-13T18:22:37.517Z"
+    "activeFrom" : "1989-09-20T09:24:45.911Z",
+    "activeTo" : "1999-06-02T06:33:26.439Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/5bfb225e-e07b-4636-8f6d-767ade74104c",
-    "id" : "https://www.example.org/7431edde-f4ba-4a2d-bd0b-2212b08ab42f",
-    "identifier" : "XdzAqP8Ou4tdapf6",
+    "source" : "https://www.example.org/728bce9f-aacd-42cd-9e48-a45430951977",
+    "id" : "https://www.example.org/30ad996c-5250-452a-b484-1a01ee69aee6",
+    "identifier" : "ZwdE5vHCNgdj",
     "labels" : {
-      "es" : "ngmQb12ZRGG"
+      "pt" : "wMbu5RpBZUBfNS4RUym"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2036728163
+      "currency" : "NOK",
+      "amount" : 238909797
     },
-    "activeFrom" : "2014-03-17T20:44:11.003Z",
-    "activeTo" : "2020-12-31T14:34:12.442Z"
+    "activeFrom" : "1984-07-07T17:46:41.289Z",
+    "activeTo" : "2019-04-23T09:08:07.637Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c2a2d3fb-4156-4ee4-aa2c-ed1d09783590" ],
+  "subjects" : [ "https://www.example.org/731a0667-c76c-4712-849b-3396e1a0b705" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ecb38efd-2663-450b-9bd0-0e209c6ecb88",
-    "name" : "oAThL21SlvX3Z1CQFj",
-    "mimeType" : "TvYmKM8t7w4DpbSyTe",
-    "size" : 1475272904,
-    "license" : "https://www.example.com/t2u69vmjft",
+    "identifier" : "c88f4ad5-787f-43ba-b7e8-2b89e1627b4d",
+    "name" : "YVcaJivyPyL6mHWHyG",
+    "mimeType" : "hmMp8oraqMp",
+    "size" : 1351934203,
+    "license" : "https://www.example.com/wp9c7w8ybw5",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "O0V9VVb9sCCUaNoXG2",
-    "publishedDate" : "1991-08-21T21:41:31.588Z",
+    "legalNote" : "zIZPSb7XsWq0L",
+    "publishedDate" : "1986-01-17T13:44:11.855Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "4BrR1pq8llhawX94Sj",
+      "uploadedDate" : "2008-03-16T11:25:01.342Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/LoFXtSo015d8b1",
-    "name" : "uMFcpO9fXKgm",
-    "description" : "rhIxtNYbibs"
+    "id" : "https://www.example.com/DSnZknSNdO6E7jiGR",
+    "name" : "6qC3mxygYECPZX",
+    "description" : "7XpLHrWXJa1jlPOqUIp"
   } ],
-  "rightsHolder" : "Wdjw3zozcBxSH4Yks7Z",
-  "duplicateOf" : "https://www.example.org/ccf62392-d03b-41a5-bb1b-781a72b47b77",
+  "rightsHolder" : "z4aYj4lSV8i51",
+  "duplicateOf" : "https://www.example.org/b7480026-15d5-4c5e-8c5e-e8a936db6f86",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "KoTwubwG9Dr"
+    "note" : "Gjh5b0SMZXJL6Hr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "e5D6CLZ5q7",
-    "createdBy" : "mh4tWBXDNj7bNKXoT",
-    "createdDate" : "1993-10-12T07:43:55.282Z"
+    "note" : "TnBkrqnkNcka",
+    "createdBy" : "SulsCy3CYkqDhrB",
+    "createdDate" : "1996-08-01T06:11:41.813Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b3f00df2-efa5-4446-b631-e6ebcc58e516" ],
+  "curatingInstitutions" : [ "https://www.example.org/b55565e6-2675-4615-9117-6e53dc39ddaf" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/Encyclopedia.json
+++ b/documentation/Encyclopedia.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "lLRq8xroz9suH",
-    "ownerAffiliation" : "https://www.example.org/5aa2449f-b14a-4fca-8151-751d9af66240"
+    "owner" : "A30ka2Z18fY",
+    "ownerAffiliation" : "https://www.example.org/3629dc82-e619-4bc8-aeef-90202f53150b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d02c938e-34ba-456c-a30c-4938d627433c"
+    "id" : "https://www.example.org/3b2e8f3f-9bfd-4940-86f2-d5aa6ee928fd"
   },
-  "createdDate" : "1999-04-30T00:57:53.527Z",
-  "modifiedDate" : "2023-04-04T20:55:14.360Z",
-  "publishedDate" : "1977-06-04T22:07:05.050Z",
-  "indexedDate" : "2006-01-07T13:34:30.109Z",
-  "handle" : "https://www.example.org/5a81270d-c46f-4fd3-af18-d35ecb0a47f2",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/d578d5f0-2962-420d-a1e2-f7ab1d9701e5",
+  "createdDate" : "1997-03-22T18:52:39.873Z",
+  "modifiedDate" : "1983-06-17T04:50:53.117Z",
+  "publishedDate" : "1972-03-13T00:19:47.979Z",
+  "indexedDate" : "2000-10-08T12:31:46.040Z",
+  "handle" : "https://www.example.org/fb2c1773-2858-42ef-b5b7-41e01a32a4bd",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/f9faa066-b714-4561-a1f9-b34164a9eacb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NnBVgahp13E5bDS7458",
+    "mainTitle" : "9G0Wmk07FXjB5c8",
     "alternativeTitles" : {
-      "ca" : "tuH6EvpZBN7PxM44C"
+      "da" : "wDDwaM6Qg2j8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "QFAHgBTNbI6gjB",
-      "month" : "RKFszD6rb9",
-      "day" : "VyTlqU3anD32V0"
+      "year" : "vUk3WsC7TqtwQxWlNqr",
+      "month" : "gg29QU3boTu",
+      "day" : "d3zwOBtRJw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/860e6e7b-9e4f-4dc0-971a-d52b93857cf5",
-        "name" : "zBKPzxBHjPGFwZ",
+        "id" : "https://www.example.org/1947219b-c181-46e0-9c96-51549c9e2505",
+        "name" : "SmYp76GDOTDwkviEt2",
         "nameType" : "Personal",
-        "orcId" : "Lpr3x5HtW4",
+        "orcId" : "6hlGhRDkmotPXWz",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T2eUm6nO2x65UzOFhyn",
-          "value" : "EKtubtflfvUl"
+          "sourceName" : "0cOcnuA2XEG7rMq8",
+          "value" : "BYG51t3m81F"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TN7GFkik61qyAfNg",
-          "value" : "ZsOfrIec4h17PHPP7S"
+          "sourceName" : "uTQRfinM8wcENcl7",
+          "value" : "rO7CTYANVEJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0dc6ae47-a12e-4d74-aea0-57c069abd4e1"
+        "id" : "https://www.example.org/0218ff32-3b26-47aa-a090-f66fa6ee3b66"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0351d68e-52ec-4569-8b1f-6408f1a01d52",
-        "name" : "utFLphxo7dc",
+        "id" : "https://www.example.org/c1b88770-de75-43b3-ac3a-2508ac8f3409",
+        "name" : "fy00zFu3TAxbNydYG",
         "nameType" : "Organizational",
-        "orcId" : "PryLG8Rs7e2Amwi",
+        "orcId" : "tz8apCqTdW",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dejJiZyb6W",
-          "value" : "QUrC9ugz1A"
+          "sourceName" : "ftdtVjLTCXQD",
+          "value" : "IyWQmfRyABWTB3thk2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DGhA0McpMC",
-          "value" : "9z0ZqPZcPxOLXh"
+          "sourceName" : "SAHCkNlU2JlepKPx6",
+          "value" : "UeQuDjXWRzQ7r"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2740e198-990f-4d92-a52e-c5d1e4d840c0"
+        "id" : "https://www.example.org/162fbeda-cefd-4d76-8e19-244fb6f72045"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Architect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "RyENdxmOsnfslVQJm"
+      "el" : "VBJYr1JxaTLA"
     },
-    "npiSubjectHeading" : "yJRd3PKibv",
-    "tags" : [ "MqDG0dctqzSYix" ],
-    "description" : "xfv3W3K6p9ZMPMxHaJ",
+    "npiSubjectHeading" : "Sh4FD0rHMoKY",
+    "tags" : [ "eL1OTefp6LkytcS5sh" ],
+    "description" : "n4WryZvBOTF0DS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/97f55545-3b0d-4475-85a9-e7f1f93b67e8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ed3e6caf-5e93-4dbf-97d5-09917cfeee57"
         },
-        "seriesNumber" : "zLu6NBeufA2uJ8j",
+        "seriesNumber" : "mUOBkhnqYSGP",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/96fd9fe8-9587-4ea7-b47b-e2266a2efd8b",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b54fe5f8-a8c4-4fcb-a902-6865264d729f",
           "valid" : true
         },
-        "isbnList" : [ "9790058694474" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9791392022749" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "w0fOUS72VQ"
+          "value" : "trcdjV6QMPU"
         } ]
       },
-      "doi" : "https://www.example.org/99d4455f-e736-4d8d-ba0c-d6840b394cf2",
+      "doi" : "https://www.example.org/020d4c50-59f1-4bf1-ac41-02fafa0619b6",
       "publicationInstance" : {
         "type" : "Encyclopedia",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "nEACGHvNMDdk0wh7",
-            "end" : "Ke2Tqgc74yvqHtfA"
+            "begin" : "npvDNk64pW",
+            "end" : "3wv2f0fBaJ8tau1"
           },
-          "pages" : "FluDuyLeOH9Km8YtaZU",
+          "pages" : "wsGZo0bY1wMgZE4oNI",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/790ee363-2603-4d34-9dfb-f7276b1130c9",
-    "abstract" : "ZbrcQkvbg3QZu"
+    "metadataSource" : "https://www.example.org/cf8cec93-bf1d-4818-8dea-70c406356681",
+    "abstract" : "YEYkeRbcV46Ksahd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/dd5462ca-ff62-4874-a2e9-2411f24b679b",
-    "name" : "5y8V0wuhKJk0",
+    "id" : "https://www.example.org/8c4f9eed-33cc-4c1f-bf88-8b1057f45731",
+    "name" : "hTdN0y8Z5ObgQ3",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-11-27T14:43:52.052Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "MR0xTDYLLNG45"
+      "approvalDate" : "2013-10-11T04:03:12.438Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "iV9T8Vv2JMj25p"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/aebd5eee-412d-42b2-9045-c79e1fe88457",
-    "identifier" : "UO0XNaW615Kwdp",
+    "source" : "https://www.example.org/4639a4dc-050f-4f48-819f-e0861329e577",
+    "identifier" : "qbyClP500J5Q06",
     "labels" : {
-      "bg" : "GXmAa2pB1OYelV"
+      "nb" : "TH6dPIfnqFqFT"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2103917486
+      "amount" : 319187957
     },
-    "activeFrom" : "1980-08-08T08:44:14.932Z",
-    "activeTo" : "2014-06-30T01:01:17.733Z"
+    "activeFrom" : "1975-02-04T04:49:43.829Z",
+    "activeTo" : "1976-04-13T18:22:37.517Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/78f3cce6-6704-4e05-a122-080cfd04c350",
-    "id" : "https://www.example.org/2ddf8d85-7e68-4cbe-8115-baf7fbbd9682",
-    "identifier" : "K1tSQ2EOkn9",
+    "source" : "https://www.example.org/5bfb225e-e07b-4636-8f6d-767ade74104c",
+    "id" : "https://www.example.org/7431edde-f4ba-4a2d-bd0b-2212b08ab42f",
+    "identifier" : "XdzAqP8Ou4tdapf6",
     "labels" : {
-      "nb" : "1UY2V46Og8qKjkwQsa"
+      "es" : "ngmQb12ZRGG"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 558989922
+      "currency" : "EUR",
+      "amount" : 2036728163
     },
-    "activeFrom" : "1983-05-07T00:11:10.172Z",
-    "activeTo" : "2008-04-05T16:52:12.952Z"
+    "activeFrom" : "2014-03-17T20:44:11.003Z",
+    "activeTo" : "2020-12-31T14:34:12.442Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e243359b-1769-45a9-84e5-37209b52b3e9" ],
+  "subjects" : [ "https://www.example.org/c2a2d3fb-4156-4ee4-aa2c-ed1d09783590" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4f813dce-9469-4f08-a020-44af15e1098e",
-    "name" : "vw1iVQG3IOL3lDtAE",
-    "mimeType" : "rSgRgaf2U2bRi2hwk7",
-    "size" : 1606316464,
-    "license" : "https://www.example.com/mclppm9qqkzyu",
+    "identifier" : "ecb38efd-2663-450b-9bd0-0e209c6ecb88",
+    "name" : "oAThL21SlvX3Z1CQFj",
+    "mimeType" : "TvYmKM8t7w4DpbSyTe",
+    "size" : 1475272904,
+    "license" : "https://www.example.com/t2u69vmjft",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "1n715zEjPGRZrM",
-    "publishedDate" : "1996-01-20T06:16:50.202Z",
+    "legalNote" : "O0V9VVb9sCCUaNoXG2",
+    "publishedDate" : "1991-08-21T21:41:31.588Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/inpNuiIeRmwSr",
-    "name" : "HR1fu87FJ3XtHCX",
-    "description" : "TiR9PbfiH5wMTvi"
+    "id" : "https://www.example.com/LoFXtSo015d8b1",
+    "name" : "uMFcpO9fXKgm",
+    "description" : "rhIxtNYbibs"
   } ],
-  "rightsHolder" : "tIpUwrC2QP",
-  "duplicateOf" : "https://www.example.org/40dd71fd-df4e-446e-8139-275641d0f3d4",
+  "rightsHolder" : "Wdjw3zozcBxSH4Yks7Z",
+  "duplicateOf" : "https://www.example.org/ccf62392-d03b-41a5-bb1b-781a72b47b77",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "dUKnHKz0H7IZ6yJ"
+    "note" : "KoTwubwG9Dr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dlLYnK5J83",
-    "createdBy" : "H4Gel518qmWH2emyBC",
-    "createdDate" : "1977-05-31T20:57:25.015Z"
+    "note" : "e5D6CLZ5q7",
+    "createdBy" : "mh4tWBXDNj7bNKXoT",
+    "createdDate" : "1993-10-12T07:43:55.282Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a724cfe8-cfcb-4c7c-bbcf-dd20a2708027" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/b3f00df2-efa5-4446-b631-e6ebcc58e516" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "mugcbwKZ6PeQq",
-    "ownerAffiliation" : "https://www.example.org/29030b32-a54a-4157-96ec-d7171dc81b7a"
+    "owner" : "u2NKZb5wYQ",
+    "ownerAffiliation" : "https://www.example.org/b1005ec5-5a32-4c2b-9725-a9c03f949d74"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9eb3c6b3-0975-4d93-89eb-775fbbfb3fb9"
+    "id" : "https://www.example.org/e10124c5-648d-482b-8b9a-53f0a06fc987"
   },
-  "createdDate" : "2010-01-27T00:22:26.587Z",
-  "modifiedDate" : "1976-10-05T04:37:33.469Z",
-  "publishedDate" : "1981-05-03T07:32:06.573Z",
-  "indexedDate" : "1980-12-24T09:47:14.910Z",
-  "handle" : "https://www.example.org/9e6912d1-44c4-4f07-8d0f-fc02cd3bfa16",
-  "doi" : "https://doi.org/10.1234/asperiores",
-  "link" : "https://www.example.org/814885a1-30a7-48ab-99e2-e61bc4f3e65d",
+  "createdDate" : "2010-07-26T21:39:53.705Z",
+  "modifiedDate" : "1981-08-29T06:13:56.511Z",
+  "publishedDate" : "1976-01-09T21:22:18.726Z",
+  "indexedDate" : "2015-12-13T07:25:43.601Z",
+  "handle" : "https://www.example.org/74fcb03a-5c29-4c36-8b18-7eb61d8d3370",
+  "doi" : "https://doi.org/10.1234/aperiam",
+  "link" : "https://www.example.org/ee59fa1d-11ab-43ad-9628-8716b3a63c40",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Ict3EjMpB0oRRz",
+    "mainTitle" : "dLMTY25KAA0B",
     "alternativeTitles" : {
-      "hu" : "8cGb1i6idccS"
+      "en" : "hslXZC0sbj5eQS33tPY"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iJLOQiBub2AzR",
-      "month" : "UcOdpNkmJWK6l7m",
-      "day" : "Rxj54rBCG96ue"
+      "year" : "iEVYXFPgMJ",
+      "month" : "D50rlwlIWs6j2I",
+      "day" : "LVYT1T52ywfNsD2"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0060ae87-60b7-4d72-bee6-e178d194f9d5",
-        "name" : "fVV9vEqQ8d2cd",
-        "nameType" : "Personal",
-        "orcId" : "jiIYCr7QKH",
+        "id" : "https://www.example.org/9286d043-429d-4fc2-aff6-bfe3a5a03c61",
+        "name" : "0tCLWfIAkYJ7NNloi",
+        "nameType" : "Organizational",
+        "orcId" : "XLDSqOivo1",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YCEXIQ4UzjuNELI3",
-          "value" : "uGxHf02EhhMqDhSfkU"
+          "sourceName" : "mDre2n3fBXTUj",
+          "value" : "dRRSZly5sWoKjpn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w53DpW6dHDgrlyQ04",
-          "value" : "o68G7EwRWthXN2PX1"
+          "sourceName" : "HZxK2MHTKG",
+          "value" : "bRdmxjzWT70ar"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ab3e4a4c-62f1-46be-a9d6-388b45556ac1"
+        "id" : "https://www.example.org/7b995d53-1371-4837-abf3-629ed36fa93a"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/544841e5-07fe-4c97-b347-481025d1e265",
-        "name" : "dciaPBeZMe4d",
+        "id" : "https://www.example.org/4ac09a40-4f7c-4b28-900d-1404ba1c31b9",
+        "name" : "XzTwB19lHgCOcCvPtPl",
         "nameType" : "Organizational",
-        "orcId" : "Eq98ShsL9rtGdAODvPr",
-        "verificationStatus" : "Verified",
+        "orcId" : "EQHtzQmVsVu4Pn",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WufuXxrWJCPp0R8",
-          "value" : "Tz8TtOnn1irf"
+          "sourceName" : "5ZTROpmHWoNBP",
+          "value" : "UWRKp4e8kQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DmAg29Aylt3Gs80Ms",
-          "value" : "bkRfxu8iJ95aHcj"
+          "sourceName" : "ivRkQGP0cs",
+          "value" : "VpRNoabG3hCe86e0iGg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b467c1ed-c30d-4c14-8bfc-897254dcf691"
+        "id" : "https://www.example.org/06ff6feb-f77c-4194-8002-03398d9bf909"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "nJWUvm3GnqgVZ0"
+      "sv" : "KqQTQzKGsk"
     },
-    "npiSubjectHeading" : "PSSWlAuRSaNd",
-    "tags" : [ "2po1O0Meyb8wTdD50" ],
-    "description" : "X3OEqwjVPBvFYoTeB",
+    "npiSubjectHeading" : "2Il0TlqZDSJ2IU5",
+    "tags" : [ "HKkE4h62cLC7" ],
+    "description" : "bTRDJEiyEwn2adVvIaR",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/hzw1FaaX8L2n"
+        "id" : "https://www.example.com/EL7N5iIRlXothZL6"
       },
-      "doi" : "https://www.example.org/57417a25-840b-4ad2-b8ac-76e337f445e4",
+      "doi" : "https://www.example.org/6bd2b254-d086-4aed-aba2-2c9dac08c404",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "PwhSC8y7MttN4Ptjw",
-          "end" : "WOqrpjYTzZvs"
+          "begin" : "70gK78YMBCgNbTUY",
+          "end" : "r27O99glhC"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d9dbd5d1-77ca-4cc5-8d14-9249bebb1c95",
-    "abstract" : "86GG70YKUQ46IXUY5"
+    "metadataSource" : "https://www.example.org/97462bde-a874-40f3-b873-3c6893e45a09",
+    "abstract" : "3vcGtIXsDbBGcSL"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1b90fa9a-0ba7-467c-b457-e2a4fc81a349",
-    "name" : "iYgdhVrjTM",
+    "id" : "https://www.example.org/a947390e-270e-4484-8e7b-146ed9f5e94b",
+    "name" : "dhuvd7SN5dh",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-07-25T05:19:24.142Z",
+      "approvalDate" : "1994-05-31T01:11:56.368Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "kt6BW9bFDt4k1Dx"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "FW6jxSdCI0uPg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6f09c834-5390-4904-874d-8464374afcec",
-    "identifier" : "HwU7j6RqCpypP",
+    "source" : "https://www.example.org/66657995-b85b-40bb-98f0-13e7d53436ad",
+    "identifier" : "oBoyR7ySbTBL1kf",
     "labels" : {
-      "pt" : "7PnVfIp5e5ab5mv"
+      "el" : "R9asdafqjXj6dHazR"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1718616698
+      "currency" : "GBP",
+      "amount" : 1091269971
     },
-    "activeFrom" : "2018-05-09T05:40:56.249Z",
-    "activeTo" : "2022-07-10T00:04:21.574Z"
+    "activeFrom" : "2006-09-23T02:01:58.082Z",
+    "activeTo" : "2021-11-03T04:43:01.258Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2b7afe2a-91f7-43e3-9f25-8ec2406b2942",
-    "id" : "https://www.example.org/42c3fc53-4f59-41d3-9d60-4809f9ad9858",
-    "identifier" : "N6Fcr0na3Rr8qv6jseG",
+    "source" : "https://www.example.org/131e0515-e67a-44e9-8b52-eb19559b70fd",
+    "id" : "https://www.example.org/a370acb7-81ff-4b95-9064-4894d7034859",
+    "identifier" : "f77PP3lpPe4F",
     "labels" : {
-      "pt" : "JJxBdIkeDPz004l8WC"
+      "is" : "U0Uux1wi6Q24"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 48184772
+      "currency" : "GBP",
+      "amount" : 1840205759
     },
-    "activeFrom" : "1985-03-03T07:27:17.515Z",
-    "activeTo" : "2014-09-25T06:08:49.015Z"
+    "activeFrom" : "2008-07-03T21:22:07.065Z",
+    "activeTo" : "2020-09-06T03:05:13.052Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3b2ca68f-0982-4529-a0cc-7ea6238d5de9" ],
+  "subjects" : [ "https://www.example.org/4f5f0aed-34f5-4614-801a-3d4d37e7341f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "916a1aa5-223e-4a7b-9c4f-c90aa87ac72d",
-    "name" : "6AhyPMtG4Xx4",
-    "mimeType" : "4YyHUpEZWMDlJ87ts7",
-    "size" : 655601638,
-    "license" : "https://www.example.com/d4zmal5a2k3xghbc",
+    "identifier" : "5821e3e3-9a83-4671-8f6c-f903ad772a14",
+    "name" : "Pk8eJ3ZlWXTF4sC6U",
+    "mimeType" : "bqhUpuSYtOIZp5P8iaR",
+    "size" : 1734825753,
+    "license" : "https://www.example.com/ryujmymlqoeukp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "isTvdILvQbNZlFvcmf"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "fcubgP372XPB8mFi",
-    "publishedDate" : "1996-12-01T17:42:33.257Z",
+    "legalNote" : "1P620ueC5sLPNpu1",
+    "publishedDate" : "1988-02-12T05:09:09.050Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gjFCck3WWoCj1Ghf",
-    "name" : "jPccNfYftrk0mOe3TN",
-    "description" : "oqddwQY5Glrm"
+    "id" : "https://www.example.com/ejICx24gr9TTDh",
+    "name" : "78J9FjQ2RrnrDCkz3us",
+    "description" : "4YEJ9WKv1aAz7O"
   } ],
-  "rightsHolder" : "pjCSEvhpiI4k3Ta",
-  "duplicateOf" : "https://www.example.org/f3c29b5f-65bf-4cca-8f52-de47347dc3e1",
+  "rightsHolder" : "s79Rhk2XVaWiPu",
+  "duplicateOf" : "https://www.example.org/ad75d89d-4375-4ec3-8535-0b39178ffb97",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "rquO6InSBDAA"
+    "note" : "VRdVUkNO5mfOy7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "x5RjAhxHnV4h",
-    "createdBy" : "ZiYNtzCOLFEH7V",
-    "createdDate" : "1978-07-02T02:09:34.924Z"
+    "note" : "Q2WecJ6sysFqdPvn",
+    "createdBy" : "kQ6HKOjpVY3giOm",
+    "createdDate" : "1980-02-20T22:27:00.923Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/06c18fa9-594d-46a9-ae9b-decd40cec54f" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/131c40e7-2721-40cb-84f4-13869d0179a2" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/EncyclopediaChapter.json
+++ b/documentation/EncyclopediaChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "u2NKZb5wYQ",
-    "ownerAffiliation" : "https://www.example.org/b1005ec5-5a32-4c2b-9725-a9c03f949d74"
+    "owner" : "PcOW23tlUUJi",
+    "ownerAffiliation" : "https://www.example.org/6280a4bf-1841-425c-86af-3cd532a84850"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e10124c5-648d-482b-8b9a-53f0a06fc987"
+    "id" : "https://www.example.org/0d3675bc-cd14-40b7-8934-fc5d6f2183bb"
   },
-  "createdDate" : "2010-07-26T21:39:53.705Z",
-  "modifiedDate" : "1981-08-29T06:13:56.511Z",
-  "publishedDate" : "1976-01-09T21:22:18.726Z",
-  "indexedDate" : "2015-12-13T07:25:43.601Z",
-  "handle" : "https://www.example.org/74fcb03a-5c29-4c36-8b18-7eb61d8d3370",
-  "doi" : "https://doi.org/10.1234/aperiam",
-  "link" : "https://www.example.org/ee59fa1d-11ab-43ad-9628-8716b3a63c40",
+  "createdDate" : "2017-05-13T03:48:19.313Z",
+  "modifiedDate" : "1983-04-06T10:10:49.806Z",
+  "publishedDate" : "1995-08-01T10:00:03.418Z",
+  "indexedDate" : "2014-04-26T03:36:32.740Z",
+  "handle" : "https://www.example.org/6bdeae86-64b0-4fb7-8761-898b1a749520",
+  "doi" : "https://doi.org/10.1234/saepe",
+  "link" : "https://www.example.org/2c798b13-b56e-4912-b14f-c5ec3614ad8c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "dLMTY25KAA0B",
+    "mainTitle" : "ajBpiNOwTea4y6axT",
     "alternativeTitles" : {
-      "en" : "hslXZC0sbj5eQS33tPY"
+      "fr" : "lp5MANXvOjk0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iEVYXFPgMJ",
-      "month" : "D50rlwlIWs6j2I",
-      "day" : "LVYT1T52ywfNsD2"
+      "year" : "bhfU2pRgIA",
+      "month" : "kAem7NNCnzvqbW",
+      "day" : "cVUQw8fnYDbhzD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9286d043-429d-4fc2-aff6-bfe3a5a03c61",
-        "name" : "0tCLWfIAkYJ7NNloi",
+        "id" : "https://www.example.org/96f57ad4-4232-4e8d-ae24-f30c2cf7dd63",
+        "name" : "Tz1UHAlwJV7p",
         "nameType" : "Organizational",
-        "orcId" : "XLDSqOivo1",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "EXjkETBAGgIEU",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mDre2n3fBXTUj",
-          "value" : "dRRSZly5sWoKjpn"
+          "sourceName" : "T2JO5LlVM5hz",
+          "value" : "fXSD4NlxGYc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HZxK2MHTKG",
-          "value" : "bRdmxjzWT70ar"
+          "sourceName" : "AGSOX7yOZaooV3",
+          "value" : "yI0XiwmqcPRR0tV7T"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7b995d53-1371-4837-abf3-629ed36fa93a"
+        "id" : "https://www.example.org/20dbdb8b-7cc3-4dc8-89c1-05b00dcb3c7c"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4ac09a40-4f7c-4b28-900d-1404ba1c31b9",
-        "name" : "XzTwB19lHgCOcCvPtPl",
+        "id" : "https://www.example.org/1f9899ae-c17a-4f8f-b320-8b76298982d8",
+        "name" : "VKRSinLn1IPHC",
         "nameType" : "Organizational",
-        "orcId" : "EQHtzQmVsVu4Pn",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "2kdDMdlToYiuO3u4",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5ZTROpmHWoNBP",
-          "value" : "UWRKp4e8kQ"
+          "sourceName" : "55SvQKA1Wndg0KVO4xq",
+          "value" : "48Kff7spkQkRutrRO"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ivRkQGP0cs",
-          "value" : "VpRNoabG3hCe86e0iGg"
+          "sourceName" : "LYRK4XvX380HL",
+          "value" : "rULd23QaByW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/06ff6feb-f77c-4194-8002-03398d9bf909"
+        "id" : "https://www.example.org/7559d27d-8c06-443b-a988-1569b8d0382c"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "KqQTQzKGsk"
+      "bg" : "nLhgI9wczlWJbVaQSy3"
     },
-    "npiSubjectHeading" : "2Il0TlqZDSJ2IU5",
-    "tags" : [ "HKkE4h62cLC7" ],
-    "description" : "bTRDJEiyEwn2adVvIaR",
+    "npiSubjectHeading" : "jN9bA3tDtCs0GbxQr",
+    "tags" : [ "YsATECs9peiAmpy" ],
+    "description" : "A3s2y8YKEoHkz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/EL7N5iIRlXothZL6"
+        "id" : "https://www.example.com/GSV0x5CDNwe"
       },
-      "doi" : "https://www.example.org/6bd2b254-d086-4aed-aba2-2c9dac08c404",
+      "doi" : "https://www.example.org/b56d0288-03b8-4f1e-acd3-6a2ae8187a83",
       "publicationInstance" : {
         "type" : "EncyclopediaChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "70gK78YMBCgNbTUY",
-          "end" : "r27O99glhC"
+          "begin" : "UdcHm0QkdgfkHWKJ",
+          "end" : "rrtYJJRVvQs1TTTe"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/97462bde-a874-40f3-b873-3c6893e45a09",
-    "abstract" : "3vcGtIXsDbBGcSL"
+    "metadataSource" : "https://www.example.org/d47cd433-a12f-4ab9-a101-dd7a9a7acf12",
+    "abstract" : "MchHHnZbrOign"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a947390e-270e-4484-8e7b-146ed9f5e94b",
-    "name" : "dhuvd7SN5dh",
+    "id" : "https://www.example.org/ec5c908d-21de-484e-b755-cfe27c8ef1bd",
+    "name" : "Y8KuvRLJ6xVkxGG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1994-05-31T01:11:56.368Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "2006-12-19T09:34:09.594Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "FW6jxSdCI0uPg"
+      "applicationCode" : "85jdGzXWgDtkXBCJP3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/66657995-b85b-40bb-98f0-13e7d53436ad",
-    "identifier" : "oBoyR7ySbTBL1kf",
+    "source" : "https://www.example.org/03f405ce-d728-43c3-b3bd-ad98d59f1b71",
+    "identifier" : "Ysej07KsXtedg8ra",
     "labels" : {
-      "el" : "R9asdafqjXj6dHazR"
+      "se" : "hUGVvPCDK8akO4Rd9c"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1091269971
+      "currency" : "NOK",
+      "amount" : 1941438593
     },
-    "activeFrom" : "2006-09-23T02:01:58.082Z",
-    "activeTo" : "2021-11-03T04:43:01.258Z"
+    "activeFrom" : "1983-11-11T05:38:51.031Z",
+    "activeTo" : "1986-02-02T02:37:53.738Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/131e0515-e67a-44e9-8b52-eb19559b70fd",
-    "id" : "https://www.example.org/a370acb7-81ff-4b95-9064-4894d7034859",
-    "identifier" : "f77PP3lpPe4F",
+    "source" : "https://www.example.org/879a58e0-7f8b-4ef7-b71b-e74b2b059598",
+    "id" : "https://www.example.org/5891fb0a-1402-47cd-860d-40314f199764",
+    "identifier" : "YLfiM34cX4Myy8AHeXN",
     "labels" : {
-      "is" : "U0Uux1wi6Q24"
+      "zh" : "DZi6N4wfUA2MpdLjU5"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1840205759
+      "currency" : "USD",
+      "amount" : 1689143310
     },
-    "activeFrom" : "2008-07-03T21:22:07.065Z",
-    "activeTo" : "2020-09-06T03:05:13.052Z"
+    "activeFrom" : "1972-07-11T19:01:03.795Z",
+    "activeTo" : "1993-06-16T00:35:19.846Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4f5f0aed-34f5-4614-801a-3d4d37e7341f" ],
+  "subjects" : [ "https://www.example.org/ad72f23d-b1f5-4ed8-8ae8-e021d6560f5f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5821e3e3-9a83-4671-8f6c-f903ad772a14",
-    "name" : "Pk8eJ3ZlWXTF4sC6U",
-    "mimeType" : "bqhUpuSYtOIZp5P8iaR",
-    "size" : 1734825753,
-    "license" : "https://www.example.com/ryujmymlqoeukp",
+    "identifier" : "8c7f9e87-f800-4cdd-bebb-3a82e63e246b",
+    "name" : "oE2M1VcAYOrtxNpO8",
+    "mimeType" : "smeoD7HVn6s",
+    "size" : 1259328649,
+    "license" : "https://www.example.com/fworgu81nll1mx",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "1P620ueC5sLPNpu1",
-    "publishedDate" : "1988-02-12T05:09:09.050Z",
+    "legalNote" : "qJQOlGTlySCjLgqRc",
+    "publishedDate" : "1986-07-27T13:33:20.468Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "BOu3LRh8Md2qZAzOS",
+      "uploadedDate" : "2022-12-22T03:26:20.086Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ejICx24gr9TTDh",
-    "name" : "78J9FjQ2RrnrDCkz3us",
-    "description" : "4YEJ9WKv1aAz7O"
+    "id" : "https://www.example.com/Q9negtalfoqWG0H",
+    "name" : "TxOqbyhifiG",
+    "description" : "lubZi9podMm"
   } ],
-  "rightsHolder" : "s79Rhk2XVaWiPu",
-  "duplicateOf" : "https://www.example.org/ad75d89d-4375-4ec3-8535-0b39178ffb97",
+  "rightsHolder" : "Kdzs9snIjIsF",
+  "duplicateOf" : "https://www.example.org/45182c76-f1d7-4076-a15f-3da07e419204",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "VRdVUkNO5mfOy7"
+    "note" : "GuiWPnO0dy9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Q2WecJ6sysFqdPvn",
-    "createdBy" : "kQ6HKOjpVY3giOm",
-    "createdDate" : "1980-02-20T22:27:00.923Z"
+    "note" : "gGi97ay3MDgDNzt",
+    "createdBy" : "7KgrMM7iTTuh0xK",
+    "createdDate" : "1993-01-22T15:11:08.607Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/131c40e7-2721-40cb-84f4-13869d0179a2" ],
+  "curatingInstitutions" : [ "https://www.example.org/c8d4f9b1-e939-4913-a1a9-0f0d2803363b" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "pqne9rqjAXglbGdINZb",
-    "ownerAffiliation" : "https://www.example.org/9c87df7f-f855-430f-acb8-4935f07f9e0e"
+    "owner" : "fuAl1rKOKXnEKeEXv",
+    "ownerAffiliation" : "https://www.example.org/662e1d1b-1f12-4c59-98d1-40ced1c72366"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/649a92e8-8356-43a1-9206-df1759deb348"
+    "id" : "https://www.example.org/0c1a9c8f-5206-40c2-a6fa-c07cbda7489a"
   },
-  "createdDate" : "2014-09-21T16:19:14.908Z",
-  "modifiedDate" : "2023-08-12T19:50:50.045Z",
-  "publishedDate" : "1988-02-27T03:04:52.624Z",
-  "indexedDate" : "1988-02-25T21:07:14.107Z",
-  "handle" : "https://www.example.org/8542a177-3c73-48db-a1d7-8a6fe31326d8",
-  "doi" : "https://doi.org/10.1234/maxime",
-  "link" : "https://www.example.org/26891e15-186d-4162-8344-31e21a50e7e0",
+  "createdDate" : "2010-01-11T08:56:23.896Z",
+  "modifiedDate" : "1977-05-31T02:42:16.533Z",
+  "publishedDate" : "1987-05-15T07:45:12.340Z",
+  "indexedDate" : "1993-11-19T23:36:18.929Z",
+  "handle" : "https://www.example.org/71976a46-416c-4678-9b18-c9a9c0a87c85",
+  "doi" : "https://doi.org/10.1234/tempora",
+  "link" : "https://www.example.org/87b1dcf9-b747-4ef6-82d2-a24d719fc46c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "xTcfHNF98XYTIf",
+    "mainTitle" : "tAWoco1DZWi",
     "alternativeTitles" : {
-      "hu" : "I8DbjhS2JLzqwCL"
+      "ca" : "ry3syFiqqlZcn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "p4EbT7JYEZT8dr",
-      "month" : "NzBGa5cAajAZ39K",
-      "day" : "VVnjOohR7VoexBNT"
+      "year" : "qq6rQp8agHFqfKcWO",
+      "month" : "sDfBNGCIJ2q",
+      "day" : "PdJVl6BaBAuaMd"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5fe020a2-abcd-4674-bf7a-c11e02c8fd22",
-        "name" : "41yZ4LIOjTW",
-        "nameType" : "Organizational",
-        "orcId" : "5RGU23VXUVteNisXXHu",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f134f570-0005-4e15-966b-8ee5ce7fa24b",
+        "name" : "heYLqRNSBiM",
+        "nameType" : "Personal",
+        "orcId" : "Oh8JQndX2qjEy",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3KLIA7FdzZ2T5yRWHjg",
-          "value" : "3HutRIXv36ekKz24F"
+          "sourceName" : "KWWP6L7QwOCNIrV",
+          "value" : "othr329RxFFzwKUe7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hctHBv82MG9PG2DjGg",
-          "value" : "Qi4W5X8c4v"
+          "sourceName" : "aA8uv8axgGY31",
+          "value" : "hHTE4e89fSUsl1j"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9d6309f0-a36f-46de-b132-9a3238e8fc87"
+        "id" : "https://www.example.org/ec6fd223-4884-438b-815d-0aabd5c02b3c"
       } ],
       "role" : {
-        "type" : "Conductor"
+        "type" : "Director"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,158 +62,163 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/38f1448c-1692-4837-a5b6-33980355ebd7",
-        "name" : "WWtiMP8S9e",
+        "id" : "https://www.example.org/7860ce4d-f185-46ef-a18a-7f8a714961d8",
+        "name" : "SrQGtLMlEMiQnU",
         "nameType" : "Personal",
-        "orcId" : "KkYEPiGU2o5f",
-        "verificationStatus" : "Verified",
+        "orcId" : "2DzcRcAMymcRULKRSK",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2Sq1id4YihLbN",
-          "value" : "bbawmprXtzAzNBeJ"
+          "sourceName" : "6HIL7ixv2WrIr68",
+          "value" : "ZPu1LOrlg6J4E"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sCi8f60SHrWPm",
-          "value" : "mqyLsL251NlieyNT"
+          "sourceName" : "27YuAzmg07N257QS3n",
+          "value" : "Czn6v5WHLHO"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2675e3f1-1b36-44a4-87f6-332e2bec95a6"
+        "id" : "https://www.example.org/f1b014a1-180d-467f-9daf-109d32e7fc6e"
       } ],
       "role" : {
-        "type" : "Dancer"
+        "type" : "CuratorOrganizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nb" : "0GugmOVWhy55pGFGPO"
+      "el" : "aRQnCIrTGg97o"
     },
-    "npiSubjectHeading" : "LGCaGOpR1S",
-    "tags" : [ "NN3IYiEP3sQ5X" ],
-    "description" : "Hzfd6CvRKcBq",
+    "npiSubjectHeading" : "KnvtC6mQjrV7X",
+    "tags" : [ "rP7rcizsuj" ],
+    "description" : "7zOf1lX0MM5MWjMYu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d31a345d-c770-4f7c-9b86-b780c804b141"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d6e8e485-7b6f-4d27-8308-eb3e7eb8c43f"
         },
-        "seriesNumber" : "RVOT3B2h7hrMksLOHzW",
+        "seriesNumber" : "VtOTRpqeb9q8Jk",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5c90834d-2d13-470f-a87a-8c1b652076f7",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/88f3aa10-f626-4fb4-bdb9-205dc5ce928d",
           "valid" : true
         },
-        "isbnList" : [ "9791355144617" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9780959308822", "9781932458855" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "f4lD2SZNX02G1upnqN"
+          "value" : "1932458859"
         } ]
       },
-      "doi" : "https://www.example.org/0449f2ef-dcae-44c2-a457-1cb1a12e13e6",
+      "doi" : "https://www.example.org/534f7acb-da31-49de-844d-4704e177104d",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "UU3JRxsK0rVqi7",
-            "end" : "UTWuj1kcIXwV3a9L"
+            "begin" : "aEANPC6PwOm",
+            "end" : "rNPXRb3if8VRa"
           },
-          "pages" : "zU70grLNkE50te",
-          "illustrated" : false
+          "pages" : "5aqeDit2ZZkckBqO",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8bc2dafb-9f3c-4b8e-9e68-d5377b52367c",
-    "abstract" : "No6xG766K86U"
+    "metadataSource" : "https://www.example.org/cd8c653d-31e3-4bdb-b0a8-ea4e257d0cff",
+    "abstract" : "ZcQ3g6xKNWaVlch"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9d17b90c-cf8f-4379-b1e5-0b90e373fb68",
-    "name" : "1n805w7jEcQNl2",
+    "id" : "https://www.example.org/64f6013a-9394-4d97-b04c-3fd57ef3cbc8",
+    "name" : "EVNqmRYkuojW0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-07-30T16:28:56.040Z",
+      "approvalDate" : "1987-07-26T22:38:49.838Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "fpXSXO1sugiT8ogQMkJ"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "1kpgILg5hrShJyeSuF"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b06fb29c-e5d7-4dc6-b104-f228fc945d45",
-    "identifier" : "OK0lhw2xnHdmf5wfdq",
+    "source" : "https://www.example.org/e2db5f45-8b5c-4767-be3a-900e4fcfdfaa",
+    "identifier" : "sihxrItbPM",
     "labels" : {
-      "sv" : "GTcslgJMxKZ2n8NNM"
+      "nb" : "dfaMITUqXC7PEswF29"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 989958721
+      "currency" : "EUR",
+      "amount" : 1585373947
     },
-    "activeFrom" : "1993-12-03T08:35:31.952Z",
-    "activeTo" : "2013-06-01T18:32:01.212Z"
+    "activeFrom" : "2016-01-16T20:58:55.696Z",
+    "activeTo" : "2021-08-16T01:18:15.062Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2cb9d264-38b8-474e-bb63-2fe3a714e598",
-    "id" : "https://www.example.org/30affccc-378e-46ac-93ce-ad5bfb727de0",
-    "identifier" : "ceog4lMaPpm",
+    "source" : "https://www.example.org/6a06d62c-1329-4b01-865e-3c66ec4fefe4",
+    "id" : "https://www.example.org/97c37ce7-c654-49b1-a144-9201b9af883a",
+    "identifier" : "YK3q1Om0ObQES5n",
     "labels" : {
-      "pl" : "RxwTiuCKlL8qQ5tu"
+      "en" : "SPWHepuo6Nwz5g7dEk"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1037540099
+      "currency" : "GBP",
+      "amount" : 1960804901
     },
-    "activeFrom" : "2002-05-08T15:28:59.135Z",
-    "activeTo" : "2017-12-21T00:33:16.785Z"
+    "activeFrom" : "2016-04-24T09:35:48.678Z",
+    "activeTo" : "2021-08-11T07:44:22.938Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/477debf3-2bf9-4f02-b37f-a04671502bed" ],
+  "subjects" : [ "https://www.example.org/249a24ff-f641-4a9d-a4e0-6c6633fd88c8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "628f632c-15c9-4469-b8fe-341d0e9cc611",
-    "name" : "9WnU5VdKU4D",
-    "mimeType" : "GNv7JmgEeDG",
-    "size" : 746666146,
-    "license" : "https://www.example.com/lte0tcnuyqyfeib1y5g",
+    "identifier" : "a5cc93b2-f2a7-4830-91bb-f3ac83434ab2",
+    "name" : "WR2dFo2G5A",
+    "mimeType" : "pYLTuMNqSG1B5KHAS",
+    "size" : 1268544129,
+    "license" : "https://www.example.com/39jiurzhyieccxkuecj",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "FKeovLuSOzb"
+      "overriddenBy" : "oWBfK6IKolSO3YXp"
     },
-    "legalNote" : "xu5lNQI6vILQOK9Jes7",
-    "publishedDate" : "1983-12-16T19:00:11.628Z",
+    "legalNote" : "vVJLgjOVs0E60Ng",
+    "publishedDate" : "2009-02-19T02:10:56.266Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "0iD0XFYCMGwyBt9",
+      "uploadedDate" : "1984-05-27T00:37:08.824Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/adDq7Pio855Qv",
-    "name" : "E2WnMtcOOauyd",
-    "description" : "Qt3ZtkQzLF4hQfus0L"
+    "id" : "https://www.example.com/KM87rLwiRQ0x",
+    "name" : "UEdG4geh4lyCUoFh3",
+    "description" : "Kx8h9eNE3T"
   } ],
-  "rightsHolder" : "mw2r6YOoNz815BLa",
-  "duplicateOf" : "https://www.example.org/82a969d2-76ea-4351-8914-c2e33467202e",
+  "rightsHolder" : "eYIZwd8y0VG",
+  "duplicateOf" : "https://www.example.org/68fe0d49-da14-4c26-a9c1-6b026e3a555f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "AidA7pRTkfptgLa"
+    "note" : "6p5ZyUuomN5Yh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "lOExDZDUyY",
-    "createdBy" : "yLOXBOf9rav9w7lIROu",
-    "createdDate" : "2007-06-23T18:11:32.196Z"
+    "note" : "O9y1AfPcWkIyCm1",
+    "createdBy" : "041FpkvnV1zeAd0WmSH",
+    "createdDate" : "2020-12-26T21:19:22.079Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/531c0ee0-921e-40d3-b85e-6e3a915d0898" ],
+  "curatingInstitutions" : [ "https://www.example.org/30702303-ceaa-4210-98b1-581a50d77876" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ExhibitionCatalog.json
+++ b/documentation/ExhibitionCatalog.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "Zj6YHZ6a8IUvJu",
-    "ownerAffiliation" : "https://www.example.org/e824df6c-fd54-4f9c-a2b6-dc0ea92775cf"
+    "owner" : "pqne9rqjAXglbGdINZb",
+    "ownerAffiliation" : "https://www.example.org/9c87df7f-f855-430f-acb8-4935f07f9e0e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1b12ecdc-e727-42c6-a413-1d3bedd10b54"
+    "id" : "https://www.example.org/649a92e8-8356-43a1-9206-df1759deb348"
   },
-  "createdDate" : "1986-12-23T13:37:40.401Z",
-  "modifiedDate" : "2023-07-15T16:57:42.367Z",
-  "publishedDate" : "1978-05-27T06:21:28.540Z",
-  "indexedDate" : "2013-04-09T10:01:11.278Z",
-  "handle" : "https://www.example.org/472ea485-4ec0-4271-9d2e-2aafe8811ee8",
-  "doi" : "https://doi.org/10.1234/expedita",
-  "link" : "https://www.example.org/3c6a0cfb-75da-440a-908b-84cfad063f4f",
+  "createdDate" : "2014-09-21T16:19:14.908Z",
+  "modifiedDate" : "2023-08-12T19:50:50.045Z",
+  "publishedDate" : "1988-02-27T03:04:52.624Z",
+  "indexedDate" : "1988-02-25T21:07:14.107Z",
+  "handle" : "https://www.example.org/8542a177-3c73-48db-a1d7-8a6fe31326d8",
+  "doi" : "https://doi.org/10.1234/maxime",
+  "link" : "https://www.example.org/26891e15-186d-4162-8344-31e21a50e7e0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bMIPxjMI19",
+    "mainTitle" : "xTcfHNF98XYTIf",
     "alternativeTitles" : {
-      "el" : "Ndg47cccOoppfsVL"
+      "hu" : "I8DbjhS2JLzqwCL"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "FWa01qFjJBD0xbsY",
-      "month" : "K8oUd4oMk3HN7K4odO",
-      "day" : "sh3gWydt4m"
+      "year" : "p4EbT7JYEZT8dr",
+      "month" : "NzBGa5cAajAZ39K",
+      "day" : "VVnjOohR7VoexBNT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9c18f8f2-08a6-4fcf-815c-8c672426a61d",
-        "name" : "4kbJz65emI7AAblYx",
-        "nameType" : "Personal",
-        "orcId" : "wlLxR7cN5F",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/5fe020a2-abcd-4674-bf7a-c11e02c8fd22",
+        "name" : "41yZ4LIOjTW",
+        "nameType" : "Organizational",
+        "orcId" : "5RGU23VXUVteNisXXHu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "arD21iIHonxGmsM1tV",
-          "value" : "mshkCdjxnCA"
+          "sourceName" : "3KLIA7FdzZ2T5yRWHjg",
+          "value" : "3HutRIXv36ekKz24F"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZRjer78hh9r1EQJ",
-          "value" : "ggc576e2VsizzYr"
+          "sourceName" : "hctHBv82MG9PG2DjGg",
+          "value" : "Qi4W5X8c4v"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2a78ae7e-aff0-4c33-a2c5-6ab8e6b3cb8b"
+        "id" : "https://www.example.org/9d6309f0-a36f-46de-b132-9a3238e8fc87"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "Conductor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,158 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/84898af4-ecd6-47f5-83a1-4b119ac47544",
-        "name" : "inTxWakloA2",
-        "nameType" : "Organizational",
-        "orcId" : "FSejCf8eaS6",
+        "id" : "https://www.example.org/38f1448c-1692-4837-a5b6-33980355ebd7",
+        "name" : "WWtiMP8S9e",
+        "nameType" : "Personal",
+        "orcId" : "KkYEPiGU2o5f",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hk2ia5t0ABLHSrdAhNu",
-          "value" : "MI8o6WlHRX"
+          "sourceName" : "2Sq1id4YihLbN",
+          "value" : "bbawmprXtzAzNBeJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "S735a1Jf6sm8cFmv9",
-          "value" : "xirGtp8hCeTi2QEj"
+          "sourceName" : "sCi8f60SHrWPm",
+          "value" : "mqyLsL251NlieyNT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8d7fc637-ba49-4fe3-883e-2271d3ad8a15"
+        "id" : "https://www.example.org/2675e3f1-1b36-44a4-87f6-332e2bec95a6"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "C8AtbV83ljB1OCC0i"
+        "type" : "Dancer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "T9DFjchfACi"
+      "nb" : "0GugmOVWhy55pGFGPO"
     },
-    "npiSubjectHeading" : "4AKRDM3GWhhu02",
-    "tags" : [ "MGj1s0nc5grl4wH" ],
-    "description" : "Ahq9ZqV9lXYHJb",
+    "npiSubjectHeading" : "LGCaGOpR1S",
+    "tags" : [ "NN3IYiEP3sQ5X" ],
+    "description" : "Hzfd6CvRKcBq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ea14cf30-05d2-444c-a71b-efaf80c96346"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d31a345d-c770-4f7c-9b86-b780c804b141"
         },
-        "seriesNumber" : "XMeqPUzNdfk9",
+        "seriesNumber" : "RVOT3B2h7hrMksLOHzW",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/62e9ae6c-c531-4c63-8588-32633bcbc375",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/5c90834d-2d13-470f-a87a-8c1b652076f7",
           "valid" : true
         },
-        "isbnList" : [ "9780487417546" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9791355144617" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "SLipjDcMtbR"
+          "value" : "f4lD2SZNX02G1upnqN"
         } ]
       },
-      "doi" : "https://www.example.org/994c4acb-1ac3-46b4-843b-357ee2df04dc",
+      "doi" : "https://www.example.org/0449f2ef-dcae-44c2-a457-1cb1a12e13e6",
       "publicationInstance" : {
         "type" : "ExhibitionCatalog",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "3479bwAiism4ncrl8",
-            "end" : "B1f1iAptm1G"
+            "begin" : "UU3JRxsK0rVqi7",
+            "end" : "UTWuj1kcIXwV3a9L"
           },
-          "pages" : "hkGGX9DA9630Q4f",
-          "illustrated" : true
+          "pages" : "zU70grLNkE50te",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3028bb06-d694-4478-901a-900a66daa398",
-    "abstract" : "5wPbMBCifxjXJPlcIu"
+    "metadataSource" : "https://www.example.org/8bc2dafb-9f3c-4b8e-9e68-d5377b52367c",
+    "abstract" : "No6xG766K86U"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/82ab1214-616c-4052-ba62-4b042090e8d2",
-    "name" : "M3z8hMOrdtjS",
+    "id" : "https://www.example.org/9d17b90c-cf8f-4379-b1e5-0b90e373fb68",
+    "name" : "1n805w7jEcQNl2",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-09-17T08:39:00.179Z",
+      "approvalDate" : "2011-07-30T16:28:56.040Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "n2SP6BcPLgr"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "fpXSXO1sugiT8ogQMkJ"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ad5d90bb-1f5b-4e4f-b786-b842558eabf9",
-    "identifier" : "uae3ybsXsD4xIxnaeJD",
+    "source" : "https://www.example.org/b06fb29c-e5d7-4dc6-b104-f228fc945d45",
+    "identifier" : "OK0lhw2xnHdmf5wfdq",
     "labels" : {
-      "fi" : "d1PwbgZvDTeKpZQg"
+      "sv" : "GTcslgJMxKZ2n8NNM"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 513911708
+      "currency" : "USD",
+      "amount" : 989958721
     },
-    "activeFrom" : "2018-06-05T08:52:09.208Z",
-    "activeTo" : "2021-01-08T21:33:08.503Z"
+    "activeFrom" : "1993-12-03T08:35:31.952Z",
+    "activeTo" : "2013-06-01T18:32:01.212Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d4060688-d2da-4d18-8aea-17e7452c31b4",
-    "id" : "https://www.example.org/709735a8-314d-43ac-b90a-f2c7eb0d8867",
-    "identifier" : "iieCs0GCGDBei",
+    "source" : "https://www.example.org/2cb9d264-38b8-474e-bb63-2fe3a714e598",
+    "id" : "https://www.example.org/30affccc-378e-46ac-93ce-ad5bfb727de0",
+    "identifier" : "ceog4lMaPpm",
     "labels" : {
-      "ru" : "y9hgHh0ACb"
+      "pl" : "RxwTiuCKlL8qQ5tu"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1843994734
+      "currency" : "USD",
+      "amount" : 1037540099
     },
-    "activeFrom" : "2013-03-13T16:20:33.042Z",
-    "activeTo" : "2022-08-31T03:53:41.740Z"
+    "activeFrom" : "2002-05-08T15:28:59.135Z",
+    "activeTo" : "2017-12-21T00:33:16.785Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/05ebdf8d-52d2-4307-b5d0-abf5a0139a53" ],
+  "subjects" : [ "https://www.example.org/477debf3-2bf9-4f02-b37f-a04671502bed" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "73cb2992-4db3-4452-9b65-74796ea9ef4d",
-    "name" : "Uxf8q1LzCWTS",
-    "mimeType" : "d3oyz1JsPJEJCt0PcGt",
-    "size" : 593066865,
-    "license" : "https://www.example.com/6nzq8lypbrrp5b",
+    "identifier" : "628f632c-15c9-4469-b8fe-341d0e9cc611",
+    "name" : "9WnU5VdKU4D",
+    "mimeType" : "GNv7JmgEeDG",
+    "size" : 746666146,
+    "license" : "https://www.example.com/lte0tcnuyqyfeib1y5g",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "FKeovLuSOzb"
     },
-    "legalNote" : "egNGjBqYUeU",
-    "publishedDate" : "1977-06-09T00:28:08.509Z",
+    "legalNote" : "xu5lNQI6vILQOK9Jes7",
+    "publishedDate" : "1983-12-16T19:00:11.628Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/p6FGXrLYQnYrxqI",
-    "name" : "qYJwhpZYuuG",
-    "description" : "xiVQOs9q2VCJuWr"
+    "id" : "https://www.example.com/adDq7Pio855Qv",
+    "name" : "E2WnMtcOOauyd",
+    "description" : "Qt3ZtkQzLF4hQfus0L"
   } ],
-  "rightsHolder" : "8zGpcELF45I1R",
-  "duplicateOf" : "https://www.example.org/476df73f-3934-4528-885c-484b0ed47108",
+  "rightsHolder" : "mw2r6YOoNz815BLa",
+  "duplicateOf" : "https://www.example.org/82a969d2-76ea-4351-8914-c2e33467202e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7yLXKLPDls"
+    "note" : "AidA7pRTkfptgLa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "gzyZrUBmghzGO",
-    "createdBy" : "OtClGR8f6O2N",
-    "createdDate" : "1988-05-05T20:34:30.113Z"
+    "note" : "lOExDZDUyY",
+    "createdBy" : "yLOXBOf9rav9w7lIROu",
+    "createdDate" : "2007-06-23T18:11:32.196Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/0b84bc3d-3a19-431d-81d0-eda2e422adff" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/531c0ee0-921e-40d3-b85e-6e3a915d0898" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Duvpj9r965Yffgo5L",
-    "ownerAffiliation" : "https://www.example.org/35e4fc6a-36e9-45fd-be9e-c8fb39041e5f"
+    "owner" : "vx0u1cU3XSQ1YxhDd",
+    "ownerAffiliation" : "https://www.example.org/61f7342c-ab3b-4577-bbaf-0c347a3a0dde"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ffa78cbd-097c-488c-8fbb-ce64a4e67509"
+    "id" : "https://www.example.org/25cd58cd-7d12-42f3-b957-2f40f4112311"
   },
-  "createdDate" : "1976-05-31T00:02:14.069Z",
-  "modifiedDate" : "2014-09-25T01:25:47.004Z",
-  "publishedDate" : "1972-09-20T03:56:50.467Z",
-  "indexedDate" : "1978-05-05T08:21:22.357Z",
-  "handle" : "https://www.example.org/a9db8de5-9239-46aa-9dd7-93dd0c0f801f",
-  "doi" : "https://doi.org/10.1234/nobis",
-  "link" : "https://www.example.org/ccee6558-ba55-40f7-bddd-5b229a092976",
+  "createdDate" : "2021-02-25T06:06:06.830Z",
+  "modifiedDate" : "1995-12-25T18:19:43.836Z",
+  "publishedDate" : "2013-11-07T08:28:30.039Z",
+  "indexedDate" : "1996-08-27T13:32:10.541Z",
+  "handle" : "https://www.example.org/3b72490d-b2c5-4df6-9eb9-9e0ec6b0f287",
+  "doi" : "https://doi.org/10.1234/enim",
+  "link" : "https://www.example.org/6b084716-8245-451d-8c6f-0a81a58f609a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nCWRgPDMKP3",
+    "mainTitle" : "YQi5Z48cn8vmOpFB9Wx",
     "alternativeTitles" : {
-      "es" : "Y62kiZ2CNc"
+      "ru" : "JLhTGUmiXdRROwXSQ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KkbOCxBDfkV",
-      "month" : "O6qkfcaufx",
-      "day" : "NMKTrESOwIy"
+      "year" : "6cDmokgmso7",
+      "month" : "9JGOm2jYs4o3N9UK8",
+      "day" : "54lnkhh8mW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a92ea343-0f55-4bd6-be2f-719213f2f17c",
-        "name" : "E8PRhZ16NovXMB",
+        "id" : "https://www.example.org/77bf79c1-462c-4fc4-94ea-09a586a9355f",
+        "name" : "r4c0aNZzPRNdgajjZog",
         "nameType" : "Organizational",
-        "orcId" : "oU3r07OOB0",
-        "verificationStatus" : "Verified",
+        "orcId" : "6wzzuzrq8NwZzRBpzi6",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HLbZNtzQtPYudbtRP",
-          "value" : "YZod6Yoq05G4X90b0J"
+          "sourceName" : "0OI9BdQ6FNJOSX",
+          "value" : "S9AERAV1JMaio79"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hroN7Necnh",
-          "value" : "saCDqAJajeq"
+          "sourceName" : "iqOtu4Qa6t",
+          "value" : "eLSMJX7eTIV1"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/86e50ab4-fdae-417f-b412-51f6f6c1375c"
+        "id" : "https://www.example.org/e265f6b5-4abd-4d1d-b996-cd8c3cedba94"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0233bcb9-adcb-41df-aaaa-d4ebe0d3c61e",
-        "name" : "LWHhYPp7C9Nz",
-        "nameType" : "Organizational",
-        "orcId" : "tK5NnocNeChcOlH37",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1366b548-62e2-42e2-8a0e-11cc823710b4",
+        "name" : "rd6mH7vQZHBgJa",
+        "nameType" : "Personal",
+        "orcId" : "0RltehNLSGTUd0dPJ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PZy6ic0fV5s8ON",
-          "value" : "DRKpDudLUx8LeBjVX"
+          "sourceName" : "WwOLTlPmgVy",
+          "value" : "xneY7c0EiKv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pTHGFZTRcKox",
-          "value" : "Ng63RYZ0Reki9Ix"
+          "sourceName" : "DLu7VmEUxcAox",
+          "value" : "qc6WQl5mq0mL"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/59f2daca-4eb2-4680-8d3c-d360c1670ae9"
+        "id" : "https://www.example.org/5772f05b-2d8a-4c51-a264-b2e3cd15fe00"
       } ],
       "role" : {
-        "type" : "Photographer"
+        "type" : "Supervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "7TRF6nLsZYKB"
+      "ru" : "n3XvdUeWu6odxPGim"
     },
-    "npiSubjectHeading" : "SXPcVqqf9BtZr4K",
-    "tags" : [ "EEtxHUlcxDe" ],
-    "description" : "J7MTu2JGVMqjjxLb",
+    "npiSubjectHeading" : "o2FBh2eEYyk98KaFTuY",
+    "tags" : [ "VannDjXLme4yp" ],
+    "description" : "VjJZNPbyDBIO",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/ECsvY5CT750ydgesS"
+        "id" : "https://www.example.com/960vfYTWPfn0D09W9d"
       },
-      "doi" : "https://www.example.org/edfc4b3d-9c13-4148-991c-941b2505f52d",
+      "doi" : "https://www.example.org/abdeb856-e12e-4328-8fd8-c368d2d5e36a",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "aM2mosKFehEosIbLi8Y",
-          "end" : "3gVcTSsIZ1jSN1TwZ"
+          "begin" : "Wi5R05r2dws",
+          "end" : "YflFoxardHSIJQE"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4829e598-a133-4dc5-9560-09b304175055",
-    "abstract" : "Sp1KT0GDvc"
+    "metadataSource" : "https://www.example.org/6ea8ad6b-4505-4bc9-9489-ec033bf82e61",
+    "abstract" : "xOQ9wKSokMcTq26"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d44e5ae5-8406-4f2a-b09d-55a46eafe029",
-    "name" : "YgZTCkpALfq4",
+    "id" : "https://www.example.org/6b506f76-e934-464d-b2b7-7becc05d8b16",
+    "name" : "To0IP6nnpB2vN7y4o",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-05-10T21:21:30.790Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "26QZMteAsBBndN"
+      "approvalDate" : "2012-09-28T21:15:55.591Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "aqJix1okgcSVv47lK"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f5d168d3-8123-45f6-9c72-bbde58a11d3c",
-    "identifier" : "Oh93zOPiU81S4CO",
+    "source" : "https://www.example.org/05441831-2e27-49db-b34e-c8cc0befcd0a",
+    "identifier" : "ph28QhekSNV",
     "labels" : {
-      "pt" : "ZbiINQKo3HsYY"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1154374887
-    },
-    "activeFrom" : "2001-03-01T04:33:33.090Z",
-    "activeTo" : "2002-08-25T16:39:51.399Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c8c63b64-790a-4fa1-82e6-2fbe883b2382",
-    "id" : "https://www.example.org/2d972f97-c77a-4f2f-8ca7-ae8639af7cb4",
-    "identifier" : "2dsY9nSmOniA8vyjuMa",
-    "labels" : {
-      "ca" : "aL5zhiTUgE"
+      "nl" : "hXpJHqd8DOs4XWT"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1541109457
+      "amount" : 1296787759
     },
-    "activeFrom" : "2000-03-23T03:44:28.099Z",
-    "activeTo" : "2022-09-21T20:41:47.919Z"
+    "activeFrom" : "1971-03-03T07:09:42.733Z",
+    "activeTo" : "1972-04-19T19:16:15.518Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/8771d116-1bb1-4974-8ada-250d52a0d39a",
+    "id" : "https://www.example.org/214dea7d-8b31-40a9-979a-519120c1415a",
+    "identifier" : "ABfr7Uz4UXdva0e",
+    "labels" : {
+      "nb" : "pAveWadEoTiQXykeI"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 434053215
+    },
+    "activeFrom" : "2020-12-24T18:18:31.914Z",
+    "activeTo" : "2021-05-24T09:38:42.991Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/47930f88-effa-45a8-ac97-07c9a5e81f4d" ],
+  "subjects" : [ "https://www.example.org/509da144-b206-4bab-b7e5-2c0afeffe7ec" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "16c77f87-bbe4-4e98-a64d-55b22475bdd4",
-    "name" : "wV28WyLdgVje3BXNhWt",
-    "mimeType" : "8hlmPWvWtaQ",
-    "size" : 1469080085,
-    "license" : "https://www.example.com/dcvyoxavzyg",
+    "identifier" : "6f92843f-c4a2-427d-b512-0c94a98c1a6b",
+    "name" : "Re4pCBBdIex1jirrF",
+    "mimeType" : "QvRX9PF1FXadUI7",
+    "size" : 1066162538,
+    "license" : "https://www.example.com/zbfa6i4rji9",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "NCVs3R68Q83q1V36Z",
-    "publishedDate" : "1988-03-27T07:01:37.746Z",
+    "legalNote" : "vT4rF3mXv7N1i88o",
+    "publishedDate" : "2020-08-27T01:02:55.109Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "rVWsiQg7Lz37XNA6GQW",
+      "uploadedDate" : "1985-11-15T08:07:52.944Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NFrlP89UcNOXzUqP",
-    "name" : "t1hLnfsaywPS",
-    "description" : "MchwGfnmJJEjkaKSa"
+    "id" : "https://www.example.com/MgH9hDsa24",
+    "name" : "ULNzf1fSpoU1BW",
+    "description" : "qlrGbYWjRu9vjFisq"
   } ],
-  "rightsHolder" : "SI5i3VOyQMaW3Qfvyc",
-  "duplicateOf" : "https://www.example.org/21bd791b-9b1f-4f76-bbb1-3c49c9cf1a4c",
+  "rightsHolder" : "6FACvLlwoS7Oysp",
+  "duplicateOf" : "https://www.example.org/23b58de9-03c8-40c4-bd36-182fe4b82661",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "rsyQyH1Sf7wp"
+    "note" : "MaXqlf7WEq8UqKL"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "BmkT3KRdmNi6TLk2rb8",
-    "createdBy" : "hb6bELeeudRSg29",
-    "createdDate" : "2005-01-15T15:53:12.460Z"
+    "note" : "wgHM6Yx2Rxr",
+    "createdBy" : "R2izJeBX4SaE1W3Bqx",
+    "createdDate" : "1981-01-05T11:40:58.508Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fe432d98-4887-48a8-815f-47040a5b17c5" ],
+  "curatingInstitutions" : [ "https://www.example.org/ddf31413-93f4-4626-a035-51c0c3b8d6c9" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ExhibitionCatalogChapter.json
+++ b/documentation/ExhibitionCatalogChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "GH2QMPJyIIleJW",
-    "ownerAffiliation" : "https://www.example.org/8ddd5087-7c35-4887-98b7-7921dbb4a7b2"
+    "owner" : "Duvpj9r965Yffgo5L",
+    "ownerAffiliation" : "https://www.example.org/35e4fc6a-36e9-45fd-be9e-c8fb39041e5f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ce7bac2a-a6b4-49aa-a0e7-39bf926aaaf9"
+    "id" : "https://www.example.org/ffa78cbd-097c-488c-8fbb-ce64a4e67509"
   },
-  "createdDate" : "1995-01-31T11:02:54.189Z",
-  "modifiedDate" : "1983-01-27T05:45:52.561Z",
-  "publishedDate" : "1987-11-27T05:45:08.177Z",
-  "indexedDate" : "2002-02-11T20:01:53.621Z",
-  "handle" : "https://www.example.org/d5d18b2a-4630-4b49-a346-180cfd4c21c5",
-  "doi" : "https://doi.org/10.1234/illum",
-  "link" : "https://www.example.org/03fbe0fb-f3da-4e1d-834c-b2860f47d036",
+  "createdDate" : "1976-05-31T00:02:14.069Z",
+  "modifiedDate" : "2014-09-25T01:25:47.004Z",
+  "publishedDate" : "1972-09-20T03:56:50.467Z",
+  "indexedDate" : "1978-05-05T08:21:22.357Z",
+  "handle" : "https://www.example.org/a9db8de5-9239-46aa-9dd7-93dd0c0f801f",
+  "doi" : "https://doi.org/10.1234/nobis",
+  "link" : "https://www.example.org/ccee6558-ba55-40f7-bddd-5b229a092976",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "e2bqlbE3IR",
+    "mainTitle" : "nCWRgPDMKP3",
     "alternativeTitles" : {
-      "fi" : "U8vtzwncqR0l"
+      "es" : "Y62kiZ2CNc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "W5vsGiUAR6FBnZd",
-      "month" : "iP1v0XCUbBJXDU",
-      "day" : "kmQF9DTKr3xsUja"
+      "year" : "KkbOCxBDfkV",
+      "month" : "O6qkfcaufx",
+      "day" : "NMKTrESOwIy"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/10efa344-7658-43b4-8c14-f2ed443cdb82",
-        "name" : "sFz5Sc5Kdi06Vx",
-        "nameType" : "Personal",
-        "orcId" : "CjtrtIFToMgwGCIUTn",
+        "id" : "https://www.example.org/a92ea343-0f55-4bd6-be2f-719213f2f17c",
+        "name" : "E8PRhZ16NovXMB",
+        "nameType" : "Organizational",
+        "orcId" : "oU3r07OOB0",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vXJ10UyzpaB5",
-          "value" : "RJyRsZTzjpNbSUu6"
+          "sourceName" : "HLbZNtzQtPYudbtRP",
+          "value" : "YZod6Yoq05G4X90b0J"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kMiDSvBKBFQManMit8",
-          "value" : "sHByJ323Gpl8ypg"
+          "sourceName" : "hroN7Necnh",
+          "value" : "saCDqAJajeq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2ac33e54-1f99-4984-bf75-95cb24362bdb"
+        "id" : "https://www.example.org/86e50ab4-fdae-417f-b412-51f6f6c1375c"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "VideoEditor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/19a0e069-a872-4de4-ad4e-798d1577e968",
-        "name" : "8fp532gHWGrvzg",
+        "id" : "https://www.example.org/0233bcb9-adcb-41df-aaaa-d4ebe0d3c61e",
+        "name" : "LWHhYPp7C9Nz",
         "nameType" : "Organizational",
-        "orcId" : "raskYupz7DOwtX7x",
+        "orcId" : "tK5NnocNeChcOlH37",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CPKKxRoitJjK",
-          "value" : "VjzvikSYDY8YiQF2Q"
+          "sourceName" : "PZy6ic0fV5s8ON",
+          "value" : "DRKpDudLUx8LeBjVX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0IqAM5BpXV2V",
-          "value" : "335OPLOHFp6"
+          "sourceName" : "pTHGFZTRcKox",
+          "value" : "Ng63RYZ0Reki9Ix"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/025efc54-7179-4dd0-b65c-1847e738799f"
+        "id" : "https://www.example.org/59f2daca-4eb2-4680-8d3c-d360c1670ae9"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "DDIQGzmacRAJlk"
+      "el" : "7TRF6nLsZYKB"
     },
-    "npiSubjectHeading" : "AqjLnqURVggk",
-    "tags" : [ "mKwwvlzG2hDkpxZgH" ],
-    "description" : "NNCJVxH40M1n9FXk9D2",
+    "npiSubjectHeading" : "SXPcVqqf9BtZr4K",
+    "tags" : [ "EEtxHUlcxDe" ],
+    "description" : "J7MTu2JGVMqjjxLb",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/pSdRAsdONM"
+        "id" : "https://www.example.com/ECsvY5CT750ydgesS"
       },
-      "doi" : "https://www.example.org/45baab26-a89d-47c8-a5aa-d00811ff0087",
+      "doi" : "https://www.example.org/edfc4b3d-9c13-4148-991c-941b2505f52d",
       "publicationInstance" : {
         "type" : "ExhibitionCatalogChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "NOOrmi1M1m7AoaEW3",
-          "end" : "G0zmU2LtywP0IS"
+          "begin" : "aM2mosKFehEosIbLi8Y",
+          "end" : "3gVcTSsIZ1jSN1TwZ"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/41fa844a-5a1a-47d0-83c8-9ee3e29b0d1b",
-    "abstract" : "jaUyC6YzeRg"
+    "metadataSource" : "https://www.example.org/4829e598-a133-4dc5-9560-09b304175055",
+    "abstract" : "Sp1KT0GDvc"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7150b31e-1167-4eb9-876d-3bb7ccc91c97",
-    "name" : "Ddt1tRmJNsZ",
+    "id" : "https://www.example.org/d44e5ae5-8406-4f2a-b09d-55a46eafe029",
+    "name" : "YgZTCkpALfq4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1974-07-10T22:28:20.663Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "783f4b9JbfLVCw"
+      "approvalDate" : "1975-05-10T21:21:30.790Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "26QZMteAsBBndN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/83b9149a-dffd-4b60-a869-2091a4e59b3f",
-    "identifier" : "yLbkKfSBK9eFOMwFg",
+    "source" : "https://www.example.org/f5d168d3-8123-45f6-9c72-bbde58a11d3c",
+    "identifier" : "Oh93zOPiU81S4CO",
     "labels" : {
-      "fr" : "00ioMFn2oqT"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 913622642
-    },
-    "activeFrom" : "1974-07-22T03:28:16.165Z",
-    "activeTo" : "1977-06-13T10:22:13.676Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/46b024b0-645a-4501-badd-4391114e7487",
-    "id" : "https://www.example.org/305d9fcd-dbba-4a9a-8c85-9a30f8c7a89b",
-    "identifier" : "Fzt0wVsuXqlvPzxObp",
-    "labels" : {
-      "nl" : "2HztjZzWNjP9usaaJug"
+      "pt" : "ZbiINQKo3HsYY"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 240865083
+      "amount" : 1154374887
     },
-    "activeFrom" : "2013-02-12T21:13:22.032Z",
-    "activeTo" : "2018-04-02T05:01:14.298Z"
+    "activeFrom" : "2001-03-01T04:33:33.090Z",
+    "activeTo" : "2002-08-25T16:39:51.399Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/c8c63b64-790a-4fa1-82e6-2fbe883b2382",
+    "id" : "https://www.example.org/2d972f97-c77a-4f2f-8ca7-ae8639af7cb4",
+    "identifier" : "2dsY9nSmOniA8vyjuMa",
+    "labels" : {
+      "ca" : "aL5zhiTUgE"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 1541109457
+    },
+    "activeFrom" : "2000-03-23T03:44:28.099Z",
+    "activeTo" : "2022-09-21T20:41:47.919Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4100192d-e4b6-44a9-972e-f57cc2b06b11" ],
+  "subjects" : [ "https://www.example.org/47930f88-effa-45a8-ac97-07c9a5e81f4d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2079eb08-14ec-43b1-bc00-f6f42a5b2da6",
-    "name" : "lVCi1LZzlqNLMSVTLE",
-    "mimeType" : "taBfKjX77zXsvn",
-    "size" : 1721761504,
-    "license" : "https://www.example.com/iq3fujr1ps4asgls9",
+    "identifier" : "16c77f87-bbe4-4e98-a64d-55b22475bdd4",
+    "name" : "wV28WyLdgVje3BXNhWt",
+    "mimeType" : "8hlmPWvWtaQ",
+    "size" : 1469080085,
+    "license" : "https://www.example.com/dcvyoxavzyg",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "X0PHnpftM3313V9",
-    "publishedDate" : "2007-04-20T02:38:52.482Z",
+    "legalNote" : "NCVs3R68Q83q1V36Z",
+    "publishedDate" : "1988-03-27T07:01:37.746Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/mSx9ihPGItFY0qpxF",
-    "name" : "0llXT9btWyw5iMCUGlM",
-    "description" : "sKS3ksEaHNxPqPft"
+    "id" : "https://www.example.com/NFrlP89UcNOXzUqP",
+    "name" : "t1hLnfsaywPS",
+    "description" : "MchwGfnmJJEjkaKSa"
   } ],
-  "rightsHolder" : "gxWvo22aI9q36JHCSpf",
-  "duplicateOf" : "https://www.example.org/a776a0fe-6522-4ca5-9b4f-8a861882c565",
+  "rightsHolder" : "SI5i3VOyQMaW3Qfvyc",
+  "duplicateOf" : "https://www.example.org/21bd791b-9b1f-4f76-bbb1-3c49c9cf1a4c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "h3ovnrQOHQHEvy"
+    "note" : "rsyQyH1Sf7wp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WVdG4pg7N9zFXPBC",
-    "createdBy" : "oVqRD8qjPWy1DTT",
-    "createdDate" : "2022-08-31T01:58:52.141Z"
+    "note" : "BmkT3KRdmNi6TLk2rb8",
+    "createdBy" : "hb6bELeeudRSg29",
+    "createdDate" : "2005-01-15T15:53:12.460Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/70c3a5cd-9f5b-4c0d-833a-d1e291259592" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/fe432d98-4887-48a8-815f-47040a5b17c5" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "PcyTMS6HsLOx69",
-    "ownerAffiliation" : "https://www.example.org/576518dc-9092-4bae-a7a7-40b297980907"
+    "owner" : "UGCglmTJ4XlZSUkfv51",
+    "ownerAffiliation" : "https://www.example.org/7375a704-1bc3-44b7-bebe-57cc7a82583e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5c340b6e-e8b1-4a52-919f-685ce46b0b7d"
+    "id" : "https://www.example.org/3d7aaa4a-8471-4293-8c40-3313abed01c5"
   },
-  "createdDate" : "2001-11-03T18:35:51.874Z",
-  "modifiedDate" : "1992-04-04T22:32:15.566Z",
-  "publishedDate" : "2011-08-12T13:18:36.574Z",
-  "indexedDate" : "1995-10-29T20:28:46.614Z",
-  "handle" : "https://www.example.org/856a6a74-4225-4d1d-a838-a81084275fff",
-  "doi" : "https://doi.org/10.1234/beatae",
-  "link" : "https://www.example.org/3d63a873-2e15-41b1-a241-583ba6c9cc1e",
+  "createdDate" : "1982-06-04T06:20:25.075Z",
+  "modifiedDate" : "1980-06-04T22:10:02.033Z",
+  "publishedDate" : "1980-06-24T21:12:52.989Z",
+  "indexedDate" : "2000-10-10T10:52:45.385Z",
+  "handle" : "https://www.example.org/0d486409-6f9c-49a7-b56b-0438eaeda32f",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/4078caed-7764-4955-a49d-9644f13ddcb5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "NCFcjXi2oGedHqB",
+    "mainTitle" : "UmZK60Okq4zJfy",
     "alternativeTitles" : {
-      "cs" : "xVaM6AKO3Xg9DfaF4uh"
+      "ca" : "aH28esrMumGtp8"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TFTrmz3djqP",
-      "month" : "iPmiilE9d7Nx65A",
-      "day" : "Xnm5rdOcneoBGrZgvG"
+      "year" : "BWJdoMYRKDWM5F3EEs",
+      "month" : "DlPBMKa1JFBQ",
+      "day" : "Qiken4Vw9o3LNkZU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4b6ee6aa-4f3f-468e-9ce6-b3189c35da7b",
-        "name" : "Xy8EnRLmqUcivUMj2",
-        "nameType" : "Personal",
-        "orcId" : "o2cAMVSdf8NR",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/2b3b739d-9e2d-44e0-aa28-b48ff7d01a45",
+        "name" : "NotzgVIxGIzEO9FD",
+        "nameType" : "Organizational",
+        "orcId" : "FtpuvhK1YnI",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mUQ2rcbJXQYfJrJrgbJ",
-          "value" : "HsiqAeT7jMJap2ln4DQ"
+          "sourceName" : "48Ll6m0hRXxm",
+          "value" : "0kYidezUWl8T8e"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "A9F3Irj3BqbNhKQ",
-          "value" : "dJPeiVz0brYNUQXb9mT"
+          "sourceName" : "yPVsZYX43BMI",
+          "value" : "aizoXZyhIXIm9krM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/979f6b92-0588-4f98-9be7-a27830cb8909"
+        "id" : "https://www.example.org/3e5b1597-04f6-4316-8cb0-6a380ea6f145"
       } ],
       "role" : {
-        "type" : "EditorialBoardMember"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,95 +62,94 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/240a7901-30bd-45a9-af26-556ab2d0e6a8",
-        "name" : "m5N5xmlpQaBNAUSPq",
-        "nameType" : "Personal",
-        "orcId" : "NvuGyeD4ODWxoheM",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/93417131-9c6f-446b-bccd-576e9668c9f4",
+        "name" : "rsL4eOnDPAov08",
+        "nameType" : "Organizational",
+        "orcId" : "tzG3C6wCSA1",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hOiWDXYsHJUsbOm",
-          "value" : "kZAoeK7gsXL0FHDuBG9"
+          "sourceName" : "TS2znoMM6Ve",
+          "value" : "cux2JbHnBX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rbxpKhepCRlcZmOBCL3",
-          "value" : "IOr8Y6Lpda7yJ"
+          "sourceName" : "aq7n6EtejVj",
+          "value" : "3AX0P12T9WD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0617ad84-e7b2-4f58-8aea-afb8e4298926"
+        "id" : "https://www.example.org/fd617940-a65b-4b3b-acb6-88e081800457"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "4mLeh0fTpucy"
+      "ru" : "CwueJcJABrD"
     },
-    "npiSubjectHeading" : "KW7mILfL6twmE1OW4",
-    "tags" : [ "mgQjqXYmh9jbwNEJWt" ],
-    "description" : "U2SPrHocPxBrUF0R",
+    "npiSubjectHeading" : "fj1gmsK3My3aoVZJ",
+    "tags" : [ "kykHKVZbTswyF9" ],
+    "description" : "PP1QIJHW1DJJ",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/37288c14-e0d6-4306-904a-975f47042001",
+      "doi" : "https://www.example.org/3263d7f1-9f1b-4573-9afd-dbed2a1a1aca",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "ExhibitionProductionOther",
-          "description" : "2PDctqD0LgSmq"
+          "type" : "DigitalExhibition"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/eoIBxnoh0Xcudu2XD"
+          "id" : "https://www.example.com/7s7bJYIPFIwe7"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "MzLwRekQx5fZ9Ga76vI"
+            "name" : "kDZoDDCBdIq"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Uba46uXy7BUdBB",
-            "country" : "jQk7I1bB6pz0t"
+            "label" : "ZQXUzDwLWJornXggx",
+            "country" : "wixxyaCnujxUk8QpWeZ"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2005-01-12T00:25:38.862Z",
-            "to" : "2019-03-04T02:51:02.432Z"
+            "from" : "1989-11-27T02:20:37.533Z",
+            "to" : "2005-04-19T07:00:16.898Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "A2FRzbBH7VY6T5YUt",
-          "issue" : "ISnCSv1kEaOrou4zD",
-          "pages" : "o2RzqMovuv",
+          "title" : "sedGIP5adOL7K4NC",
+          "issue" : "JVl8vBPtuIRx",
+          "pages" : "q7gmvN7npXEn1xfwAa",
           "date" : {
             "type" : "Instant",
-            "value" : "1981-04-21T19:22:17.269Z"
+            "value" : "2016-04-11T05:18:24.609Z"
           },
-          "otherInformation" : "Oo9j2qgCXcE"
+          "otherInformation" : "eoYSvLM2nU0Sn"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "sjaUwyJhvyeNaWlJDA",
-          "description" : "8QU1nldx2qAT",
+          "typeDescription" : "UT0paydKwlxNIMJH",
+          "description" : "Wv3KuoAeiULHxg7D",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "0gdobZHGWjA",
-            "country" : "LOMQjfomIoGQfY"
+            "label" : "lzojtvPPJDi",
+            "country" : "pjSZDFkxSw4hy2u"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "UVt2KcKdGDVavvqtrf8",
+            "name" : "7tvPVRRPWSQbCbiO8",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2010-03-22T03:29:47.022Z"
+            "value" : "1984-08-18T19:25:30.106Z"
           }
         } ],
         "pages" : {
@@ -158,90 +157,95 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4f663072-aaf0-47dd-8859-e0a1126478eb",
-    "abstract" : "TWxAj1xDvYWH"
+    "metadataSource" : "https://www.example.org/7da7acc3-d817-4490-a937-e852077539b0",
+    "abstract" : "tvFlCT1zh1NGS70"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/74508895-2719-42b6-9cec-235849cb412a",
-    "name" : "ySn27FPdV41q",
+    "id" : "https://www.example.org/ea1a104c-3e6c-41ac-b126-35db689bc24c",
+    "name" : "hg4jva6Wg1n1Uw",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-10-23T16:50:05.018Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "dzCIP2k9KVBGVtoD2v"
+      "approvalDate" : "2003-07-01T13:52:47.280Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "YiMIiOhua6BD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dc3a19d7-cbaf-42cb-a6f5-12bff441fc58",
-    "identifier" : "gspICKHo9TMxa6Oz",
+    "source" : "https://www.example.org/f55f9d7d-a0a9-4109-b66b-141542cd0e16",
+    "identifier" : "VLQGClyGqp",
     "labels" : {
-      "de" : "N2wz7L3u1ELwDBat"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2003662479
-    },
-    "activeFrom" : "2010-09-30T19:08:28.877Z",
-    "activeTo" : "2023-07-01T13:27:28.968Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/debcb829-af82-475b-9f6b-9f75d15a099a",
-    "id" : "https://www.example.org/41aaac90-2409-400d-b718-ad7bad25624d",
-    "identifier" : "RjWaeKdaJw6ypjXR",
-    "labels" : {
-      "el" : "ta4wx2rthO8tU"
+      "pl" : "IIeP38Lpz8IhpDfr32B"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1688599313
+      "amount" : 1608781446
     },
-    "activeFrom" : "2005-01-27T08:46:14.281Z",
-    "activeTo" : "2021-10-06T05:21:23.121Z"
+    "activeFrom" : "2010-01-10T14:56:40.400Z",
+    "activeTo" : "2024-05-02T06:02:51.368Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/bacdaa16-9f8e-461d-8c5d-1d8133619f9a",
+    "id" : "https://www.example.org/78f99b33-bcf6-43b9-a8a0-8961b380d6e3",
+    "identifier" : "KFVKxmVWkh9I1U",
+    "labels" : {
+      "sv" : "uI2PLpYiS3QCU95A8F"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1739366536
+    },
+    "activeFrom" : "2018-09-30T15:32:31.764Z",
+    "activeTo" : "2020-08-27T00:37:58.226Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9f1bbd65-38ef-4238-a82a-54f0e4581711" ],
+  "subjects" : [ "https://www.example.org/23345f5f-e219-4247-a62a-1b1f7d660126" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1d678e93-6bdd-4bcf-897b-2fd424582787",
-    "name" : "aGjwSOSAod9JJ",
-    "mimeType" : "DWtzH7u8K69A",
-    "size" : 59451833,
-    "license" : "https://www.example.com/fapxsoarsbna",
+    "identifier" : "f025a615-8e7d-40a1-b796-a6185bbcda37",
+    "name" : "7ZEEMfhoxW",
+    "mimeType" : "ajkrz41nZaYnMek",
+    "size" : 796698277,
+    "license" : "https://www.example.com/queslr3nm2cur",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "K7QB02Hbv8qL728tcd"
+      "overriddenBy" : "1NZmdCuEMIl"
     },
-    "legalNote" : "s3D88XUwgzxMSl",
-    "publishedDate" : "2018-09-05T11:00:24.938Z",
+    "legalNote" : "q8rYduHhcJ4Kcif",
+    "publishedDate" : "2023-10-24T05:01:56.201Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "GGvMxRfbwGfUYY",
+      "uploadedDate" : "1993-09-27T17:00:54.729Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Llt48mIXScN8968QB",
-    "name" : "JZlRnyVXcORPmJcuR",
-    "description" : "8sa7bm1DBXtagMMC"
+    "id" : "https://www.example.com/W80Gyt24j36",
+    "name" : "DgWc1PlKGbvL",
+    "description" : "aZ1qfw40vMLJI8z"
   } ],
-  "rightsHolder" : "Y1Ne1SkdJAIYumzYh",
-  "duplicateOf" : "https://www.example.org/3683a654-9511-4feb-ab25-afb7681f4b6e",
+  "rightsHolder" : "wIjNKdjpqDuqDQ0xZ",
+  "duplicateOf" : "https://www.example.org/0b4e34a6-c806-4526-bdd8-11af0f6015fc",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "geWlfWfyjJyKXSqslV3"
+    "note" : "4b3uYDZP7b"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "enW3LgsDUScvf",
-    "createdBy" : "rLoLHyvs1bT2",
-    "createdDate" : "2009-04-13T07:15:54.021Z"
+    "note" : "3SzPCGuEiT3ivI0la",
+    "createdBy" : "2GtgrOqzKR6Y",
+    "createdDate" : "1992-11-22T05:45:27.066Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/636189a3-61a2-4d3c-90a8-706d729b4612" ],
+  "curatingInstitutions" : [ "https://www.example.org/70e3bc11-7f6b-44ae-b72d-04f321ae3846" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ExhibitionProduction.json
+++ b/documentation/ExhibitionProduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Z1Y7NNcaBC",
-    "ownerAffiliation" : "https://www.example.org/d8cc2139-da92-4184-84dc-15a1c5520d98"
+    "owner" : "PcyTMS6HsLOx69",
+    "ownerAffiliation" : "https://www.example.org/576518dc-9092-4bae-a7a7-40b297980907"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4aac1396-b96c-47b1-aa1f-b7f51edd33de"
+    "id" : "https://www.example.org/5c340b6e-e8b1-4a52-919f-685ce46b0b7d"
   },
-  "createdDate" : "1994-10-29T01:33:01.540Z",
-  "modifiedDate" : "1984-09-14T01:12:11.151Z",
-  "publishedDate" : "2015-09-13T05:24:27.480Z",
-  "indexedDate" : "2013-10-31T09:22:11.660Z",
-  "handle" : "https://www.example.org/4d27825b-c6d3-4d61-bcc9-c6a195c1e95b",
-  "doi" : "https://doi.org/10.1234/laudantium",
-  "link" : "https://www.example.org/1c3d475c-0530-44a9-a147-2cbf812ec9e9",
+  "createdDate" : "2001-11-03T18:35:51.874Z",
+  "modifiedDate" : "1992-04-04T22:32:15.566Z",
+  "publishedDate" : "2011-08-12T13:18:36.574Z",
+  "indexedDate" : "1995-10-29T20:28:46.614Z",
+  "handle" : "https://www.example.org/856a6a74-4225-4d1d-a838-a81084275fff",
+  "doi" : "https://doi.org/10.1234/beatae",
+  "link" : "https://www.example.org/3d63a873-2e15-41b1-a241-583ba6c9cc1e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "sKBljLQWzNeA17XXtT",
+    "mainTitle" : "NCFcjXi2oGedHqB",
     "alternativeTitles" : {
-      "sv" : "qvd3tTJHcNMdzS"
+      "cs" : "xVaM6AKO3Xg9DfaF4uh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "POqWPMxZ2CCG",
-      "month" : "xqDUJzWdv1n7d",
-      "day" : "N5zT6WAbIh"
+      "year" : "TFTrmz3djqP",
+      "month" : "iPmiilE9d7Nx65A",
+      "day" : "Xnm5rdOcneoBGrZgvG"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0d616374-6b28-4ba2-80e1-010826744dd2",
-        "name" : "N3O9PdDLKgrID0ROQPE",
+        "id" : "https://www.example.org/4b6ee6aa-4f3f-468e-9ce6-b3189c35da7b",
+        "name" : "Xy8EnRLmqUcivUMj2",
         "nameType" : "Personal",
-        "orcId" : "hJmgTWJPQSG",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "o2cAMVSdf8NR",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IVPFLb7uI05Pj",
-          "value" : "j07oXDTyfVYlT3IIpP"
+          "sourceName" : "mUQ2rcbJXQYfJrJrgbJ",
+          "value" : "HsiqAeT7jMJap2ln4DQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1FvfDdLlzjjJY80tSy8",
-          "value" : "8R0B7x5EjZgQWBtdC"
+          "sourceName" : "A9F3Irj3BqbNhKQ",
+          "value" : "dJPeiVz0brYNUQXb9mT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1b8bba87-15ae-46eb-ac38-787757aa89d1"
+        "id" : "https://www.example.org/979f6b92-0588-4f98-9be7-a27830cb8909"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "EditorialBoardMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,94 +62,95 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8edbb30c-91ba-40f5-977c-1aebe7ff4a9c",
-        "name" : "i0SRMEP9opI2pQP0T",
-        "nameType" : "Organizational",
-        "orcId" : "nzayF19hsyZv",
+        "id" : "https://www.example.org/240a7901-30bd-45a9-af26-556ab2d0e6a8",
+        "name" : "m5N5xmlpQaBNAUSPq",
+        "nameType" : "Personal",
+        "orcId" : "NvuGyeD4ODWxoheM",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fpcyX6bzgxgGaNi",
-          "value" : "yvi92IEpgXxvOo8LD"
+          "sourceName" : "hOiWDXYsHJUsbOm",
+          "value" : "kZAoeK7gsXL0FHDuBG9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hpYPwSopzSkO0",
-          "value" : "mXSuSFVqYR5Mk"
+          "sourceName" : "rbxpKhepCRlcZmOBCL3",
+          "value" : "IOr8Y6Lpda7yJ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9c3c25b9-6545-49e4-89de-fb5539f9ca52"
+        "id" : "https://www.example.org/0617ad84-e7b2-4f58-8aea-afb8e4298926"
       } ],
       "role" : {
-        "type" : "Artist"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "7MuY4zOG3fxmP"
+      "ru" : "4mLeh0fTpucy"
     },
-    "npiSubjectHeading" : "XR6QWX7VsllsB",
-    "tags" : [ "1nxCYNWFb6peWF" ],
-    "description" : "yB5hq2UhQ8t",
+    "npiSubjectHeading" : "KW7mILfL6twmE1OW4",
+    "tags" : [ "mgQjqXYmh9jbwNEJWt" ],
+    "description" : "U2SPrHocPxBrUF0R",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "ExhibitionContent"
       },
-      "doi" : "https://www.example.org/00ade809-a2e1-447d-870e-2c15a357a046",
+      "doi" : "https://www.example.org/37288c14-e0d6-4306-904a-975f47042001",
       "publicationInstance" : {
         "type" : "ExhibitionProduction",
         "subtype" : {
-          "type" : "DigitalExhibition"
+          "type" : "ExhibitionProductionOther",
+          "description" : "2PDctqD0LgSmq"
         },
         "manifestations" : [ {
           "type" : "ExhibitionCatalog",
-          "id" : "https://www.example.com/pBMkV6zBszn"
+          "id" : "https://www.example.com/eoIBxnoh0Xcudu2XD"
         }, {
           "type" : "ExhibitionBasic",
           "organization" : {
             "type" : "UnconfirmedOrganization",
-            "name" : "fAyZA7bxvn1"
+            "name" : "MzLwRekQx5fZ9Ga76vI"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "cM9PzjOpodnTk",
-            "country" : "Wv0oZZa8HB"
+            "label" : "Uba46uXy7BUdBB",
+            "country" : "jQk7I1bB6pz0t"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2019-12-04T23:36:35.672Z",
-            "to" : "2020-07-21T17:53:39.258Z"
+            "from" : "2005-01-12T00:25:38.862Z",
+            "to" : "2019-03-04T02:51:02.432Z"
           }
         }, {
           "type" : "ExhibitionMentionInPublication",
-          "title" : "0xUei5wUsnRqwez",
-          "issue" : "D94ASJCnMWbRMa7",
-          "pages" : "TCNrksoAOCA",
+          "title" : "A2FRzbBH7VY6T5YUt",
+          "issue" : "ISnCSv1kEaOrou4zD",
+          "pages" : "o2RzqMovuv",
           "date" : {
             "type" : "Instant",
-            "value" : "2003-06-09T01:30:57.360Z"
+            "value" : "1981-04-21T19:22:17.269Z"
           },
-          "otherInformation" : "V8DFyaevtzTga3Y"
+          "otherInformation" : "Oo9j2qgCXcE"
         }, {
           "type" : "ExhibitionOtherPresentation",
-          "typeDescription" : "r4kGo60teuqzMtxbTYT",
-          "description" : "gb5V4erqRLoO",
+          "typeDescription" : "sjaUwyJhvyeNaWlJDA",
+          "description" : "8QU1nldx2qAT",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "XK7vYmIozKnzEiwv",
-            "country" : "7uHoNJkTKK1kfpGSk"
+            "label" : "0gdobZHGWjA",
+            "country" : "LOMQjfomIoGQfY"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "eaNBtdcVtO",
+            "name" : "UVt2KcKdGDVavvqtrf8",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2001-12-18T05:55:45.208Z"
+            "value" : "2010-03-22T03:29:47.022Z"
           }
         } ],
         "pages" : {
@@ -157,88 +158,90 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fdc60f14-fe6b-45de-a908-e1e29eda454e",
-    "abstract" : "UFeZhQGuE91KDRDQvlL"
+    "metadataSource" : "https://www.example.org/4f663072-aaf0-47dd-8859-e0a1126478eb",
+    "abstract" : "TWxAj1xDvYWH"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8f8787ee-7a82-47be-9dfa-63562c94911d",
-    "name" : "uw5GjoziUG0jBWcbi",
+    "id" : "https://www.example.org/74508895-2719-42b6-9cec-235849cb412a",
+    "name" : "ySn27FPdV41q",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-05-21T23:47:06.485Z",
+      "approvalDate" : "2002-10-23T16:50:05.018Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "I4DPKxMW7waTnkrMLL"
+      "applicationCode" : "dzCIP2k9KVBGVtoD2v"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9c28c39c-076a-43fe-8f68-e3b8c33405fd",
-    "identifier" : "bnBfowCBCHKpphq",
+    "source" : "https://www.example.org/dc3a19d7-cbaf-42cb-a6f5-12bff441fc58",
+    "identifier" : "gspICKHo9TMxa6Oz",
     "labels" : {
-      "el" : "ol73eLcSDgyEAZptxTu"
+      "de" : "N2wz7L3u1ELwDBat"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 527317047
+      "amount" : 2003662479
     },
-    "activeFrom" : "2016-03-03T04:54:29.215Z",
-    "activeTo" : "2023-01-02T13:43:18.718Z"
+    "activeFrom" : "2010-09-30T19:08:28.877Z",
+    "activeTo" : "2023-07-01T13:27:28.968Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/040b08ce-2285-4a39-8ade-fb85ddaf9dfd",
-    "id" : "https://www.example.org/cfa66885-f1c7-4328-a8a8-12dc837d7b90",
-    "identifier" : "Xs2Cn0PycGLqEA",
+    "source" : "https://www.example.org/debcb829-af82-475b-9f6b-9f75d15a099a",
+    "id" : "https://www.example.org/41aaac90-2409-400d-b718-ad7bad25624d",
+    "identifier" : "RjWaeKdaJw6ypjXR",
     "labels" : {
-      "ru" : "gKMhFrclVC"
+      "el" : "ta4wx2rthO8tU"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 469482451
+      "currency" : "NOK",
+      "amount" : 1688599313
     },
-    "activeFrom" : "1995-02-21T09:37:02.523Z",
-    "activeTo" : "2006-11-18T23:19:30.033Z"
+    "activeFrom" : "2005-01-27T08:46:14.281Z",
+    "activeTo" : "2021-10-06T05:21:23.121Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/84215195-19a6-435c-a0f4-b0b2ebe24030" ],
+  "subjects" : [ "https://www.example.org/9f1bbd65-38ef-4238-a82a-54f0e4581711" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b240e5c7-0fde-4c3f-8de1-a1ad598a2bab",
-    "name" : "nxIQjXYXgg644inwGif",
-    "mimeType" : "735zY40BIgW2AweM",
-    "size" : 1690190381,
-    "license" : "https://www.example.com/8mjrtfdmjzjnv2qdx",
+    "identifier" : "1d678e93-6bdd-4bcf-897b-2fd424582787",
+    "name" : "aGjwSOSAod9JJ",
+    "mimeType" : "DWtzH7u8K69A",
+    "size" : 59451833,
+    "license" : "https://www.example.com/fapxsoarsbna",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "K7QB02Hbv8qL728tcd"
     },
-    "legalNote" : "qWEMn31O2Y5",
-    "publishedDate" : "2012-04-14T00:22:07.575Z",
+    "legalNote" : "s3D88XUwgzxMSl",
+    "publishedDate" : "2018-09-05T11:00:24.938Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Bz59v2UuiveHna6LsT",
-    "name" : "A11VxRQmol4iZGUPI",
-    "description" : "tGZkJdEjTwdmv4Df"
+    "id" : "https://www.example.com/Llt48mIXScN8968QB",
+    "name" : "JZlRnyVXcORPmJcuR",
+    "description" : "8sa7bm1DBXtagMMC"
   } ],
-  "rightsHolder" : "82w0SaF83M6Is2CK1j3",
-  "duplicateOf" : "https://www.example.org/bba4faf2-f65d-40e0-bf44-fa04b5ca7a09",
+  "rightsHolder" : "Y1Ne1SkdJAIYumzYh",
+  "duplicateOf" : "https://www.example.org/3683a654-9511-4feb-ab25-afb7681f4b6e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "z3QiUd37WcD5nw29Q"
+    "note" : "geWlfWfyjJyKXSqslV3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GcTU3m38pviAOj7",
-    "createdBy" : "4fnXsAUO94ct",
-    "createdDate" : "2020-11-24T08:17:13.556Z"
+    "note" : "enW3LgsDUScvf",
+    "createdBy" : "rLoLHyvs1bT2",
+    "createdDate" : "2009-04-13T07:15:54.021Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d460ef7f-7233-4fc5-88c3-edc2d2af8c7f" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/636189a3-61a2-4d3c-90a8-706d729b4612" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "EQUY35ZjOXJ8cqhS",
-    "ownerAffiliation" : "https://www.example.org/fbb8c865-a8a1-46dc-9d74-faf7fbc43c17"
+    "owner" : "OYu1vauYgHotJAay",
+    "ownerAffiliation" : "https://www.example.org/a73e1bbb-b229-45de-a1dd-f885dee96de7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/87689b44-72c9-4cc7-8729-a889b3dc74c4"
+    "id" : "https://www.example.org/3c42b6c5-7b45-4cb4-9e09-9d4205f45363"
   },
-  "createdDate" : "2010-03-30T14:57:42.282Z",
-  "modifiedDate" : "2003-01-09T17:42:23.616Z",
-  "publishedDate" : "1973-04-27T07:33:13.907Z",
-  "indexedDate" : "2007-10-04T15:38:44.731Z",
-  "handle" : "https://www.example.org/90f69161-6286-4b8a-9805-42b934ff40d9",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/5f6f8b73-dd00-443a-8833-ca1a8debcd2d",
+  "createdDate" : "2002-08-04T20:13:39.447Z",
+  "modifiedDate" : "2022-10-09T08:33:05.452Z",
+  "publishedDate" : "2000-10-12T08:01:09.882Z",
+  "indexedDate" : "1990-12-24T00:53:31.403Z",
+  "handle" : "https://www.example.org/04d22fbc-ed4c-4f4c-a5cb-07206d218ace",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/63e6581b-03bd-4374-96aa-162ce90278a9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bjTW34BfZA1Lq3tmD3",
+    "mainTitle" : "DiMV7Wre41j4zTLu",
     "alternativeTitles" : {
-      "cs" : "9G3PhD6JqReXtYl8GbR"
+      "ru" : "Gsg2yRjQvWakvrtls"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "XcNDVl6bGiuWk",
-      "month" : "s2IKi7WKzab1YnnIux8",
-      "day" : "4BP9WIrG6qwT"
+      "year" : "MzaLQjMoh8IEvOV",
+      "month" : "ZlkwSUJ7Q0",
+      "day" : "2t5AcHCmROv7wXDek"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7da7f054-5d3f-44c9-b0d0-d6f5907cbfa2",
-        "name" : "QZcqNvzVXOJwX62vBS",
-        "nameType" : "Personal",
-        "orcId" : "fRtmGFwtS4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/72367cdb-4c94-4fd4-92df-c0833b476436",
+        "name" : "LRpZ7ej8HjbFavkx1",
+        "nameType" : "Organizational",
+        "orcId" : "BYRmF4EIV3z",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "45NGGgpjqR0r",
-          "value" : "z1S4lbx61DYvYnWCLK"
+          "sourceName" : "Tl0XIH9WbUs5Nh",
+          "value" : "oFprgPZKkpCNy2b"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "w7oyg4mYS3j",
-          "value" : "v1emzAOwz3odq"
+          "sourceName" : "kRWao7hmUJSiRqFOA",
+          "value" : "gdVSuOTFSSQ16vT6x"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a312129f-bf57-4045-8661-9739b2b71e7c"
+        "id" : "https://www.example.org/e93372b9-2043-4fd3-91c3-7e3e6e1de866"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "InterviewSubject"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,135 +62,137 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/01c13b4b-519c-4649-a1fd-5678349f3c9b",
-        "name" : "M6DHHCQlYG",
+        "id" : "https://www.example.org/1a87b2eb-5421-4e8b-afef-aeca9cef724f",
+        "name" : "MCAVqKmC3VINC",
         "nameType" : "Organizational",
-        "orcId" : "KGxahrUFbaZvfMxvp",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "9KSRl35MNEk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "LlyKfBGAMHAKJ",
-          "value" : "eFAcnQzzs00fOgFqbzh"
+          "sourceName" : "vEjAXYIjvve",
+          "value" : "YKI7N2tOM4FX7zz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7paqUtHd97aw",
-          "value" : "qdnnyXQvRlv4sp"
+          "sourceName" : "sUOummOplBqi",
+          "value" : "gQ880NlxTFdQZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4a9e0d85-815f-4563-b1b6-8dc073eff037"
+        "id" : "https://www.example.org/ddfd6196-1c6f-43d9-8801-93f2088a77cf"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "ContactPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "Vu0EKsQaRgHdddBCRI"
+      "cs" : "qQsx0GRmS45e"
     },
-    "npiSubjectHeading" : "O0xLzybkwt2Uc8",
-    "tags" : [ "52vtDMw6mwYLbA" ],
-    "description" : "B4B2mfA8JsWyd0u772",
+    "npiSubjectHeading" : "efL24NJQj69xb",
+    "tags" : [ "jOIFKIVRvf" ],
+    "description" : "Tw2e8e5xXY0Zy",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/Az3WG6ylK16WBwS"
+        "id" : "https://www.example.com/WU1HkAUeSteFrIL6qOI"
       },
-      "doi" : "https://www.example.org/6e674d61-9ddd-4fde-b71f-ea97816d4f40",
+      "doi" : "https://www.example.org/e179a9e8-f69c-49b0-9fff-45d4f31f0888",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "2Uwp0kppZ5VLuzj5d",
-          "end" : "6M7TT8xub5"
+          "begin" : "hlzGsUFoz2IqZEw",
+          "end" : "35XUDhUzuBvMeu3kNou"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e69952e1-0b1a-4dfc-ba72-8ffd1af91f36",
-    "abstract" : "YFs10NswnYaAY6W"
+    "metadataSource" : "https://www.example.org/69022d57-b3e4-4fe5-8919-fed7e901629f",
+    "abstract" : "mI8eeh8LLtTW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/25e64a12-0234-4a16-aa58-a12764df4dab",
-    "name" : "ipjE8IDGYL9p",
+    "id" : "https://www.example.org/e26fd6ac-5d9b-4c87-8ed7-7bef77b00df2",
+    "name" : "ZPTJXIMAmKqA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-03-10T11:16:54.390Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "TeW2uFm7Zo1"
+      "approvalDate" : "2006-01-18T01:46:04.002Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ZFyGogSnfE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/17b3ae3c-f359-4d67-86e4-ce09b8fa1077",
-    "identifier" : "6Hkva4poRpt8",
+    "source" : "https://www.example.org/4e214f19-fe01-4ed8-a1d9-1cdfb5ee164c",
+    "identifier" : "FG8tVKbwCWAIBS3v",
     "labels" : {
-      "af" : "yHH4ljFzQt"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1581048908
-    },
-    "activeFrom" : "1998-06-27T00:57:09.652Z",
-    "activeTo" : "2010-04-30T14:43:08.193Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/64918f9b-e6d1-4e60-ad7a-02cbbfa999b2",
-    "id" : "https://www.example.org/336d6a94-884c-476c-9afd-1c2dfa60e15a",
-    "identifier" : "cWjJTJHLpzE",
-    "labels" : {
-      "pl" : "lHggGhDzwF0zA1h9"
+      "ca" : "yQiQ3ilCM1y"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2037094726
+      "amount" : 624196336
     },
-    "activeFrom" : "2017-01-31T01:48:36.600Z",
-    "activeTo" : "2023-10-19T15:43:20.383Z"
+    "activeFrom" : "1990-08-29T05:31:48.924Z",
+    "activeTo" : "2012-06-10T16:46:44.092Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/1f84a3e1-d413-4684-b25a-ee815ee3491f",
+    "id" : "https://www.example.org/97721a10-949b-426e-b41c-80b603b7ec74",
+    "identifier" : "hHTSYoIuWoVFDK",
+    "labels" : {
+      "es" : "XA6F5IY0DRSlV8d"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 646777164
+    },
+    "activeFrom" : "1988-11-06T22:35:13.978Z",
+    "activeTo" : "2003-10-24T19:47:22.746Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0df27ca8-fb84-4dc6-89b7-26be7a92b4d7" ],
+  "subjects" : [ "https://www.example.org/71d56112-5e29-47db-bfc2-8d8f96857567" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "21632a6b-4766-4a9f-8936-4853f1846a42",
-    "name" : "C5mO01rGtYv7aw",
-    "mimeType" : "T6mrFxufQt6",
-    "size" : 1936071209,
-    "license" : "https://www.example.com/ji1xqsfvpf",
+    "identifier" : "f5e351f6-6f87-4bd0-91ae-3bcc8e62f506",
+    "name" : "xi79gDKynRNfSWJ",
+    "mimeType" : "olWxeCX93fCZEr",
+    "size" : 1128997356,
+    "license" : "https://www.example.com/nlqhvocv33zb2",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "FibfdGnxZAaTiHz"
     },
-    "legalNote" : "s8QMH9304qXAEl2iV",
-    "publishedDate" : "2010-11-05T02:33:54.461Z",
+    "legalNote" : "E5Z6z06aZ4o",
+    "publishedDate" : "1991-02-10T06:53:36.023Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/YhP2cgMItK9WUzr6D",
-    "name" : "VD3C0KZcmYMF6H",
-    "description" : "AuHofqpKFT9uOFdNZB"
+    "id" : "https://www.example.com/rNJBfCxDqfNA4CzC",
+    "name" : "GhzgEbwie1l",
+    "description" : "jLEEfyIDh3t9Pl"
   } ],
-  "rightsHolder" : "9Zkk5dLWm2PAM",
-  "duplicateOf" : "https://www.example.org/b47d20a1-9f01-4d00-9e59-7bf0d76ae29c",
+  "rightsHolder" : "C5OgQKgmJd8i9D",
+  "duplicateOf" : "https://www.example.org/af0b3979-bd5a-4033-9fe7-e14d1d2ef86c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DJB7njg9O6RYtkN0Gy"
+    "note" : "CwbnOiKQJFwby"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "9YW8nrUsghWk",
-    "createdBy" : "oFs7TVzSMUojF",
-    "createdDate" : "1991-08-22T02:48:57.437Z"
+    "note" : "WQ7RMvQ6tna",
+    "createdBy" : "BBjaioht3tZme",
+    "createdDate" : "1992-10-19T22:41:20.337Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2bb3c964-2934-436f-bfc4-8afbdeaf8a7d" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/2233f71b-85fc-4f10-ae59-a9d9f04f5027" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Introduction.json
+++ b/documentation/Introduction.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "OYu1vauYgHotJAay",
-    "ownerAffiliation" : "https://www.example.org/a73e1bbb-b229-45de-a1dd-f885dee96de7"
+    "owner" : "pWKHgpRtqw98",
+    "ownerAffiliation" : "https://www.example.org/a4865e67-2115-4839-8015-a4e02c8ebf8c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/3c42b6c5-7b45-4cb4-9e09-9d4205f45363"
+    "id" : "https://www.example.org/4e215048-29c8-44f7-bd51-1ec329cdc2a4"
   },
-  "createdDate" : "2002-08-04T20:13:39.447Z",
-  "modifiedDate" : "2022-10-09T08:33:05.452Z",
-  "publishedDate" : "2000-10-12T08:01:09.882Z",
-  "indexedDate" : "1990-12-24T00:53:31.403Z",
-  "handle" : "https://www.example.org/04d22fbc-ed4c-4f4c-a5cb-07206d218ace",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/63e6581b-03bd-4374-96aa-162ce90278a9",
+  "createdDate" : "2012-04-04T18:46:44.277Z",
+  "modifiedDate" : "1989-09-18T23:16:55.293Z",
+  "publishedDate" : "2005-09-14T04:33:48.909Z",
+  "indexedDate" : "2001-08-05T03:30:04.672Z",
+  "handle" : "https://www.example.org/c6273bb8-c5ca-4bcf-993b-ab242d71bb74",
+  "doi" : "https://doi.org/10.1234/eum",
+  "link" : "https://www.example.org/54f8b838-54f3-4809-9325-c3b5e5b6d5f6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "DiMV7Wre41j4zTLu",
+    "mainTitle" : "fXGoBPiSyBStjer",
     "alternativeTitles" : {
-      "ru" : "Gsg2yRjQvWakvrtls"
+      "it" : "DlEiuFDO2R5mZh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "MzaLQjMoh8IEvOV",
-      "month" : "ZlkwSUJ7Q0",
-      "day" : "2t5AcHCmROv7wXDek"
+      "year" : "MsjdcoFwOIJ6UxyrSp",
+      "month" : "HBncY2pH0SI5h",
+      "day" : "g137YyKIjh9UYJjDPlL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/72367cdb-4c94-4fd4-92df-c0833b476436",
-        "name" : "LRpZ7ej8HjbFavkx1",
+        "id" : "https://www.example.org/14c653df-9ef2-48e6-bc8f-0aa26c308e55",
+        "name" : "JzmLPGPFi9lpcXfigy2",
         "nameType" : "Organizational",
-        "orcId" : "BYRmF4EIV3z",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "HvjLaoXJKDG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Tl0XIH9WbUs5Nh",
-          "value" : "oFprgPZKkpCNy2b"
+          "sourceName" : "DD2kavrtghtfvfs",
+          "value" : "73l74H3xBBKTsbquG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kRWao7hmUJSiRqFOA",
-          "value" : "gdVSuOTFSSQ16vT6x"
+          "sourceName" : "tVmzxKSrvyv",
+          "value" : "eZJnQwg6CYW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e93372b9-2043-4fd3-91c3-7e3e6e1de866"
+        "id" : "https://www.example.org/202c313f-259a-4efc-9713-7ffb66b019a2"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Dramaturge"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,137 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1a87b2eb-5421-4e8b-afef-aeca9cef724f",
-        "name" : "MCAVqKmC3VINC",
-        "nameType" : "Organizational",
-        "orcId" : "9KSRl35MNEk",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/d27ac20d-4b19-4fa3-a832-243df41d31ac",
+        "name" : "Ky2Rp4NIdn8w",
+        "nameType" : "Personal",
+        "orcId" : "AabH8STPq3GIp",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vEjAXYIjvve",
-          "value" : "YKI7N2tOM4FX7zz"
+          "sourceName" : "987lRuQD57ykfC",
+          "value" : "rZZZ3DrbMKjheMe"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sUOummOplBqi",
-          "value" : "gQ880NlxTFdQZ"
+          "sourceName" : "TCUvVKbCc9zaiMQcVc",
+          "value" : "pS4GYhG724"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ddfd6196-1c6f-43d9-8801-93f2088a77cf"
+        "id" : "https://www.example.org/a29b061d-d9e7-43da-85ca-95f49a2b2af8"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Illustrator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "qQsx0GRmS45e"
+      "en" : "FvdgZgOfdsc"
     },
-    "npiSubjectHeading" : "efL24NJQj69xb",
-    "tags" : [ "jOIFKIVRvf" ],
-    "description" : "Tw2e8e5xXY0Zy",
+    "npiSubjectHeading" : "yYPmE1MG94zK0r",
+    "tags" : [ "LEoQkhemyXIh1" ],
+    "description" : "eZ0jkhCl6KOwT34",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/WU1HkAUeSteFrIL6qOI"
+        "id" : "https://www.example.com/mBIzauECfwpmPaHQEK"
       },
-      "doi" : "https://www.example.org/e179a9e8-f69c-49b0-9fff-45d4f31f0888",
+      "doi" : "https://www.example.org/bd6dcab8-587c-4096-96cb-bc992314dfb6",
       "publicationInstance" : {
         "type" : "Introduction",
         "pages" : {
           "type" : "Range",
-          "begin" : "hlzGsUFoz2IqZEw",
-          "end" : "35XUDhUzuBvMeu3kNou"
+          "begin" : "F1Y9EpfBnCUp",
+          "end" : "H40xgGdZodI"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/69022d57-b3e4-4fe5-8919-fed7e901629f",
-    "abstract" : "mI8eeh8LLtTW"
+    "metadataSource" : "https://www.example.org/7ed69091-5945-4e36-bce6-dbf23382ef8c",
+    "abstract" : "1tAZYjTtxA8taMZ8LQ"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e26fd6ac-5d9b-4c87-8ed7-7bef77b00df2",
-    "name" : "ZPTJXIMAmKqA",
+    "id" : "https://www.example.org/ba9a0e93-01fa-402a-861a-e469186ec993",
+    "name" : "qceVzdDNna",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-01-18T01:46:04.002Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "ZFyGogSnfE"
+      "approvalDate" : "1998-04-04T13:28:14.006Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "xbXFPQZxk3Ozt"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4e214f19-fe01-4ed8-a1d9-1cdfb5ee164c",
-    "identifier" : "FG8tVKbwCWAIBS3v",
+    "source" : "https://www.example.org/dab560bb-134c-4514-8661-63676fbd972e",
+    "identifier" : "ReyLOVvrjabI4",
     "labels" : {
-      "ca" : "yQiQ3ilCM1y"
+      "zh" : "Astiyw1gNfbczhP"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 624196336
+      "amount" : 557292394
     },
-    "activeFrom" : "1990-08-29T05:31:48.924Z",
-    "activeTo" : "2012-06-10T16:46:44.092Z"
+    "activeFrom" : "2011-12-19T03:47:44.147Z",
+    "activeTo" : "2020-07-04T20:48:36.198Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1f84a3e1-d413-4684-b25a-ee815ee3491f",
-    "id" : "https://www.example.org/97721a10-949b-426e-b41c-80b603b7ec74",
-    "identifier" : "hHTSYoIuWoVFDK",
+    "source" : "https://www.example.org/e91f2e28-1649-4b89-b43a-3d2099dc62a8",
+    "id" : "https://www.example.org/c1a8021b-153c-4d05-9d19-abf3c34e9779",
+    "identifier" : "x87rqBXocaGOhTGX6OQ",
     "labels" : {
-      "es" : "XA6F5IY0DRSlV8d"
+      "se" : "uRH1ctQGzV"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 646777164
+      "currency" : "NOK",
+      "amount" : 1216590809
     },
-    "activeFrom" : "1988-11-06T22:35:13.978Z",
-    "activeTo" : "2003-10-24T19:47:22.746Z"
+    "activeFrom" : "2021-08-27T01:14:35.921Z",
+    "activeTo" : "2022-11-28T16:51:56.445Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/71d56112-5e29-47db-bfc2-8d8f96857567" ],
+  "subjects" : [ "https://www.example.org/0c7c6566-68a2-4bf7-a91e-389f2b319a93" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f5e351f6-6f87-4bd0-91ae-3bcc8e62f506",
-    "name" : "xi79gDKynRNfSWJ",
-    "mimeType" : "olWxeCX93fCZEr",
-    "size" : 1128997356,
-    "license" : "https://www.example.com/nlqhvocv33zb2",
+    "identifier" : "1dffd7f4-e6ad-4d77-bd9b-b8b5d3a58af3",
+    "name" : "0L2XfQCxZS",
+    "mimeType" : "OBlD6QOkRAjllTJ",
+    "size" : 915786703,
+    "license" : "https://www.example.com/w1qmi5rajc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "FibfdGnxZAaTiHz"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "E5Z6z06aZ4o",
-    "publishedDate" : "1991-02-10T06:53:36.023Z",
+    "legalNote" : "H5Um3pjcMBX9",
+    "publishedDate" : "1986-01-18T05:36:25.241Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "BDPLwMVHRVy9GvFHIu",
+      "uploadedDate" : "1993-12-14T13:17:48.429Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/rNJBfCxDqfNA4CzC",
-    "name" : "GhzgEbwie1l",
-    "description" : "jLEEfyIDh3t9Pl"
+    "id" : "https://www.example.com/K1DCXcc2Jzne4efBr",
+    "name" : "Oa9xUE5kniSZIxO",
+    "description" : "cFVGc6NFQpMKQ"
   } ],
-  "rightsHolder" : "C5OgQKgmJd8i9D",
-  "duplicateOf" : "https://www.example.org/af0b3979-bd5a-4033-9fe7-e14d1d2ef86c",
+  "rightsHolder" : "S8fHR0BjuanB5lm1P2x",
+  "duplicateOf" : "https://www.example.org/010c7690-2e6e-42f1-bb1c-6ba352025ee2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CwbnOiKQJFwby"
+    "note" : "gpMWw7YRFEfSSWT"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WQ7RMvQ6tna",
-    "createdBy" : "BBjaioht3tZme",
-    "createdDate" : "1992-10-19T22:41:20.337Z"
+    "note" : "ZRQ3cKHCxr9P",
+    "createdBy" : "mCcjpEOoaS",
+    "createdDate" : "1993-11-06T02:59:53.078Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2233f71b-85fc-4f10-ae59-a9d9f04f5027" ],
+  "curatingInstitutions" : [ "https://www.example.org/558e35a4-95d9-4166-a214-55d7d71eafdb" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "tpQ4Y9ZekMtkD6",
-    "ownerAffiliation" : "https://www.example.org/8a65f3d3-4c63-4eef-be50-39d0fd8b46fb"
+    "owner" : "YBw9ZxeC0z7al",
+    "ownerAffiliation" : "https://www.example.org/876f40af-cddb-4f3f-9bbf-96b94be50e6f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/744db2a8-0253-4f8a-9c85-227d72218d1a"
+    "id" : "https://www.example.org/562a9613-f780-47a9-87cb-14a7b258fc26"
   },
-  "createdDate" : "1986-11-27T07:53:28.705Z",
-  "modifiedDate" : "1972-03-18T01:53:21.689Z",
-  "publishedDate" : "2007-05-28T18:25:02.767Z",
-  "indexedDate" : "1993-03-14T16:00:14.460Z",
-  "handle" : "https://www.example.org/e9c928bd-6a3a-4e9d-9410-ed24dfb22d3a",
-  "doi" : "https://doi.org/10.1234/non",
-  "link" : "https://www.example.org/5cd6ae96-5efb-4da6-90b6-fb4fa667ef39",
+  "createdDate" : "2018-11-30T05:58:24.335Z",
+  "modifiedDate" : "1994-09-08T05:24:31.144Z",
+  "publishedDate" : "2002-02-17T16:45:05.311Z",
+  "indexedDate" : "2007-05-21T20:42:04.809Z",
+  "handle" : "https://www.example.org/12007b69-ce96-4449-b03e-c5bb8a953940",
+  "doi" : "https://doi.org/10.1234/natus",
+  "link" : "https://www.example.org/ba77be62-1931-46fa-993c-02c3a0c8bf37",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "H2vqlqlQu0GHxtmdvZ",
+    "mainTitle" : "bRUi9CkMCx3",
     "alternativeTitles" : {
-      "pt" : "RlF39exFtUKl"
+      "pt" : "NIlKXPbZ3AJdT1mS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "yC1cbscC72hxDmEr",
-      "month" : "lNPJd40VYCQAGr",
-      "day" : "qzHAp0ujMX2OCkT1Q"
+      "year" : "eVp4vvmQI3IBpXa",
+      "month" : "CAOyc2XHyJdpGtQd7",
+      "day" : "AWACZdZ3eWMsdEZhO27"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/135a051e-0cef-4475-98ee-23002a0d797e",
-        "name" : "JtCH8BCrvqqbTtJi",
+        "id" : "https://www.example.org/19ed1571-0938-4a6e-844e-37a78c290bc3",
+        "name" : "R2UKqKHETwk7Ybgthz",
         "nameType" : "Personal",
-        "orcId" : "zSk3MY2zhyYNcHc",
-        "verificationStatus" : "Verified",
+        "orcId" : "It26y8QdC3TQB",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AwbbJPLMBoke3aPjSDV",
-          "value" : "h5SSjHZ0zQGpzAxuy"
+          "sourceName" : "PYcRUwd8bVXSpD7dCG",
+          "value" : "JyjMY1MS1e7RuVNDXxm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bvKmSNi7C4wBV",
-          "value" : "X8TjZnrlr8y48wodY"
+          "sourceName" : "NGW2ik7leztO",
+          "value" : "iQkdBT780H"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/45e1198c-ea18-426b-83e7-01a99fd8efc1"
+        "id" : "https://www.example.org/dd8b1376-cc0e-4297-9d7d-873c8a888c45"
       } ],
       "role" : {
-        "type" : "Producer"
+        "type" : "ProjectMember"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/01c974c3-7491-4042-be5a-3093019f0a8b",
-        "name" : "KEPnEgDWiR8",
-        "nameType" : "Personal",
-        "orcId" : "QWHKyN9tSWDZTy",
+        "id" : "https://www.example.org/ce262f5f-b07f-430e-9f1f-f9f41065510f",
+        "name" : "i9GubW9JuzOLCn8",
+        "nameType" : "Organizational",
+        "orcId" : "iqDxPcvYD9HGSwp7QMX",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V7t9pUAhO7W33UL",
-          "value" : "gVNlI7IL7N"
+          "sourceName" : "M8LduqfbCJafcqaxBaO",
+          "value" : "WG8DsZdS7hmTuD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BXIkfLf3ymGC5",
-          "value" : "FrfgYgPulgv6"
+          "sourceName" : "sMIwW22uXthyyRC",
+          "value" : "vOKiZ6d9sMoljX7cwSt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e57111d2-e550-43bd-bf73-2e4151a63d1f"
+        "id" : "https://www.example.org/9ffcb2fa-99da-4ea3-932c-7ae5f2a284a9"
       } ],
       "role" : {
-        "type" : "ProgrammeParticipant"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "YUduNsxRDOaSDO9XGb"
+      "en" : "YY36nb9kccOKHPQ"
     },
-    "npiSubjectHeading" : "pPZWYl0BUqYtCUOdUn",
-    "tags" : [ "grgquX3ZNrEVNlkhbQ" ],
-    "description" : "2IevDOFToiN0jxq3nHn",
+    "npiSubjectHeading" : "OEUAMAeBqoLTIwOEPd9",
+    "tags" : [ "4xmVSR5PPygikB" ],
+    "description" : "31t4lkG5VPTxiFCUt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/334a331c-c33e-442b-a691-373770dd9a8a"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9cad902a-4084-467e-a7fe-f678da16c34c"
       },
-      "doi" : "https://www.example.org/2ef36299-ef91-4300-b922-a1a62c9c7ef8",
+      "doi" : "https://www.example.org/7c04d8fd-c44d-4b7e-804a-bb4482e6594d",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "6eddVtjZ8JU50gP",
-        "issue" : "3GtAXfGHTh",
-        "articleNumber" : "gwXvrQ2AlR38VnRUMG",
+        "volume" : "fV1YT80BPwD4Rr9KWCC",
+        "issue" : "3odlVnIVRvAxru6VRDx",
+        "articleNumber" : "DrYeupjGBwImfd",
         "pages" : {
           "type" : "Range",
-          "begin" : "XqyX8vrelFF",
-          "end" : "FVZU2VTBpYR"
+          "begin" : "noLVk4ttfQUosrDc",
+          "end" : "ZW8KbfDNyZ"
         },
-        "corrigendumFor" : "https://www.example.com/gp3hXp5TQ1voiD"
+        "corrigendumFor" : "https://www.example.com/jAWSdBfpPM"
       }
     },
-    "metadataSource" : "https://www.example.org/b2219c37-d831-429c-b33b-0a8c3dc0fff9",
-    "abstract" : "gtHDdHcDjbzzhA"
+    "metadataSource" : "https://www.example.org/cd610762-449a-4d03-aeb9-69299ac5f7f5",
+    "abstract" : "Pke6naEp24fy3Svt"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/874ed038-832d-4a1a-b094-31c9f335b5a8",
-    "name" : "gK7MO52naJn35",
+    "id" : "https://www.example.org/b0b337cc-fba7-44c6-b07c-beb3374d3911",
+    "name" : "CvbgesbTnh72u2P",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-05-08T11:21:35.581Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1972-06-08T18:15:45.919Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "txg1c2wT9mHD6"
+      "applicationCode" : "bP1P2w8Ooy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/79bf99e9-7336-477f-ad0e-fe4a742d00d0",
-    "identifier" : "s4prQrlOmYuhQXI",
+    "source" : "https://www.example.org/8ef06c8a-4dbf-4ae5-8b7a-c8867310e1db",
+    "identifier" : "343JavfTDp9f",
     "labels" : {
-      "nb" : "D3WkxiXZt5xuOk"
+      "is" : "1JrSuSl7imfmYBup"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1705145105
+      "currency" : "USD",
+      "amount" : 903155489
     },
-    "activeFrom" : "2003-01-22T07:36:11.969Z",
-    "activeTo" : "2023-11-26T03:43:09.977Z"
+    "activeFrom" : "2015-09-17T02:14:32.106Z",
+    "activeTo" : "2023-09-23T22:11:51.220Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/2e0c5a92-3cfa-4ab2-bf90-98df24e9be32",
-    "id" : "https://www.example.org/7ad4ad7f-7a3e-4491-9449-2fe4bed9375f",
-    "identifier" : "AdMd930FhuN70",
+    "source" : "https://www.example.org/1a3592f2-6202-4d88-8865-260703d56133",
+    "id" : "https://www.example.org/e8e07fbc-aa39-487a-ae5b-40e6a1fa1f12",
+    "identifier" : "Azv428dLH6i",
     "labels" : {
-      "fi" : "8tWbTywEzlVZUWRaJ7t"
+      "pt" : "dz9Mte3Dd8Mje0rWV"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1575867256
+      "currency" : "USD",
+      "amount" : 2041235699
     },
-    "activeFrom" : "1999-04-09T23:20:34.297Z",
-    "activeTo" : "1999-07-31T12:53:00.111Z"
+    "activeFrom" : "2017-05-27T19:28:53.940Z",
+    "activeTo" : "2019-05-07T01:31:32.734Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/d0cd815a-e430-4d31-bfb5-e7f6e7e71aa2" ],
+  "subjects" : [ "https://www.example.org/cde4fdc9-e64a-484b-a6ab-4c502a033393" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "247e2d46-8513-4f11-8a38-f73c90435f19",
-    "name" : "6h1VobAQUg0",
-    "mimeType" : "tR5Bb8njEvDi",
-    "size" : 1515738704,
-    "license" : "https://www.example.com/wfkifqx2h3",
+    "identifier" : "0502f18d-6397-4b73-91a1-93573eb20187",
+    "name" : "25TgYS3mmNxrr",
+    "mimeType" : "RFokCXpsUZjbc4snbFC",
+    "size" : 221858231,
+    "license" : "https://www.example.com/xq6rejfigtt",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "EZLEZnwWuY0hb3Vb",
-    "publishedDate" : "1982-05-31T15:10:58.112Z",
+    "legalNote" : "hAblMnSjU0vF",
+    "publishedDate" : "2012-05-29T00:34:42.143Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/J0B6OEKg0bTw",
-    "name" : "otkk4PQfkDw1",
-    "description" : "kFloAcB2ydv2UZT"
+    "id" : "https://www.example.com/2BMoUWqlvA",
+    "name" : "Lqe9x0Dykj",
+    "description" : "QdTAEi6EhwGF"
   } ],
-  "rightsHolder" : "BAp0Vu4wtgXN",
-  "duplicateOf" : "https://www.example.org/fbc6dcee-8b6a-4e3f-9ed2-faaefdc52115",
+  "rightsHolder" : "nwXOM3uOJR6DZGi",
+  "duplicateOf" : "https://www.example.org/d4de4583-e054-493c-94bc-e8b8216df1f7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "45Lo2hgXVHRIQPYk7Jk"
+    "note" : "VAlt9fqXlNNVa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "rQrPVUlKN759XNoxX",
-    "createdBy" : "4eVOozHkSWb",
-    "createdDate" : "1984-10-19T09:36:54.192Z"
+    "note" : "svPyqTTVmYqLrvXhne6",
+    "createdBy" : "LAHxD2XKFF2pRbWBe",
+    "createdDate" : "1997-04-11T01:35:33.201Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9bcec0bc-f0fc-483f-892b-fe775eb6f535" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/33a65592-0aa0-4f3b-a190-732c2af0aa29" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/JournalCorrigendum.json
+++ b/documentation/JournalCorrigendum.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "YBw9ZxeC0z7al",
-    "ownerAffiliation" : "https://www.example.org/876f40af-cddb-4f3f-9bbf-96b94be50e6f"
+    "owner" : "wXDXvxbsGr",
+    "ownerAffiliation" : "https://www.example.org/b06f1441-cf89-4b53-a424-3fdcca6a36bc"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/562a9613-f780-47a9-87cb-14a7b258fc26"
+    "id" : "https://www.example.org/e14d46fb-a8a8-4c5c-b8e1-0cad2f2bf198"
   },
-  "createdDate" : "2018-11-30T05:58:24.335Z",
-  "modifiedDate" : "1994-09-08T05:24:31.144Z",
-  "publishedDate" : "2002-02-17T16:45:05.311Z",
-  "indexedDate" : "2007-05-21T20:42:04.809Z",
-  "handle" : "https://www.example.org/12007b69-ce96-4449-b03e-c5bb8a953940",
-  "doi" : "https://doi.org/10.1234/natus",
-  "link" : "https://www.example.org/ba77be62-1931-46fa-993c-02c3a0c8bf37",
+  "createdDate" : "1973-05-19T20:29:08.028Z",
+  "modifiedDate" : "2017-05-30T10:23:06.742Z",
+  "publishedDate" : "2009-08-03T05:24:34.241Z",
+  "indexedDate" : "2014-09-28T02:40:59.722Z",
+  "handle" : "https://www.example.org/54df1552-5d1a-489a-b4bc-19d1a263b9f0",
+  "doi" : "https://doi.org/10.1234/iste",
+  "link" : "https://www.example.org/76110481-7bf4-4d7b-a945-47a1a66e13a6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bRUi9CkMCx3",
+    "mainTitle" : "3Xh9rSK16FQUdkvk22",
     "alternativeTitles" : {
-      "pt" : "NIlKXPbZ3AJdT1mS"
+      "nn" : "QVhXB5Rl8BDifE"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "eVp4vvmQI3IBpXa",
-      "month" : "CAOyc2XHyJdpGtQd7",
-      "day" : "AWACZdZ3eWMsdEZhO27"
+      "year" : "pE85c02WAGcgXy",
+      "month" : "ypSBrfa5mnQQ",
+      "day" : "TzTheKVqzebe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/19ed1571-0938-4a6e-844e-37a78c290bc3",
-        "name" : "R2UKqKHETwk7Ybgthz",
-        "nameType" : "Personal",
-        "orcId" : "It26y8QdC3TQB",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/b3426a36-3e57-40fa-9731-3a2cc2faf93a",
+        "name" : "XJBYQbdMcAkm5R",
+        "nameType" : "Organizational",
+        "orcId" : "4hsc4d0YimXjuTL",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PYcRUwd8bVXSpD7dCG",
-          "value" : "JyjMY1MS1e7RuVNDXxm"
+          "sourceName" : "0FAGlgziTeD",
+          "value" : "6vbnmGliJMCsS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NGW2ik7leztO",
-          "value" : "iQkdBT780H"
+          "sourceName" : "wyNx71PNktXfykRdg6",
+          "value" : "YHXb3D9K4gwy7FpJMG"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/dd8b1376-cc0e-4297-9d7d-873c8a888c45"
+        "id" : "https://www.example.org/13929b35-c6f4-465a-a611-d86f9d223cbc"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,146 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ce262f5f-b07f-430e-9f1f-f9f41065510f",
-        "name" : "i9GubW9JuzOLCn8",
+        "id" : "https://www.example.org/7a8a9ee1-5ccb-475b-9c3b-7c4e1b11e1a6",
+        "name" : "FoZfNN70vRrNvFU",
         "nameType" : "Organizational",
-        "orcId" : "iqDxPcvYD9HGSwp7QMX",
-        "verificationStatus" : "Verified",
+        "orcId" : "XoqhWl7v0zq",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "M8LduqfbCJafcqaxBaO",
-          "value" : "WG8DsZdS7hmTuD"
+          "sourceName" : "NxWXqysSp2j88",
+          "value" : "EFOJpI51oACND3iD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sMIwW22uXthyyRC",
-          "value" : "vOKiZ6d9sMoljX7cwSt"
+          "sourceName" : "j5NOKqGpeFp6v",
+          "value" : "Q8kKmkHMrhgDf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9ffcb2fa-99da-4ea3-932c-7ae5f2a284a9"
+        "id" : "https://www.example.org/30be4f5b-03e1-40ca-966f-a12dedecadff"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "YY36nb9kccOKHPQ"
+      "ru" : "fVfmv3Nlv4XBP"
     },
-    "npiSubjectHeading" : "OEUAMAeBqoLTIwOEPd9",
-    "tags" : [ "4xmVSR5PPygikB" ],
-    "description" : "31t4lkG5VPTxiFCUt",
+    "npiSubjectHeading" : "TARaTMqSjf",
+    "tags" : [ "mDQPVNq1HbMF03q9" ],
+    "description" : "tzpmqJPO55B",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9cad902a-4084-467e-a7fe-f678da16c34c"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/08719541-6812-4eb9-bda7-242d563747e9"
       },
-      "doi" : "https://www.example.org/7c04d8fd-c44d-4b7e-804a-bb4482e6594d",
+      "doi" : "https://www.example.org/d58dee89-08f3-40ca-b39d-6dde942f6fd0",
       "publicationInstance" : {
         "type" : "JournalCorrigendum",
-        "volume" : "fV1YT80BPwD4Rr9KWCC",
-        "issue" : "3odlVnIVRvAxru6VRDx",
-        "articleNumber" : "DrYeupjGBwImfd",
+        "volume" : "Hx0ykcUX5P7AW",
+        "issue" : "KL8BbsT8Y5fJ02W8LA",
+        "articleNumber" : "hnuBVu6zsBYJmfpxY",
         "pages" : {
           "type" : "Range",
-          "begin" : "noLVk4ttfQUosrDc",
-          "end" : "ZW8KbfDNyZ"
+          "begin" : "mtdxjhnC0l4Zb4pnR",
+          "end" : "zFChbnTfS1ohA43STHB"
         },
-        "corrigendumFor" : "https://www.example.com/jAWSdBfpPM"
+        "corrigendumFor" : "https://www.example.com/og2bDlUuJNxAnM"
       }
     },
-    "metadataSource" : "https://www.example.org/cd610762-449a-4d03-aeb9-69299ac5f7f5",
-    "abstract" : "Pke6naEp24fy3Svt"
+    "metadataSource" : "https://www.example.org/4637a2cb-8fcd-422c-9290-ec15feee23e7",
+    "abstract" : "NIKO3ohL9xyuVzDEP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b0b337cc-fba7-44c6-b07c-beb3374d3911",
-    "name" : "CvbgesbTnh72u2P",
+    "id" : "https://www.example.org/cfec3bb7-94ce-4841-baee-a63e6ccb9275",
+    "name" : "Q4VxMQA9Y0u",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-06-08T18:15:45.919Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "bP1P2w8Ooy"
+      "approvalDate" : "2022-04-27T10:38:00.367Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "2WCxjli9Sk11"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/8ef06c8a-4dbf-4ae5-8b7a-c8867310e1db",
-    "identifier" : "343JavfTDp9f",
+    "source" : "https://www.example.org/50400a71-7ae5-4eed-91f5-2822c8df9d49",
+    "identifier" : "FtVJsBNjsdS",
     "labels" : {
-      "is" : "1JrSuSl7imfmYBup"
+      "nb" : "swrZWCqzpqO9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 903155489
+      "currency" : "NOK",
+      "amount" : 848306146
     },
-    "activeFrom" : "2015-09-17T02:14:32.106Z",
-    "activeTo" : "2023-09-23T22:11:51.220Z"
+    "activeFrom" : "2004-11-13T06:31:40.711Z",
+    "activeTo" : "2009-06-06T04:23:13.960Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1a3592f2-6202-4d88-8865-260703d56133",
-    "id" : "https://www.example.org/e8e07fbc-aa39-487a-ae5b-40e6a1fa1f12",
-    "identifier" : "Azv428dLH6i",
+    "source" : "https://www.example.org/4a0cb8fd-9c2d-420e-9c3a-594e8622a6ed",
+    "id" : "https://www.example.org/77825a24-0859-40e0-8df9-29f2eb6af8a6",
+    "identifier" : "YRh50Kr9DyJVMCqgJOz",
     "labels" : {
-      "pt" : "dz9Mte3Dd8Mje0rWV"
+      "de" : "SQeSwRJtCAdl"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2041235699
+      "currency" : "NOK",
+      "amount" : 1977872657
     },
-    "activeFrom" : "2017-05-27T19:28:53.940Z",
-    "activeTo" : "2019-05-07T01:31:32.734Z"
+    "activeFrom" : "1999-12-17T06:16:18.081Z",
+    "activeTo" : "2016-10-17T07:36:59.608Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cde4fdc9-e64a-484b-a6ab-4c502a033393" ],
+  "subjects" : [ "https://www.example.org/bdc52e6d-aa30-42c8-a53a-9e4efcf5ba95" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0502f18d-6397-4b73-91a1-93573eb20187",
-    "name" : "25TgYS3mmNxrr",
-    "mimeType" : "RFokCXpsUZjbc4snbFC",
-    "size" : 221858231,
-    "license" : "https://www.example.com/xq6rejfigtt",
+    "identifier" : "af662ce0-f374-4bf7-aa0e-2cb6fd4b1aa0",
+    "name" : "Y30YneohjGuhPIlhnn8",
+    "mimeType" : "HF1r2LJ90XLEZSNmu",
+    "size" : 392181913,
+    "license" : "https://www.example.com/miyeoeivkixvgkfyr",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "HbhxPv6CU9nTV5yKxM"
     },
-    "legalNote" : "hAblMnSjU0vF",
-    "publishedDate" : "2012-05-29T00:34:42.143Z",
+    "legalNote" : "JhBuWazFE6rtc089",
+    "publishedDate" : "1982-08-10T04:07:57.375Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "rMdPyDN3vSb62TGjgM5",
+      "uploadedDate" : "2008-10-04T03:46:58.907Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/2BMoUWqlvA",
-    "name" : "Lqe9x0Dykj",
-    "description" : "QdTAEi6EhwGF"
+    "id" : "https://www.example.com/3goWuTG88iPmEm574DF",
+    "name" : "GVcKlR3tk2c5z0",
+    "description" : "BJFMkZwss1p"
   } ],
-  "rightsHolder" : "nwXOM3uOJR6DZGi",
-  "duplicateOf" : "https://www.example.org/d4de4583-e054-493c-94bc-e8b8216df1f7",
+  "rightsHolder" : "iU52Vc1cKtx8wVe",
+  "duplicateOf" : "https://www.example.org/7348a6ab-f796-4e5d-b8f9-c58f4cd4dd8f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "VAlt9fqXlNNVa"
+    "note" : "2Wpj3WXUFHtOV"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "svPyqTTVmYqLrvXhne6",
-    "createdBy" : "LAHxD2XKFF2pRbWBe",
-    "createdDate" : "1997-04-11T01:35:33.201Z"
+    "note" : "Cm9e0d3WXiZQTqBMlA",
+    "createdBy" : "GO2kO3FytDheGTEo4",
+    "createdDate" : "2012-12-05T13:02:42.638Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/33a65592-0aa0-4f3b-a190-732c2af0aa29" ],
+  "curatingInstitutions" : [ "https://www.example.org/81a04c96-324c-4c8c-9df1-8f3757971727" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "mzoICjSq76dN",
-    "ownerAffiliation" : "https://www.example.org/4b333e00-ff69-4455-ae32-fd504ac9ec5c"
+    "owner" : "TO0c1dTlKC5hrzA",
+    "ownerAffiliation" : "https://www.example.org/4c91767f-1b84-45a4-9a9d-db41829b984b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/af205281-9a21-48a2-9f1a-3b16833413e1"
+    "id" : "https://www.example.org/0e207dad-1339-4c2f-9744-11f4fd7b90ce"
   },
-  "createdDate" : "2003-01-25T14:34:52.708Z",
-  "modifiedDate" : "2009-10-09T10:58:48.572Z",
-  "publishedDate" : "1986-06-29T11:19:12.361Z",
-  "indexedDate" : "1988-07-06T23:30:51.083Z",
-  "handle" : "https://www.example.org/9cccf48d-bc31-473e-99e5-48d1a3203aa9",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/57dc244f-bbcc-403f-8f0f-504e46d6a9e8",
+  "createdDate" : "2021-06-16T10:37:37.954Z",
+  "modifiedDate" : "1980-05-09T20:26:06.740Z",
+  "publishedDate" : "1982-01-23T12:51:24.305Z",
+  "indexedDate" : "1979-04-17T09:35:07.130Z",
+  "handle" : "https://www.example.org/f0ba286e-1479-455c-ab0f-f0e5095b9290",
+  "doi" : "https://doi.org/10.1234/nam",
+  "link" : "https://www.example.org/8e13aba7-f21b-4fd5-9a05-44290264da47",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "q4UOQ8ZinCC",
+    "mainTitle" : "KJZC6cDV68L10E0PzaD",
     "alternativeTitles" : {
-      "nl" : "9q0xUI1T1xcfKNgAX0"
+      "es" : "sFw4w4UTrEs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dtmwv7fkSr",
-      "month" : "mVlo6d2F6jl",
-      "day" : "J2YJzLVPfd138UM4rD"
+      "year" : "UZmnMAqcArUBFT4gQh",
+      "month" : "sUZbNrDHTY34Du",
+      "day" : "G1ySVfUADzFTbv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/371a4f7a-95b4-48da-aaff-273b3035753b",
-        "name" : "OHPmKJETutzIH9e",
-        "nameType" : "Organizational",
-        "orcId" : "31ofLmVmf1FPO",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/f1266136-6d1a-49c4-9c0d-f204fc50e0e5",
+        "name" : "KTFq18YiY217HEXB",
+        "nameType" : "Personal",
+        "orcId" : "24UMfpNzByYuk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nNxvpmQgyiEVfRevV",
-          "value" : "nAFtSOXw9DGP"
+          "sourceName" : "8UVaLwu0KJY8XW",
+          "value" : "8v2RON6gA1JCWGg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "whDELT5kXJwjYy9oJ0",
-          "value" : "mH8fVFyfoPrJv9kSKh"
+          "sourceName" : "A2FfGv1bmeZuornOHrR",
+          "value" : "1QuIHZzkZhNlQbEtdu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d88890a1-e8ea-469e-94ce-5375252e0081"
+        "id" : "https://www.example.org/8ffdae57-6c07-4962-bd09-8fa8d7117659"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ce8edbbf-8cba-40c1-9d9e-83c77f337afc",
-        "name" : "f9ew74eWjp1zjMZi",
-        "nameType" : "Organizational",
-        "orcId" : "9h8gpXknlD1My0voG",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/04144150-e0f7-4dfb-bdb1-8ef7761f78dd",
+        "name" : "FxhNRJ6VlOySRssXr0",
+        "nameType" : "Personal",
+        "orcId" : "rY4xA4saHA2xKa",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "oH753J9u4i2G0S3kA0M",
-          "value" : "TBe92Tamx6eWmw"
+          "sourceName" : "EpKlR8Wrmjc",
+          "value" : "krpoxjMP3qD6jkC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9Hc63slWFT0lGI0foGG",
-          "value" : "Mvrlds5wiXFRlwj"
+          "sourceName" : "lnufLHm6HI",
+          "value" : "nw374YcKXAQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/89f5f1af-e860-4e2f-af3a-86c2a9dad08c"
+        "id" : "https://www.example.org/fd3299b0-e258-4ab9-b6ae-4082d8104a0c"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Journalist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "gpufH6Gyx6"
+      "is" : "ejRsawEZIDgouB"
     },
-    "npiSubjectHeading" : "51CtiIAGNuKP6z",
-    "tags" : [ "3nJKUjNMalMMTLdjvE" ],
-    "description" : "jLVwccZSBZp",
+    "npiSubjectHeading" : "21EsKoiR5M",
+    "tags" : [ "82Kz6wLF9MT" ],
+    "description" : "SDyLVnLvSfD",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/88cebba0-99ac-4249-b197-e0ea43b205cd"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d254ff95-f30b-45c1-9ee9-bc9bb175dd8e"
       },
-      "doi" : "https://www.example.org/8fd5a201-d4eb-4b76-be52-c1a9a9ef1e29",
+      "doi" : "https://www.example.org/8b14ba5c-57b7-408b-a25e-c0f4f1a7e2ff",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "FEdLzHKvybzjyGesp",
-        "issue" : "c3CD8aby7AHPePwE",
-        "articleNumber" : "wfehhUh3CZQ5aJx5",
+        "volume" : "hK3MrsMhY3UDyahuqSb",
+        "issue" : "uiup3bnH2iTsZPh",
+        "articleNumber" : "EbB4lh2UIlZ2OY",
         "pages" : {
           "type" : "Range",
-          "begin" : "4VGsUCCmdZJBK291mat",
-          "end" : "1rhKM4khCj"
+          "begin" : "uowWImT9vU",
+          "end" : "0zjOokZe8vxLuoUslf9"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/db83a041-1342-47c7-a89d-01a38fbcc1ef",
-    "abstract" : "2hAY31YCpByMOdWhTyq"
+    "metadataSource" : "https://www.example.org/1f7611cb-3cf3-4ca5-9105-615608b77b5a",
+    "abstract" : "ySkdmvYgMtA2jz6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f4fd74bf-bfec-4d2b-a2bc-2533b8c7daa0",
-    "name" : "zlQcwvtHOsFCwz",
+    "id" : "https://www.example.org/b516b032-4168-4dea-b53e-6671f3736b2b",
+    "name" : "VBdDewBqQD9DdmYc",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2011-08-22T15:18:24.273Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "2009-03-20T09:13:17.780Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "DECLINED",
-      "applicationCode" : "lniNwaMgNw1GO2quaD"
+      "applicationCode" : "hzC98DERuVa"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/160a48a4-6ed1-4ddd-90d0-d9a62d32f1d2",
-    "identifier" : "tqtbkkCUEV",
+    "source" : "https://www.example.org/bc892c06-f62d-4036-a20f-f61dd55eae85",
+    "identifier" : "bK3huQ2Lss1QK9Zh",
     "labels" : {
-      "cs" : "L2jHey2kFwLJbWg7"
+      "se" : "tFnpIvEbyBCy3Fc88JQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1288636541
+      "currency" : "NOK",
+      "amount" : 1431288465
     },
-    "activeFrom" : "2016-06-28T11:57:40.309Z",
-    "activeTo" : "2022-03-29T22:58:58.896Z"
+    "activeFrom" : "2011-07-11T01:16:42.608Z",
+    "activeTo" : "2019-07-03T02:46:15.685Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/970a9ef2-5f0a-4393-ab7a-626af607451a",
-    "id" : "https://www.example.org/8caf5aac-c8e8-414c-b9ad-337647a7f7cc",
-    "identifier" : "VVb15IkKlhtIEj",
+    "source" : "https://www.example.org/c5b88664-03da-46d7-ad7e-897a133aa040",
+    "id" : "https://www.example.org/563e1a67-2a26-452a-a4dc-42226bad869b",
+    "identifier" : "INTKtR4G27",
     "labels" : {
-      "bg" : "lZruEG3ToV6yZ0z8M"
+      "cs" : "nirHa4sBfmvAU"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2063593099
+      "amount" : 1001960181
     },
-    "activeFrom" : "1991-09-21T23:28:07.921Z",
-    "activeTo" : "2015-06-08T07:09:52.266Z"
+    "activeFrom" : "1982-04-03T20:01:25.838Z",
+    "activeTo" : "2014-12-27T19:46:38.357Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e8354142-382a-4a5d-8126-61df3a80b480" ],
+  "subjects" : [ "https://www.example.org/71b070ab-4623-4848-abec-0cf10b05bb63" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c3843fae-d202-4a07-aa6c-66c936d54c03",
-    "name" : "O9JzQkDaiczMJm",
-    "mimeType" : "hAnhUJmInzYl",
-    "size" : 682622982,
-    "license" : "https://www.example.com/01yomcyn1f",
+    "identifier" : "a648a3f9-5712-4cf4-b07a-c6c5c9331e72",
+    "name" : "qMNcSLhvKs8NZvJplZ",
+    "mimeType" : "6mMFtqNHf6skhyiy9",
+    "size" : 2009641205,
+    "license" : "https://www.example.com/tgkjopqmi55iiihvjvh",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "DJxuA1EuKr2mSd"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "raVpq5ilasz37gygWO",
-    "publishedDate" : "1971-10-03T17:22:13.136Z",
+    "legalNote" : "it4nLgLypFLWqx5Izh",
+    "publishedDate" : "1993-09-27T07:08:59.400Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "lXNly8DwvR4xpk",
+      "uploadedDate" : "2022-02-16T00:01:44.184Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ErrXQTvTR6UPkx910z",
-    "name" : "G2MnFknZY4hcU8piy",
-    "description" : "3gOeSdhLQsFTIkjoBa"
+    "id" : "https://www.example.com/tv6jO9EbfdSPOh9j6D",
+    "name" : "HF5MVQeyW8ZuJp",
+    "description" : "V8JIRkCZ5827hQHYP6"
   } ],
-  "rightsHolder" : "qwiX99Df1GD2",
-  "duplicateOf" : "https://www.example.org/e2e7935b-da5d-4c9c-a114-8dc5b55152c9",
+  "rightsHolder" : "dDu0Rqaqon1y6wDYBj",
+  "duplicateOf" : "https://www.example.org/3e2f557c-5136-4364-a3c2-2db59bdd34ad",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "9QPnzfCwb4cN"
+    "note" : "i7CqXy7SNW"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vy18rd2ELO",
-    "createdBy" : "vAg1O9Z98laeUIPa",
-    "createdDate" : "2011-03-24T05:20:47.602Z"
+    "note" : "EOWYTS9vI5OxB9ytX",
+    "createdBy" : "EMQZInKdULi",
+    "createdDate" : "1976-06-20T00:46:11.023Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2686b1e7-ff31-4be0-b41f-b9c0383738a4" ],
+  "curatingInstitutions" : [ "https://www.example.org/866bd352-b9aa-4853-8826-4788939f74b6" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalIssue.json
+++ b/documentation/JournalIssue.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "JE8oPF8WyCrlb",
-    "ownerAffiliation" : "https://www.example.org/71afbe23-6ced-409f-8300-2436aacc4475"
+    "owner" : "mzoICjSq76dN",
+    "ownerAffiliation" : "https://www.example.org/4b333e00-ff69-4455-ae32-fd504ac9ec5c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fd741b85-696b-4a53-87fe-cb2864d2d328"
+    "id" : "https://www.example.org/af205281-9a21-48a2-9f1a-3b16833413e1"
   },
-  "createdDate" : "2001-04-06T11:52:46.036Z",
-  "modifiedDate" : "1973-06-09T04:42:39.107Z",
-  "publishedDate" : "2012-12-07T06:18:32.171Z",
-  "indexedDate" : "1998-06-12T00:47:41.230Z",
-  "handle" : "https://www.example.org/1ee1b8fd-7e79-4de9-908d-be502224d8f2",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/a1b4b7cb-f2dc-4f1d-b98d-46f3265a9af5",
+  "createdDate" : "2003-01-25T14:34:52.708Z",
+  "modifiedDate" : "2009-10-09T10:58:48.572Z",
+  "publishedDate" : "1986-06-29T11:19:12.361Z",
+  "indexedDate" : "1988-07-06T23:30:51.083Z",
+  "handle" : "https://www.example.org/9cccf48d-bc31-473e-99e5-48d1a3203aa9",
+  "doi" : "https://doi.org/10.1234/praesentium",
+  "link" : "https://www.example.org/57dc244f-bbcc-403f-8f0f-504e46d6a9e8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "07BD6uWksuqEKWRHbYu",
+    "mainTitle" : "q4UOQ8ZinCC",
     "alternativeTitles" : {
-      "es" : "ZUFso7OE79UYna"
+      "nl" : "9q0xUI1T1xcfKNgAX0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "CtILM40KocHwjbged",
-      "month" : "0msTi5DNXxaEou",
-      "day" : "CoIpGSyRshbS"
+      "year" : "dtmwv7fkSr",
+      "month" : "mVlo6d2F6jl",
+      "day" : "J2YJzLVPfd138UM4rD"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a74ea5f6-0cb8-43e5-993a-b32aeca568b9",
-        "name" : "kXU3MxFQXL7yJHLBRA",
-        "nameType" : "Personal",
-        "orcId" : "iEDYNkNZsI13",
+        "id" : "https://www.example.org/371a4f7a-95b4-48da-aaff-273b3035753b",
+        "name" : "OHPmKJETutzIH9e",
+        "nameType" : "Organizational",
+        "orcId" : "31ofLmVmf1FPO",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Gc9aPU7WqJqr",
-          "value" : "64dCu8p9fX3j"
+          "sourceName" : "nNxvpmQgyiEVfRevV",
+          "value" : "nAFtSOXw9DGP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mQlC7r44sXN6ofwB",
-          "value" : "fCI21wvWUoIrCrifr"
+          "sourceName" : "whDELT5kXJwjYy9oJ0",
+          "value" : "mH8fVFyfoPrJv9kSKh"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/777ec091-0601-4fdb-9963-5b965f7925a3"
+        "id" : "https://www.example.org/d88890a1-e8ea-469e-94ce-5375252e0081"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e1823735-8b5d-4638-85bd-4c7da1dabd6b",
-        "name" : "PHsplvsFaX",
+        "id" : "https://www.example.org/ce8edbbf-8cba-40c1-9d9e-83c77f337afc",
+        "name" : "f9ew74eWjp1zjMZi",
         "nameType" : "Organizational",
-        "orcId" : "T7IJdQ1H8icqRt4si",
+        "orcId" : "9h8gpXknlD1My0voG",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "19P7beyzKB",
-          "value" : "WD44whgueQt"
+          "sourceName" : "oH753J9u4i2G0S3kA0M",
+          "value" : "TBe92Tamx6eWmw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YPn8bJzmyx1rue7",
-          "value" : "ZwCItPkHlU5TrKA5Fr"
+          "sourceName" : "9Hc63slWFT0lGI0foGG",
+          "value" : "Mvrlds5wiXFRlwj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fcc6507e-0129-4f1d-84b7-013de02e607c"
+        "id" : "https://www.example.org/89f5f1af-e860-4e2f-af3a-86c2a9dad08c"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "nhIA8GLujjUh21Ppt"
+      "de" : "gpufH6Gyx6"
     },
-    "npiSubjectHeading" : "m5v5kmbhB14yhdh",
-    "tags" : [ "xApvgAQpiWQj" ],
-    "description" : "gsWQK57RCKO1YLC",
+    "npiSubjectHeading" : "51CtiIAGNuKP6z",
+    "tags" : [ "3nJKUjNMalMMTLdjvE" ],
+    "description" : "jLVwccZSBZp",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8bbd614a-5ce8-4794-a0db-97b531b3f8a0"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/88cebba0-99ac-4249-b197-e0ea43b205cd"
       },
-      "doi" : "https://www.example.org/f596d14f-744e-47a5-931d-2e0a02d5bc33",
+      "doi" : "https://www.example.org/8fd5a201-d4eb-4b76-be52-c1a9a9ef1e29",
       "publicationInstance" : {
         "type" : "JournalIssue",
-        "volume" : "VlSrOl7COBA5ZRy",
-        "issue" : "oizWimV0gtGR3O",
-        "articleNumber" : "79tW8ShajsjFp",
+        "volume" : "FEdLzHKvybzjyGesp",
+        "issue" : "c3CD8aby7AHPePwE",
+        "articleNumber" : "wfehhUh3CZQ5aJx5",
         "pages" : {
           "type" : "Range",
-          "begin" : "J7J9mo7Qk6564L",
-          "end" : "govFUJxhXYVS35Tsvy"
+          "begin" : "4VGsUCCmdZJBK291mat",
+          "end" : "1rhKM4khCj"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/95026741-154a-411a-9550-c0f9c07f354f",
-    "abstract" : "UYEHHX4kkXg"
+    "metadataSource" : "https://www.example.org/db83a041-1342-47c7-a89d-01a38fbcc1ef",
+    "abstract" : "2hAY31YCpByMOdWhTyq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/87870262-9f6f-40ea-affa-70cce4d3f5f7",
-    "name" : "QQ4aVSC3z62gCz",
+    "id" : "https://www.example.org/f4fd74bf-bfec-4d2b-a2bc-2533b8c7daa0",
+    "name" : "zlQcwvtHOsFCwz",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-09-13T16:09:15.760Z",
+      "approvalDate" : "2011-08-22T15:18:24.273Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Gzd5F9uJS56ms"
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "lniNwaMgNw1GO2quaD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ad386357-fd19-498c-9d6b-dacf710447e4",
-    "identifier" : "wLZCzZm9aXF2TgZYTI",
+    "source" : "https://www.example.org/160a48a4-6ed1-4ddd-90d0-d9a62d32f1d2",
+    "identifier" : "tqtbkkCUEV",
     "labels" : {
-      "ca" : "mDLMBeJE5zAKN7q"
+      "cs" : "L2jHey2kFwLJbWg7"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1757577915
+      "currency" : "GBP",
+      "amount" : 1288636541
     },
-    "activeFrom" : "1991-09-10T17:36:40.228Z",
-    "activeTo" : "2018-02-28T06:05:01.606Z"
+    "activeFrom" : "2016-06-28T11:57:40.309Z",
+    "activeTo" : "2022-03-29T22:58:58.896Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c1d4c4ec-6f36-4451-931a-478340081bf0",
-    "id" : "https://www.example.org/2c5766f2-817f-4861-947d-1aee0634db41",
-    "identifier" : "8SEMFIbbTn",
+    "source" : "https://www.example.org/970a9ef2-5f0a-4393-ab7a-626af607451a",
+    "id" : "https://www.example.org/8caf5aac-c8e8-414c-b9ad-337647a7f7cc",
+    "identifier" : "VVb15IkKlhtIEj",
     "labels" : {
-      "fi" : "Ub8qUHykN6nBr0"
+      "bg" : "lZruEG3ToV6yZ0z8M"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1066885921
+      "amount" : 2063593099
     },
-    "activeFrom" : "2000-11-11T12:02:47.467Z",
-    "activeTo" : "2008-03-09T21:05:01.995Z"
+    "activeFrom" : "1991-09-21T23:28:07.921Z",
+    "activeTo" : "2015-06-08T07:09:52.266Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8cfa21cf-9cde-4ad7-ac83-54ce961d4f71" ],
+  "subjects" : [ "https://www.example.org/e8354142-382a-4a5d-8126-61df3a80b480" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6a42540e-8605-4bf0-bf8d-3eb946014011",
-    "name" : "MJJfXR93K2fViK",
-    "mimeType" : "TANzu0MFvfr",
-    "size" : 2134530936,
-    "license" : "https://www.example.com/aornfyamfqbtr0q6",
+    "identifier" : "c3843fae-d202-4a07-aa6c-66c936d54c03",
+    "name" : "O9JzQkDaiczMJm",
+    "mimeType" : "hAnhUJmInzYl",
+    "size" : 682622982,
+    "license" : "https://www.example.com/01yomcyn1f",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "DJxuA1EuKr2mSd"
     },
-    "legalNote" : "sGKcbPqNH95n80",
-    "publishedDate" : "1994-04-12T03:18:18.045Z",
+    "legalNote" : "raVpq5ilasz37gygWO",
+    "publishedDate" : "1971-10-03T17:22:13.136Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/m7tAdAnQmgALj3",
-    "name" : "eTHyoeQtZxj",
-    "description" : "CHZJiXspAC"
+    "id" : "https://www.example.com/ErrXQTvTR6UPkx910z",
+    "name" : "G2MnFknZY4hcU8piy",
+    "description" : "3gOeSdhLQsFTIkjoBa"
   } ],
-  "rightsHolder" : "9ib5qhBhxhy8kKmOuIY",
-  "duplicateOf" : "https://www.example.org/fce23075-e659-49c2-a034-1df727ba41be",
+  "rightsHolder" : "qwiX99Df1GD2",
+  "duplicateOf" : "https://www.example.org/e2e7935b-da5d-4c9c-a114-8dc5b55152c9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "i52G3eqdmG3PgMrY"
+    "note" : "9QPnzfCwb4cN"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "EQCSGi3ZvWHIGTK",
-    "createdBy" : "Q1HbhxQn7Buki",
-    "createdDate" : "1979-09-19T12:19:00.564Z"
+    "note" : "vy18rd2ELO",
+    "createdBy" : "vAg1O9Z98laeUIPa",
+    "createdDate" : "2011-03-24T05:20:47.602Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b5f4347a-7d87-45b8-8182-6ec8ab17fc94" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/2686b1e7-ff31-4be0-b41f-b9c0383738a4" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "Cf3XsCH4UODS6S8Izg",
-    "ownerAffiliation" : "https://www.example.org/e7d3df39-4469-44a4-8249-40d8c07167f6"
+    "owner" : "sYYyhcQWYbdTsV",
+    "ownerAffiliation" : "https://www.example.org/69076a85-fc47-46df-8c56-4e7db3780ff5"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6e991edf-df64-4821-927d-8cf861b52ad1"
+    "id" : "https://www.example.org/801585b4-aa50-4d1f-bd2b-56469e369c1c"
   },
-  "createdDate" : "1976-02-17T00:36:55.783Z",
-  "modifiedDate" : "2023-03-24T05:06:18.230Z",
-  "publishedDate" : "1979-10-16T05:32:39.882Z",
-  "indexedDate" : "1977-04-16T21:57:21.641Z",
-  "handle" : "https://www.example.org/1a6cdcb1-d11a-4a3a-9274-ff31bbe11168",
-  "doi" : "https://doi.org/10.1234/doloremque",
-  "link" : "https://www.example.org/f76c7bcb-e7e3-475d-8706-690f5ae2a7f4",
+  "createdDate" : "1996-03-05T23:50:36.765Z",
+  "modifiedDate" : "1992-04-26T07:11:48.749Z",
+  "publishedDate" : "2005-07-03T21:23:45.587Z",
+  "indexedDate" : "2019-05-16T05:35:18.775Z",
+  "handle" : "https://www.example.org/e984f560-2a60-480d-9191-3f5fffe0596c",
+  "doi" : "https://doi.org/10.1234/esse",
+  "link" : "https://www.example.org/1cbdb546-7cfc-4539-bde3-d1a7f8465a36",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nLfAjirXW1A5q8oIBx",
+    "mainTitle" : "vrskzTrMwp6uc3PrNkz",
     "alternativeTitles" : {
-      "is" : "M3IVWptyZ94VB"
+      "ca" : "lsUY1QTWTQ6dcZHH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GoGcO2guhjccOewF",
-      "month" : "ITvbVoIX15nKJFNSrG",
-      "day" : "l8ky3tj8udtMA0gq"
+      "year" : "DXKYs0FVSf6q2Zf8lD",
+      "month" : "p6EIJoEMDApVUo6Tbp",
+      "day" : "2g37Yb5nZ9a8L5F"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a64cca06-9b2a-43b1-842a-76b0eba0aead",
-        "name" : "HBRMIvgACZq6",
-        "nameType" : "Organizational",
-        "orcId" : "wyTaNiFF3LP",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/fe387931-cdaf-438b-9aa4-a097bc7723b8",
+        "name" : "612qCWdof3NQMCe4XJ",
+        "nameType" : "Personal",
+        "orcId" : "FWxginCL4bjID",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "v5s1v5ePvUqs6S",
-          "value" : "gPBxKo318ih7qMr0P5Y"
+          "sourceName" : "BQu3xUaMPZhjf6",
+          "value" : "4kzhCQo34fWJSXsMLT"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gvRGD0R4u30w",
-          "value" : "Kxa0FqvFT50"
+          "sourceName" : "bQFZRMZ1WKfm",
+          "value" : "2t3wGpPPXf"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9642dc6c-b380-4e26-8f06-e0ab45d66a24"
+        "id" : "https://www.example.org/dec6f99f-c258-4b4a-b742-cefbc661fe1f"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "RelatedPerson"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a01a3f83-a151-4193-abd2-cd12665ec478",
-        "name" : "M4O0LKcNbs2",
-        "nameType" : "Organizational",
-        "orcId" : "bZ3eXfQRyBO",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/32f22e6c-06d6-4018-be8f-4e3fa3a576c9",
+        "name" : "h1iErX5kHFsBXk9",
+        "nameType" : "Personal",
+        "orcId" : "F2XeIkkDiYj0lWFfPu",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EGgdUyXlFMSSrJOn",
-          "value" : "E46F4PiLWkLBQ"
+          "sourceName" : "4kWS2gg8Gq9mW7Ij",
+          "value" : "O6LsWj5VLHi"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "htaWh0v6XsPrgj6Qhb",
-          "value" : "v39eITcrkQtIKj9p"
+          "sourceName" : "aPSFKZWFvl",
+          "value" : "EHKyAwLN9awx0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c69cba55-8db7-4f90-a5a8-901cea64ad02"
+        "id" : "https://www.example.org/ae5577b2-c8ce-4511-a99a-0be148c099ab"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "S9tZw8T0poGwIv"
+      "hu" : "UwZg09r7h4z"
     },
-    "npiSubjectHeading" : "Fq2iqZWFAl4",
-    "tags" : [ "hko0mffPQG7DH3" ],
-    "description" : "W2VJrQ979F",
+    "npiSubjectHeading" : "m0GGIiY8vdqjKl9DkcQ",
+    "tags" : [ "QrsqH5aBFk" ],
+    "description" : "SlN7ooLUIuW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d1059dd4-9300-479a-a090-69ecaa8cfd81"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/eaa0a47a-d543-49e9-94f2-b048c7d1b162"
       },
-      "doi" : "https://www.example.org/0c5296ba-73b4-4c86-a169-b91fd3bee356",
+      "doi" : "https://www.example.org/9fa06dc6-1d8e-495b-820d-3a651abd9901",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "L2kcmOitUvLFXlP",
-        "issue" : "PQz6FTTnfqh",
-        "articleNumber" : "yf44UgQmc8w",
+        "volume" : "q72eEvQtXS",
+        "issue" : "4pk6uiFsCu",
+        "articleNumber" : "IcwqDAmksEKA",
         "pages" : {
           "type" : "Range",
-          "begin" : "bWYWtfpK1Y1rkx",
-          "end" : "B8m4toszSKxhZeUwQT"
+          "begin" : "9reGwCsJ2cZ",
+          "end" : "hDIvrrDaMLN1k8xS"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/72785768-140e-4365-b05c-413f91b30f66",
-    "abstract" : "Ko9teHrjuG"
+    "metadataSource" : "https://www.example.org/a800c342-4032-482a-9f93-ce299fed8410",
+    "abstract" : "OcEgiiqELK4fOXez8O"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0ea08df3-e88b-415b-a7ba-cb79e3731bb5",
-    "name" : "1THD5jyXBkvnOZzjH",
+    "id" : "https://www.example.org/e90288c8-5347-45ae-aa61-ef59e7cdea6b",
+    "name" : "RPL3VyceARU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-01-26T20:16:49.158Z",
+      "approvalDate" : "2011-11-12T15:34:46.592Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "vRvUkYTYkNHkJWjy"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "VSLe7SUXyAkKc0c7CJi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/47f59f06-c80f-4cdd-8fd1-b895df810ca4",
-    "identifier" : "RQ899oCOHOt",
+    "source" : "https://www.example.org/58b01cdd-fdb2-4b21-b08a-984e9808e379",
+    "identifier" : "axyAIMy3MIKA1y",
     "labels" : {
-      "bg" : "OrAmMLODfPdQU4"
+      "nb" : "Ap5REYy2pXMNqSs"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1369245875
+      "currency" : "USD",
+      "amount" : 563630820
     },
-    "activeFrom" : "1977-11-19T21:56:26.448Z",
-    "activeTo" : "1984-09-18T20:24:04.307Z"
+    "activeFrom" : "1994-12-16T00:48:52.921Z",
+    "activeTo" : "2014-04-10T07:10:23.043Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4199b3aa-0fcb-4473-b8ae-9227a6062e66",
-    "id" : "https://www.example.org/6a4c9f54-3893-4ee6-9ca1-c5cbfe56c8e7",
-    "identifier" : "Hy1yFBbHeR7VU",
+    "source" : "https://www.example.org/55b24ae6-b49f-4cbd-ae34-5b7dd568bfc0",
+    "id" : "https://www.example.org/cdd1c855-66f0-42c3-9c46-e6f4ef43955d",
+    "identifier" : "t00TXuHMS4Eh6xIMpnt",
     "labels" : {
-      "nb" : "t9CEsSDyxX"
+      "hu" : "9r1WZYp8Zo4yQ"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 855645487
+      "currency" : "USD",
+      "amount" : 2042366579
     },
-    "activeFrom" : "1983-08-22T21:06:08.098Z",
-    "activeTo" : "2022-07-29T07:27:26.448Z"
+    "activeFrom" : "1999-06-11T11:32:03.290Z",
+    "activeTo" : "2012-02-04T10:57:06.946Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/efcdd0dc-2e66-47a9-8da5-77db5d08d7b1" ],
+  "subjects" : [ "https://www.example.org/3bc86b6a-f412-4337-a6cb-ed7bc0344031" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "2486357f-55b0-4c13-8004-bd8bdf405347",
-    "name" : "RWlPyhxnJbfCaw2EUZY",
-    "mimeType" : "Jqomjgxtr64",
-    "size" : 1353711948,
-    "license" : "https://www.example.com/3r1glqyufnkb",
+    "identifier" : "e659e394-75ad-438a-8278-95589b5a6e87",
+    "name" : "Utb2PmC1ZCaAEm1drS",
+    "mimeType" : "uppApCX5uoZk680",
+    "size" : 648082043,
+    "license" : "https://www.example.com/cjbpgjhmymmx8",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "2K1lszIrtWod",
-    "publishedDate" : "1979-10-14T13:56:08.508Z",
+    "legalNote" : "vU2DRFitz48VCy",
+    "publishedDate" : "2007-04-02T23:38:23.036Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "j0eJbA6CaltG9ewne",
+      "uploadedDate" : "2011-04-15T10:04:44.165Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ik3Fm51BqL1HIjxmp3f",
-    "name" : "ZokSqLMzRQdD62fjo",
-    "description" : "Wkk27xh5ws4T4R7"
+    "id" : "https://www.example.com/ovvtukLeogncpvkg",
+    "name" : "bYp4fNcb4R",
+    "description" : "KpqBtAxbDfOKPf"
   } ],
-  "rightsHolder" : "AwzBZyNp2Q7VCP",
-  "duplicateOf" : "https://www.example.org/0d2cf824-e541-4631-b68c-c54d72646a18",
+  "rightsHolder" : "tSHfRmn8rw3SdB",
+  "duplicateOf" : "https://www.example.org/bbbd24c1-4861-4bf6-9c07-0e516eeb68c2",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "FcnSRL6dcn"
+    "note" : "UJSgDMIHSNgs3TWomVU"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "t4a6qQusyidp3",
-    "createdBy" : "q48CDfMsymju2pgH",
-    "createdDate" : "2016-01-11T16:31:44.149Z"
+    "note" : "faj8mfLcv0",
+    "createdBy" : "U7VebFqjUD7DmMf",
+    "createdDate" : "2005-03-11T23:41:24.485Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/9586e44a-1a68-4001-81ff-d30e821ef5e2" ],
+  "curatingInstitutions" : [ "https://www.example.org/3388090f-0a22-4374-9bd9-c60913d83deb" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalLeader.json
+++ b/documentation/JournalLeader.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "p0xFBYWwGA3sXRWf",
-    "ownerAffiliation" : "https://www.example.org/70e7f165-73fa-4cdc-b5ab-5882d22c584c"
+    "owner" : "Cf3XsCH4UODS6S8Izg",
+    "ownerAffiliation" : "https://www.example.org/e7d3df39-4469-44a4-8249-40d8c07167f6"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0400b1ca-ea12-4321-a54b-15efd7898052"
+    "id" : "https://www.example.org/6e991edf-df64-4821-927d-8cf861b52ad1"
   },
-  "createdDate" : "2011-04-03T22:08:48.871Z",
-  "modifiedDate" : "1993-05-30T09:43:43.500Z",
-  "publishedDate" : "2012-11-01T21:05:16.799Z",
-  "indexedDate" : "2005-01-05T21:55:10.579Z",
-  "handle" : "https://www.example.org/e1798dd1-df1e-41e3-beea-41e7fd943703",
-  "doi" : "https://doi.org/10.1234/nam",
-  "link" : "https://www.example.org/e53f161a-b253-41ff-9ad5-5adb88cc127f",
+  "createdDate" : "1976-02-17T00:36:55.783Z",
+  "modifiedDate" : "2023-03-24T05:06:18.230Z",
+  "publishedDate" : "1979-10-16T05:32:39.882Z",
+  "indexedDate" : "1977-04-16T21:57:21.641Z",
+  "handle" : "https://www.example.org/1a6cdcb1-d11a-4a3a-9274-ff31bbe11168",
+  "doi" : "https://doi.org/10.1234/doloremque",
+  "link" : "https://www.example.org/f76c7bcb-e7e3-475d-8706-690f5ae2a7f4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GUQFIvdBi5dM3dk1sN",
+    "mainTitle" : "nLfAjirXW1A5q8oIBx",
     "alternativeTitles" : {
-      "af" : "lC4NeU7Jduh3TAh5F"
+      "is" : "M3IVWptyZ94VB"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3pfhcXCiTnseu8z",
-      "month" : "VOj46W2feB1voj4",
-      "day" : "ztuQDjhP2Z0"
+      "year" : "GoGcO2guhjccOewF",
+      "month" : "ITvbVoIX15nKJFNSrG",
+      "day" : "l8ky3tj8udtMA0gq"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ad5743cf-187a-4cd2-9feb-270c3b7850a1",
-        "name" : "8SYE4KgUUMCPWgmA",
-        "nameType" : "Personal",
-        "orcId" : "M05rpxvz14teFFI",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/a64cca06-9b2a-43b1-842a-76b0eba0aead",
+        "name" : "HBRMIvgACZq6",
+        "nameType" : "Organizational",
+        "orcId" : "wyTaNiFF3LP",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2t77YrrpancUiQcb",
-          "value" : "cW2UR1YLrvgK0"
+          "sourceName" : "v5s1v5ePvUqs6S",
+          "value" : "gPBxKo318ih7qMr0P5Y"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BgnATfiUXs",
-          "value" : "n9vdgL3aZ7u34T"
+          "sourceName" : "gvRGD0R4u30w",
+          "value" : "Kxa0FqvFT50"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cd082667-54e6-4954-9d20-faecdaf2df1c"
+        "id" : "https://www.example.org/9642dc6c-b380-4e26-8f06-e0ab45d66a24"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c5c8cf53-fe0a-42d7-b599-72101bb70f89",
-        "name" : "WoCVXT9GEgPPuYlQA",
+        "id" : "https://www.example.org/a01a3f83-a151-4193-abd2-cd12665ec478",
+        "name" : "M4O0LKcNbs2",
         "nameType" : "Organizational",
-        "orcId" : "n2e3b2WSDo6bN9",
+        "orcId" : "bZ3eXfQRyBO",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UmsG8gxkfSM",
-          "value" : "HGk60chm9Ovp8kXJBI"
+          "sourceName" : "EGgdUyXlFMSSrJOn",
+          "value" : "E46F4PiLWkLBQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mipjMuJEGzv",
-          "value" : "4OzdWL0g6S7NLsT3XIt"
+          "sourceName" : "htaWh0v6XsPrgj6Qhb",
+          "value" : "v39eITcrkQtIKj9p"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/053fce9d-1873-46b6-b20a-66cd87bba09f"
+        "id" : "https://www.example.org/c69cba55-8db7-4f90-a5a8-901cea64ad02"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "bg" : "X5Ak5Kv0gibU6n77Y9"
+      "zh" : "S9tZw8T0poGwIv"
     },
-    "npiSubjectHeading" : "EzypcGYYx8hQVc4ed9I",
-    "tags" : [ "MVPGkn4CMUe" ],
-    "description" : "GmJrfQjOfrr",
+    "npiSubjectHeading" : "Fq2iqZWFAl4",
+    "tags" : [ "hko0mffPQG7DH3" ],
+    "description" : "W2VJrQ979F",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e8d523d6-fb32-4179-9e89-1eaca51ed75a"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d1059dd4-9300-479a-a090-69ecaa8cfd81"
       },
-      "doi" : "https://www.example.org/30872a74-802a-4f7c-a790-9b600450ce25",
+      "doi" : "https://www.example.org/0c5296ba-73b4-4c86-a169-b91fd3bee356",
       "publicationInstance" : {
         "type" : "JournalLeader",
-        "volume" : "vojLTnlmVEAk",
-        "issue" : "79l5ptx4zu",
-        "articleNumber" : "x4AYkzdZ86VwCRTwsob",
+        "volume" : "L2kcmOitUvLFXlP",
+        "issue" : "PQz6FTTnfqh",
+        "articleNumber" : "yf44UgQmc8w",
         "pages" : {
           "type" : "Range",
-          "begin" : "040btXZlBlGdhkcT",
-          "end" : "YcNBF1oPM1CPwvYci"
+          "begin" : "bWYWtfpK1Y1rkx",
+          "end" : "B8m4toszSKxhZeUwQT"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3302c570-4ba2-4d5d-a6be-fd1c4bc2321e",
-    "abstract" : "RQl7ECRbHZ"
+    "metadataSource" : "https://www.example.org/72785768-140e-4365-b05c-413f91b30f66",
+    "abstract" : "Ko9teHrjuG"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c1e47550-aaf4-49cb-96a4-399f7a945be2",
-    "name" : "TMfSA7t7dLPr",
+    "id" : "https://www.example.org/0ea08df3-e88b-415b-a7ba-cb79e3731bb5",
+    "name" : "1THD5jyXBkvnOZzjH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2018-02-12T17:07:28.196Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "AFvf5vpEgXl9SV6"
+      "approvalDate" : "1998-01-26T20:16:49.158Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "vRvUkYTYkNHkJWjy"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/481f6a49-5382-4475-9c47-3b912f2d459e",
-    "identifier" : "KOel8qYUmi",
+    "source" : "https://www.example.org/47f59f06-c80f-4cdd-8fd1-b895df810ca4",
+    "identifier" : "RQ899oCOHOt",
     "labels" : {
-      "da" : "24xoZTKZbTu"
+      "bg" : "OrAmMLODfPdQU4"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1369245875
+    },
+    "activeFrom" : "1977-11-19T21:56:26.448Z",
+    "activeTo" : "1984-09-18T20:24:04.307Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/4199b3aa-0fcb-4473-b8ae-9227a6062e66",
+    "id" : "https://www.example.org/6a4c9f54-3893-4ee6-9ca1-c5cbfe56c8e7",
+    "identifier" : "Hy1yFBbHeR7VU",
+    "labels" : {
+      "nb" : "t9CEsSDyxX"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1989976585
+      "amount" : 855645487
     },
-    "activeFrom" : "2010-09-30T00:11:40.889Z",
-    "activeTo" : "2017-11-12T21:53:34.187Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/706175c2-6bcf-4d32-9d1f-c52901d4bf96",
-    "id" : "https://www.example.org/bfa9a345-310a-4909-bd80-9001f788e8c8",
-    "identifier" : "HJMUomxSftJ3OM",
-    "labels" : {
-      "af" : "yaA7164KZ2"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1246233618
-    },
-    "activeFrom" : "2003-12-05T09:41:43.385Z",
-    "activeTo" : "2015-06-26T05:14:34.711Z"
+    "activeFrom" : "1983-08-22T21:06:08.098Z",
+    "activeTo" : "2022-07-29T07:27:26.448Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c5ed4d40-efa4-499d-b93e-d747755c70e2" ],
+  "subjects" : [ "https://www.example.org/efcdd0dc-2e66-47a9-8da5-77db5d08d7b1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "490d8db0-99a1-459f-a948-ebed871c82bb",
-    "name" : "7q6xuoxTgROK5O3r",
-    "mimeType" : "G9uxuFxQfWnFjn99",
-    "size" : 910240937,
-    "license" : "https://www.example.com/uszr9ggot0zfb6",
+    "identifier" : "2486357f-55b0-4c13-8004-bd8bdf405347",
+    "name" : "RWlPyhxnJbfCaw2EUZY",
+    "mimeType" : "Jqomjgxtr64",
+    "size" : 1353711948,
+    "license" : "https://www.example.com/3r1glqyufnkb",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "JoBcLaXZekjYMC1ZeY8",
-    "publishedDate" : "2010-06-29T19:28:38.967Z",
+    "legalNote" : "2K1lszIrtWod",
+    "publishedDate" : "1979-10-14T13:56:08.508Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/t8X5JFcoSM",
-    "name" : "iizjOCUZj2",
-    "description" : "y8Isx8ov0d48"
+    "id" : "https://www.example.com/ik3Fm51BqL1HIjxmp3f",
+    "name" : "ZokSqLMzRQdD62fjo",
+    "description" : "Wkk27xh5ws4T4R7"
   } ],
-  "rightsHolder" : "cExR67p39sqZxJF0I",
-  "duplicateOf" : "https://www.example.org/358bfdd4-c1db-484c-b8a5-2c1bbeafc5b4",
+  "rightsHolder" : "AwzBZyNp2Q7VCP",
+  "duplicateOf" : "https://www.example.org/0d2cf824-e541-4631-b68c-c54d72646a18",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "i5Svu4FgvvJoSib"
+    "note" : "FcnSRL6dcn"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "z6hJkdNezz9NebPNj",
-    "createdBy" : "Pk5XRHTSeknh",
-    "createdDate" : "1995-11-08T17:05:37.754Z"
+    "note" : "t4a6qQusyidp3",
+    "createdBy" : "q48CDfMsymju2pgH",
+    "createdDate" : "2016-01-11T16:31:44.149Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3df65b25-69c6-4e7f-9f71-bbee726996f2" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/9586e44a-1a68-4001-81ff-d30e821ef5e2" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "3DyMHhm0RnkX",
-    "ownerAffiliation" : "https://www.example.org/74f5e76d-1734-4039-b972-5a01fc77f984"
+    "owner" : "SqQDbb9DLnuJmu0LVG",
+    "ownerAffiliation" : "https://www.example.org/077b08f0-fa60-499b-8370-b34a1f201cd7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/18706a59-c629-4090-a74b-c01ca6550aec"
+    "id" : "https://www.example.org/e783b2c3-d989-43a2-9d58-4c3bae7d215c"
   },
-  "createdDate" : "2012-01-03T02:54:54.698Z",
-  "modifiedDate" : "2014-09-14T15:42:56.426Z",
-  "publishedDate" : "2022-03-03T03:39:08.780Z",
-  "indexedDate" : "1998-04-15T18:10:18.614Z",
-  "handle" : "https://www.example.org/cc234ad5-79a4-43a7-ab50-81d2816d7017",
-  "doi" : "https://doi.org/10.1234/voluptatem",
-  "link" : "https://www.example.org/024a6a12-ba8a-436e-990a-c63407d562ed",
+  "createdDate" : "2018-08-30T01:49:59.288Z",
+  "modifiedDate" : "2010-11-05T13:17:43.891Z",
+  "publishedDate" : "2007-06-13T00:20:06.663Z",
+  "indexedDate" : "2009-04-27T10:45:13.453Z",
+  "handle" : "https://www.example.org/7b27757a-9cb3-448a-802f-63752bc1ddc4",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/fcfc2c2e-648d-4ecf-bff1-b1bad8a41314",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "05gAw62bwE69AjqX",
+    "mainTitle" : "6vjALjRo3Bb",
     "alternativeTitles" : {
-      "is" : "CTdg1dUnWQ8MmVI"
+      "nn" : "BXGWXOAFe0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ayiAxVLJCysKW1DwXTd",
-      "month" : "GlhToFSMzz5K71yaBI",
-      "day" : "67nFaFm3xz"
+      "year" : "GyZp9xDtLtwq1s",
+      "month" : "sfnqMmImhtnVa5",
+      "day" : "kcMRVuJ1laEJ4"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e0ff60a8-5433-42f4-9021-f954de39a4c3",
-        "name" : "6ubR7zK8DRGfe3T",
+        "id" : "https://www.example.org/255cf210-a679-4925-be6d-dc7068385381",
+        "name" : "0XpFzfMWcy",
         "nameType" : "Organizational",
-        "orcId" : "CBn5OJXMlYadPzUzn7r",
-        "verificationStatus" : "Verified",
+        "orcId" : "SHNZD11wXD3R7tL2hr",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xsl3fbqUe8dQ57",
-          "value" : "6puYP62YLec9RyKFD"
+          "sourceName" : "2UoqbXq8VFOltki8",
+          "value" : "8liC3DrGUldlKFuN"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "c1N886GEKaXvh0",
-          "value" : "s4Koq4LRoPHA"
+          "sourceName" : "leAihOKokQR5MoQWs0",
+          "value" : "tso4uKt9A1BZEC5Iu95"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2950f968-48d0-4dee-b443-af54c71d5055"
+        "id" : "https://www.example.org/a083776e-5589-4487-aee4-4d82ef771071"
       } ],
       "role" : {
-        "type" : "TranslatorAdapter"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cbb00347-624f-4fbc-9d48-7de3708044f1",
-        "name" : "1HPLFzxC4o6",
-        "nameType" : "Organizational",
-        "orcId" : "YGYa8Iz04wbTpOcstG",
+        "id" : "https://www.example.org/206b214a-c6ea-4154-bf55-3ddb2ea81619",
+        "name" : "Eso6kRmcLh9",
+        "nameType" : "Personal",
+        "orcId" : "mvNr7CDeVeekB",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yfPnbngcJPrAGw1z",
-          "value" : "Q1j6pNpvHRsRL"
+          "sourceName" : "Q5gx6uToH4LaLe",
+          "value" : "dNqIhnjRN1ckn2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "se80hiKhXNiHJkCK",
-          "value" : "YF95l6VRM5drAZi374r"
+          "sourceName" : "Pn584rPVmn5CF",
+          "value" : "mAfZ1yylxHA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4afe10d-0f82-45ad-a614-8692819cb772"
+        "id" : "https://www.example.org/9ef861a4-f7bb-4b93-b399-16e14ec88c1f"
       } ],
       "role" : {
-        "type" : "RightsHolder"
+        "type" : "Librettist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "3HK7NuRG4GLavbh0JmU"
+      "el" : "D3ktyM47SVz74OXu7r"
     },
-    "npiSubjectHeading" : "q8cJ3j4Yk8Q",
-    "tags" : [ "qCT3zMG6FI6" ],
-    "description" : "YniCkp76sfv9ABnThh8",
+    "npiSubjectHeading" : "1TjsSiEt8c9k1U",
+    "tags" : [ "jEQrBKhrgXNg" ],
+    "description" : "co85wZWgcmu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9c3e48d4-8975-4b47-b23f-9565513acc87"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b416269b-92af-44fb-908b-7c9ec10eabd2"
       },
-      "doi" : "https://www.example.org/adf861df-32ee-4b17-8495-9d8654f2afc9",
+      "doi" : "https://www.example.org/fbf7d979-2a34-4745-84ba-12e289b8212a",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "iDPbKTlTeCMFDCIz",
-        "issue" : "pwgU678Lgb1liqTEPuc",
-        "articleNumber" : "T0X2BmOvKIsTSxSxo",
+        "volume" : "YfgYWmhAObfEHZeHCE",
+        "issue" : "VZdEB76ldFfEisH5D",
+        "articleNumber" : "qjSX7DMDzD",
         "pages" : {
           "type" : "Range",
-          "begin" : "OKZ9ttXSMGEjv",
-          "end" : "kejFhCQhUEUTgr"
+          "begin" : "BomhcRyxjiWjQB02C",
+          "end" : "6MqqBwocWhuwkHi86"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/dd5c3b47-f52d-49cf-ad61-557b228ae23c",
-    "abstract" : "QLV3FCKbJkM1"
+    "metadataSource" : "https://www.example.org/f72110a1-6a87-4677-ba4a-8fd6ce05be7a",
+    "abstract" : "LUYvHm8ThwFbqxz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/184919d6-df62-41e5-a5cb-e582eb816e07",
-    "name" : "hBqVpSFoCU8MKi",
+    "id" : "https://www.example.org/8932691b-33e3-41c8-aee1-5407530b5e12",
+    "name" : "P2OkAkG7HpWwR",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-10-25T14:45:20.878Z",
+      "approvalDate" : "1994-03-16T02:06:52.298Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "frcfEyfRFFYrfFTSg"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "ZSaTxSsjZBSHO1yg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c34ab6ff-c757-4c9e-b854-030dd127ad7c",
-    "identifier" : "3gw8X3de7aoT",
+    "source" : "https://www.example.org/fc670757-7673-4469-9e92-6431877c4b1e",
+    "identifier" : "UPj7YjF8aMGnImE",
     "labels" : {
-      "fi" : "ZgbjO7yPPF"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2123663870
-    },
-    "activeFrom" : "1995-03-08T16:26:40.779Z",
-    "activeTo" : "2019-06-23T04:31:51.422Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/022ce577-8ec5-481b-bd02-26c27327d1c1",
-    "id" : "https://www.example.org/e4aad281-a419-4404-a9db-e47e10c59a8f",
-    "identifier" : "3h2gJfw3XFj0T9w",
-    "labels" : {
-      "ca" : "wFYdNVG2oap"
+      "se" : "KbVryF0B7g0adUKW2"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1940364268
+      "amount" : 1519069199
     },
-    "activeFrom" : "1971-06-01T19:10:46.267Z",
-    "activeTo" : "1975-04-19T14:04:44.599Z"
+    "activeFrom" : "1999-07-17T08:16:17.656Z",
+    "activeTo" : "1999-12-07T15:47:26.361Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/d4331186-6d08-4d6a-8900-1673f93965be",
+    "id" : "https://www.example.org/a7c3a2d0-d179-4ea1-ba21-897291262c81",
+    "identifier" : "zKz3otImMuuocoqR",
+    "labels" : {
+      "da" : "xhVP9VDRIUKD7H3B"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 1691006565
+    },
+    "activeFrom" : "1998-03-23T12:34:29.009Z",
+    "activeTo" : "2016-12-26T18:43:34.595Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f2e6e560-4d0e-4b5d-9729-71525ee348b5" ],
+  "subjects" : [ "https://www.example.org/985cb4e1-4c87-4289-8c81-918cc92128d6" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7c49ec9c-2eea-41c6-9b16-86f6feb45270",
-    "name" : "TLDLKt15E3GBoe",
-    "mimeType" : "VEWryLTIr30fQNLq8iJ",
-    "size" : 1317279784,
-    "license" : "https://www.example.com/qu3w71d1ksgwaa17t",
+    "identifier" : "0e3d40d9-18d5-4b86-ac95-918ae1f026bb",
+    "name" : "RH4NZnWLdjZ0OFNwYK",
+    "mimeType" : "EiBJIIedMW9",
+    "size" : 1072315899,
+    "license" : "https://www.example.com/p6x1s7pmrveaj99",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "lXcfpV4PCQ"
     },
-    "legalNote" : "ubJhrSWvr4j",
-    "publishedDate" : "1995-12-12T12:44:25.663Z",
+    "legalNote" : "RFOmnG7kCa2788Y10y",
+    "publishedDate" : "2009-08-02T21:45:30.640Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "bAWRknuyfFeHMDIi",
+      "uploadedDate" : "2008-11-06T08:44:03.306Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nNtyuZQGgEmnsgA9sof",
-    "name" : "BZQv5kwp1tAJ",
-    "description" : "cF7qb5L9Xu44RzL81p7"
+    "id" : "https://www.example.com/Hys1FGn3NXqyUHF",
+    "name" : "kugG80D02A4nb",
+    "description" : "0INuZCcMiAYzClOQjIO"
   } ],
-  "rightsHolder" : "chjdauckpdpzSa0opx",
-  "duplicateOf" : "https://www.example.org/69c67fa4-78d0-4db4-952d-e081ca467c47",
+  "rightsHolder" : "4UBChug6gRJBtDOR",
+  "duplicateOf" : "https://www.example.org/c63662e7-034e-4bdd-a8e8-d65e654a22e7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "nhOWsuqqwT04QVb5OB"
+    "note" : "z3iDkBgkL42zBAvMzg3"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "qWSwPi8Ax8v0yoJVa",
-    "createdBy" : "hmLL7KkjeNgCjgjA6dv",
-    "createdDate" : "1986-11-26T09:17:00.386Z"
+    "note" : "TPpwtgK1dWoI",
+    "createdBy" : "AyHVHtugUfJqq",
+    "createdDate" : "1972-01-22T01:00:23.007Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/980fcff8-4b0f-469e-b64d-97f516b57865" ],
+  "curatingInstitutions" : [ "https://www.example.org/8c6daf6c-3c97-4e5f-a00d-91108ccb1df8" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalLetter.json
+++ b/documentation/JournalLetter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "jcKcw0t2AiQV3955V",
-    "ownerAffiliation" : "https://www.example.org/a489292e-a0e9-48a5-b95e-eddc87208d40"
+    "owner" : "3DyMHhm0RnkX",
+    "ownerAffiliation" : "https://www.example.org/74f5e76d-1734-4039-b972-5a01fc77f984"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/df5c23ad-5f8e-4cb7-8a92-6e75578470ac"
+    "id" : "https://www.example.org/18706a59-c629-4090-a74b-c01ca6550aec"
   },
-  "createdDate" : "2017-12-15T04:45:14.241Z",
-  "modifiedDate" : "2004-02-15T00:58:14.423Z",
-  "publishedDate" : "1998-05-11T04:20:00.692Z",
-  "indexedDate" : "1991-05-04T12:40:53.356Z",
-  "handle" : "https://www.example.org/9df0b3ac-c8cd-48da-9efd-dd03e8c9a9b9",
-  "doi" : "https://doi.org/10.1234/veritatis",
-  "link" : "https://www.example.org/71575446-80b0-4053-ac48-fb83d667e913",
+  "createdDate" : "2012-01-03T02:54:54.698Z",
+  "modifiedDate" : "2014-09-14T15:42:56.426Z",
+  "publishedDate" : "2022-03-03T03:39:08.780Z",
+  "indexedDate" : "1998-04-15T18:10:18.614Z",
+  "handle" : "https://www.example.org/cc234ad5-79a4-43a7-ab50-81d2816d7017",
+  "doi" : "https://doi.org/10.1234/voluptatem",
+  "link" : "https://www.example.org/024a6a12-ba8a-436e-990a-c63407d562ed",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fdZfLX6UlKqwv",
+    "mainTitle" : "05gAw62bwE69AjqX",
     "alternativeTitles" : {
-      "it" : "3asKcbRrTquzxlblM"
+      "is" : "CTdg1dUnWQ8MmVI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "HYTbTFyxQcI6",
-      "month" : "PE0k8TPnNbZb",
-      "day" : "dt0vDFSWRCy"
+      "year" : "ayiAxVLJCysKW1DwXTd",
+      "month" : "GlhToFSMzz5K71yaBI",
+      "day" : "67nFaFm3xz"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/08fd3344-9dfb-45f6-b531-e9c2a3be3843",
-        "name" : "KTeru18mTdqqeFU8kn",
+        "id" : "https://www.example.org/e0ff60a8-5433-42f4-9021-f954de39a4c3",
+        "name" : "6ubR7zK8DRGfe3T",
         "nameType" : "Organizational",
-        "orcId" : "r1L68dqYMMdsnH9av",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CBn5OJXMlYadPzUzn7r",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SNMbAHnYExlf7",
-          "value" : "x1Cajm311admy"
+          "sourceName" : "xsl3fbqUe8dQ57",
+          "value" : "6puYP62YLec9RyKFD"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1fW06JHCOkZ0eQH",
-          "value" : "tSqzgYylkYy2Ko"
+          "sourceName" : "c1N886GEKaXvh0",
+          "value" : "s4Koq4LRoPHA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/66174f52-9e69-4770-8283-c99b76fabe61"
+        "id" : "https://www.example.org/2950f968-48d0-4dee-b443-af54c71d5055"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cb94e105-4a76-428e-a593-0ed7076054a1",
-        "name" : "30XOor5bKo0sLBIxJ",
-        "nameType" : "Personal",
-        "orcId" : "UaggDlW63X",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/cbb00347-624f-4fbc-9d48-7de3708044f1",
+        "name" : "1HPLFzxC4o6",
+        "nameType" : "Organizational",
+        "orcId" : "YGYa8Iz04wbTpOcstG",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U9Iegztvd1zPq4H3",
-          "value" : "92r0WyOz5D"
+          "sourceName" : "yfPnbngcJPrAGw1z",
+          "value" : "Q1j6pNpvHRsRL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CTWx1o7HYEYl",
-          "value" : "GPJmHCeXnBi5gGiSI"
+          "sourceName" : "se80hiKhXNiHJkCK",
+          "value" : "YF95l6VRM5drAZi374r"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1331641b-b146-4d7d-918e-f01aef14a3fb"
+        "id" : "https://www.example.org/b4afe10d-0f82-45ad-a614-8692819cb772"
       } ],
       "role" : {
-        "type" : "DataCurator"
+        "type" : "RightsHolder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "qPNnA7jXGHf"
+      "ca" : "3HK7NuRG4GLavbh0JmU"
     },
-    "npiSubjectHeading" : "AG80pOQJ4zgN1FUZhl",
-    "tags" : [ "E03fCyL00xIjn" ],
-    "description" : "PxQoPKvsdutYH",
+    "npiSubjectHeading" : "q8cJ3j4Yk8Q",
+    "tags" : [ "qCT3zMG6FI6" ],
+    "description" : "YniCkp76sfv9ABnThh8",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9d2f7e0f-6436-4f74-9a22-2a2d587f91c6"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9c3e48d4-8975-4b47-b23f-9565513acc87"
       },
-      "doi" : "https://www.example.org/27758913-d804-44d3-ae65-bc69bd252789",
+      "doi" : "https://www.example.org/adf861df-32ee-4b17-8495-9d8654f2afc9",
       "publicationInstance" : {
         "type" : "JournalLetter",
-        "volume" : "JuzEzdR6IfI",
-        "issue" : "avXsjyxL4HQW1L",
-        "articleNumber" : "15YqhwznLBpzj8bisf",
+        "volume" : "iDPbKTlTeCMFDCIz",
+        "issue" : "pwgU678Lgb1liqTEPuc",
+        "articleNumber" : "T0X2BmOvKIsTSxSxo",
         "pages" : {
           "type" : "Range",
-          "begin" : "NbbKAyPGyzY",
-          "end" : "YxdG21tq1rtm"
+          "begin" : "OKZ9ttXSMGEjv",
+          "end" : "kejFhCQhUEUTgr"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/44760c84-9922-43f7-9f37-f47c689d84fc",
-    "abstract" : "Vd78JC34eS"
+    "metadataSource" : "https://www.example.org/dd5c3b47-f52d-49cf-ad61-557b228ae23c",
+    "abstract" : "QLV3FCKbJkM1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/99db1153-abc4-4b81-a601-bda74d321ca0",
-    "name" : "xJ4idPC7poVOTef5FC4",
+    "id" : "https://www.example.org/184919d6-df62-41e5-a5cb-e582eb816e07",
+    "name" : "hBqVpSFoCU8MKi",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-05-27T15:57:59.772Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "VPhn6x1YIN2Yl"
+      "approvalDate" : "2009-10-25T14:45:20.878Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "frcfEyfRFFYrfFTSg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f2c3c441-1ead-42e8-8f8b-0b1486a5b802",
-    "identifier" : "RK3kpkNhQni9KdCOzi",
+    "source" : "https://www.example.org/c34ab6ff-c757-4c9e-b854-030dd127ad7c",
+    "identifier" : "3gw8X3de7aoT",
     "labels" : {
-      "sv" : "trXUD5C6bjwzQFRE77H"
+      "fi" : "ZgbjO7yPPF"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1983578557
+      "currency" : "EUR",
+      "amount" : 2123663870
     },
-    "activeFrom" : "1973-01-13T23:23:04.925Z",
-    "activeTo" : "1991-11-19T02:14:00.065Z"
+    "activeFrom" : "1995-03-08T16:26:40.779Z",
+    "activeTo" : "2019-06-23T04:31:51.422Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/769919e0-9cb4-48b4-95d5-a11cfaad719c",
-    "id" : "https://www.example.org/bbbbbc88-a514-428d-8d46-5165e3c5214a",
-    "identifier" : "MNw4abRmQ6lq",
+    "source" : "https://www.example.org/022ce577-8ec5-481b-bd02-26c27327d1c1",
+    "id" : "https://www.example.org/e4aad281-a419-4404-a9db-e47e10c59a8f",
+    "identifier" : "3h2gJfw3XFj0T9w",
     "labels" : {
-      "ru" : "nYytEyTUQnve3"
+      "ca" : "wFYdNVG2oap"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1518216408
+      "currency" : "GBP",
+      "amount" : 1940364268
     },
-    "activeFrom" : "2005-07-19T17:26:02.770Z",
-    "activeTo" : "2018-10-12T22:06:50.398Z"
+    "activeFrom" : "1971-06-01T19:10:46.267Z",
+    "activeTo" : "1975-04-19T14:04:44.599Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/390d0543-86ec-42b0-b642-4511f93cbcf2" ],
+  "subjects" : [ "https://www.example.org/f2e6e560-4d0e-4b5d-9729-71525ee348b5" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9ea97fa1-18f1-4d4d-afd3-e434054def33",
-    "name" : "Z2nSsn1EUjptqiPOl28",
-    "mimeType" : "VS3tzDNHXV9g",
-    "size" : 620073703,
-    "license" : "https://www.example.com/tx6jzj53qf",
+    "identifier" : "7c49ec9c-2eea-41c6-9b16-86f6feb45270",
+    "name" : "TLDLKt15E3GBoe",
+    "mimeType" : "VEWryLTIr30fQNLq8iJ",
+    "size" : 1317279784,
+    "license" : "https://www.example.com/qu3w71d1ksgwaa17t",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "z2f8DzSVpi",
-    "publishedDate" : "1999-06-25T03:15:27.232Z",
+    "legalNote" : "ubJhrSWvr4j",
+    "publishedDate" : "1995-12-12T12:44:25.663Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/WZEUuQlVKrYl07o88fY",
-    "name" : "atd0HCd1JNGD9t",
-    "description" : "1RlFkBTdllR51OM"
+    "id" : "https://www.example.com/nNtyuZQGgEmnsgA9sof",
+    "name" : "BZQv5kwp1tAJ",
+    "description" : "cF7qb5L9Xu44RzL81p7"
   } ],
-  "rightsHolder" : "W82pbvWvxNwzMuXu4",
-  "duplicateOf" : "https://www.example.org/e57f22c0-04fb-402b-9176-eb5d91891817",
+  "rightsHolder" : "chjdauckpdpzSa0opx",
+  "duplicateOf" : "https://www.example.org/69c67fa4-78d0-4db4-952d-e081ca467c47",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TiSkbPWTlYIjD9y"
+    "note" : "nhOWsuqqwT04QVb5OB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "d4lGdVEBdoxUco",
-    "createdBy" : "6ogxUubkelTtV",
-    "createdDate" : "2003-09-09T06:04:14.960Z"
+    "note" : "qWSwPi8Ax8v0yoJVa",
+    "createdBy" : "hmLL7KkjeNgCjgjA6dv",
+    "createdDate" : "1986-11-26T09:17:00.386Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e6cbdebf-0464-4514-ae9a-659965673855" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/980fcff8-4b0f-469e-b64d-97f516b57865" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "iOdDk9v9IRIA7fVYi0N",
-    "ownerAffiliation" : "https://www.example.org/6e868fef-fff1-450b-8289-71f436ab405d"
+    "owner" : "tu8lj6nvbxjF",
+    "ownerAffiliation" : "https://www.example.org/5e2c664b-a81f-41b1-b7b5-52a08bc056c8"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/35271f8e-08b5-43dc-bf09-ebf5fe91f1c3"
+    "id" : "https://www.example.org/9a7bb6d9-7ebe-4407-97ee-76f72b9ecfbf"
   },
-  "createdDate" : "2018-02-07T04:41:37.753Z",
-  "modifiedDate" : "2015-05-21T18:41:10.166Z",
-  "publishedDate" : "1981-01-02T18:26:54.897Z",
-  "indexedDate" : "2008-11-15T03:19:56.463Z",
-  "handle" : "https://www.example.org/55217014-a634-4310-8e0a-6b94eb2e9a33",
-  "doi" : "https://doi.org/10.1234/vel",
-  "link" : "https://www.example.org/1457876b-4b0e-443b-a124-f21ef9dd7cfd",
+  "createdDate" : "2007-09-30T23:09:32.746Z",
+  "modifiedDate" : "1993-06-04T19:16:14.974Z",
+  "publishedDate" : "2012-08-07T15:38:34.069Z",
+  "indexedDate" : "1975-06-13T03:37:05.542Z",
+  "handle" : "https://www.example.org/a42e8119-58b5-45b8-afb5-648d39dd6169",
+  "doi" : "https://doi.org/10.1234/sunt",
+  "link" : "https://www.example.org/952b854b-b699-4c2b-94a0-d8ca492180ed",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "LcToHTvqmSmkH",
+    "mainTitle" : "mwRWM2Fl91UtAYjXL",
     "alternativeTitles" : {
-      "cs" : "XRoSUCfz4u9eYrqt"
+      "nl" : "UEfBNIqsjdr"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "OGRDaoG4wRHZNa",
-      "month" : "xCrA7eET2Aze0a4m",
-      "day" : "0CJWSV062Wefw"
+      "year" : "tkEMVRsuDnZnRV2n",
+      "month" : "dzM24EaTBPNjr27OZyi",
+      "day" : "12cVWPYhcxuCLooldKM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/77eb47e0-d087-4556-9522-9078e89d339b",
-        "name" : "M3YH9AN8QuWcwW",
+        "id" : "https://www.example.org/e749fbbb-dec8-4ac2-a692-e851dafb20ce",
+        "name" : "gcrGmFj4D9mT",
         "nameType" : "Personal",
-        "orcId" : "onyN1USJoa1K9llS7F",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "lj2QIxyVY3e3E5R92UP",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dwqUmkL5lyAd96fpW",
-          "value" : "OymrdtCNHRmLzG"
+          "sourceName" : "3F0ym83Yv6kpcG",
+          "value" : "4RArOYKGd1kF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V6FYyLmcGE",
-          "value" : "ekNbYFQCh40OGr"
+          "sourceName" : "I0kFgugIiKlq9z1bpV",
+          "value" : "uzdSJeXUWu1mbg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/05ed7c2c-1027-4385-b9f8-3a570790c849"
+        "id" : "https://www.example.org/cedbb546-c53b-42b5-9f24-dcad7dced9fe"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c8d4dee9-79af-4d1f-910f-65db30535527",
-        "name" : "hbieF0idJNaMZog",
+        "id" : "https://www.example.org/48cf6308-1267-416c-b9ba-3b3bf0735b96",
+        "name" : "qgsDJlzpnyd",
         "nameType" : "Personal",
-        "orcId" : "ymQxkrhpWlG10xWKSRJ",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "xXjFAQxRzfmWN3",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CuvXOa35nN",
-          "value" : "8mSpUiRM2UcLfp"
+          "sourceName" : "XdJQESDgE1v",
+          "value" : "JtjyBs5hpFvPV7NoVDY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YZOqlOSTxZLrbATl",
-          "value" : "AJTmK1aIq37O44"
+          "sourceName" : "kohmV825kKrysYL",
+          "value" : "ewwIsALOpjq3y"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e62c0b7f-e8e5-4b5b-b2b0-5eb129f18e5d"
+        "id" : "https://www.example.org/686ef58f-b7a1-4cba-98ad-4ef1d469d400"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "EASo6w3BPf"
+      "hu" : "n9RetUdeHTqEZnK"
     },
-    "npiSubjectHeading" : "lRGYv7beb2rF",
-    "tags" : [ "HxmZ4yPGq6avY" ],
-    "description" : "47Sx7Ir3Mq4oMLbgWc",
+    "npiSubjectHeading" : "xPLvj53jxbIWW9f70",
+    "tags" : [ "XfME7Ds5xY8PT6ebXR5" ],
+    "description" : "XjAFusAnGRAMlxm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/14c565ba-1fc1-4e05-aad0-bb1fb73b1c8e"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a54b369c-f8e4-41f2-8bc6-80d953adea08"
       },
-      "doi" : "https://www.example.org/329f01c7-1b7b-4664-8dac-5f0e34293503",
+      "doi" : "https://www.example.org/d78c2210-02d5-4d3e-9887-57771b27477b",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "j1JFXOB33Kvrj5zI7f",
-        "issue" : "zExn3ZJXnK9eM3PC4C",
-        "articleNumber" : "jLG5lpVMIK",
+        "volume" : "GHr538m7WZt",
+        "issue" : "wLpwZJNXjXQb",
+        "articleNumber" : "QZGZuDVakNsjo9K",
         "pages" : {
           "type" : "Range",
-          "begin" : "xWkJIw8IJj3le8b9",
-          "end" : "0nJVOk3pF9bn"
+          "begin" : "ISrvUAErg4zUb",
+          "end" : "5jEc22Sv5u"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e0fbb0ab-7eac-407f-99bd-897acff333c8",
-    "abstract" : "QLUR78p5ywax"
+    "metadataSource" : "https://www.example.org/f0f35ab3-0b33-4837-8bc0-97090e14ccd9",
+    "abstract" : "atrlDxL2Y7bQeo"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7a5fd2f7-99f3-4770-a1b1-0f672e68c051",
-    "name" : "Mqw3jh4m4hFydm",
+    "id" : "https://www.example.org/4e52325c-ad20-4686-82b8-e940334d18d6",
+    "name" : "pKPeAGxcSeZHPrYEQlL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2009-03-02T09:38:52.193Z",
+      "approvalDate" : "2014-02-27T00:05:15.568Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "IEh4xUbfPUKE"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "f2kPK7yN73FvUII6Vi"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/af542ae1-1a53-447b-9b42-4f4d19f00d9d",
-    "identifier" : "J2muyKz3Brj",
+    "source" : "https://www.example.org/c354b951-d7e7-4f81-bd28-8e36b292adfb",
+    "identifier" : "XV5fxJuUJbBSx",
     "labels" : {
-      "nl" : "pHemKTnMPdXD"
+      "is" : "FF0uIblb8t"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1336678211
+      "currency" : "EUR",
+      "amount" : 1101208271
     },
-    "activeFrom" : "1990-02-02T22:21:27.961Z",
-    "activeTo" : "1990-08-04T20:40:39.995Z"
+    "activeFrom" : "2015-10-15T06:22:57.890Z",
+    "activeTo" : "2016-06-14T08:25:25.258Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c7f90bac-aa58-4d86-9044-12ff398493e3",
-    "id" : "https://www.example.org/aa42f57e-da70-4d1d-93da-18359bec5457",
-    "identifier" : "eAuC2BFNcm",
+    "source" : "https://www.example.org/0906e3df-064a-46b4-bdf6-a6cfb9d6dd8f",
+    "id" : "https://www.example.org/f5cb6cf7-a487-47eb-ad0c-2a3148087b11",
+    "identifier" : "ysoeksHZkxwb4kSe90",
     "labels" : {
-      "fr" : "Vl2jETOcglUxp"
+      "da" : "FtL03FFqQKGusYQ"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1585340422
+      "amount" : 350972576
     },
-    "activeFrom" : "2000-12-21T21:44:26.126Z",
-    "activeTo" : "2023-07-12T01:14:26.961Z"
+    "activeFrom" : "2024-02-14T00:28:33.050Z",
+    "activeTo" : "2024-04-14T11:43:22.520Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ee21b5cb-b64e-40f9-88db-3046d10db5b7" ],
+  "subjects" : [ "https://www.example.org/3ddbdf95-6164-4d25-8387-da948ea38596" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4b66f004-a0dc-4b0a-bc54-c291e330a9d6",
-    "name" : "GHrcmoZStfTH3a",
-    "mimeType" : "4le6f6YFKBizlq7er",
-    "size" : 1320189156,
-    "license" : "https://www.example.com/0wh1akulmsl2ohwwxr",
+    "identifier" : "d2d6d006-2a2c-490d-9d73-bfbb30e3ef77",
+    "name" : "ok5iC7ZQPp",
+    "mimeType" : "EU9GhM8xFOX",
+    "size" : 398603704,
+    "license" : "https://www.example.com/ywwjuxurzknkvw",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "7pj1Hq96rvxPl3CyRj",
-    "publishedDate" : "2001-03-02T06:08:22.404Z",
+    "legalNote" : "3GfLhMZn27bELjNwUwr",
+    "publishedDate" : "1981-09-09T22:03:05.348Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "yqYkkZEyjg",
+      "uploadedDate" : "1971-10-06T19:45:48.974Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/aDRxOSE3dgTaXdmqlD",
-    "name" : "wXlvboGkS55zz",
-    "description" : "A6I6v9Hcthd"
+    "id" : "https://www.example.com/1tiZhlVvJLoRm",
+    "name" : "uGwCMIl23K7Hv4N5Y",
+    "description" : "9jtLwpFlJVEWhjGvje"
   } ],
-  "rightsHolder" : "zeysKxINhUeF",
-  "duplicateOf" : "https://www.example.org/346516e6-adf7-46e7-a691-717ce258be1f",
+  "rightsHolder" : "70Hcy30XR8FL",
+  "duplicateOf" : "https://www.example.org/2727a23d-d572-4eba-8285-95dbce4d1348",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kvA01IvNxAdlpZ"
+    "note" : "RphpE3ymM4p"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "caaiLB2C0wTno0gvGcE",
-    "createdBy" : "VeK3Cvd75Vmp0K8",
-    "createdDate" : "2001-09-16T02:45:12.727Z"
+    "note" : "HhpdWH7KG6sPKPAmQ5o",
+    "createdBy" : "2AW8MbPfLkypj",
+    "createdDate" : "2023-12-02T17:15:10.691Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/37fb4944-4b70-4c90-80e1-7a69a39e335e" ],
+  "curatingInstitutions" : [ "https://www.example.org/26032a54-5b69-4433-9802-1832aa847539" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/JournalReview.json
+++ b/documentation/JournalReview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "imJQZdQ2lG8w",
-    "ownerAffiliation" : "https://www.example.org/b1303101-000f-4734-99fe-3c59ecd5bbea"
+    "owner" : "iOdDk9v9IRIA7fVYi0N",
+    "ownerAffiliation" : "https://www.example.org/6e868fef-fff1-450b-8289-71f436ab405d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d78556c7-3a5a-4fce-a57a-470c33f2e602"
+    "id" : "https://www.example.org/35271f8e-08b5-43dc-bf09-ebf5fe91f1c3"
   },
-  "createdDate" : "1976-05-31T06:53:52.082Z",
-  "modifiedDate" : "1985-10-13T17:06:34.643Z",
-  "publishedDate" : "1988-06-23T00:18:25.581Z",
-  "indexedDate" : "1995-03-24T07:11:32.870Z",
-  "handle" : "https://www.example.org/5680b1a9-022a-4a96-b88b-15d6a5fb4569",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/b9f68d17-47cd-4746-bd13-f74ca2793699",
+  "createdDate" : "2018-02-07T04:41:37.753Z",
+  "modifiedDate" : "2015-05-21T18:41:10.166Z",
+  "publishedDate" : "1981-01-02T18:26:54.897Z",
+  "indexedDate" : "2008-11-15T03:19:56.463Z",
+  "handle" : "https://www.example.org/55217014-a634-4310-8e0a-6b94eb2e9a33",
+  "doi" : "https://doi.org/10.1234/vel",
+  "link" : "https://www.example.org/1457876b-4b0e-443b-a124-f21ef9dd7cfd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2kd3wfwhTeCCyY04q",
+    "mainTitle" : "LcToHTvqmSmkH",
     "alternativeTitles" : {
-      "sv" : "Z8WLHclNeuhNn"
+      "cs" : "XRoSUCfz4u9eYrqt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "PCcYAo8Wx84hJre",
-      "month" : "yNcyEXQdro",
-      "day" : "NNbVNh3QE2"
+      "year" : "OGRDaoG4wRHZNa",
+      "month" : "xCrA7eET2Aze0a4m",
+      "day" : "0CJWSV062Wefw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/121c5c79-0555-45d8-87c5-7d5223f438c2",
-        "name" : "nsO7wNmug2ZZrLql",
+        "id" : "https://www.example.org/77eb47e0-d087-4556-9522-9078e89d339b",
+        "name" : "M3YH9AN8QuWcwW",
         "nameType" : "Personal",
-        "orcId" : "1762DUgPJEB",
-        "verificationStatus" : "Verified",
+        "orcId" : "onyN1USJoa1K9llS7F",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xnvOlN4ZrsjNh8EcnDL",
-          "value" : "EvAtyGzwLkOUTyj"
+          "sourceName" : "dwqUmkL5lyAd96fpW",
+          "value" : "OymrdtCNHRmLzG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dKstRN6FXIa",
-          "value" : "Y357i2wseoR7gc"
+          "sourceName" : "V6FYyLmcGE",
+          "value" : "ekNbYFQCh40OGr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3515266b-04a1-4216-9884-0bacd29bb687"
+        "id" : "https://www.example.org/05ed7c2c-1027-4385-b9f8-3a570790c849"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/492468c1-a225-406c-8663-a9a6ad622faf",
-        "name" : "s9CJTC8bhz0A",
-        "nameType" : "Organizational",
-        "orcId" : "4AMEZqIKByjklc7",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/c8d4dee9-79af-4d1f-910f-65db30535527",
+        "name" : "hbieF0idJNaMZog",
+        "nameType" : "Personal",
+        "orcId" : "ymQxkrhpWlG10xWKSRJ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sfnbScmwAg",
-          "value" : "m3nDvFWPNL4u42F"
+          "sourceName" : "CuvXOa35nN",
+          "value" : "8mSpUiRM2UcLfp"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UAeNba3DG8E0hOtBKqS",
-          "value" : "mZ5xgfAzJKUxaA"
+          "sourceName" : "YZOqlOSTxZLrbATl",
+          "value" : "AJTmK1aIq37O44"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/106cd054-37ab-4c3c-9d09-0ea0c74c0e2f"
+        "id" : "https://www.example.org/e62c0b7f-e8e5-4b5b-b2b0-5eb129f18e5d"
       } ],
       "role" : {
-        "type" : "Illustrator"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "bhq579fTth"
+      "pl" : "EASo6w3BPf"
     },
-    "npiSubjectHeading" : "wE3VWihbDJ3zt",
-    "tags" : [ "0AShFzUlK6pFNf8" ],
-    "description" : "iTAmITpzjRnau9Z",
+    "npiSubjectHeading" : "lRGYv7beb2rF",
+    "tags" : [ "HxmZ4yPGq6avY" ],
+    "description" : "47Sx7Ir3Mq4oMLbgWc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0b24a49b-26c7-4394-afab-951b0e5e7168"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/14c565ba-1fc1-4e05-aad0-bb1fb73b1c8e"
       },
-      "doi" : "https://www.example.org/738459ff-2bfa-4c03-8086-0bf7f846fb56",
+      "doi" : "https://www.example.org/329f01c7-1b7b-4664-8dac-5f0e34293503",
       "publicationInstance" : {
         "type" : "JournalReview",
-        "volume" : "r7Zo7aQ8VHoUum",
-        "issue" : "EZhTv1bGsc",
-        "articleNumber" : "Xa2pxvhFCr",
+        "volume" : "j1JFXOB33Kvrj5zI7f",
+        "issue" : "zExn3ZJXnK9eM3PC4C",
+        "articleNumber" : "jLG5lpVMIK",
         "pages" : {
           "type" : "Range",
-          "begin" : "qu7hDEkCHh0Q27",
-          "end" : "X0HDIzq7J1LEZ7Sa"
+          "begin" : "xWkJIw8IJj3le8b9",
+          "end" : "0nJVOk3pF9bn"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/90d76e05-bd3e-452c-9bcf-60a1a7f260ca",
-    "abstract" : "mCkN8RYHgUkr"
+    "metadataSource" : "https://www.example.org/e0fbb0ab-7eac-407f-99bd-897acff333c8",
+    "abstract" : "QLUR78p5ywax"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/28dbdf36-d420-4b3e-a8dc-8b53e48f36f6",
-    "name" : "VBk6msaQLhhdJgjC5e",
+    "id" : "https://www.example.org/7a5fd2f7-99f3-4770-a1b1-0f672e68c051",
+    "name" : "Mqw3jh4m4hFydm",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1973-10-21T21:24:42.200Z",
+      "approvalDate" : "2009-03-02T09:38:52.193Z",
       "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "FKCkj1vpWK5RTtnE"
+      "applicationCode" : "IEh4xUbfPUKE"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/30187184-2ca7-4122-b64e-d63969d46fd6",
-    "identifier" : "8qPbkCr7VnwF7R7y94",
+    "source" : "https://www.example.org/af542ae1-1a53-447b-9b42-4f4d19f00d9d",
+    "identifier" : "J2muyKz3Brj",
     "labels" : {
-      "it" : "zWUXhQbqNbuBD3e6"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1202180487
-    },
-    "activeFrom" : "1993-08-12T09:08:39.543Z",
-    "activeTo" : "2012-04-05T17:58:55.014Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8117e9ce-7fc0-4089-a8e7-9cfcb8070f25",
-    "id" : "https://www.example.org/1cb14c11-3c8a-432e-b477-fb15be0cf7a0",
-    "identifier" : "JP4ugHFpWkY",
-    "labels" : {
-      "sv" : "vAuwBbpCHNjKY"
+      "nl" : "pHemKTnMPdXD"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 810806010
+      "amount" : 1336678211
     },
-    "activeFrom" : "2007-04-17T17:59:18.221Z",
-    "activeTo" : "2016-12-15T23:26:57.053Z"
+    "activeFrom" : "1990-02-02T22:21:27.961Z",
+    "activeTo" : "1990-08-04T20:40:39.995Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/c7f90bac-aa58-4d86-9044-12ff398493e3",
+    "id" : "https://www.example.org/aa42f57e-da70-4d1d-93da-18359bec5457",
+    "identifier" : "eAuC2BFNcm",
+    "labels" : {
+      "fr" : "Vl2jETOcglUxp"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1585340422
+    },
+    "activeFrom" : "2000-12-21T21:44:26.126Z",
+    "activeTo" : "2023-07-12T01:14:26.961Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/91c90f37-91f6-4824-83e0-091c9257a3e7" ],
+  "subjects" : [ "https://www.example.org/ee21b5cb-b64e-40f9-88db-3046d10db5b7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d3245479-d6a4-4187-80e3-dbefd4bbe0fb",
-    "name" : "7d089WNuXhybHpouhF",
-    "mimeType" : "oMISH12PFVp",
-    "size" : 1036365227,
-    "license" : "https://www.example.com/ozkjkti5sof8u0vc0t",
+    "identifier" : "4b66f004-a0dc-4b0a-bc54-c291e330a9d6",
+    "name" : "GHrcmoZStfTH3a",
+    "mimeType" : "4le6f6YFKBizlq7er",
+    "size" : 1320189156,
+    "license" : "https://www.example.com/0wh1akulmsl2ohwwxr",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "lgOSZ8jNk94ii2gTm",
-    "publishedDate" : "1972-09-11T05:22:16.729Z",
+    "legalNote" : "7pj1Hq96rvxPl3CyRj",
+    "publishedDate" : "2001-03-02T06:08:22.404Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/LafnSsXJFHD8igyh",
-    "name" : "CtWVlDRxpOQw3pqMr",
-    "description" : "YmECdvSoxRI"
+    "id" : "https://www.example.com/aDRxOSE3dgTaXdmqlD",
+    "name" : "wXlvboGkS55zz",
+    "description" : "A6I6v9Hcthd"
   } ],
-  "rightsHolder" : "nVkWLZ5mqwLChaEsqaL",
-  "duplicateOf" : "https://www.example.org/4debeeb7-50dd-481a-b708-4bc168637e48",
+  "rightsHolder" : "zeysKxINhUeF",
+  "duplicateOf" : "https://www.example.org/346516e6-adf7-46e7-a691-717ce258be1f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "OHhXvHjz7JXqSbP9oBn"
+    "note" : "kvA01IvNxAdlpZ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jObXwuxzMYHK7Q4",
-    "createdBy" : "Byb4UJ5kiPu",
-    "createdDate" : "2013-03-06T10:15:41.753Z"
+    "note" : "caaiLB2C0wTno0gvGcE",
+    "createdBy" : "VeK3Cvd75Vmp0K8",
+    "createdDate" : "2001-09-16T02:45:12.727Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/37595696-0b89-4c51-b030-3fec5854b0cf" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/37fb4944-4b70-4c90-80e1-7a69a39e335e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "hBVIP3wiovLkOsuF",
-    "ownerAffiliation" : "https://www.example.org/5c55517f-9a05-42ae-aa69-30115cb844e0"
+    "owner" : "nedinWGgDsT1",
+    "ownerAffiliation" : "https://www.example.org/bc0815ab-1a07-4899-b696-abfabec7d01c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/94dd3094-e551-474c-b2f7-8f9f576e7b6d"
+    "id" : "https://www.example.org/09d71ec3-3bc2-4e73-9045-3abff663c5f2"
   },
-  "createdDate" : "2006-04-25T18:32:01.728Z",
-  "modifiedDate" : "1972-09-30T23:32:51.594Z",
-  "publishedDate" : "1973-03-26T18:06:07.023Z",
-  "indexedDate" : "1995-02-24T06:24:50.878Z",
-  "handle" : "https://www.example.org/36fa90fc-b4a0-4ae3-bf68-b2cf199e350c",
-  "doi" : "https://doi.org/10.1234/delectus",
-  "link" : "https://www.example.org/384aa43b-1587-4df5-bb42-d8e1adf5e14b",
+  "createdDate" : "2021-08-14T11:54:58.867Z",
+  "modifiedDate" : "1973-02-18T00:17:43.928Z",
+  "publishedDate" : "1991-09-05T19:02:00.657Z",
+  "indexedDate" : "2001-06-18T23:42:05.905Z",
+  "handle" : "https://www.example.org/26b40c5b-f781-42c5-b314-9ea9416e6ea5",
+  "doi" : "https://doi.org/10.1234/iure",
+  "link" : "https://www.example.org/ec78bfba-ed31-4e8b-98d6-f6c25f5753f0",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "kOtHojXErgQHIrjeb",
+    "mainTitle" : "HHthu3DPZV9IJbqNr",
     "alternativeTitles" : {
-      "bg" : "HNwKHp40TUXhVE9HiPS"
+      "fr" : "Qx6dEc1e6hLWOBJMGZF"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "vnU0AC22oxJffZc",
-      "month" : "dLkENDcysfcUIQ8UhA1",
-      "day" : "bKSV5D0rSB0sNF"
+      "year" : "osjUIyYgCcO",
+      "month" : "R0uRTztXVXRQ",
+      "day" : "8158YNJknXGDr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dfa164bd-46e8-4c63-a82f-bab0581182d1",
-        "name" : "79dj6ghEZeD",
+        "id" : "https://www.example.org/16c98049-17ca-42fa-9a4d-8394d845d6a4",
+        "name" : "oPBSLeCuuVqbKgIYFn",
         "nameType" : "Personal",
-        "orcId" : "J1Y6fox30VZ9SOMm",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "As4KTGW3sY",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zOvipGKR8YsNY",
-          "value" : "XKEwt834jP"
+          "sourceName" : "zWEETSnFov9fLeJ7dy",
+          "value" : "YVkRrKdEiDLK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uF34lHde9dBYp8",
-          "value" : "amu9YpDs2Ol"
+          "sourceName" : "dbAWs68JTum",
+          "value" : "o4tN1FFosbdY09gJlZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a2bdb7f7-40b3-4bfc-b6e5-ea858899a0e9"
+        "id" : "https://www.example.org/1f5391cb-7e9f-488a-a9c5-567f44de65c7"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "DataManager"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,59 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2e0813c5-1473-49b4-970d-5efa553a09ec",
-        "name" : "tztyRQ8nn3DU",
+        "id" : "https://www.example.org/3aa438c4-1471-4ff0-9338-03f57b4c80df",
+        "name" : "iKdn9UNnN5J4Mwj0e",
         "nameType" : "Personal",
-        "orcId" : "0eK4d5ZuMotSHHmq",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "72s3bobGHOUWKN3DyC4",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8z2vvzR7uSf",
-          "value" : "9Upb7Na1bmyiIcuCZ"
+          "sourceName" : "YgiiwlqvoX",
+          "value" : "l15dQH1t0E0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "n25ZSolZPuertHf3",
-          "value" : "5KzEZTMNAsUCC"
+          "sourceName" : "Vt8iEShwVBhao",
+          "value" : "mhMVvfaUVvq10X6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/74b78017-aec9-4942-91bf-c586243f065e"
+        "id" : "https://www.example.org/d9f26a69-df59-4410-96fd-6855cd5227e9"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "brhdH70kez9q"
+      "fi" : "FSGHgz6WZlvm"
     },
-    "npiSubjectHeading" : "yALy6Tc8Ix",
-    "tags" : [ "uAn6zvsQ2RlOSNMqIw" ],
-    "description" : "MA1K0yWs5Oa2B0Rd",
+    "npiSubjectHeading" : "JvofGfZlTcuUIiPqFKd",
+    "tags" : [ "olAGaasaH1SX4sEX1Qk" ],
+    "description" : "1SFTYxU5cjNgRSqh3j",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "DDMVYttOEtnp54F",
+        "label" : "ccTTHArd8HMp",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "6Didm4W6TymmtDuKGj",
-          "country" : "pipkzIsnXnDuu"
+          "label" : "fVI0Kdb6WwJ",
+          "country" : "IlAdMCSNtnDMZ4TjW"
         },
         "time" : {
-          "type" : "Period",
-          "from" : "1981-03-22T21:18:00.250Z",
-          "to" : "1994-02-20T16:00:41.948Z"
+          "type" : "Instant",
+          "value" : "2014-09-02T06:39:36.908Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/L7XcJL257Ld"
+          "id" : "https://www.example.com/icqcNbTlV94"
         },
-        "product" : "https://www.example.com/YlSOOeWYryxdjJa"
+        "product" : "https://www.example.com/Or1hyJzUh1sc"
       },
-      "doi" : "https://www.example.org/647f3f5d-9f46-4adb-b806-293a68838831",
+      "doi" : "https://www.example.org/83103eed-3edd-4ca1-8f65-d74fa0fa113e",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -122,88 +121,90 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/61ef9ca2-b3ed-405e-8c2a-fc4d920e82aa",
-    "abstract" : "4X53mqOncRKNAqm"
+    "metadataSource" : "https://www.example.org/dd2356f3-75ca-49f1-8fa0-2439f4dab98c",
+    "abstract" : "HXpAPIqWeSJuk4eJy"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e45e3d42-c370-4638-80e2-1ffb0d4c921f",
-    "name" : "wMsevMLf5GbQ0E",
+    "id" : "https://www.example.org/3d301158-f490-42b9-b8ae-013281995333",
+    "name" : "t7y55tq3hJd0FRTBDT1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-06-24T09:15:35.889Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "QXoRTLwBVxDiKZU8WuN"
+      "approvalDate" : "1981-04-16T17:00:30.646Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "q0VuD6lXGcYO"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/52831da1-e885-49f1-ba95-4ff6f3b940b5",
-    "identifier" : "WeTjyaE6SJqfaaEw8wa",
+    "source" : "https://www.example.org/bbb3419f-f853-4832-9f60-d6c299e4e0b6",
+    "identifier" : "E5Mi5dbGIgPHY",
     "labels" : {
-      "bg" : "AIqSqBbYGLcB"
+      "fi" : "8L3nsCt8BhccxNfW"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1503566759
+      "currency" : "GBP",
+      "amount" : 295619177
     },
-    "activeFrom" : "2023-04-16T09:27:04.569Z",
-    "activeTo" : "2023-08-06T02:57:02.638Z"
+    "activeFrom" : "1976-07-17T00:18:33.917Z",
+    "activeTo" : "2020-06-08T23:54:16.212Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/cceb9863-b425-43d5-b2ea-4cab4a7b55d6",
-    "id" : "https://www.example.org/801f603b-65ae-4441-9796-da20f2b6aed3",
-    "identifier" : "05O1py87jVeeOMtbD",
+    "source" : "https://www.example.org/36eb6bd7-f7df-4580-b248-78ebc762371b",
+    "id" : "https://www.example.org/ab77c6e3-01dc-447b-ac0e-68d68fb7b08a",
+    "identifier" : "Z9Utlouz9equ3lHzZkk",
     "labels" : {
-      "cs" : "PvGIRsIFYcw"
+      "it" : "4APfizzfF5QbwRB0P9"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1494714969
+      "currency" : "USD",
+      "amount" : 1135967679
     },
-    "activeFrom" : "2004-11-24T23:01:59.870Z",
-    "activeTo" : "2011-12-26T01:37:03.948Z"
+    "activeFrom" : "2003-11-24T11:47:38.446Z",
+    "activeTo" : "2006-07-21T23:51:22.275Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/02ee50d3-a8c0-41c6-beb3-c8b2363aa3db" ],
+  "subjects" : [ "https://www.example.org/6035fffa-f74f-4715-a126-00e411312378" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "942ffe40-d596-4b4a-9b0c-223cc1f3c21b",
-    "name" : "eSkWovrr09gSvKsA",
-    "mimeType" : "J3vHrS3ypGGxJp3cMf7",
-    "size" : 1404267037,
-    "license" : "https://www.example.com/gmddigggldyle",
+    "identifier" : "c8395162-44d2-4302-9c19-f5e17adab082",
+    "name" : "As5G4Jutik",
+    "mimeType" : "TfYZsHriCmcf9H",
+    "size" : 84734508,
+    "license" : "https://www.example.com/dlqncnvbcjic",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "sZ0eBFl5ZkyDshLQoGw"
     },
-    "legalNote" : "JXP7QF0gPYPGGM3kNQ0",
-    "publishedDate" : "1973-01-02T11:48:08.586Z",
+    "legalNote" : "jti4AqOfIlJJfOS",
+    "publishedDate" : "1994-03-09T23:36:00.015Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/edNEaUKX1Nbn0oAB6",
-    "name" : "ZCSrShOjJe6SF6hVy",
-    "description" : "LNSZtPCGuha1"
+    "id" : "https://www.example.com/PNJE7yV3tCkCKjAMAI",
+    "name" : "SDfFByfMZ8z8crExN",
+    "description" : "ln5vWpckCMmn"
   } ],
-  "rightsHolder" : "DDUF0WIBYRim72INnD",
-  "duplicateOf" : "https://www.example.org/eaedf1fa-48f0-49e1-b5e0-52c8e5938c7f",
+  "rightsHolder" : "it2JORn1LyR9igo",
+  "duplicateOf" : "https://www.example.org/71772654-2e39-48eb-93bb-5f7efad4d3fd",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Ury5r3Ley4MdABec7Q"
+    "note" : "aE9V01PXH5b"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QtAzqPLBh3kPU4NgV",
-    "createdBy" : "aGgBT6loD754iO1Pq",
-    "createdDate" : "1985-02-12T15:10:02.594Z"
+    "note" : "QveZmiTOEdSh",
+    "createdBy" : "haak8Gd7KT5i",
+    "createdDate" : "1977-09-27T17:41:21.800Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ad2fe199-505f-4f36-b74a-5cfbea91ab7f" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/8c566753-127c-4f06-8553-69780171505f" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Lecture.json
+++ b/documentation/Lecture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "nedinWGgDsT1",
-    "ownerAffiliation" : "https://www.example.org/bc0815ab-1a07-4899-b696-abfabec7d01c"
+    "owner" : "fnXEURjG7eJTiH",
+    "ownerAffiliation" : "https://www.example.org/12582472-7e5b-44cc-bd23-ef2fab47b79b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/09d71ec3-3bc2-4e73-9045-3abff663c5f2"
+    "id" : "https://www.example.org/7dfad0f4-f042-46bd-a80d-b973deebb8f5"
   },
-  "createdDate" : "2021-08-14T11:54:58.867Z",
-  "modifiedDate" : "1973-02-18T00:17:43.928Z",
-  "publishedDate" : "1991-09-05T19:02:00.657Z",
-  "indexedDate" : "2001-06-18T23:42:05.905Z",
-  "handle" : "https://www.example.org/26b40c5b-f781-42c5-b314-9ea9416e6ea5",
-  "doi" : "https://doi.org/10.1234/iure",
-  "link" : "https://www.example.org/ec78bfba-ed31-4e8b-98d6-f6c25f5753f0",
+  "createdDate" : "1997-04-07T17:09:49.899Z",
+  "modifiedDate" : "1976-12-03T17:50:41.165Z",
+  "publishedDate" : "2015-08-28T23:28:31.417Z",
+  "indexedDate" : "1992-08-01T09:58:15.174Z",
+  "handle" : "https://www.example.org/4eab7b1d-3651-4ef1-bb06-5a19a8381b98",
+  "doi" : "https://doi.org/10.1234/dolores",
+  "link" : "https://www.example.org/c2a4ebe9-ad43-4b6d-b664-58e128ffb988",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HHthu3DPZV9IJbqNr",
+    "mainTitle" : "i09VxZbzatUr",
     "alternativeTitles" : {
-      "fr" : "Qx6dEc1e6hLWOBJMGZF"
+      "de" : "2dCzxou1KXVfTwkMNeU"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "osjUIyYgCcO",
-      "month" : "R0uRTztXVXRQ",
-      "day" : "8158YNJknXGDr"
+      "year" : "SXcL291sv6zOr",
+      "month" : "H7kUFn7OyBSogTmpHIl",
+      "day" : "GjdYyU6hH9kyc8ihM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/16c98049-17ca-42fa-9a4d-8394d845d6a4",
-        "name" : "oPBSLeCuuVqbKgIYFn",
+        "id" : "https://www.example.org/36ecb1a3-ad28-4175-907c-7263ae003e38",
+        "name" : "QquznESErlx04KJnl0",
         "nameType" : "Personal",
-        "orcId" : "As4KTGW3sY",
+        "orcId" : "UsCp9tI7F3z13H",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zWEETSnFov9fLeJ7dy",
-          "value" : "YVkRrKdEiDLK"
+          "sourceName" : "td6V1URwnUx89",
+          "value" : "MG8rlLtlMzf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dbAWs68JTum",
-          "value" : "o4tN1FFosbdY09gJlZ"
+          "sourceName" : "4T8PlcHGJ9W4P4N",
+          "value" : "IgPyTLXkPuw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1f5391cb-7e9f-488a-a9c5-567f44de65c7"
+        "id" : "https://www.example.org/176a882b-d728-425d-a295-7172811c634d"
       } ],
       "role" : {
-        "type" : "DataManager"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3aa438c4-1471-4ff0-9338-03f57b4c80df",
-        "name" : "iKdn9UNnN5J4Mwj0e",
-        "nameType" : "Personal",
-        "orcId" : "72s3bobGHOUWKN3DyC4",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/098206c4-69c5-4d0b-b093-c02d1c1c69ec",
+        "name" : "fUUuGjSAAHq",
+        "nameType" : "Organizational",
+        "orcId" : "I6xiWR5Fdyyxd",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YgiiwlqvoX",
-          "value" : "l15dQH1t0E0"
+          "sourceName" : "i7r2pqTRIRkuFG",
+          "value" : "RSChuIoUP8DulMPv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Vt8iEShwVBhao",
-          "value" : "mhMVvfaUVvq10X6"
+          "sourceName" : "dyYyhnsQtnz4qCjIJ5",
+          "value" : "0AYiOHGxytgcQ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d9f26a69-df59-4410-96fd-6855cd5227e9"
+        "id" : "https://www.example.org/f7d636a5-5990-4a28-8d04-fa32ccda8fc5"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "Editor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "FSGHgz6WZlvm"
+      "pt" : "q2TCtkwubZl"
     },
-    "npiSubjectHeading" : "JvofGfZlTcuUIiPqFKd",
-    "tags" : [ "olAGaasaH1SX4sEX1Qk" ],
-    "description" : "1SFTYxU5cjNgRSqh3j",
+    "npiSubjectHeading" : "nE3psu9hSpRGscLl",
+    "tags" : [ "pRqRpRCUKdhZZWQcUu" ],
+    "description" : "Wzogb2phEHdsSgHpGP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "ccTTHArd8HMp",
+        "label" : "XKPYfWCOxipP6Om9x9G",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "fVI0Kdb6WwJ",
-          "country" : "IlAdMCSNtnDMZ4TjW"
+          "label" : "tYDSSjG78XMc90PH",
+          "country" : "HtBQaPCBc1FKuSOgDvJ"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "2014-09-02T06:39:36.908Z"
+          "type" : "Period",
+          "from" : "2009-12-09T22:01:12.255Z",
+          "to" : "2023-06-10T18:39:11.764Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/icqcNbTlV94"
+          "id" : "https://www.example.com/cUOj80ALYopxdjYRSY"
         },
-        "product" : "https://www.example.com/Or1hyJzUh1sc"
+        "product" : "https://www.example.com/7ZusFJKebQuGrd7"
       },
-      "doi" : "https://www.example.org/83103eed-3edd-4ca1-8f65-d74fa0fa113e",
+      "doi" : "https://www.example.org/1d4c9c50-0428-4605-b9af-61a8d966a193",
       "publicationInstance" : {
         "type" : "Lecture",
         "pages" : {
@@ -121,90 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/dd2356f3-75ca-49f1-8fa0-2439f4dab98c",
-    "abstract" : "HXpAPIqWeSJuk4eJy"
+    "metadataSource" : "https://www.example.org/0f7fc9b5-5bf6-4f79-ba14-69e583eaa35a",
+    "abstract" : "hes0WnsJLzZBG1gxm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/3d301158-f490-42b9-b8ae-013281995333",
-    "name" : "t7y55tq3hJd0FRTBDT1",
+    "id" : "https://www.example.org/d83932c2-58d1-433a-b501-20796e298a6a",
+    "name" : "yyxAem1ce3PjYS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1981-04-16T17:00:30.646Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "q0VuD6lXGcYO"
+      "approvalDate" : "1989-04-06T06:38:13.272Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "YS4VOhl23iqAzY"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/bbb3419f-f853-4832-9f60-d6c299e4e0b6",
-    "identifier" : "E5Mi5dbGIgPHY",
+    "source" : "https://www.example.org/c7190d32-8ee2-487b-9826-8de66daa8d52",
+    "identifier" : "Odd0L7jwUk2aj",
     "labels" : {
-      "fi" : "8L3nsCt8BhccxNfW"
+      "en" : "u3rqMzrqIqzx"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 295619177
+      "amount" : 1417280258
     },
-    "activeFrom" : "1976-07-17T00:18:33.917Z",
-    "activeTo" : "2020-06-08T23:54:16.212Z"
+    "activeFrom" : "1978-03-26T20:59:04.821Z",
+    "activeTo" : "2000-08-05T22:28:17.411Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/36eb6bd7-f7df-4580-b248-78ebc762371b",
-    "id" : "https://www.example.org/ab77c6e3-01dc-447b-ac0e-68d68fb7b08a",
-    "identifier" : "Z9Utlouz9equ3lHzZkk",
+    "source" : "https://www.example.org/549fef42-b5c0-46f2-a49e-8e882bfcd547",
+    "id" : "https://www.example.org/c17c18ff-13d7-4bba-a393-6a5c31b186a0",
+    "identifier" : "4IZhOU9nwi4HJ3836N",
     "labels" : {
-      "it" : "4APfizzfF5QbwRB0P9"
+      "it" : "zg5TVUzreVwfzx8"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1135967679
+      "currency" : "GBP",
+      "amount" : 1481549031
     },
-    "activeFrom" : "2003-11-24T11:47:38.446Z",
-    "activeTo" : "2006-07-21T23:51:22.275Z"
+    "activeFrom" : "2021-10-02T06:20:28.701Z",
+    "activeTo" : "2023-10-20T14:35:49.750Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6035fffa-f74f-4715-a126-00e411312378" ],
+  "subjects" : [ "https://www.example.org/44494c19-a50d-450e-831f-f26dfb2a3f9a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c8395162-44d2-4302-9c19-f5e17adab082",
-    "name" : "As5G4Jutik",
-    "mimeType" : "TfYZsHriCmcf9H",
-    "size" : 84734508,
-    "license" : "https://www.example.com/dlqncnvbcjic",
+    "identifier" : "bf36b127-11d3-4c8f-870b-e03d8522cabb",
+    "name" : "MJ7RMm3qAT",
+    "mimeType" : "Jfj4jfFDnOmwuGFFW1t",
+    "size" : 26240183,
+    "license" : "https://www.example.com/cugjq5gp6qj3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "sZ0eBFl5ZkyDshLQoGw"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "jti4AqOfIlJJfOS",
-    "publishedDate" : "1994-03-09T23:36:00.015Z",
+    "legalNote" : "8zPZf8l5aVvDihK",
+    "publishedDate" : "1994-07-09T01:38:07.026Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "qTfzbnFevOVo9aA30",
+      "uploadedDate" : "1978-02-11T17:24:59.075Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/PNJE7yV3tCkCKjAMAI",
-    "name" : "SDfFByfMZ8z8crExN",
-    "description" : "ln5vWpckCMmn"
+    "id" : "https://www.example.com/ZP4lsA0k7pSt",
+    "name" : "2IOxsOsLddiRq6GBq",
+    "description" : "CLfwPGDcazAT030H"
   } ],
-  "rightsHolder" : "it2JORn1LyR9igo",
-  "duplicateOf" : "https://www.example.org/71772654-2e39-48eb-93bb-5f7efad4d3fd",
+  "rightsHolder" : "wFwi65q4bIo1X1S89e",
+  "duplicateOf" : "https://www.example.org/70d21fdd-13e3-4415-a10d-f790a4360aa5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "aE9V01PXH5b"
+    "note" : "spslvCvRagvVc3NgKd9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QveZmiTOEdSh",
-    "createdBy" : "haak8Gd7KT5i",
-    "createdDate" : "1977-09-27T17:41:21.800Z"
+    "note" : "NHKsiaoqDwvSNd7Xx",
+    "createdBy" : "MJI9chvntBvmzJlnx",
+    "createdDate" : "1982-07-06T19:51:20.496Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8c566753-127c-4f06-8553-69780171505f" ],
+  "curatingInstitutions" : [ "https://www.example.org/1c858f8f-c088-4e77-a841-e7a620218060" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "0iWT7iAuAn7RTH",
-    "ownerAffiliation" : "https://www.example.org/8ddc1b05-e3ca-45f4-8c86-6fa421fb50e3"
+    "owner" : "vCKobFXwvG5YAYia",
+    "ownerAffiliation" : "https://www.example.org/dd56c2b4-6228-42bd-86e3-1518adf85131"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a219ea03-0b6a-4519-81fd-491c26573042"
+    "id" : "https://www.example.org/d1e2a619-00b6-4b6e-a0c7-67dca966527f"
   },
-  "createdDate" : "1971-08-27T09:12:10.732Z",
-  "modifiedDate" : "1973-05-23T18:28:14.389Z",
-  "publishedDate" : "1997-10-05T18:19:06.998Z",
-  "indexedDate" : "1984-01-24T13:15:44.820Z",
-  "handle" : "https://www.example.org/c5a8f98f-40d0-4454-8367-5a696fd58d6c",
-  "doi" : "https://doi.org/10.1234/omnis",
-  "link" : "https://www.example.org/9ab8e4cf-7ade-4e1b-98fd-84446527b1cb",
+  "createdDate" : "1981-07-01T20:09:07.740Z",
+  "modifiedDate" : "1978-12-30T09:43:58.602Z",
+  "publishedDate" : "1986-05-26T17:27:23.981Z",
+  "indexedDate" : "1979-01-23T21:30:00.535Z",
+  "handle" : "https://www.example.org/29a8152f-d17a-4b8a-9d34-07948980288e",
+  "doi" : "https://doi.org/10.1234/autem",
+  "link" : "https://www.example.org/701bdcf9-8a15-4035-a40f-71618dbc8d5c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7d2SYZXRx9c5Aoz",
+    "mainTitle" : "nCdGcamxrvAIue",
     "alternativeTitles" : {
-      "nn" : "trV8t7f6ng7"
+      "cs" : "BSzqUumP3mc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "e6PyrsEUUegRdsAy",
-      "month" : "rGUxQw7zYY4Z",
-      "day" : "EYK9Mghq75J2T"
+      "year" : "OHYxHYOJB3fuk799",
+      "month" : "JbYV07vKGDW",
+      "day" : "pqbS8ocYJPjPnAzn"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c3dfb836-b796-487b-8c6e-8ae3508a63ae",
-        "name" : "51tV9cX50NTpM6wB",
+        "id" : "https://www.example.org/1696b45e-de37-4437-b033-8e6cfa74b6dd",
+        "name" : "N7VuJeJh7G",
         "nameType" : "Personal",
-        "orcId" : "x43PNNndPVYdYv",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Gl4DpPj6k8r2iMz5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1bUzCKerLdH5RuNp",
-          "value" : "SzKJHFZiJbDmhu"
+          "sourceName" : "htz7EVfwaVlHcekz",
+          "value" : "HGg2L91t9cBw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YDWYHOmw2wxe75",
-          "value" : "gcGNADN8Xs3Ss"
+          "sourceName" : "8e6b4X6TDq5LA",
+          "value" : "A0FRADlQ1L6og"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/210ff190-4b73-46c1-a80b-d4a3bd69361e"
+        "id" : "https://www.example.org/0eb5b171-7f51-4d29-9a8b-0b18bfbbf25b"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,212 +62,215 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f44e5e31-7937-454c-a9a7-ed901f7f8715",
-        "name" : "e26HyATxbDsJ",
+        "id" : "https://www.example.org/b8e1dc99-b77c-446b-95c8-cdb547f628d2",
+        "name" : "AtT599BvxWQ",
         "nameType" : "Personal",
-        "orcId" : "T9RzOwTtEbb9Wa",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "0nDf0CXYcWk",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wUlI0dmPAoV",
-          "value" : "lLoAIgn8rNMGGGz"
+          "sourceName" : "fgBZ18we0r8nVUbl",
+          "value" : "VjKNZ2MQzrVpUG95DGS"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "49HNdY6XuCBZFsNdI",
-          "value" : "8z8gwC9jku"
+          "sourceName" : "2BcpuK4iby",
+          "value" : "pESce4cnlkR0eMSg"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0c2ad0f3-bb78-4743-9795-8383677e2bbd"
+        "id" : "https://www.example.org/d8810ccf-6b1c-4c8f-b4c0-2c76b17fd0ca"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "oHBFtuFK4rkLYYv"
+      "es" : "OlLt5pmgbEkj"
     },
-    "npiSubjectHeading" : "3otkBlBnbpd",
-    "tags" : [ "yFUh7BAUiW" ],
-    "description" : "NtAb32AcG17H",
+    "npiSubjectHeading" : "teuRj4BCl9vqV3DK",
+    "tags" : [ "eNjXwFzMLDdtsELvEt6" ],
+    "description" : "KcvTCfHwu1Jj",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/1dfbb101-4623-42ae-9ed4-b69756adca1a",
+      "doi" : "https://www.example.org/5866f1cc-aa77-485c-bfc2-045c7b5f3249",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
-          "type" : "Novella"
+          "type" : "Novel"
         },
         "manifestations" : [ {
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "VboGcQPTCOeyonChm",
+            "name" : "6GQ2Pm8I7MNCpQgWV",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "QnsoiNmgzsWD53RK",
-            "month" : "eLCBf0JDaEJ",
-            "day" : "YO2KaG6KMi"
+            "year" : "89WBL8lNrW1P",
+            "month" : "9jCUwhHxUq",
+            "day" : "JjjunFfG0d4bwoMbb"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "9o4VZLfDWuNa6I7dd",
-              "end" : "KYSUF80eb7sCdFp"
+              "begin" : "U2wa9N94kv8In8",
+              "end" : "jm312jGk2ZlSBq1QLB"
             },
-            "pages" : "eGd8sFL9g4KbVxKX",
-            "illustrated" : true
+            "pages" : "uy0Xv3Lhxkcjm",
+            "illustrated" : false
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
-            "type" : "LiteraryArtsAudioVisualOther",
-            "description" : "fsSE1ZfMpWPg"
+            "type" : "Audiobook"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "d4nOpmwRDIZ2jw13PuK",
+            "name" : "iVS0acOSYqJkjvQH",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "29tgNtpOp6Oe2Cz8",
-            "month" : "1jWNybWNcxqCaG",
-            "day" : "Ni9hYz8PSMpt"
+            "year" : "uldMzOKA9qvmcO",
+            "month" : "ZsF5kaXCD24YmTc",
+            "day" : "Om2HW0GtYaIOhclhW4V"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 931426263
+          "extent" : 1489543098
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "LiteraryArtsPerformanceOther",
-            "description" : "qDAng51r3YBOBVM"
+            "type" : "Play"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "ZfumF18U1JgJhS6t",
-            "country" : "KhQDNFlm3nH"
+            "label" : "jCeLrFnOHKw",
+            "country" : "2hJgMMPGu7xHvlNJ"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "O5VgpQ7P3pDSefd2O",
-            "month" : "NWhUXdZWCT",
-            "day" : "8gBkAggZcUVADH"
+            "year" : "8La9KC6sVAtAePius",
+            "month" : "LRurt6TElorX7jo",
+            "day" : "XNHagz8uKpL4"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/0modHHiPaWNcJOSqJ",
+          "id" : "https://www.example.com/l27LGL9Ftw7Z",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "Tj9qm5VRLaY2wWk9",
+            "name" : "yhlk8GTvEaRtZr",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "SskHbcXBv0NPq",
-            "month" : "qQwP88DsnQzAYDtX",
-            "day" : "HuqKAnvhnS"
+            "year" : "SZ0N89rwBDdL",
+            "month" : "1FXfDIIHQCD05m",
+            "day" : "gi8Q7ddGYTrZ4xG"
           }
         } ],
-        "description" : "ByGOpDEusJmjN8a1",
+        "description" : "X9z6Xelzyctx8IImJ",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f451c421-4c48-40d3-9570-319989eed72a",
-    "abstract" : "RnK1Gun9frQA"
+    "metadataSource" : "https://www.example.org/616f2b6a-5518-4489-9a5f-08dbc64b193e",
+    "abstract" : "67x7qoki20noxvqWg"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7a0ec2c0-1e3a-4436-9fa4-26ba90179bd1",
-    "name" : "O9OhVYGCyiW8MW1",
+    "id" : "https://www.example.org/b81e46d3-7985-423d-9a3e-9bdee5a581e1",
+    "name" : "XC4gvsoh0U5ayl",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2005-05-01T21:28:52.629Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "m3yVMMUgOmK0W1Tzm"
+      "approvalDate" : "2009-11-18T19:58:28.804Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "aMsmaxNRad"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2ad40ff2-3638-4b2e-8884-b24ba43417d9",
-    "identifier" : "hPnVnyvG2aW",
+    "source" : "https://www.example.org/45ec547d-34e1-4332-9b9b-234be02f183b",
+    "identifier" : "WRg7uKKgjG5lnnnElt",
     "labels" : {
-      "nb" : "IbxPfHnes195UhIGk"
+      "pl" : "lKGzmIdry7Hm4Wr"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 162233688
+      "currency" : "NOK",
+      "amount" : 1787286233
     },
-    "activeFrom" : "1975-06-29T11:39:57.668Z",
-    "activeTo" : "2002-01-17T21:40:25.626Z"
+    "activeFrom" : "1993-09-14T10:36:57.548Z",
+    "activeTo" : "2007-12-01T12:13:14.562Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/243e55c8-3594-409f-9e3c-b0f7a8747e40",
-    "id" : "https://www.example.org/efdb01d4-5588-469e-8c02-b750f8d9f31a",
-    "identifier" : "lLGljQ07R9kd2H4k",
+    "source" : "https://www.example.org/98918b33-4d51-4a36-a384-0fd43721ef52",
+    "id" : "https://www.example.org/606f19df-d863-4087-90df-2be67b4f52e1",
+    "identifier" : "jCiWudix75wt1pO9G",
     "labels" : {
-      "pl" : "bpPVTG22vLpCl3L"
+      "sv" : "4wMVt9dfaJwluZit2"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 129322751
+      "currency" : "GBP",
+      "amount" : 1743449743
     },
-    "activeFrom" : "2016-03-05T06:40:30.526Z",
-    "activeTo" : "2017-11-22T01:49:15.820Z"
+    "activeFrom" : "1972-03-17T02:33:18.136Z",
+    "activeTo" : "2014-04-20T03:34:21.501Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/00a072a3-185f-4a0d-a41c-0f9a1e8c6af2" ],
+  "subjects" : [ "https://www.example.org/60f3528f-2e8c-4c7d-b222-c4abbdfd044e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dd9f0548-8ea3-482a-992a-45b5752686fd",
-    "name" : "2Z8ZOM69SFLoaQSQMZZ",
-    "mimeType" : "kJuJq2I3mUVB",
-    "size" : 1637083537,
-    "license" : "https://www.example.com/qpz0tm5isic0paraq",
+    "identifier" : "27e67915-919e-4c1c-954a-0fa79313a040",
+    "name" : "nyEQIWi2KCtKc8pjz7",
+    "mimeType" : "YluY9d1r9ZwQU",
+    "size" : 999545048,
+    "license" : "https://www.example.com/ijpkbw8uhcl",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "yVyG0kf7WgxJ",
-    "publishedDate" : "2009-11-17T20:02:49.328Z",
+    "legalNote" : "eEVNo1q27MG",
+    "publishedDate" : "1995-04-20T07:06:05.084Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "eiyGdGtcdyXZf0d4Y",
+      "uploadedDate" : "2002-01-18T11:41:09.059Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/7C4AcaGejK8",
-    "name" : "02XQgS5skU3N0tS",
-    "description" : "cFqJz3xnPJbHol3"
+    "id" : "https://www.example.com/8QKXEH2DihhaAe",
+    "name" : "yILqW2cYZZi",
+    "description" : "aDxIJjiN2hM3D"
   } ],
-  "rightsHolder" : "wROOQjD8djS4UgCUE5",
-  "duplicateOf" : "https://www.example.org/427de50e-9230-4d30-b765-db18b9c4b9fb",
+  "rightsHolder" : "kesUb5EtcnqQw",
+  "duplicateOf" : "https://www.example.org/8de6fb83-c7e9-4b5d-afb6-3e2567e8fab1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "A2PAg4NBII"
+    "note" : "Oxx8P4AIJqDw9W"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jDeUTBltjMpRuSayquE",
-    "createdBy" : "3JKqmdu7LbtmvFU",
-    "createdDate" : "1976-06-02T06:09:10.756Z"
+    "note" : "aSbOnI5helt0QC0",
+    "createdBy" : "15h1hhpDAklc1w",
+    "createdDate" : "1992-04-19T16:06:22.126Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e3b98a8e-d91e-4064-a656-eaf4fdca96bb" ],
+  "curatingInstitutions" : [ "https://www.example.org/7af11775-0146-448e-93be-bd5852f7349f" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/LiteraryArts.json
+++ b/documentation/LiteraryArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "SiGBx6wvkYNRvyTn8",
-    "ownerAffiliation" : "https://www.example.org/bd80f170-1d6b-4f28-9538-a4a0c7d8e5ce"
+    "owner" : "0iWT7iAuAn7RTH",
+    "ownerAffiliation" : "https://www.example.org/8ddc1b05-e3ca-45f4-8c86-6fa421fb50e3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/79cea8a7-c8e1-4a03-b5af-770952081290"
+    "id" : "https://www.example.org/a219ea03-0b6a-4519-81fd-491c26573042"
   },
-  "createdDate" : "2004-11-22T16:39:43.215Z",
-  "modifiedDate" : "2022-01-18T06:17:49.936Z",
-  "publishedDate" : "1978-06-10T09:39:39.567Z",
-  "indexedDate" : "1987-06-24T15:02:32.184Z",
-  "handle" : "https://www.example.org/f577f1cb-7be7-4327-8aa6-705116dcb131",
-  "doi" : "https://doi.org/10.1234/ipsa",
-  "link" : "https://www.example.org/2b0bd5ac-006d-48c3-ad5b-77fa93149ba4",
+  "createdDate" : "1971-08-27T09:12:10.732Z",
+  "modifiedDate" : "1973-05-23T18:28:14.389Z",
+  "publishedDate" : "1997-10-05T18:19:06.998Z",
+  "indexedDate" : "1984-01-24T13:15:44.820Z",
+  "handle" : "https://www.example.org/c5a8f98f-40d0-4454-8367-5a696fd58d6c",
+  "doi" : "https://doi.org/10.1234/omnis",
+  "link" : "https://www.example.org/9ab8e4cf-7ade-4e1b-98fd-84446527b1cb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "BiwMwNVr4CFsGjhBJ",
+    "mainTitle" : "7d2SYZXRx9c5Aoz",
     "alternativeTitles" : {
-      "es" : "FAtoWBcEoD1"
+      "nn" : "trV8t7f6ng7"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "yyhhaY928Wn1ee",
-      "month" : "J0pkQTv8HQCjqfTlYA9",
-      "day" : "f67dt6f6b6k"
+      "year" : "e6PyrsEUUegRdsAy",
+      "month" : "rGUxQw7zYY4Z",
+      "day" : "EYK9Mghq75J2T"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/627087a9-00ff-49a1-8df7-b10ad2cd5244",
-        "name" : "byn7ajl6zgao",
+        "id" : "https://www.example.org/c3dfb836-b796-487b-8c6e-8ae3508a63ae",
+        "name" : "51tV9cX50NTpM6wB",
         "nameType" : "Personal",
-        "orcId" : "mD8qnJYdVxGJiLaCL4e",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "x43PNNndPVYdYv",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IJJoqfNxGbsBZ",
-          "value" : "9GGysSQWyHQoqj6b9Z5"
+          "sourceName" : "1bUzCKerLdH5RuNp",
+          "value" : "SzKJHFZiJbDmhu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "E2HXVOzkZ6nD2oh",
-          "value" : "ILboX7xIKo7Xdxum18T"
+          "sourceName" : "YDWYHOmw2wxe75",
+          "value" : "gcGNADN8Xs3Ss"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f408c36b-d3d3-4f28-8c16-07ef234bce15"
+        "id" : "https://www.example.org/210ff190-4b73-46c1-a80b-d4a3bd69361e"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,43 +62,43 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f866509f-a957-4df6-a480-13cc79310b5e",
-        "name" : "ZCfLc4slQh",
+        "id" : "https://www.example.org/f44e5e31-7937-454c-a9a7-ed901f7f8715",
+        "name" : "e26HyATxbDsJ",
         "nameType" : "Personal",
-        "orcId" : "ENgUcbPmtIP3",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "T9RzOwTtEbb9Wa",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Wa6Jceu9MCENmXx5wV",
-          "value" : "FEvxNH7YXMQ22L8u"
+          "sourceName" : "wUlI0dmPAoV",
+          "value" : "lLoAIgn8rNMGGGz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ftY7FVFGKUdfo9B",
-          "value" : "mWsrwqfcmYgxjBct7Xu"
+          "sourceName" : "49HNdY6XuCBZFsNdI",
+          "value" : "8z8gwC9jku"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e37b99f5-46e4-43d0-b3f8-5e54686abd5d"
+        "id" : "https://www.example.org/0c2ad0f3-bb78-4743-9795-8383677e2bbd"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "XtxeWoX23IOXSHCzFFB"
+      "en" : "oHBFtuFK4rkLYYv"
     },
-    "npiSubjectHeading" : "ZBAqRDUxluRCcXNSw",
-    "tags" : [ "ITCMyY7M809g" ],
-    "description" : "PSJlIUjFDz9EPzj6iEQ",
+    "npiSubjectHeading" : "3otkBlBnbpd",
+    "tags" : [ "yFUh7BAUiW" ],
+    "description" : "NtAb32AcG17H",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/9cecc3a7-f97e-473d-b7e4-f8d89997a330",
+      "doi" : "https://www.example.org/1dfbb101-4623-42ae-9ed4-b69756adca1a",
       "publicationInstance" : {
         "type" : "LiteraryArts",
         "subtype" : {
@@ -108,164 +108,166 @@
           "type" : "LiteraryArtsMonograph",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "axHJD7CXHIgOPtqy",
+            "name" : "VboGcQPTCOeyonChm",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "4D5f8cVcZs1K2f",
-            "month" : "ETCs9mciGix8BgSz0O",
-            "day" : "vkeEcuSQrsXJFJTb1N"
+            "year" : "QnsoiNmgzsWD53RK",
+            "month" : "eLCBf0JDaEJ",
+            "day" : "YO2KaG6KMi"
           },
           "isbnList" : [ "9780099470434" ],
           "pages" : {
             "type" : "MonographPages",
             "introduction" : {
               "type" : "Range",
-              "begin" : "rVhyCWFQbuVfLjrnxdd",
-              "end" : "fzOmcHJLdXDRyP"
+              "begin" : "9o4VZLfDWuNa6I7dd",
+              "end" : "KYSUF80eb7sCdFp"
             },
-            "pages" : "MR6sIwaiq0b0LGUVhBc",
+            "pages" : "eGd8sFL9g4KbVxKX",
             "illustrated" : true
           }
         }, {
           "type" : "LiteraryArtsAudioVisual",
           "subtype" : {
             "type" : "LiteraryArtsAudioVisualOther",
-            "description" : "lw1ls42vXrqJgk3mJ"
+            "description" : "fsSE1ZfMpWPg"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "qRM5lrM7c4oMCrOZbO",
+            "name" : "d4nOpmwRDIZ2jw13PuK",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "VpSpn3Z49fa",
-            "month" : "HRtFNfEMdq4saV",
-            "day" : "zM5ZjBE3IsGxAODAi6"
+            "year" : "29tgNtpOp6Oe2Cz8",
+            "month" : "1jWNybWNcxqCaG",
+            "day" : "Ni9hYz8PSMpt"
           },
           "isbnList" : [ "9780099470434" ],
-          "extent" : 1537899248
+          "extent" : 931426263
         }, {
           "type" : "LiteraryArtsPerformance",
           "subtype" : {
-            "type" : "Reading"
+            "type" : "LiteraryArtsPerformanceOther",
+            "description" : "qDAng51r3YBOBVM"
           },
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "qsOSQLkoUyb",
-            "country" : "460UaHGhKllSPYwMO4d"
+            "label" : "ZfumF18U1JgJhS6t",
+            "country" : "KhQDNFlm3nH"
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "4OUPQL2q6X",
-            "month" : "CZdSlvZbwLz",
-            "day" : "kgDIbEI87loHyj0vDS"
+            "year" : "O5VgpQ7P3pDSefd2O",
+            "month" : "NWhUXdZWCT",
+            "day" : "8gBkAggZcUVADH"
           }
         }, {
           "type" : "LiteraryArtsWeb",
-          "id" : "https://www.example.com/jGsTXipc0V0BDzIgc",
+          "id" : "https://www.example.com/0modHHiPaWNcJOSqJ",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "W4j6ssxwJ0d",
+            "name" : "Tj9qm5VRLaY2wWk9",
             "valid" : true
           },
           "publicationDate" : {
             "type" : "PublicationDate",
-            "year" : "znSa03xtvkX",
-            "month" : "kUjvwkqdXQe3U7Edix",
-            "day" : "EJYi7xQ19XBGHj"
+            "year" : "SskHbcXBv0NPq",
+            "month" : "qQwP88DsnQzAYDtX",
+            "day" : "HuqKAnvhnS"
           }
         } ],
-        "description" : "RvvomRbdcyTi",
+        "description" : "ByGOpDEusJmjN8a1",
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d23a0837-80b6-4637-8edb-572f02c8ca5b",
-    "abstract" : "c5BlZ7nFHMBP"
+    "metadataSource" : "https://www.example.org/f451c421-4c48-40d3-9570-319989eed72a",
+    "abstract" : "RnK1Gun9frQA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a59cf98d-207d-495a-9640-5dc4d40890c7",
-    "name" : "qrvELjKLENn8",
+    "id" : "https://www.example.org/7a0ec2c0-1e3a-4436-9fa4-26ba90179bd1",
+    "name" : "O9OhVYGCyiW8MW1",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2010-05-04T20:27:50.088Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "ZhgGp9FLaQDsut5"
+      "approvalDate" : "2005-05-01T21:28:52.629Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "m3yVMMUgOmK0W1Tzm"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/87b3f36b-98c0-4c76-9743-25e9a8736adc",
-    "identifier" : "i23wpjML8FArmSh3",
+    "source" : "https://www.example.org/2ad40ff2-3638-4b2e-8884-b24ba43417d9",
+    "identifier" : "hPnVnyvG2aW",
     "labels" : {
-      "nn" : "3bjTW71cwbpkMlMRIE"
-    },
-    "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2027772786
-    },
-    "activeFrom" : "1990-05-19T19:50:37.749Z",
-    "activeTo" : "1995-08-18T09:00:20.885Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/affdf105-c05c-40d1-8d6e-3475ae0fc5ad",
-    "id" : "https://www.example.org/5e41c5be-2e9b-49fa-b5da-93b9485dd6cc",
-    "identifier" : "dAZM8kbfXf",
-    "labels" : {
-      "pl" : "rsduuG9gkfa"
+      "nb" : "IbxPfHnes195UhIGk"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1303885430
+      "amount" : 162233688
     },
-    "activeFrom" : "1987-05-25T08:59:47.299Z",
-    "activeTo" : "2013-10-23T09:21:32.310Z"
+    "activeFrom" : "1975-06-29T11:39:57.668Z",
+    "activeTo" : "2002-01-17T21:40:25.626Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/243e55c8-3594-409f-9e3c-b0f7a8747e40",
+    "id" : "https://www.example.org/efdb01d4-5588-469e-8c02-b750f8d9f31a",
+    "identifier" : "lLGljQ07R9kd2H4k",
+    "labels" : {
+      "pl" : "bpPVTG22vLpCl3L"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 129322751
+    },
+    "activeFrom" : "2016-03-05T06:40:30.526Z",
+    "activeTo" : "2017-11-22T01:49:15.820Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/4f7c7340-c2fa-4bb3-8607-44b3615d9643" ],
+  "subjects" : [ "https://www.example.org/00a072a3-185f-4a0d-a41c-0f9a1e8c6af2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "efd22186-63dc-4e6e-82e4-4df300da6a4f",
-    "name" : "qf4DyCVauUGhmJmdP",
-    "mimeType" : "4ppZsVhtUtOi8UG",
-    "size" : 1847589232,
-    "license" : "https://www.example.com/xzqxior0tby",
+    "identifier" : "dd9f0548-8ea3-482a-992a-45b5752686fd",
+    "name" : "2Z8ZOM69SFLoaQSQMZZ",
+    "mimeType" : "kJuJq2I3mUVB",
+    "size" : 1637083537,
+    "license" : "https://www.example.com/qpz0tm5isic0paraq",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ndLRKEBakDJsTcF",
-    "publishedDate" : "1999-12-26T21:11:43.065Z",
+    "legalNote" : "yVyG0kf7WgxJ",
+    "publishedDate" : "2009-11-17T20:02:49.328Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/02rJmvInJuyg",
-    "name" : "7c1GgtVlaxv1gwGHM",
-    "description" : "HBRieUl89J8O"
+    "id" : "https://www.example.com/7C4AcaGejK8",
+    "name" : "02XQgS5skU3N0tS",
+    "description" : "cFqJz3xnPJbHol3"
   } ],
-  "rightsHolder" : "UdN0xDESoSqK6nV4",
-  "duplicateOf" : "https://www.example.org/a64255aa-5836-4f81-a3c9-fdab680f100f",
+  "rightsHolder" : "wROOQjD8djS4UgCUE5",
+  "duplicateOf" : "https://www.example.org/427de50e-9230-4d30-b765-db18b9c4b9fb",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "jEz7QSq1f7G7XkfB"
+    "note" : "A2PAg4NBII"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "nnPJdL4FmQBgAqC",
-    "createdBy" : "FShs1HQVcUEVN0C",
-    "createdDate" : "2001-08-20T05:15:41.090Z"
+    "note" : "jDeUTBltjMpRuSayquE",
+    "createdBy" : "3JKqmdu7LbtmvFU",
+    "createdDate" : "1976-06-02T06:09:10.756Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/40a41e55-3022-49ce-8574-bb157b811642" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/e3b98a8e-d91e-4064-a656-eaf4fdca96bb" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "7ShHHjXXJRugDjqb",
-    "ownerAffiliation" : "https://www.example.org/55933b6b-dbac-4ef5-ba91-df673323d36f"
+    "owner" : "0vLRLZOwbwz",
+    "ownerAffiliation" : "https://www.example.org/2833032e-a8fc-4235-bf8c-cc136106685b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/fef2e361-ad79-4499-82c9-b9dfdf825683"
+    "id" : "https://www.example.org/dfd3be80-8941-4986-91dd-33da1d0327a0"
   },
-  "createdDate" : "2006-06-25T05:28:11.490Z",
-  "modifiedDate" : "1983-08-12T16:01:29.877Z",
-  "publishedDate" : "2005-12-02T10:38:34.564Z",
-  "indexedDate" : "1988-12-31T17:20:42.217Z",
-  "handle" : "https://www.example.org/e96e695f-f171-446a-abf2-5c9bb1407bdc",
-  "doi" : "https://doi.org/10.1234/exercitationem",
-  "link" : "https://www.example.org/0de0a53f-203f-4335-a302-3a64eef670e3",
+  "createdDate" : "1973-10-25T02:06:55.006Z",
+  "modifiedDate" : "1991-04-04T23:38:26.518Z",
+  "publishedDate" : "1994-12-02T01:58:53.673Z",
+  "indexedDate" : "2017-12-11T14:22:34.270Z",
+  "handle" : "https://www.example.org/00d983e7-1454-46df-8aec-71e71612da09",
+  "doi" : "https://doi.org/10.1234/excepturi",
+  "link" : "https://www.example.org/a2c47910-d7eb-4460-b0ee-7f6b10d432f8",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Q4OBZUhPl5xnf",
+    "mainTitle" : "VHVOJGnuXcCw9BMsVLm",
     "alternativeTitles" : {
-      "zh" : "z6MstEUc1kCzH"
+      "hu" : "DarDTvscSc9zwNoLqI"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "RTxL59MEUdsBD",
-      "month" : "6Zy3QBt26n",
-      "day" : "lrJBc0yQWLLMnRE"
+      "year" : "Z2QAe9NrWLayNX9dT",
+      "month" : "ysY6WV1SehD3d1aNx",
+      "day" : "SIQG0k7F24F"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aa7500d3-5611-4523-b12e-4368b625c6dd",
-        "name" : "TJZ4xtJaq0AYqtyXXl",
+        "id" : "https://www.example.org/80a7ffe1-7749-4b0b-abb8-8ace2e994426",
+        "name" : "Yr5XOcq4jgEZDdt4ZGV",
         "nameType" : "Personal",
-        "orcId" : "yBYWBV4FHU",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "WXD9fUwLnLuZRHd",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bXTgnPQWnx",
-          "value" : "6l9V6gT32a2Lp6L"
+          "sourceName" : "3Z78pmXi1oGq",
+          "value" : "lkxrcJqK56Q77DOK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BU7rgGXr8iUZnKJf",
-          "value" : "M9hplsIf6hhNt3E"
+          "sourceName" : "dvYetM9fHKqeo0tN",
+          "value" : "w8pZ2Ot99hN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ee150722-2559-48c3-8587-ec8e77031a38"
+        "id" : "https://www.example.org/d6ce876d-a2a0-4666-935e-a6099d8e1e67"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,146 +62,151 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9a0c7859-3c13-4049-b9b0-1ce658676308",
-        "name" : "jADIJbCeflxr",
+        "id" : "https://www.example.org/db02d3cb-12fb-438d-912d-dd16b1db75ac",
+        "name" : "PzGzzZvnPhd",
         "nameType" : "Personal",
-        "orcId" : "clLhG7OCTW3TFneQ4",
-        "verificationStatus" : "Verified",
+        "orcId" : "lxcRCxcG53hDD1IKVf",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3aAcbcSzvbh87C",
-          "value" : "h6AyemzhbQy43Bpw"
+          "sourceName" : "9enTa6uTw5b",
+          "value" : "vwk7NnQhIHDDbD0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dV7ZzP91d6Pu3UL",
-          "value" : "Ao8wW4RFD58j869v"
+          "sourceName" : "NkaV1v4xoFKjo",
+          "value" : "Xkp0le6UaPMN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8633e2ed-2255-4396-968e-87e17191391a"
+        "id" : "https://www.example.org/d9225bde-2a6e-4c80-aee3-71eb88419e50"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "tvdmMGt3wyo98ZiV9Fn"
+      "it" : "45X8gAB60Xkwi8"
     },
-    "npiSubjectHeading" : "zV6zTBNiG2BXgpd",
-    "tags" : [ "ZYYdmDfS7Gf" ],
-    "description" : "6zGlDUjULvZsIjEg",
+    "npiSubjectHeading" : "qOj0pCNDTt",
+    "tags" : [ "TlmZatfRWoB" ],
+    "description" : "Uc4L1jZNb9ChpmK",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7eac6f2f-d196-4668-a5c1-51776f0d2037",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c4e1580a-be3a-4196-91e7-4b65f11a7324",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/06ddaa82-cd21-4c95-ab31-2f10b7d6c124",
+      "doi" : "https://www.example.org/997cbe72-073f-4182-8d03-c1834d3c742d",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "1gwNNoYqwSgt",
+        "description" : "9Ru9xPgJA5Klu0",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Yd0MfCJhA5l2vsa2ip",
-            "end" : "CXzjRQIP7g8P"
+            "begin" : "fCNZxWVHpC",
+            "end" : "f8V7IzykuEtUiort"
           },
-          "pages" : "DKuocU4loAeDOHd",
-          "illustrated" : true
+          "pages" : "tNnpvocfXT1I",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/43a470f0-b11c-47e7-92ba-9de8f14faeb2",
-    "abstract" : "VGYs0KTMJbqr"
+    "metadataSource" : "https://www.example.org/9825bef0-63f2-4cb3-adc7-d4aef7366edc",
+    "abstract" : "OAc43LmJfLU1TU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1fe0ee78-883b-4b48-a3d0-2c52883f78c1",
-    "name" : "aQqKfzu0qVH",
+    "id" : "https://www.example.org/3e72a5bd-5341-41e2-8148-0529f740aa1c",
+    "name" : "cUBZxjftNvk7g",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2020-05-28T23:02:58.954Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "PY4eY02zaln"
+      "approvalDate" : "1997-08-25T06:52:18.401Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "D2vQgGiVwZhSllK16D2"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6eb3bb6a-0629-4483-9525-916c1be13018",
-    "identifier" : "Y3tjflDFsFW5kmcuhgT",
+    "source" : "https://www.example.org/d77e7413-e924-45e3-8117-4bfffd4653c1",
+    "identifier" : "fxMD4FtbeAJZE48DiK",
     "labels" : {
-      "hu" : "NJ4dnlL9yi99Omo5Tm"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 243400634
-    },
-    "activeFrom" : "1979-04-01T17:42:58.465Z",
-    "activeTo" : "2006-06-12T14:26:38.436Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/76471897-b8c4-4832-b1d1-951b124ae304",
-    "id" : "https://www.example.org/2d0f2d3e-ef7f-41d0-99e7-706f0cc0cdaa",
-    "identifier" : "imZHxF4vSu",
-    "labels" : {
-      "zh" : "DcW9Hi4B50jyCmH6xKT"
+      "pt" : "q91vFTbJDguau"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 2064513068
+      "amount" : 298918796
     },
-    "activeFrom" : "2007-07-10T07:28:43.954Z",
-    "activeTo" : "2021-11-04T23:55:20.292Z"
+    "activeFrom" : "1972-08-10T06:36:16.822Z",
+    "activeTo" : "2008-01-25T21:09:41.968Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/c332ef1e-c89e-4bed-8870-e6878d6b44f7",
+    "id" : "https://www.example.org/7daebea6-3ea9-4ba4-98fe-9809f3d13583",
+    "identifier" : "AcRwAktPphmTeaw",
+    "labels" : {
+      "ru" : "qsmQJAMQBDN"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 503541449
+    },
+    "activeFrom" : "1995-04-22T13:33:56.234Z",
+    "activeTo" : "2004-04-23T19:04:41.016Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/da712bd8-851d-4187-8940-6b30e9927db1" ],
+  "subjects" : [ "https://www.example.org/ec7df7dc-03ee-4f14-8332-48bb3eedd29e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b8fb7a11-edc9-433b-8a26-3ad7df3eecd7",
-    "name" : "zoy5EpcTCT2N5e",
-    "mimeType" : "Z5V3EzGMq7P",
-    "size" : 109559200,
-    "license" : "https://www.example.com/lw20kjm0koynvfiwn",
+    "identifier" : "91b0ed05-ec36-4b8d-87e8-991b490d3aa0",
+    "name" : "8UX6YUuIkXZvu",
+    "mimeType" : "h06y2NXm7rnQu",
+    "size" : 851223915,
+    "license" : "https://www.example.com/5rhjnhv2vz8gsoz",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ML55FkywLDGjA6DzV70",
-    "publishedDate" : "2017-06-29T14:45:38.648Z",
+    "legalNote" : "ucBYxfgkUs",
+    "publishedDate" : "1997-03-14T01:19:41.673Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "RdXyx2vNVj",
+      "uploadedDate" : "1979-02-17T13:57:12.153Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SMdJcKFlOJNWxlxF",
-    "name" : "4o6aoxnhii44AvPzgd",
-    "description" : "tinYQNxy5hsdsrRm"
+    "id" : "https://www.example.com/z6e1dHCLlw",
+    "name" : "1pDcfqgQ5m",
+    "description" : "AZa295iRDrrCzJzc0m1"
   } ],
-  "rightsHolder" : "RQWX9VzoCg",
-  "duplicateOf" : "https://www.example.org/7de62423-400b-4854-9e41-5f7b209c1b4c",
+  "rightsHolder" : "uWEHpHtmnpVVwF",
+  "duplicateOf" : "https://www.example.org/2e8738e8-311e-4684-bc4a-a94a714184ba",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "u0iudp8glwh"
+    "note" : "MPRdh8dmkMy"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "rJR7QHF9TPpV",
-    "createdBy" : "HWYlYlxbbphK2S",
-    "createdDate" : "2016-07-10T21:56:22.212Z"
+    "note" : "LOYAinwX9tk",
+    "createdBy" : "YOGT0zi9Mzt",
+    "createdDate" : "1980-04-30T02:19:30.175Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5b7ea2cf-9dd3-4519-a1e5-f182dbf2e0b4" ],
+  "curatingInstitutions" : [ "https://www.example.org/e5078eef-9761-46c6-b4b8-28ccc791f78c" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/Map.json
+++ b/documentation/Map.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "rOZMv1iZ4zu1zMoDLnS",
-    "ownerAffiliation" : "https://www.example.org/2639aef5-9fc6-4d01-8562-be387154fe1e"
+    "owner" : "7ShHHjXXJRugDjqb",
+    "ownerAffiliation" : "https://www.example.org/55933b6b-dbac-4ef5-ba91-df673323d36f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c20dfef8-eb2b-49b6-9696-15b2952d44f9"
+    "id" : "https://www.example.org/fef2e361-ad79-4499-82c9-b9dfdf825683"
   },
-  "createdDate" : "1989-05-05T14:07:24.588Z",
-  "modifiedDate" : "1976-08-03T01:43:53.415Z",
-  "publishedDate" : "2010-08-30T02:10:14.217Z",
-  "indexedDate" : "2014-11-23T10:27:35.272Z",
-  "handle" : "https://www.example.org/c9639aee-bd56-48e4-ba02-a8ef96ff5c84",
-  "doi" : "https://doi.org/10.1234/veritatis",
-  "link" : "https://www.example.org/614d2327-206a-4c2f-a942-2650bdf6c806",
+  "createdDate" : "2006-06-25T05:28:11.490Z",
+  "modifiedDate" : "1983-08-12T16:01:29.877Z",
+  "publishedDate" : "2005-12-02T10:38:34.564Z",
+  "indexedDate" : "1988-12-31T17:20:42.217Z",
+  "handle" : "https://www.example.org/e96e695f-f171-446a-abf2-5c9bb1407bdc",
+  "doi" : "https://doi.org/10.1234/exercitationem",
+  "link" : "https://www.example.org/0de0a53f-203f-4335-a302-3a64eef670e3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1EUyeaAdTMUVI",
+    "mainTitle" : "Q4OBZUhPl5xnf",
     "alternativeTitles" : {
-      "nl" : "ofNYeEC1va3Ek9"
+      "zh" : "z6MstEUc1kCzH"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "e5xtzOyC7Ja",
-      "month" : "PytCaJ18UU2EifR",
-      "day" : "cq0mOuovhPXm"
+      "year" : "RTxL59MEUdsBD",
+      "month" : "6Zy3QBt26n",
+      "day" : "lrJBc0yQWLLMnRE"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ec7b3a65-4828-4db5-9e31-5f31498a8f06",
-        "name" : "TRaN6g01W719ObqH",
+        "id" : "https://www.example.org/aa7500d3-5611-4523-b12e-4368b625c6dd",
+        "name" : "TJZ4xtJaq0AYqtyXXl",
         "nameType" : "Personal",
-        "orcId" : "usaWsAjNNTMtWt",
-        "verificationStatus" : "Verified",
+        "orcId" : "yBYWBV4FHU",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "CgbRmg8TdJWd",
-          "value" : "yULlmbN2CRxUeEjtYTP"
+          "sourceName" : "bXTgnPQWnx",
+          "value" : "6l9V6gT32a2Lp6L"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "J550ewbsxWXEeyIRAr",
-          "value" : "zqhjJ8f4Z7Yox5RbkFy"
+          "sourceName" : "BU7rgGXr8iUZnKJf",
+          "value" : "M9hplsIf6hhNt3E"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7eedd8c7-902f-4e83-b653-14309f54cf2d"
+        "id" : "https://www.example.org/ee150722-2559-48c3-8587-ec8e77031a38"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,145 +62,146 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b0b77a41-fc58-4415-b7bd-e8444287c663",
-        "name" : "Yp7ZlKfHEsTEU0",
-        "nameType" : "Organizational",
-        "orcId" : "Z5V9ljyY7ek31",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/9a0c7859-3c13-4049-b9b0-1ce658676308",
+        "name" : "jADIJbCeflxr",
+        "nameType" : "Personal",
+        "orcId" : "clLhG7OCTW3TFneQ4",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rGVdmxJrsDtkt",
-          "value" : "bhDC3yDw1cKXJGKq"
+          "sourceName" : "3aAcbcSzvbh87C",
+          "value" : "h6AyemzhbQy43Bpw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "buY7rNThXkhg8",
-          "value" : "TFfJmMLMQPs"
+          "sourceName" : "dV7ZzP91d6Pu3UL",
+          "value" : "Ao8wW4RFD58j869v"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/478dc956-370d-40d7-af48-4f6afdfaf617"
+        "id" : "https://www.example.org/8633e2ed-2255-4396-968e-87e17191391a"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "y4pKbIKhUMh4fMlbYy"
+      "se" : "tvdmMGt3wyo98ZiV9Fn"
     },
-    "npiSubjectHeading" : "XvLFofGXET4i678",
-    "tags" : [ "FBwb7v8TV0EuRBJ5EB" ],
-    "description" : "DyOsgVpudKuilHXy",
+    "npiSubjectHeading" : "zV6zTBNiG2BXgpd",
+    "tags" : [ "ZYYdmDfS7Gf" ],
+    "description" : "6zGlDUjULvZsIjEg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "GeographicalContent",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fe55d371-b1b6-4278-a7b9-30a844b01755",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7eac6f2f-d196-4668-a5c1-51776f0d2037",
           "valid" : true
         }
       },
-      "doi" : "https://www.example.org/07d313cc-8cb2-4992-8ea2-6555548296e7",
+      "doi" : "https://www.example.org/06ddaa82-cd21-4c95-ab31-2f10b7d6c124",
       "publicationInstance" : {
         "type" : "Map",
-        "description" : "Z3BTI60e4iqPZaV",
+        "description" : "1gwNNoYqwSgt",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "9rlPMEhBpdQepF6l0kS",
-            "end" : "d6NI05tbdFTmpK"
+            "begin" : "Yd0MfCJhA5l2vsa2ip",
+            "end" : "CXzjRQIP7g8P"
           },
-          "pages" : "VXPHYXwxv2Kk",
-          "illustrated" : false
+          "pages" : "DKuocU4loAeDOHd",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7f1f0ebb-e94f-43b6-95bc-47efbbf87582",
-    "abstract" : "OoZSLzY0Ke"
+    "metadataSource" : "https://www.example.org/43a470f0-b11c-47e7-92ba-9de8f14faeb2",
+    "abstract" : "VGYs0KTMJbqr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0828936e-1d69-4c3b-bd30-ccfa23320706",
-    "name" : "hfCMt2xuO7",
+    "id" : "https://www.example.org/1fe0ee78-883b-4b48-a3d0-2c52883f78c1",
+    "name" : "aQqKfzu0qVH",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2006-12-07T18:49:52.357Z",
-      "approvedBy" : "DIRHEALTH",
+      "approvalDate" : "2020-05-28T23:02:58.954Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "bPxxZ7DDTb2ad"
+      "applicationCode" : "PY4eY02zaln"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c337e737-f44e-4a9a-83d3-85fd5e55547b",
-    "identifier" : "pyzbctybhWcs4DNg",
+    "source" : "https://www.example.org/6eb3bb6a-0629-4483-9525-916c1be13018",
+    "identifier" : "Y3tjflDFsFW5kmcuhgT",
     "labels" : {
-      "es" : "FQ6YsPwjfldZ"
+      "hu" : "NJ4dnlL9yi99Omo5Tm"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1127901847
+      "currency" : "EUR",
+      "amount" : 243400634
     },
-    "activeFrom" : "1980-05-02T10:50:12.595Z",
-    "activeTo" : "1996-12-13T19:55:19.381Z"
+    "activeFrom" : "1979-04-01T17:42:58.465Z",
+    "activeTo" : "2006-06-12T14:26:38.436Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/12a7f00f-f7d2-40d0-9fc1-d6fe521ef17e",
-    "id" : "https://www.example.org/a5ef2865-2e03-412a-89b0-e645e791bd90",
-    "identifier" : "Sy7JBTF9yUrYRDD",
+    "source" : "https://www.example.org/76471897-b8c4-4832-b1d1-951b124ae304",
+    "id" : "https://www.example.org/2d0f2d3e-ef7f-41d0-99e7-706f0cc0cdaa",
+    "identifier" : "imZHxF4vSu",
     "labels" : {
-      "ca" : "NagDg2LvxTYruqT"
+      "zh" : "DcW9Hi4B50jyCmH6xKT"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1832331273
+      "currency" : "GBP",
+      "amount" : 2064513068
     },
-    "activeFrom" : "1972-10-20T05:37:28.163Z",
-    "activeTo" : "1977-07-13T00:46:24.950Z"
+    "activeFrom" : "2007-07-10T07:28:43.954Z",
+    "activeTo" : "2021-11-04T23:55:20.292Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0a47ac59-3c72-47b1-a13c-39a3a075afcc" ],
+  "subjects" : [ "https://www.example.org/da712bd8-851d-4187-8940-6b30e9927db1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d8bf62a9-a1a7-4ee0-a7b6-c21305c09b40",
-    "name" : "tpiUxhMwEKVAyDovBmZ",
-    "mimeType" : "LuKW89HlVy3E",
-    "size" : 1469202392,
-    "license" : "https://www.example.com/wxux3hpttmntfykxn",
+    "identifier" : "b8fb7a11-edc9-433b-8a26-3ad7df3eecd7",
+    "name" : "zoy5EpcTCT2N5e",
+    "mimeType" : "Z5V3EzGMq7P",
+    "size" : 109559200,
+    "license" : "https://www.example.com/lw20kjm0koynvfiwn",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kN4a698ag1vut",
-    "publishedDate" : "1980-10-17T04:49:40.574Z",
+    "legalNote" : "ML55FkywLDGjA6DzV70",
+    "publishedDate" : "2017-06-29T14:45:38.648Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VkxoGlvPh5U",
-    "name" : "R0B9AplIOlq0avqZ1HG",
-    "description" : "f9PyUvSiqaQRyLamvo"
+    "id" : "https://www.example.com/SMdJcKFlOJNWxlxF",
+    "name" : "4o6aoxnhii44AvPzgd",
+    "description" : "tinYQNxy5hsdsrRm"
   } ],
-  "rightsHolder" : "hNqr7lDwWR",
-  "duplicateOf" : "https://www.example.org/5b8ac6eb-f065-4d5d-a9f6-3eb3ab98433b",
+  "rightsHolder" : "RQWX9VzoCg",
+  "duplicateOf" : "https://www.example.org/7de62423-400b-4854-9e41-5f7b209c1b4c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ZJsnI1N1rq8kfZ3PATj"
+    "note" : "u0iudp8glwh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "2SDhpAMnZnGhfz",
-    "createdBy" : "I7UHqH2mIUj9gyQ",
-    "createdDate" : "2008-09-08T01:44:04.587Z"
+    "note" : "rJR7QHF9TPpV",
+    "createdBy" : "HWYlYlxbbphK2S",
+    "createdDate" : "2016-07-10T21:56:22.212Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5036e188-4518-42da-bbee-c757cbe511bf" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/5b7ea2cf-9dd3-4519-a1e5-f182dbf2e0b4" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "7blfqlj0e8J",
-    "ownerAffiliation" : "https://www.example.org/db69230e-9f5e-4886-8d41-07ef0db192ad"
+    "owner" : "XlPlV3PnOHJyLJ",
+    "ownerAffiliation" : "https://www.example.org/4b0791c7-0f38-4e66-a2e2-328a78996432"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/2ab98b5d-aa82-4964-b81d-7ea2e03614e7"
+    "id" : "https://www.example.org/e5459ce7-b7dc-4c20-bfb8-e40082c92c5c"
   },
-  "createdDate" : "1997-11-20T05:35:38.116Z",
-  "modifiedDate" : "1978-12-14T23:44:37.007Z",
-  "publishedDate" : "1976-11-12T03:03:20.466Z",
-  "indexedDate" : "2009-09-03T02:35:19.338Z",
-  "handle" : "https://www.example.org/a24e2d2e-c9b3-45c1-a30b-98b62369bfc5",
-  "doi" : "https://doi.org/10.1234/unde",
-  "link" : "https://www.example.org/74fb8da3-72c4-4204-bcb9-48aa8aab315e",
+  "createdDate" : "2018-02-20T13:42:35.128Z",
+  "modifiedDate" : "2008-07-21T05:07:56.568Z",
+  "publishedDate" : "2014-10-07T22:25:02.772Z",
+  "indexedDate" : "2006-01-21T11:59:55.844Z",
+  "handle" : "https://www.example.org/dd4dba37-9b5b-40e8-bc4e-d1d97eee3fa6",
+  "doi" : "https://doi.org/10.1234/eveniet",
+  "link" : "https://www.example.org/869d61cb-131a-4083-942d-c8dc30a52d97",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0mm9RvkQoF2",
+    "mainTitle" : "76PSoKBxik9TD",
     "alternativeTitles" : {
-      "hu" : "Zl0LuicOJ2GTkA34zy"
+      "is" : "9mOdGQrcJYKrVfBjNh"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zuPj9UBp200cg80",
-      "month" : "CxPnZGh1GCGdu",
-      "day" : "BJlZLONCSe"
+      "year" : "uSPor6ONmqwTKI",
+      "month" : "cj4XBJUeS4zTaLV",
+      "day" : "3ewq1GiXIjZbFDJhVw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d30d3a08-f9f3-444f-9457-83b233e49522",
-        "name" : "9X63uTK9Tt",
-        "nameType" : "Personal",
-        "orcId" : "YKzy1HLbpiBaM",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/4649c129-84a3-4acd-9233-a181cbee1abd",
+        "name" : "FbXb0dYLIE",
+        "nameType" : "Organizational",
+        "orcId" : "x3Il2Oo3nY2UJVTqu",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NCnua2hpJFxKq",
-          "value" : "goBY9CB4zeoSrumeyP"
+          "sourceName" : "3YubN4logHYXLKV",
+          "value" : "AaDC2OCAEjpl"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8BUiKNOZTgY",
-          "value" : "ATtNa8qZTxF"
+          "sourceName" : "OMmY4a04N9uPB0Pt",
+          "value" : "asAzq70giGfSIdMVc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e4a8de9d-e16e-482a-aaaf-353439283f48"
+        "id" : "https://www.example.org/298862a9-f0f2-45dd-b40b-2b6d466eb340"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "fKceNYsw5tQsyBQ"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/79e450a1-7557-445f-b5b7-a627aa1d5858",
-        "name" : "CwEK8I3DY1WmOwD",
+        "id" : "https://www.example.org/f06ce9f0-e9f4-4e00-a39a-940f4e67c50c",
+        "name" : "euP6rER8y6YQ007l",
         "nameType" : "Personal",
-        "orcId" : "JNuJYq8SJNFV",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CcpEvukxTu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0ui3ymsTf5SO6PIUo",
-          "value" : "Qkm7uxKUxjK8"
+          "sourceName" : "XWRa7TFpxTVI",
+          "value" : "bqX40u7wgw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ENi1ogyAWOn",
-          "value" : "RbTYsd9iYS1OHwxjb"
+          "sourceName" : "yfnOASydwqNj76Ig4B",
+          "value" : "uMspvOcOzJnY5gAF8r"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/91e1994c-f14e-4287-9dfb-95bac8b08931"
+        "id" : "https://www.example.org/b4823f5d-6417-4296-ab57-1018ae65e29c"
       } ],
       "role" : {
-        "type" : "LandscapeArchitect"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "ydQFjXzqhr4McnD"
+      "pt" : "AxwbreV0yD"
     },
-    "npiSubjectHeading" : "tvzCZK20cbT6k",
-    "tags" : [ "SmNeT4HwVA5" ],
-    "description" : "WP7sp6RVKYCSgDIYiwq",
+    "npiSubjectHeading" : "Teo6aFDIbFNi",
+    "tags" : [ "9qHhyErTuvlD" ],
+    "description" : "8Zg0RhF4fwzxxN5qsz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Internet"
+          "type" : "TV"
         },
-        "format" : "Video",
-        "disseminationChannel" : "TRDsUQeJfuYtL",
+        "format" : "Text",
+        "disseminationChannel" : "FmU8w9IQ4YPCl7ovfr",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "v1e02FyRPq1lPKCc",
-          "seriesPart" : "Nb8UYWhz5T9Z0"
+          "seriesName" : "eAMvbEWU3sjVgprNed",
+          "seriesPart" : "6zT0xVejxN0A7FCBg"
         }
       },
-      "doi" : "https://www.example.org/bca2c424-7ee6-45f2-99ce-063c51fcc4bd",
+      "doi" : "https://www.example.org/6a7aeb97-dfbf-4d21-9860-7f7423353d19",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -117,89 +116,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/fced37b8-ccc8-45ed-8ce9-ce9043535465",
-    "abstract" : "CejqqrvR7Ib1VTKG8I"
+    "metadataSource" : "https://www.example.org/90416741-b834-498a-8aef-0e0396efcdfa",
+    "abstract" : "QHGN1bPipjpsRpG1"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b9e24d12-f73f-4a35-865c-cf107c1618f0",
-    "name" : "ww2ulDolOhypRE",
+    "id" : "https://www.example.org/84a37eb4-e813-4afb-a163-94d21a5e979c",
+    "name" : "LbY3A3rpLA8Z",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1996-01-04T20:22:59.287Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "PIBzGdxJfnevkthtk"
+      "approvalDate" : "2009-09-03T19:04:52.177Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "xHsxygTIZgBpTc4v"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dbb6035d-a88b-4bfd-9fd8-dd6b30a516a4",
-    "identifier" : "dvwWIbg0bf",
+    "source" : "https://www.example.org/13128fe8-e93b-472d-bb96-431c0d51bddd",
+    "identifier" : "Ax2lIlJlgrM",
     "labels" : {
-      "en" : "3pWDuqkwve9Y4gf"
+      "ru" : "T0RQOj8vY1Y"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1600435836
+      "amount" : 647898363
     },
-    "activeFrom" : "2018-02-19T13:15:07.315Z",
-    "activeTo" : "2023-01-04T04:48:33.379Z"
+    "activeFrom" : "2019-02-02T21:28:45.756Z",
+    "activeTo" : "2023-03-01T13:51:02.448Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e0e77e41-70a6-4a42-8e75-3c9779c38217",
-    "id" : "https://www.example.org/c493e0bb-c035-44aa-a7ef-c9fb605346a4",
-    "identifier" : "7UvA99s7XM",
+    "source" : "https://www.example.org/95904436-8ae5-4d88-9f26-79b036f9e353",
+    "id" : "https://www.example.org/a57c0daf-7c33-4d99-b3b2-0fd852f2f1a2",
+    "identifier" : "yJWdzthyiH",
     "labels" : {
-      "en" : "T2xeuNGZsCRS"
+      "de" : "UYcnCYwrB4"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1115581673
+      "currency" : "NOK",
+      "amount" : 755254615
     },
-    "activeFrom" : "2006-03-24T16:42:50.316Z",
-    "activeTo" : "2009-01-25T13:06:19.968Z"
+    "activeFrom" : "1978-03-05T09:17:04.503Z",
+    "activeTo" : "1988-11-17T15:38:35.852Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ab37c9e3-90bb-4ebd-b9c0-6184f9171892" ],
+  "subjects" : [ "https://www.example.org/047b979d-769f-437d-811a-556a10524904" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6f829a41-a4b0-47cd-a5bd-f085f5029541",
-    "name" : "T5x96agpRGeNtRIY",
-    "mimeType" : "LuxPz5hS2oS7",
-    "size" : 1424193790,
-    "license" : "https://www.example.com/sku62lyslcljdynwry",
+    "identifier" : "ec3c8945-d967-4c45-8da8-bd637cd0bc6c",
+    "name" : "seDyjdk0Im2",
+    "mimeType" : "u9ASqydv5FM",
+    "size" : 1738905899,
+    "license" : "https://www.example.com/1r1li9urrafgph7s",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "kMR1L2FJ4yzv5hY7he3",
-    "publishedDate" : "1974-05-17T14:15:05.662Z",
+    "legalNote" : "UuvR940vAnX60HT",
+    "publishedDate" : "2010-11-16T23:52:42.489Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "M7HpombWvK",
+      "uploadedDate" : "1987-06-04T12:38:28.391Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/E1N0KRudPNKc4hb",
-    "name" : "UuXLp4dZVPBcH2ZMsNZ",
-    "description" : "z6AsxbVPqKVVxmHW6"
+    "id" : "https://www.example.com/Of8NRhDRvVjAE",
+    "name" : "LRi95ODumMeO",
+    "description" : "XbYkCIAkFv5b64"
   } ],
-  "rightsHolder" : "Qgi1OFGtMaLgAo0Xd",
-  "duplicateOf" : "https://www.example.org/176a0588-a35e-454f-b4de-5dd5c86e3243",
+  "rightsHolder" : "X4lHjh3x7p",
+  "duplicateOf" : "https://www.example.org/0e218ae2-9bad-4e56-9b69-70a070997629",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gvbWy7eh286W"
+    "note" : "AYAL0Vmk1EI64"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "I05bkMuJLkNtrDW",
-    "createdBy" : "bD2RSNoE00H8QU7LgaU",
-    "createdDate" : "1988-10-20T08:03:00.086Z"
+    "note" : "DBNfTE00i6",
+    "createdBy" : "REulbOk5ex1x",
+    "createdDate" : "1998-10-02T08:57:36.768Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3dfbfcc4-cf91-473f-9b18-0b76f268fc44" ],
+  "curatingInstitutions" : [ "https://www.example.org/44508dae-949a-41b8-8d57-03773f6b61a0" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MediaBlogPost.json
+++ b/documentation/MediaBlogPost.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "YRfS13uuQvtKZL",
-    "ownerAffiliation" : "https://www.example.org/d607778e-9842-4aa3-b4df-e59e0faefc3b"
+    "owner" : "7blfqlj0e8J",
+    "ownerAffiliation" : "https://www.example.org/db69230e-9f5e-4886-8d41-07ef0db192ad"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9f1400d6-a6a0-4fdd-9f42-a759958335ac"
+    "id" : "https://www.example.org/2ab98b5d-aa82-4964-b81d-7ea2e03614e7"
   },
-  "createdDate" : "2001-08-22T01:50:05.120Z",
-  "modifiedDate" : "2009-08-04T13:51:00.214Z",
-  "publishedDate" : "2020-09-18T13:17:24.234Z",
-  "indexedDate" : "1999-02-20T17:43:38.131Z",
-  "handle" : "https://www.example.org/9a2b988a-3bee-4d64-85c1-c063c6d5248e",
-  "doi" : "https://doi.org/10.1234/possimus",
-  "link" : "https://www.example.org/cda66fa9-1e7c-4250-8e26-13f6de9bd51b",
+  "createdDate" : "1997-11-20T05:35:38.116Z",
+  "modifiedDate" : "1978-12-14T23:44:37.007Z",
+  "publishedDate" : "1976-11-12T03:03:20.466Z",
+  "indexedDate" : "2009-09-03T02:35:19.338Z",
+  "handle" : "https://www.example.org/a24e2d2e-c9b3-45c1-a30b-98b62369bfc5",
+  "doi" : "https://doi.org/10.1234/unde",
+  "link" : "https://www.example.org/74fb8da3-72c4-4204-bcb9-48aa8aab315e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "gwKNEEvBD7Hbb",
+    "mainTitle" : "0mm9RvkQoF2",
     "alternativeTitles" : {
-      "af" : "3vRJbXzOnQbGZ5Mo"
+      "hu" : "Zl0LuicOJ2GTkA34zy"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "NPrN8rOEdueJTi",
-      "month" : "aBMcY6xgQZupTxO",
-      "day" : "VDqpwX7pPeI"
+      "year" : "zuPj9UBp200cg80",
+      "month" : "CxPnZGh1GCGdu",
+      "day" : "BJlZLONCSe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7930a42b-a7e6-4c44-827f-875ca749d3c3",
-        "name" : "6jQFhNs7nJ4",
+        "id" : "https://www.example.org/d30d3a08-f9f3-444f-9457-83b233e49522",
+        "name" : "9X63uTK9Tt",
         "nameType" : "Personal",
-        "orcId" : "e3XI972NkFFs",
-        "verificationStatus" : "Verified",
+        "orcId" : "YKzy1HLbpiBaM",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3aKJpeHBp8T",
-          "value" : "pvLb3fv1s7J1SIz"
+          "sourceName" : "NCnua2hpJFxKq",
+          "value" : "goBY9CB4zeoSrumeyP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "aP4uW4DWEKb",
-          "value" : "Oepg3OYanzw"
+          "sourceName" : "8BUiKNOZTgY",
+          "value" : "ATtNa8qZTxF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/33c679c1-63aa-43d9-8b23-badad0fa08a7"
+        "id" : "https://www.example.org/e4a8de9d-e16e-482a-aaaf-353439283f48"
       } ],
       "role" : {
-        "type" : "DataCollector"
+        "type" : "RoleOther",
+        "description" : "fKceNYsw5tQsyBQ"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +63,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f45a6680-3949-403c-8852-1127fdc50b5f",
-        "name" : "vEsTQqcry3h2jmnzlc2",
-        "nameType" : "Organizational",
-        "orcId" : "cbdqN8raA6Tes5l1Ky",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/79e450a1-7557-445f-b5b7-a627aa1d5858",
+        "name" : "CwEK8I3DY1WmOwD",
+        "nameType" : "Personal",
+        "orcId" : "JNuJYq8SJNFV",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "d685Wavqi9cywJW",
-          "value" : "IwlbG0SedMMPEY5ozRG"
+          "sourceName" : "0ui3ymsTf5SO6PIUo",
+          "value" : "Qkm7uxKUxjK8"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ykMRAs9LBx7Mc1R",
-          "value" : "MBVO3XYFZaSpXj"
+          "sourceName" : "ENi1ogyAWOn",
+          "value" : "RbTYsd9iYS1OHwxjb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/28a7017d-be50-498d-be42-ee363ddd1344"
+        "id" : "https://www.example.org/91e1994c-f14e-4287-9dfb-95bac8b08931"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "is" : "pL0geg7zzoDFpCJje"
+      "ru" : "ydQFjXzqhr4McnD"
     },
-    "npiSubjectHeading" : "EBMOInTzMYI",
-    "tags" : [ "beJj2U0nGN886" ],
-    "description" : "IuJJwVwXrl0hp",
+    "npiSubjectHeading" : "tvzCZK20cbT6k",
+    "tags" : [ "SmNeT4HwVA5" ],
+    "description" : "WP7sp6RVKYCSgDIYiwq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "Internet"
         },
         "format" : "Video",
-        "disseminationChannel" : "l1pKo7MR1qj7Uok",
+        "disseminationChannel" : "TRDsUQeJfuYtL",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "kgyD2jYcHOwmOizJty",
-          "seriesPart" : "wu7ZIrmZoIL"
+          "seriesName" : "v1e02FyRPq1lPKCc",
+          "seriesPart" : "Nb8UYWhz5T9Z0"
         }
       },
-      "doi" : "https://www.example.org/351e19c7-25fc-4601-a629-e43f501d049e",
+      "doi" : "https://www.example.org/bca2c424-7ee6-45f2-99ce-063c51fcc4bd",
       "publicationInstance" : {
         "type" : "MediaBlogPost",
         "pages" : {
@@ -116,89 +117,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9b65dad2-0a58-4a9c-a262-cbd0d30b2173",
-    "abstract" : "AI7u9DYtuqWId1tli4I"
+    "metadataSource" : "https://www.example.org/fced37b8-ccc8-45ed-8ce9-ce9043535465",
+    "abstract" : "CejqqrvR7Ib1VTKG8I"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e08c714a-f7d9-4276-9deb-613220d7e9e0",
-    "name" : "uCEJB0XPdMiS9CZvdj9",
+    "id" : "https://www.example.org/b9e24d12-f73f-4a35-865c-cf107c1618f0",
+    "name" : "ww2ulDolOhypRE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-12-08T00:56:04.424Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Fje1LvmVsw2mJgr"
+      "approvalDate" : "1996-01-04T20:22:59.287Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "PIBzGdxJfnevkthtk"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/dade78ad-5a6b-4af2-a13f-ab651a3656a5",
-    "identifier" : "NERRHAZvjc",
+    "source" : "https://www.example.org/dbb6035d-a88b-4bfd-9fd8-dd6b30a516a4",
+    "identifier" : "dvwWIbg0bf",
     "labels" : {
-      "pl" : "xtOcFpAPLcz7h3"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1097304855
-    },
-    "activeFrom" : "1986-07-09T10:07:01.746Z",
-    "activeTo" : "1987-06-24T01:43:40.401Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ef53dda0-f26e-4b76-87db-e7f1b22ac472",
-    "id" : "https://www.example.org/a4c7ffc4-1a14-49cb-b0db-c030b91e5024",
-    "identifier" : "LhnK3ehoFjPG0xRlk",
-    "labels" : {
-      "it" : "rk80teDVoA9r793a"
+      "en" : "3pWDuqkwve9Y4gf"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1270185441
+      "amount" : 1600435836
     },
-    "activeFrom" : "1973-04-13T17:34:48.238Z",
-    "activeTo" : "1988-01-12T17:33:49.875Z"
+    "activeFrom" : "2018-02-19T13:15:07.315Z",
+    "activeTo" : "2023-01-04T04:48:33.379Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/e0e77e41-70a6-4a42-8e75-3c9779c38217",
+    "id" : "https://www.example.org/c493e0bb-c035-44aa-a7ef-c9fb605346a4",
+    "identifier" : "7UvA99s7XM",
+    "labels" : {
+      "en" : "T2xeuNGZsCRS"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1115581673
+    },
+    "activeFrom" : "2006-03-24T16:42:50.316Z",
+    "activeTo" : "2009-01-25T13:06:19.968Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/15ecb00b-cdb7-4a1e-b7c0-0b35c8161c52" ],
+  "subjects" : [ "https://www.example.org/ab37c9e3-90bb-4ebd-b9c0-6184f9171892" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "0679ac2f-5dd9-4047-a660-1686dee5656d",
-    "name" : "ekRiBWNpvzobiedthtV",
-    "mimeType" : "KknKmFLMQVl",
-    "size" : 236448066,
-    "license" : "https://www.example.com/xl6mtuk6qdfs",
+    "identifier" : "6f829a41-a4b0-47cd-a5bd-f085f5029541",
+    "name" : "T5x96agpRGeNtRIY",
+    "mimeType" : "LuxPz5hS2oS7",
+    "size" : 1424193790,
+    "license" : "https://www.example.com/sku62lyslcljdynwry",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "oKDcLfDhG6i"
+      "type" : "NullRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "9Hsgn4Gv7f4kTT1ahJm",
-    "publishedDate" : "1977-01-28T15:56:06.688Z",
+    "legalNote" : "kMR1L2FJ4yzv5hY7he3",
+    "publishedDate" : "1974-05-17T14:15:05.662Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/KuWEGb4w2mMvcn3OF",
-    "name" : "9GWGYEuDfGa5zOM",
-    "description" : "RT76WOPPmIn55"
+    "id" : "https://www.example.com/E1N0KRudPNKc4hb",
+    "name" : "UuXLp4dZVPBcH2ZMsNZ",
+    "description" : "z6AsxbVPqKVVxmHW6"
   } ],
-  "rightsHolder" : "MUxLxNrNgrMTzgsap",
-  "duplicateOf" : "https://www.example.org/c45a58c5-7056-412f-9dfc-524c28d96bf4",
+  "rightsHolder" : "Qgi1OFGtMaLgAo0Xd",
+  "duplicateOf" : "https://www.example.org/176a0588-a35e-454f-b4de-5dd5c86e3243",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5wJKElGy2JXi"
+    "note" : "gvbWy7eh286W"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "M10UrJJ0PD",
-    "createdBy" : "Wf4wPALQ7gcMw",
-    "createdDate" : "2007-01-22T17:27:18.847Z"
+    "note" : "I05bkMuJLkNtrDW",
+    "createdBy" : "bD2RSNoE00H8QU7LgaU",
+    "createdDate" : "1988-10-20T08:03:00.086Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/aa39435a-f258-4729-aa5d-7c3150168809" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/3dfbfcc4-cf91-473f-9b18-0b76f268fc44" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "6cO0j38Dpcwyh",
-    "ownerAffiliation" : "https://www.example.org/fdabfe0b-fa41-46f1-8ea6-4ca7b6507ece"
+    "owner" : "4hGJQGq22TEhS3CM",
+    "ownerAffiliation" : "https://www.example.org/081e7d76-4f9f-404f-a0d3-118ef133022b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/47b0d936-1eb8-4e2f-a4ba-213777c927e1"
+    "id" : "https://www.example.org/cc6e8683-8232-4b45-be45-135251fee601"
   },
-  "createdDate" : "2011-07-29T05:23:58.358Z",
-  "modifiedDate" : "1984-06-12T18:32:41.466Z",
-  "publishedDate" : "2003-12-12T00:04:31.359Z",
-  "indexedDate" : "2007-06-18T06:40:07.996Z",
-  "handle" : "https://www.example.org/755b7816-2e24-41e9-a7e9-90afecd767f8",
-  "doi" : "https://doi.org/10.1234/id",
-  "link" : "https://www.example.org/33c9216e-2e9e-42ff-8614-6d2dfe2cc4fe",
+  "createdDate" : "2024-06-03T06:00:09.714Z",
+  "modifiedDate" : "2014-05-21T20:42:25.420Z",
+  "publishedDate" : "1983-06-28T06:11:43.830Z",
+  "indexedDate" : "2003-09-20T06:55:37.409Z",
+  "handle" : "https://www.example.org/8b8d5eea-27c0-4f32-beb6-73a0cc51e569",
+  "doi" : "https://doi.org/10.1234/fugiat",
+  "link" : "https://www.example.org/56de1a92-13e4-4f37-89d4-8dada2086b5a",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "crFEUOZoQRN",
+    "mainTitle" : "8uxKa8udPZxPV",
     "alternativeTitles" : {
-      "it" : "mb0z3BBBApFeNo2b5"
+      "pl" : "uywdWUvv52OfVt2"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "3zxelLKkBleHqy0Lt55",
-      "month" : "raLSB7qLSdXKxH",
-      "day" : "LwtwE1BefGt7OqI"
+      "year" : "gCXxSvXdrbbjZ",
+      "month" : "VVdb1P7A6Rx",
+      "day" : "2wcCHxqslUpFP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94cd2296-8672-497a-aad1-56af6102130a",
-        "name" : "UUB2qcMIg7MGO",
-        "nameType" : "Organizational",
-        "orcId" : "S7GqbaG0Lu",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/ebfd7338-9c53-463c-ad26-48d4639ec0a2",
+        "name" : "XahY3nSyxS",
+        "nameType" : "Personal",
+        "orcId" : "hgW6zceK1i",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NuyKMIpaDrpzQY",
-          "value" : "SQvbWlmXGG"
+          "sourceName" : "8yYpkQw2q1",
+          "value" : "6BuZAGp9Bv1UVQYorcf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "FBebI10ljnYGM53rq",
-          "value" : "mLC6LYbk9t75zaceRYl"
+          "sourceName" : "zb2TXjWPAWak4Z",
+          "value" : "QNQPFNSjJpkXlWN9"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2d13a2ef-1509-4a1e-a937-a347a6f92464"
+        "id" : "https://www.example.org/721279e4-a0d9-4b03-a2d4-d6d34c66779c"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,142 +62,145 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/365fb2dc-dc42-4b0c-9e61-0906c13e3a33",
-        "name" : "zaY5CPRrQ5Xh6n3ndW",
+        "id" : "https://www.example.org/7a8599a5-bd66-4010-8e64-34828fc0e2ac",
+        "name" : "FwukTFeG3upJej",
         "nameType" : "Personal",
-        "orcId" : "uF2FvPebj1f4J7G",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "2IIPNPvYvYhqhkd8H3",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IBV1CcxoQNeS",
-          "value" : "8FDag8FOvem"
+          "sourceName" : "WT3GwlLJLpANavSl5Aw",
+          "value" : "w0FRlhgEwdgn90u"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "GYwPP9gyF7W",
-          "value" : "UulVar1k3PMpRwxA"
+          "sourceName" : "Qzb6dSBX16cuQ",
+          "value" : "WauqgZ5w6V6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e1041ac2-42bb-4ea7-9f02-5b168b2282ac"
+        "id" : "https://www.example.org/0a10a5ce-87ca-43f3-ae5e-e0074127345c"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "hu" : "GtVZg2qARYxrJS9"
+      "es" : "ylVuIuYWhMDn49f"
     },
-    "npiSubjectHeading" : "pxO94LAr82tDIwE",
-    "tags" : [ "sgqoqv9m8lvQJPC" ],
-    "description" : "FlGXy0iFGoMA43G4",
+    "npiSubjectHeading" : "0Q5SGCaV3JV0",
+    "tags" : [ "YF74Pzy9xB27ZL" ],
+    "description" : "icGg42kTJ0p",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "UnconfirmedMediaContributionPeriodical",
-        "title" : "jKDdH0LTXUcq2HDP",
-        "printIssn" : "9806-651X",
-        "onlineIssn" : "2019-3203"
+        "type" : "MediaContributionPeriodical",
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e3a77015-8c0c-415c-a2cc-2306b6dbb179"
       },
-      "doi" : "https://www.example.org/9e15eb0f-41fb-4010-8099-0ce857eac5b7",
+      "doi" : "https://www.example.org/63cc6c8a-8dd4-480d-bba0-bd25a7ff6305",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "s8qixz51ygHq",
-        "issue" : "1DAicLWfqjd47E3",
-        "articleNumber" : "ilS1a9vuGsS29siR",
+        "volume" : "geE9BfV9nmbj7",
+        "issue" : "lfjmzVROCAEhWVV7",
+        "articleNumber" : "AJT9cUcbx5S",
         "pages" : {
           "type" : "Range",
-          "begin" : "GPsZ7h1ML7CHyY",
-          "end" : "EgQDXN463SI4Ib"
+          "begin" : "SlJ5h0hW3EkwpA87uBz",
+          "end" : "9OUqSJJbZnUtPW9eHgA"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/12e40d75-97fb-4b97-b7bf-10f75aa54856",
-    "abstract" : "hv2x4NaujzGPm"
+    "metadataSource" : "https://www.example.org/67c361e2-47cf-47f2-8226-23464014342f",
+    "abstract" : "6pdnxdLTnws6dC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/1b7b9e5c-8c25-45db-be9b-d03e96c2ed82",
-    "name" : "l2aBgdvO2Y",
+    "id" : "https://www.example.org/ad871ec4-1439-4492-894b-e54593757d01",
+    "name" : "5RqZqpqwB76xyB",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2003-10-27T08:04:12.371Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "IpMlplMTDtewnp"
+      "approvalDate" : "2005-01-28T15:01:26.745Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "DB4cYOuk9w8yz6"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9d70514b-af8f-44e3-9240-739303797650",
-    "identifier" : "rCY7gsim8t8j",
+    "source" : "https://www.example.org/5c0fb7c0-2389-461a-a7c6-ad39a6ce630c",
+    "identifier" : "7Fj1A41HAuYguS6",
     "labels" : {
-      "se" : "VPugz7pmDv4X1Abd"
+      "ru" : "zAmL2CwQ4RWKsK"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 35446891
+      "amount" : 1871542710
     },
-    "activeFrom" : "1995-01-21T13:48:23.717Z",
-    "activeTo" : "2008-02-03T23:59:29.595Z"
+    "activeFrom" : "1985-08-22T11:05:10.136Z",
+    "activeTo" : "2017-01-21T05:21:02.220Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0126f8c0-58aa-4167-9aad-e8fc1b17f96c",
-    "id" : "https://www.example.org/322fddf7-b413-4ed5-afcd-bf82f0b28820",
-    "identifier" : "9MZ029FthjTLjOR",
+    "source" : "https://www.example.org/ce8f02c1-bc76-4df6-a20b-2c04c17d12c0",
+    "id" : "https://www.example.org/405e445e-4e6a-40b1-b6a1-c922071f52fe",
+    "identifier" : "79RlI3MiHDVD2faf",
     "labels" : {
-      "se" : "T6RMoQfQUbG8T2"
+      "nn" : "4aCpO33uo7LkqJU4wP"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1779191501
+      "currency" : "NOK",
+      "amount" : 1363002575
     },
-    "activeFrom" : "2007-05-18T12:21:18.387Z",
-    "activeTo" : "2012-09-01T08:13:15.644Z"
+    "activeFrom" : "2001-05-06T20:23:31.998Z",
+    "activeTo" : "2006-11-25T14:56:32.839Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/698022cd-70b3-4896-99a2-a8bc6208264d" ],
+  "subjects" : [ "https://www.example.org/9f7245f8-87dc-4d8b-b888-4bc7b185f045" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "b4cb36ba-d603-4a11-954c-efb6585b597f",
-    "name" : "0w7DelPS46TN93G",
-    "mimeType" : "meYgJovrPMFWKU",
-    "size" : 1146412827,
-    "license" : "https://www.example.com/luiu5neadkz",
+    "identifier" : "19565494-1210-4128-884d-8a9827dfffc2",
+    "name" : "SfZvhptoNT",
+    "mimeType" : "1Wt4l0aN03g44ki",
+    "size" : 1639491389,
+    "license" : "https://www.example.com/hmjo6rvektewm7",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "MpKocnuJvkSt5hNiF2"
+      "overriddenBy" : "lXFgXsNXvqy"
     },
-    "legalNote" : "x1WnJZ59x9pqU",
-    "publishedDate" : "2004-12-17T18:10:22.525Z",
+    "legalNote" : "jSp6CjcVNrpy",
+    "publishedDate" : "2015-08-12T02:21:40.819Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "01noNIiqappMc",
+      "uploadedDate" : "1977-08-26T20:27:19.347Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gG9zxKF5tjKAuDNTiv",
-    "name" : "Evzwn409Myd0No8",
-    "description" : "CNDW9LwVTtbFJxVh1zU"
+    "id" : "https://www.example.com/KVreyKUxiDs",
+    "name" : "GdQ4wFWHjPo4GVF",
+    "description" : "9FEIe2anarqvaGl4Bra"
   } ],
-  "rightsHolder" : "ZE0DFgOgNyNOPzFxXw",
-  "duplicateOf" : "https://www.example.org/4268bae2-185d-47cc-bf96-af20900c2808",
+  "rightsHolder" : "b50ssYU9pwqD0",
+  "duplicateOf" : "https://www.example.org/cbf2d3f5-90c6-4921-bdc2-50348f06a8b0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "TRKpfCeN3n7W5z"
+    "note" : "wjpxkHcOqaq8VKGwh"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "DHtl2QWL6M",
-    "createdBy" : "u2il2oR8ken3k2t",
-    "createdDate" : "1985-07-06T05:27:53.187Z"
+    "note" : "pklutsjJGY",
+    "createdBy" : "PV93gwnPgincH255",
+    "createdDate" : "2018-04-10T18:48:18.156Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/123f84f3-f469-4d44-822e-c8e8f744d5b9" ],
+  "curatingInstitutions" : [ "https://www.example.org/7c8f50c0-4fcd-488c-b034-4403101ba95c" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MediaFeatureArticle.json
+++ b/documentation/MediaFeatureArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "0nb99WO7xqWmLiVL",
-    "ownerAffiliation" : "https://www.example.org/0872e1bd-7cf9-4162-ac94-308f57d00bd6"
+    "owner" : "6cO0j38Dpcwyh",
+    "ownerAffiliation" : "https://www.example.org/fdabfe0b-fa41-46f1-8ea6-4ca7b6507ece"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4868ddab-34d5-4ffe-9dbd-d1aeb83885ab"
+    "id" : "https://www.example.org/47b0d936-1eb8-4e2f-a4ba-213777c927e1"
   },
-  "createdDate" : "2012-05-27T19:32:59.945Z",
-  "modifiedDate" : "1985-10-30T02:53:41.107Z",
-  "publishedDate" : "1992-07-21T09:46:07.335Z",
-  "indexedDate" : "1996-11-16T13:18:14.671Z",
-  "handle" : "https://www.example.org/9bb88afa-ee16-4d7e-a470-9a991c681d82",
-  "doi" : "https://doi.org/10.1234/iste",
-  "link" : "https://www.example.org/600ea418-4825-476f-9f9d-8a2cb35f3992",
+  "createdDate" : "2011-07-29T05:23:58.358Z",
+  "modifiedDate" : "1984-06-12T18:32:41.466Z",
+  "publishedDate" : "2003-12-12T00:04:31.359Z",
+  "indexedDate" : "2007-06-18T06:40:07.996Z",
+  "handle" : "https://www.example.org/755b7816-2e24-41e9-a7e9-90afecd767f8",
+  "doi" : "https://doi.org/10.1234/id",
+  "link" : "https://www.example.org/33c9216e-2e9e-42ff-8614-6d2dfe2cc4fe",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "f69RQfqoXdTNYKgL",
+    "mainTitle" : "crFEUOZoQRN",
     "alternativeTitles" : {
-      "se" : "KBzEHpqMZjSFrw2J"
+      "it" : "mb0z3BBBApFeNo2b5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "MG8uyiYp9jVV",
-      "month" : "z76RqSOKml4",
-      "day" : "1kUyUp0oFNUMSWF5O3d"
+      "year" : "3zxelLKkBleHqy0Lt55",
+      "month" : "raLSB7qLSdXKxH",
+      "day" : "LwtwE1BefGt7OqI"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/37752110-c75a-4638-8f9e-2e4b1591022d",
-        "name" : "dpGMZgupXLm2UqQx",
-        "nameType" : "Personal",
-        "orcId" : "9YhXYFZLdO",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/94cd2296-8672-497a-aad1-56af6102130a",
+        "name" : "UUB2qcMIg7MGO",
+        "nameType" : "Organizational",
+        "orcId" : "S7GqbaG0Lu",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uuYohs5HSrqaLbjH",
-          "value" : "Eq09s2a8REFvl6X8C"
+          "sourceName" : "NuyKMIpaDrpzQY",
+          "value" : "SQvbWlmXGG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "fNGNcWCLaVptx",
-          "value" : "DyLDWaOxCvbqC"
+          "sourceName" : "FBebI10ljnYGM53rq",
+          "value" : "mLC6LYbk9t75zaceRYl"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/456736df-0f4a-481a-91fb-4fd835ff4191"
+        "id" : "https://www.example.org/2d13a2ef-1509-4a1e-a937-a347a6f92464"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "Editor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,142 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/08c0e962-5d92-4f54-b72a-049fa361d130",
-        "name" : "Caj0Fo9IsDyvA",
-        "nameType" : "Organizational",
-        "orcId" : "VbiPrIqfVTlh",
+        "id" : "https://www.example.org/365fb2dc-dc42-4b0c-9e61-0906c13e3a33",
+        "name" : "zaY5CPRrQ5Xh6n3ndW",
+        "nameType" : "Personal",
+        "orcId" : "uF2FvPebj1f4J7G",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "RNHPt5pNtPEZDu4fLHY",
-          "value" : "cFfodEauMzPkk"
+          "sourceName" : "IBV1CcxoQNeS",
+          "value" : "8FDag8FOvem"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zXojNeY2dFTQzS",
-          "value" : "JKbjdDlW7WJ"
+          "sourceName" : "GYwPP9gyF7W",
+          "value" : "UulVar1k3PMpRwxA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/831c777d-bf0a-4e4e-8d99-b076ee304cf4"
+        "id" : "https://www.example.org/e1041ac2-42bb-4ea7-9f02-5b168b2282ac"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "Scenographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "5G8Kd3A5DjG"
+      "hu" : "GtVZg2qARYxrJS9"
     },
-    "npiSubjectHeading" : "V1KVsEtosJ6dqQeHn",
-    "tags" : [ "JltLzV5iNBtDMeYh" ],
-    "description" : "gVAAm47ZKUoMVmOM",
+    "npiSubjectHeading" : "pxO94LAr82tDIwE",
+    "tags" : [ "sgqoqv9m8lvQJPC" ],
+    "description" : "FlGXy0iFGoMA43G4",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
-        "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e44b63c9-793d-4d46-8f8d-2c8511fe69ea"
+        "type" : "UnconfirmedMediaContributionPeriodical",
+        "title" : "jKDdH0LTXUcq2HDP",
+        "printIssn" : "9806-651X",
+        "onlineIssn" : "2019-3203"
       },
-      "doi" : "https://www.example.org/4bd93400-b463-4f8e-ab2d-cb361b721d40",
+      "doi" : "https://www.example.org/9e15eb0f-41fb-4010-8099-0ce857eac5b7",
       "publicationInstance" : {
         "type" : "MediaFeatureArticle",
-        "volume" : "XpQ3x7DiZ7pM",
-        "issue" : "u8ou94YClDID0FUmNtC",
-        "articleNumber" : "Rq0ROBlagkb",
+        "volume" : "s8qixz51ygHq",
+        "issue" : "1DAicLWfqjd47E3",
+        "articleNumber" : "ilS1a9vuGsS29siR",
         "pages" : {
           "type" : "Range",
-          "begin" : "HAahXT3pyQBlgTfpN",
-          "end" : "rHucKuVrSnCN8"
+          "begin" : "GPsZ7h1ML7CHyY",
+          "end" : "EgQDXN463SI4Ib"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/57ba9043-543b-4dde-b9a1-e49562415dfd",
-    "abstract" : "tTP97k9hzCdbg137q"
+    "metadataSource" : "https://www.example.org/12e40d75-97fb-4b97-b7bf-10f75aa54856",
+    "abstract" : "hv2x4NaujzGPm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/de17424e-5a05-4d50-a147-9711f97d420b",
-    "name" : "bUhWCoMSnMrC4KI54",
+    "id" : "https://www.example.org/1b7b9e5c-8c25-45db-be9b-d03e96c2ed82",
+    "name" : "l2aBgdvO2Y",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-11-04T04:48:33.512Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "f6nddHwwmxIGflYf"
+      "approvalDate" : "2003-10-27T08:04:12.371Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "IpMlplMTDtewnp"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5776f9bb-0d74-434f-a4dd-f962eea1e657",
-    "identifier" : "TIpW1OZzBN",
+    "source" : "https://www.example.org/9d70514b-af8f-44e3-9240-739303797650",
+    "identifier" : "rCY7gsim8t8j",
     "labels" : {
-      "hu" : "zfoFOFtbgF7d"
+      "se" : "VPugz7pmDv4X1Abd"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1953281114
+      "amount" : 35446891
     },
-    "activeFrom" : "2021-05-04T22:06:28.435Z",
-    "activeTo" : "2024-01-26T05:23:42.448Z"
+    "activeFrom" : "1995-01-21T13:48:23.717Z",
+    "activeTo" : "2008-02-03T23:59:29.595Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/62e375b1-85a4-44dc-ba1b-beed4755542f",
-    "id" : "https://www.example.org/4460bbda-19d1-449b-b5af-d3e31e90b8ed",
-    "identifier" : "BbIERrzhFpfQiYUd",
+    "source" : "https://www.example.org/0126f8c0-58aa-4167-9aad-e8fc1b17f96c",
+    "id" : "https://www.example.org/322fddf7-b413-4ed5-afcd-bf82f0b28820",
+    "identifier" : "9MZ029FthjTLjOR",
     "labels" : {
-      "se" : "WgdT8aYOov"
+      "se" : "T6RMoQfQUbG8T2"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 974981574
+      "currency" : "GBP",
+      "amount" : 1779191501
     },
-    "activeFrom" : "1974-03-01T12:30:08.599Z",
-    "activeTo" : "1988-10-28T10:49:46.967Z"
+    "activeFrom" : "2007-05-18T12:21:18.387Z",
+    "activeTo" : "2012-09-01T08:13:15.644Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/50c9967c-89b2-4e10-b4c8-0a689b3570b8" ],
+  "subjects" : [ "https://www.example.org/698022cd-70b3-4896-99a2-a8bc6208264d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ce5be735-f482-4427-ab22-b7bd723cbcfd",
-    "name" : "syxCexK3vuseph",
-    "mimeType" : "HGsziEyBl8TLQ",
-    "size" : 1498602129,
-    "license" : "https://www.example.com/pjbfeh2f7wplox0l",
+    "identifier" : "b4cb36ba-d603-4a11-954c-efb6585b597f",
+    "name" : "0w7DelPS46TN93G",
+    "mimeType" : "meYgJovrPMFWKU",
+    "size" : 1146412827,
+    "license" : "https://www.example.com/luiu5neadkz",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "MpKocnuJvkSt5hNiF2"
     },
-    "legalNote" : "lIfe2k3nqzHnm13pj",
-    "publishedDate" : "1990-07-15T20:54:08.736Z",
+    "legalNote" : "x1WnJZ59x9pqU",
+    "publishedDate" : "2004-12-17T18:10:22.525Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/8HTGcK9y7Uiz",
-    "name" : "4pv9n1I3nsAg",
-    "description" : "XWluIYfB9Tlva"
+    "id" : "https://www.example.com/gG9zxKF5tjKAuDNTiv",
+    "name" : "Evzwn409Myd0No8",
+    "description" : "CNDW9LwVTtbFJxVh1zU"
   } ],
-  "rightsHolder" : "lNpv3YhBoPNykcF",
-  "duplicateOf" : "https://www.example.org/5182a2ed-c051-4259-b5b4-297c41204503",
+  "rightsHolder" : "ZE0DFgOgNyNOPzFxXw",
+  "duplicateOf" : "https://www.example.org/4268bae2-185d-47cc-bf96-af20900c2808",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "UtuBvs82A6"
+    "note" : "TRKpfCeN3n7W5z"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "GV8rdfOfsfo",
-    "createdBy" : "QX8zQtWn3C",
-    "createdDate" : "2002-05-05T12:40:43.074Z"
+    "note" : "DHtl2QWL6M",
+    "createdBy" : "u2il2oR8ken3k2t",
+    "createdDate" : "1985-07-06T05:27:53.187Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1417de68-c75c-4278-92a9-1bfe1a7b3aea" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/123f84f3-f469-4d44-822e-c8e8f744d5b9" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "GPzd7UDkyBVSIARFCTL",
-    "ownerAffiliation" : "https://www.example.org/0c76f1c6-dde1-45f6-afd5-b60e95d72cc7"
+    "owner" : "G3sCBk7Tmyw5V0bIdaQ",
+    "ownerAffiliation" : "https://www.example.org/f8d0ddc5-4e65-4ad9-8a03-570b2e78a7d1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a27fac9b-25b9-4b1d-8502-ab7f18db2e34"
+    "id" : "https://www.example.org/b1f62dfd-961e-47e2-af4c-63d7453566f1"
   },
-  "createdDate" : "1988-10-18T23:36:47.443Z",
-  "modifiedDate" : "2019-03-28T03:12:00.537Z",
-  "publishedDate" : "2002-07-23T09:35:46.358Z",
-  "indexedDate" : "1974-08-26T08:48:11.843Z",
-  "handle" : "https://www.example.org/6c9c43b3-8dcc-4d55-851e-0934cee6bedd",
-  "doi" : "https://doi.org/10.1234/placeat",
-  "link" : "https://www.example.org/704a7e43-b491-4e0f-b5f6-91319fff4061",
+  "createdDate" : "2021-01-15T20:16:46.552Z",
+  "modifiedDate" : "2006-11-08T03:30:56.289Z",
+  "publishedDate" : "1988-09-22T20:35:16.765Z",
+  "indexedDate" : "1987-10-01T02:26:29.951Z",
+  "handle" : "https://www.example.org/08d4a0b7-d112-46e2-a407-318817fcc354",
+  "doi" : "https://doi.org/10.1234/nostrum",
+  "link" : "https://www.example.org/8cf4389c-31af-493c-8c87-a3e20d6f49bd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tVcf9y0DHrdr0jRUk",
+    "mainTitle" : "fkhJ908g3rfxjO3C3r",
     "alternativeTitles" : {
-      "da" : "Yk5oVKBeImd"
+      "is" : "USQuMZZSu3iv0Ca"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6Jjx0iMHvncmIcK0gDu",
-      "month" : "rCG2o2YFuzu5Gayjz",
-      "day" : "zajtf0omGKj2m"
+      "year" : "FyTeUSdN0FNb",
+      "month" : "YQF6qnt30PMB",
+      "day" : "IDBKW2XHo8kMp0I7MJ0"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d0a9427b-1371-4a7e-8189-852fa3931d55",
-        "name" : "J3uOJ1VF7UePMAE7ef",
-        "nameType" : "Personal",
-        "orcId" : "3HqaLQA4139P6Ngkg9C",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/280890d5-cbc8-42bc-97bc-cec7c8231caa",
+        "name" : "WCaYmdApuN6CA7",
+        "nameType" : "Organizational",
+        "orcId" : "ePWfEJHVobW6b",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sUnfD65j1B",
-          "value" : "FL4Qy9DCxh"
+          "sourceName" : "PbYQhJSTIVwX",
+          "value" : "XOsE7iEHEvk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7gQrfFj8hhq1l21es",
-          "value" : "cLvXnJoTgQbNBduJD"
+          "sourceName" : "gssqNocYVlYu",
+          "value" : "YviEIxLRVMs7d2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/84da461c-6e22-45b5-981b-2660cfcff846"
+        "id" : "https://www.example.org/829c44a2-5956-4b95-a5a5-cc24c781c145"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "Illustrator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/dd0aad8a-9df4-4e8a-89b3-da25ba1e1f86",
-        "name" : "9NkDwz4qEwn57iF",
+        "id" : "https://www.example.org/09f1a9a8-7e87-4e89-a949-b21d39f1a448",
+        "name" : "Kag8t8vGdhK21O",
         "nameType" : "Personal",
-        "orcId" : "pT1gpYTdZzlGOyOh",
+        "orcId" : "HqwFxPHGukZt0",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dDegouj6orysFkrpA",
-          "value" : "rLDYzCNg47Gx"
+          "sourceName" : "9ttFAbhCPpVlN",
+          "value" : "iEeNWyawjFIk"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "u57A76oO9UaYKU",
-          "value" : "YilV9HRGz7Ei"
+          "sourceName" : "VVWPkUuvhBSTJ8jeNS",
+          "value" : "nPec1a3X6b"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6a403fde-dfa1-4197-95a4-25b8d05eaa50"
+        "id" : "https://www.example.org/bca0e31d-0961-4276-9b52-088e1ef1e440"
       } ],
       "role" : {
-        "type" : "ContactPerson"
+        "type" : "TranslatorAdapter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "peQgz2EokobdSv"
+      "nn" : "aWyweIP45uR0"
     },
-    "npiSubjectHeading" : "WHit07eGQgKKRClkOo",
-    "tags" : [ "0Zv9Rtd3ZMVhZFoy" ],
-    "description" : "qQPBtWTngPEB",
+    "npiSubjectHeading" : "mb9WK9bgn4kVGXC0oCv",
+    "tags" : [ "5QqKfm989VP" ],
+    "description" : "tb1K514aqEI6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Journal"
         },
         "format" : "Text",
-        "disseminationChannel" : "NeYDzoMG5fAq",
+        "disseminationChannel" : "ZLe0A3GZI1G4J13a",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "3pxlfhf8FKnr1finKu",
-          "seriesPart" : "aKyFq5De64ggRphtCZH"
+          "seriesName" : "OHKSiF32L5O1yRY",
+          "seriesPart" : "xlWBTqNPINDGcn"
         }
       },
-      "doi" : "https://www.example.org/26610bcc-b4ed-4222-9c68-1344996e2a76",
+      "doi" : "https://www.example.org/3a7d4a97-48c7-4740-ada1-3420afd54d48",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,89 +116,95 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/2aba5a96-f6f7-4916-a6ab-db4aa656a6d9",
-    "abstract" : "amv8pfHXZg1MXydJViM"
+    "metadataSource" : "https://www.example.org/3fc80183-ac9f-4938-b34f-53dcdc7171a9",
+    "abstract" : "cIdJK08EjmavU0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f9270322-db36-44f2-934c-647866e8621f",
-    "name" : "yLinhQMkt1S",
+    "id" : "https://www.example.org/ea7c5be8-2a15-42dc-8d5d-5619786787a3",
+    "name" : "onouSk9d6a2xg",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-04-29T00:03:34.394Z",
+      "approvalDate" : "2016-05-30T22:34:50.993Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "R5d9jhJb4xArSF"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "JTFRP5htAWvxg0t3"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/36dd5d08-7ac7-4024-9235-99f9b607651c",
-    "identifier" : "e3A9pGY5G3ZJr0",
+    "source" : "https://www.example.org/4e91ec50-ece9-4cee-8143-77551fba9fad",
+    "identifier" : "CGAMrnS5Fl4",
     "labels" : {
-      "af" : "r9RnHnIOtYboVR1ba"
+      "nl" : "yEfbYbFjALmg"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1357519936
+      "amount" : 1403377801
     },
-    "activeFrom" : "1971-09-10T09:04:53.416Z",
-    "activeTo" : "1996-01-20T23:32:18.657Z"
+    "activeFrom" : "1975-04-16T10:15:57.637Z",
+    "activeTo" : "1998-02-25T06:57:53.230Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9142b7d8-85ef-4547-838b-2bceeeeb5d2e",
-    "id" : "https://www.example.org/617b91d0-e397-49e7-a319-f64772e6529e",
-    "identifier" : "EUvpLUnqKOb2GCAdwOK",
+    "source" : "https://www.example.org/949ef47c-32bf-40ab-b978-241bc5416305",
+    "id" : "https://www.example.org/0ab98ad4-3183-4abd-bbd8-dc6dbbcc7399",
+    "identifier" : "zjVom6IzSpeCN6NS",
     "labels" : {
-      "ru" : "GEnHzF9AhR8OLPVpIVO"
+      "is" : "VlB3BraKVrnR5AX66pc"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1944778329
+      "currency" : "NOK",
+      "amount" : 1792584606
     },
-    "activeFrom" : "1980-07-30T14:08:22.486Z",
-    "activeTo" : "1996-04-20T14:18:16.793Z"
+    "activeFrom" : "1997-08-07T09:50:11.527Z",
+    "activeTo" : "2013-05-02T11:56:57.305Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/286199ab-324d-4b38-98d2-4e727623d9b0" ],
+  "subjects" : [ "https://www.example.org/ae7c13f9-aa6b-4397-9128-04a1378db7a0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4e05e34e-154e-49e2-b03c-f85619ed5363",
-    "name" : "glDxPxT89dx9uAkzoW",
-    "mimeType" : "IoaXA3AxgVqGI5Lfhz",
-    "size" : 718969277,
-    "license" : "https://www.example.com/ar8lafc7tvpk7hokt4a",
+    "identifier" : "158772fc-1670-4008-bf65-fc2965ccc5c3",
+    "name" : "08K8cMAng6VD8tW5",
+    "mimeType" : "MpzZSWNWNqLS",
+    "size" : 1994267831,
+    "license" : "https://www.example.com/7qyd875zzc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "z0hD1WVO30iFY"
     },
-    "legalNote" : "jrh1JvHX0lsaJknu",
-    "publishedDate" : "2014-03-09T19:14:09.453Z",
+    "legalNote" : "MfCneFve162hP8hS",
+    "publishedDate" : "2007-02-03T02:44:30.381Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "1RH9GgyHTFn",
+      "uploadedDate" : "2001-02-14T20:30:16.063Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Yyr8WCS0bEIN7J",
-    "name" : "SxgM4TfyeMHjGN",
-    "description" : "dEJvmpQ0ne"
+    "id" : "https://www.example.com/JyeWHunZ5Em5z5FyD",
+    "name" : "QKazcWjxmJAesinw9",
+    "description" : "Oa3zg4ja1cz9cq2fGz"
   } ],
-  "rightsHolder" : "Ct6RheId2xlhlu",
-  "duplicateOf" : "https://www.example.org/ca866fc5-6575-493b-affb-8df1e8fe3de0",
+  "rightsHolder" : "wvTWszalpjl5Dy",
+  "duplicateOf" : "https://www.example.org/3731a0de-5277-4a7f-897f-568ec2eba3f9",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DNYwo7SQW51FoK1zKz9"
+    "note" : "1E1vZ88FIDl01p"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Jdut4CVVxEV",
-    "createdBy" : "3WGCSaBSLdFck9NIAfY",
-    "createdDate" : "1986-01-06T19:38:21.953Z"
+    "note" : "Vfd43YsVra",
+    "createdBy" : "nU8SkYuvUu",
+    "createdDate" : "1976-02-14T02:05:17.362Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c2f99c0e-b2de-49f3-8e78-a37212be4aec" ],
+  "curatingInstitutions" : [ "https://www.example.org/7af363ba-9f84-4f50-a640-f84dd103b6a4" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MediaInterview.json
+++ b/documentation/MediaInterview.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Evi2IGXpU9owy2G",
-    "ownerAffiliation" : "https://www.example.org/38484c9d-8833-499f-b582-3d1ac18c5160"
+    "owner" : "GPzd7UDkyBVSIARFCTL",
+    "ownerAffiliation" : "https://www.example.org/0c76f1c6-dde1-45f6-afd5-b60e95d72cc7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/18bfa140-8be1-4b70-9218-5213cb8c0b64"
+    "id" : "https://www.example.org/a27fac9b-25b9-4b1d-8502-ab7f18db2e34"
   },
-  "createdDate" : "2009-06-10T00:18:24.120Z",
-  "modifiedDate" : "1996-04-08T21:12:02.098Z",
-  "publishedDate" : "1981-06-30T22:25:41.808Z",
-  "indexedDate" : "1986-01-11T03:29:31.413Z",
-  "handle" : "https://www.example.org/623b183c-1a82-4252-80a8-540064908aef",
-  "doi" : "https://doi.org/10.1234/assumenda",
-  "link" : "https://www.example.org/78139f50-e4b9-42e9-a47b-915fa8bb5786",
+  "createdDate" : "1988-10-18T23:36:47.443Z",
+  "modifiedDate" : "2019-03-28T03:12:00.537Z",
+  "publishedDate" : "2002-07-23T09:35:46.358Z",
+  "indexedDate" : "1974-08-26T08:48:11.843Z",
+  "handle" : "https://www.example.org/6c9c43b3-8dcc-4d55-851e-0934cee6bedd",
+  "doi" : "https://doi.org/10.1234/placeat",
+  "link" : "https://www.example.org/704a7e43-b491-4e0f-b5f6-91319fff4061",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "uS8h0oHhSKENVg",
+    "mainTitle" : "tVcf9y0DHrdr0jRUk",
     "alternativeTitles" : {
-      "af" : "MAxG8SHX8fit"
+      "da" : "Yk5oVKBeImd"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "mp4xCqICwEHsm6e",
-      "month" : "I7suaIvht4dniyFqbY",
-      "day" : "Srei42yY1dn"
+      "year" : "6Jjx0iMHvncmIcK0gDu",
+      "month" : "rCG2o2YFuzu5Gayjz",
+      "day" : "zajtf0omGKj2m"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/afb2d932-760c-4bb6-81f9-7f5fba0c9fc6",
-        "name" : "bL5hfzWBUISuqWbI",
+        "id" : "https://www.example.org/d0a9427b-1371-4a7e-8189-852fa3931d55",
+        "name" : "J3uOJ1VF7UePMAE7ef",
         "nameType" : "Personal",
-        "orcId" : "EL7PfFPAB0",
+        "orcId" : "3HqaLQA4139P6Ngkg9C",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ojmfTYBuLU7pwTqjo",
-          "value" : "mv3fFLiwqHYi"
+          "sourceName" : "sUnfD65j1B",
+          "value" : "FL4Qy9DCxh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zXBqiMRAvdzev",
-          "value" : "Y9CR6XxWRY"
+          "sourceName" : "7gQrfFj8hhq1l21es",
+          "value" : "cLvXnJoTgQbNBduJD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c5cd4055-98ab-45b9-95d9-910f35c90be6"
+        "id" : "https://www.example.org/84da461c-6e22-45b5-981b-2660cfcff846"
       } ],
       "role" : {
-        "type" : "RelatedPerson"
+        "type" : "Designer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/bb9a5e3f-981d-47be-b1dd-3f2933c028ec",
-        "name" : "LeE2nalzNvs",
+        "id" : "https://www.example.org/dd0aad8a-9df4-4e8a-89b3-da25ba1e1f86",
+        "name" : "9NkDwz4qEwn57iF",
         "nameType" : "Personal",
-        "orcId" : "AoTudIcjTMKwHHLED",
+        "orcId" : "pT1gpYTdZzlGOyOh",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VYBSjGjG8eBtQRnd0RP",
-          "value" : "tmyNfF7xW458"
+          "sourceName" : "dDegouj6orysFkrpA",
+          "value" : "rLDYzCNg47Gx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "60NWHCX22cX9Hn3USg7",
-          "value" : "1sImLaRg3YzF"
+          "sourceName" : "u57A76oO9UaYKU",
+          "value" : "YilV9HRGz7Ei"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/128c561c-51ae-413a-b6c7-21c3613543d8"
+        "id" : "https://www.example.org/6a403fde-dfa1-4197-95a4-25b8d05eaa50"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "ContactPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "504OyQmFhcsBH8x6z"
+      "en" : "peQgz2EokobdSv"
     },
-    "npiSubjectHeading" : "jkH5L691md0IyhvEAn8",
-    "tags" : [ "xnekJKaVRiBSlIu8m" ],
-    "description" : "KlS2JlOtLmAuY4RTfde",
+    "npiSubjectHeading" : "WHit07eGQgKKRClkOo",
+    "tags" : [ "0Zv9Rtd3ZMVhZFoy" ],
+    "description" : "qQPBtWTngPEB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Internet"
+          "type" : "TV"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "5wYuZO57tDktku",
+        "format" : "Text",
+        "disseminationChannel" : "NeYDzoMG5fAq",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "rnC5iKJli21rIKAiTrE",
-          "seriesPart" : "pfcbpn5RJSwE"
+          "seriesName" : "3pxlfhf8FKnr1finKu",
+          "seriesPart" : "aKyFq5De64ggRphtCZH"
         }
       },
-      "doi" : "https://www.example.org/f6f2f7cf-08ba-486b-8bf3-29c9caa28220",
+      "doi" : "https://www.example.org/26610bcc-b4ed-4222-9c68-1344996e2a76",
       "publicationInstance" : {
         "type" : "MediaInterview",
         "pages" : {
@@ -116,88 +116,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e536f6fe-03b2-4ef9-b418-88e49579eedd",
-    "abstract" : "4v3HTLaDGYu"
+    "metadataSource" : "https://www.example.org/2aba5a96-f6f7-4916-a6ab-db4aa656a6d9",
+    "abstract" : "amv8pfHXZg1MXydJViM"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/097d5655-c134-41c9-b342-f7ebb36d6ca4",
-    "name" : "EB9m3g1Ixrz",
+    "id" : "https://www.example.org/f9270322-db36-44f2-934c-647866e8621f",
+    "name" : "yLinhQMkt1S",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-05-29T01:08:12.735Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "hEaVbRf3Er7a"
+      "approvalDate" : "1999-04-29T00:03:34.394Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "R5d9jhJb4xArSF"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/ae5b6acf-7483-43ab-9e9d-35050bbe9e33",
-    "identifier" : "vvXeJKiDGtOV1lC",
+    "source" : "https://www.example.org/36dd5d08-7ac7-4024-9235-99f9b607651c",
+    "identifier" : "e3A9pGY5G3ZJr0",
     "labels" : {
-      "pt" : "ZZwDc4gQkLBDxYPt"
+      "af" : "r9RnHnIOtYboVR1ba"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 2001215954
+      "amount" : 1357519936
     },
-    "activeFrom" : "2014-06-13T13:54:00.085Z",
-    "activeTo" : "2015-08-16T08:46:05.358Z"
+    "activeFrom" : "1971-09-10T09:04:53.416Z",
+    "activeTo" : "1996-01-20T23:32:18.657Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1b425336-4d36-4c83-8d97-6599f85630ff",
-    "id" : "https://www.example.org/babda0de-5acd-44a6-a62f-d014304bb145",
-    "identifier" : "h6lxhXXJ6mTgT0ZD",
+    "source" : "https://www.example.org/9142b7d8-85ef-4547-838b-2bceeeeb5d2e",
+    "id" : "https://www.example.org/617b91d0-e397-49e7-a319-f64772e6529e",
+    "identifier" : "EUvpLUnqKOb2GCAdwOK",
     "labels" : {
-      "fr" : "8XMWSKUFF45CBMkf"
+      "ru" : "GEnHzF9AhR8OLPVpIVO"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1752740598
+      "currency" : "GBP",
+      "amount" : 1944778329
     },
-    "activeFrom" : "2000-07-20T10:45:50.155Z",
-    "activeTo" : "2019-06-16T11:00:55.902Z"
+    "activeFrom" : "1980-07-30T14:08:22.486Z",
+    "activeTo" : "1996-04-20T14:18:16.793Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/83c1e4b1-1997-4ccf-a1a1-9b793623ec13" ],
+  "subjects" : [ "https://www.example.org/286199ab-324d-4b38-98d2-4e727623d9b0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "371793f7-ac57-4998-98ef-6dafed6e7ed1",
-    "name" : "acPDTfuZUaBKQQLJs5Z",
-    "mimeType" : "AfifmBtGSHVpXhCS",
-    "size" : 370676171,
-    "license" : "https://www.example.com/ivyss83bubz",
+    "identifier" : "4e05e34e-154e-49e2-b03c-f85619ed5363",
+    "name" : "glDxPxT89dx9uAkzoW",
+    "mimeType" : "IoaXA3AxgVqGI5Lfhz",
+    "size" : 718969277,
+    "license" : "https://www.example.com/ar8lafc7tvpk7hokt4a",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "C5TppxPcROZu9bfgJ4",
-    "publishedDate" : "1997-11-30T18:25:51.169Z",
+    "legalNote" : "jrh1JvHX0lsaJknu",
+    "publishedDate" : "2014-03-09T19:14:09.453Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/lUvVWXm5FJk",
-    "name" : "Owdwoh6ctT6kgqEeH7S",
-    "description" : "WwMTK7yePocmHOEv"
+    "id" : "https://www.example.com/Yyr8WCS0bEIN7J",
+    "name" : "SxgM4TfyeMHjGN",
+    "description" : "dEJvmpQ0ne"
   } ],
-  "rightsHolder" : "ByZGmz79OxK7OjReM",
-  "duplicateOf" : "https://www.example.org/82c750d8-78ee-4099-ada8-832eb97826fd",
+  "rightsHolder" : "Ct6RheId2xlhlu",
+  "duplicateOf" : "https://www.example.org/ca866fc5-6575-493b-affb-8df1e8fe3de0",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "K2QqtIT7W1ySC9Lus"
+    "note" : "DNYwo7SQW51FoK1zKz9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "uo8S1qQfFyfnDFi",
-    "createdBy" : "9wcmewLIX1PasnJ3w8",
-    "createdDate" : "1981-04-20T02:41:35.190Z"
+    "note" : "Jdut4CVVxEV",
+    "createdBy" : "3WGCSaBSLdFck9NIAfY",
+    "createdDate" : "1986-01-06T19:38:21.953Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7f7c88c9-9c38-4987-922b-9d0c89a614fd" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/c2f99c0e-b2de-49f3-8e78-a37212be4aec" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -1,60 +1,61 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "5s8FUpyB07P6pv",
-    "ownerAffiliation" : "https://www.example.org/518e92a5-9f69-49d1-80dd-67dcb29d2762"
+    "owner" : "NOhr84CL7J8BtSOQEw",
+    "ownerAffiliation" : "https://www.example.org/7e03b9fb-fcf8-48f5-8a73-a3d151f2d157"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c4e24112-cde9-4ddf-8359-03efc94a4d86"
+    "id" : "https://www.example.org/c355306a-4b10-477e-b70f-a99f6722a374"
   },
-  "createdDate" : "1997-12-11T09:58:35.321Z",
-  "modifiedDate" : "2000-02-05T23:59:14.633Z",
-  "publishedDate" : "2018-07-03T14:03:50.663Z",
-  "indexedDate" : "1979-05-25T10:52:16.630Z",
-  "handle" : "https://www.example.org/5dd8bb0a-dd50-44db-939f-6482cf556fb1",
-  "doi" : "https://doi.org/10.1234/dolor",
-  "link" : "https://www.example.org/745f86b4-342f-4cf2-84f0-bf7bab7a766d",
+  "createdDate" : "2019-08-17T23:00:31.517Z",
+  "modifiedDate" : "2000-04-28T23:23:51.064Z",
+  "publishedDate" : "1973-08-09T12:53:36.580Z",
+  "indexedDate" : "1980-03-23T00:47:08.580Z",
+  "handle" : "https://www.example.org/5b7d8797-636e-48eb-9431-522fc323fd99",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/a1fbd31e-4f84-4d11-952d-43c7fbb03436",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "v1l82Jbg3u",
+    "mainTitle" : "1lAe1DuYv127Wadr",
     "alternativeTitles" : {
-      "nb" : "EIaLdy6iDZa"
+      "af" : "7x9UvIFUwgRdiBOogV"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JX8MDEnOOcAzA5",
-      "month" : "vHDnvxBz7hl",
-      "day" : "4QvpGEjopqVT1WNHj5"
+      "year" : "3p1QgPs9qpUxXiFkQ",
+      "month" : "1PSjZos1wIc",
+      "day" : "vfzM6bD8d6LkExp"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/15c87e51-1afe-47f5-872d-d3ff6317dbd1",
-        "name" : "9Zao1mr96IuuzRFqAC",
+        "id" : "https://www.example.org/c1cfaa8b-f97f-4a8e-b68f-5e75d67fa85d",
+        "name" : "ql1Qt7IYlcRvfc1OCGg",
         "nameType" : "Personal",
-        "orcId" : "mbRCGN8A3wfeT1jOuf",
+        "orcId" : "ghujyGpgwbKiq2m",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "E4xNNHjinXKf",
-          "value" : "T4G22Ue8tEVnwCvn"
+          "sourceName" : "JgVSqOQsqrB8Y90hsv",
+          "value" : "hetfXcpgQL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "t3ZNpc4TMFD1K",
-          "value" : "RCa8Q7sXUyY8CWU"
+          "sourceName" : "0e57JrtBGK",
+          "value" : "6DCBqG4rvCG0XXn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/7ba9daf5-a6d0-45c0-b59e-98411aaeb9b1"
+        "id" : "https://www.example.org/f0b3a03e-8114-43f2-a3b9-5622e749ddae"
       } ],
       "role" : {
-        "type" : "WorkPackageLeader"
+        "type" : "RoleOther",
+        "description" : "gnvmojvugRwEWu"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +63,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6667bddb-2834-42d5-ad3c-3ccc1e643405",
-        "name" : "uuquddD7NrM",
+        "id" : "https://www.example.org/bc7825fa-d86a-442f-b70a-57dfa1a1ef6d",
+        "name" : "JiiVCcej2v",
         "nameType" : "Organizational",
-        "orcId" : "J32nIef5ZMQ",
+        "orcId" : "KGidDwdsBsQfn067r9",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6bkPQQSWgom",
-          "value" : "ndIAfuPz4l85PGrXuu"
+          "sourceName" : "VOQnGwu3gKPE92o5",
+          "value" : "fWcVUy7iwmRMcekdr"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ir1UrbLMJKjjFLT45gX",
-          "value" : "SXR0hdjIpmfN"
+          "sourceName" : "HggJKZB3Np6zpN",
+          "value" : "hOOd1yV0SVDi2bBDx"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2b83e8c3-e022-4387-962a-f43b5344afdf"
+        "id" : "https://www.example.org/3173bff8-9dba-4847-ae2c-6a11dea55795"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "RegistrationAuthority"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "y11E6UxW8sSYX7B"
+      "is" : "3a6k0vQeBm9Z"
     },
-    "npiSubjectHeading" : "ybQPMahxgsWtVKOuKZv",
-    "tags" : [ "l3K6Fu6k1NLe" ],
-    "description" : "6ZDBAlEFetTVXXJE",
+    "npiSubjectHeading" : "0XW7WHt34qrCKDetr",
+    "tags" : [ "lS9cRdOfoK1fDGY3" ],
+    "description" : "nzVQFL9gLWSvLPEmq",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Internet"
+          "type" : "Journal"
         },
-        "format" : "Video",
-        "disseminationChannel" : "nBxG6ijX0zTBHfsZ",
+        "format" : "Sound",
+        "disseminationChannel" : "tg02rTS16iPai",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "LZnLr2bMKscf21",
-          "seriesPart" : "VMytdRkofgVdi21TdSF"
+          "seriesName" : "CQEl5yHY2tz1",
+          "seriesPart" : "diRqUdRZnVRFZ"
         }
       },
-      "doi" : "https://www.example.org/1d082222-c886-48c1-bc32-ff8dab40eb80",
+      "doi" : "https://www.example.org/2dce2ca5-65f1-487a-a3df-f942047daf46",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,89 +117,95 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3cef36ea-51c8-4bc9-8f60-2815214ec699",
-    "abstract" : "Rs3yf7MLlCnU6"
+    "metadataSource" : "https://www.example.org/44cd8d6d-ca5f-4423-a4cf-444f1944b304",
+    "abstract" : "j9AD7caotDT99f8wHm"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7a761a5d-4aff-4711-b00e-9f49f09cb066",
-    "name" : "4ilfsls5JFYJGY3t",
+    "id" : "https://www.example.org/55a60d9a-b527-4675-a6db-73e32dc3a3d5",
+    "name" : "cmIDd7WBvVihjNXxd",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2000-12-25T20:37:14.568Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "zH9k0Wtpnl8UHDr"
+      "approvalDate" : "1989-10-28T20:36:32.123Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "3SKK03M0ZB7eS"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/973e0083-bab7-4a44-a5ac-697924dcb732",
-    "identifier" : "v4ExfUBVt9IbgB0D06t",
+    "source" : "https://www.example.org/83d689bc-da08-4eaf-841e-10f2e10b7712",
+    "identifier" : "HdPH7JaMkM9bXXAx",
     "labels" : {
-      "en" : "uRpOvua0KvGt"
+      "de" : "iuYfItKkTporV"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 780753120
+      "currency" : "GBP",
+      "amount" : 1582757266
     },
-    "activeFrom" : "1983-07-17T07:29:53.732Z",
-    "activeTo" : "1989-08-04T00:21:19.208Z"
+    "activeFrom" : "2019-01-06T23:00:29.326Z",
+    "activeTo" : "2024-04-16T01:35:52.047Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/40f28b15-03a6-43db-b564-419a9526e48d",
-    "id" : "https://www.example.org/32d38aaa-cfb7-4f74-9a91-9fae48f2c6bb",
-    "identifier" : "fJiwa471Ce7",
+    "source" : "https://www.example.org/f6ffa0f7-17ed-4cbd-86fd-14035743db0a",
+    "id" : "https://www.example.org/b3cddc1a-6480-41e4-9a08-03d003037004",
+    "identifier" : "nrfgOhw35qWZc5UnXf",
     "labels" : {
-      "af" : "hS1VBWBoFhh2FoAPz"
+      "it" : "6lTNLmDWZVBH5G"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 547451931
+      "amount" : 1799686984
     },
-    "activeFrom" : "2002-03-21T12:09:45.522Z",
-    "activeTo" : "2015-07-20T09:56:26.726Z"
+    "activeFrom" : "2003-07-21T03:11:57.708Z",
+    "activeTo" : "2015-08-30T02:26:18.535Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2dbce39b-77b8-4dc4-b8b0-6fca84ca9fe2" ],
+  "subjects" : [ "https://www.example.org/5f62404b-1920-45e7-a4c6-9822dde3c201" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3a2afb23-b665-4bc5-b77f-ada771655a15",
-    "name" : "RT6Hicb7qqgvl",
-    "mimeType" : "2wY5d7lDhuAE1V2L",
-    "size" : 946484211,
-    "license" : "https://www.example.com/egahx1spbhhemmt6m",
+    "identifier" : "de4d0d00-45e0-4efe-9d7b-eb28d6531960",
+    "name" : "9V5ktckS9rEb7LlkWL",
+    "mimeType" : "SGkoPsGEUmbmz",
+    "size" : 1884259362,
+    "license" : "https://www.example.com/a9qqzxcoa3ufnsa5h",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "KkvXhb3QRd3dkwV"
     },
-    "legalNote" : "Ct1IPboVqXVQIiz8C6",
-    "publishedDate" : "2012-03-20T20:23:40.998Z",
+    "legalNote" : "4BoSMGlvmUAV",
+    "publishedDate" : "1986-10-31T13:19:48.440Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "G0WEmUThX29P",
+      "uploadedDate" : "1991-09-30T05:26:42.481Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/9hzQCNTWX4T",
-    "name" : "8S0pNJ3eTRtsK",
-    "description" : "gTWC0hspXP"
+    "id" : "https://www.example.com/R08z7jOri3FP",
+    "name" : "f13kyoWFIqreXVU2g",
+    "description" : "fDH8Z4pFruViz"
   } ],
-  "rightsHolder" : "igVZM2Lhyi",
-  "duplicateOf" : "https://www.example.org/571da686-6615-4dfe-99c1-085d7d502374",
+  "rightsHolder" : "vGwmS6wctmVxFJ",
+  "duplicateOf" : "https://www.example.org/06bdd59b-9a72-4e36-8a74-251bf9489c64",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CJT35Wpau1J1r8AcY"
+    "note" : "oJrLimWkB1KS"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "A4BC0Mt9jKVvjZj0",
-    "createdBy" : "x76mGOgqLy3382",
-    "createdDate" : "2004-04-13T19:23:46.502Z"
+    "note" : "1Nmr057Rtk8cSo45TSl",
+    "createdBy" : "7ODJEjF6zLuQf",
+    "createdDate" : "1995-01-01T13:39:19.623Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a88d7f07-6cb0-43d5-bce1-ee8de27367c4" ],
+  "curatingInstitutions" : [ "https://www.example.org/9763b607-8ec7-456d-bcb0-a5d93dd40d65" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MediaParticipationInRadioOrTv.json
+++ b/documentation/MediaParticipationInRadioOrTv.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "H2H9n4M7FglPI7a",
-    "ownerAffiliation" : "https://www.example.org/5f2c073d-c59c-4c85-a134-6393aec81431"
+    "owner" : "5s8FUpyB07P6pv",
+    "ownerAffiliation" : "https://www.example.org/518e92a5-9f69-49d1-80dd-67dcb29d2762"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/a6d73797-696f-4d69-9f1d-4a16b754097c"
+    "id" : "https://www.example.org/c4e24112-cde9-4ddf-8359-03efc94a4d86"
   },
-  "createdDate" : "1991-03-09T22:30:41.450Z",
-  "modifiedDate" : "1971-04-07T00:58:31.119Z",
-  "publishedDate" : "1979-08-06T22:30:27.554Z",
-  "indexedDate" : "2012-01-27T11:34:43.298Z",
-  "handle" : "https://www.example.org/27181b61-a923-4f14-ac13-098147a5bbed",
-  "doi" : "https://doi.org/10.1234/saepe",
-  "link" : "https://www.example.org/1f474052-944c-4418-8671-4a183dcb5388",
+  "createdDate" : "1997-12-11T09:58:35.321Z",
+  "modifiedDate" : "2000-02-05T23:59:14.633Z",
+  "publishedDate" : "2018-07-03T14:03:50.663Z",
+  "indexedDate" : "1979-05-25T10:52:16.630Z",
+  "handle" : "https://www.example.org/5dd8bb0a-dd50-44db-939f-6482cf556fb1",
+  "doi" : "https://doi.org/10.1234/dolor",
+  "link" : "https://www.example.org/745f86b4-342f-4cf2-84f0-bf7bab7a766d",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fKiwU67BjB5RJbm",
+    "mainTitle" : "v1l82Jbg3u",
     "alternativeTitles" : {
-      "af" : "OeqzmZWiJD"
+      "nb" : "EIaLdy6iDZa"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "mfU8u0hPkchm1",
-      "month" : "1tQlOxImeO3pmU",
-      "day" : "eiFdg7955oOqDwxEo"
+      "year" : "JX8MDEnOOcAzA5",
+      "month" : "vHDnvxBz7hl",
+      "day" : "4QvpGEjopqVT1WNHj5"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/94c371d1-1948-4d63-b753-2635a9cb1031",
-        "name" : "0KHUfXqhsRJ",
+        "id" : "https://www.example.org/15c87e51-1afe-47f5-872d-d3ff6317dbd1",
+        "name" : "9Zao1mr96IuuzRFqAC",
         "nameType" : "Personal",
-        "orcId" : "u6VVgfXhvuBC",
+        "orcId" : "mbRCGN8A3wfeT1jOuf",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KpGo0o79lWd5",
-          "value" : "2uXeF9eGhGlJmgiG"
+          "sourceName" : "E4xNNHjinXKf",
+          "value" : "T4G22Ue8tEVnwCvn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WoiOZrkGdzXGRq4",
-          "value" : "tkIjBDn9ypVE"
+          "sourceName" : "t3ZNpc4TMFD1K",
+          "value" : "RCa8Q7sXUyY8CWU"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/18305f60-78af-46e4-ba2d-9a7d55f44d38"
+        "id" : "https://www.example.org/7ba9daf5-a6d0-45c0-b59e-98411aaeb9b1"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/980db7c1-d668-491e-a0b0-fc8c7a5c740e",
-        "name" : "BjKjN1btsYW",
-        "nameType" : "Personal",
-        "orcId" : "qS2aOL3sk2pFCgnn",
+        "id" : "https://www.example.org/6667bddb-2834-42d5-ad3c-3ccc1e643405",
+        "name" : "uuquddD7NrM",
+        "nameType" : "Organizational",
+        "orcId" : "J32nIef5ZMQ",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rJEMg6iDH1UCi",
-          "value" : "FTtR4tZ0Pxe8i"
+          "sourceName" : "6bkPQQSWgom",
+          "value" : "ndIAfuPz4l85PGrXuu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Oqv1EYnTeO",
-          "value" : "A70wsZaVwo"
+          "sourceName" : "Ir1UrbLMJKjjFLT45gX",
+          "value" : "SXR0hdjIpmfN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5793a93e-3ea2-47ed-b4c3-980cfa25940a"
+        "id" : "https://www.example.org/2b83e8c3-e022-4387-962a-f43b5344afdf"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Curator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "it" : "RC1pzx1EbQWg1UhpH"
+      "af" : "y11E6UxW8sSYX7B"
     },
-    "npiSubjectHeading" : "EvY61IePkHGwGfX",
-    "tags" : [ "X8BlDDahZEee0w" ],
-    "description" : "Q2dJS5vVbYFPLZ54m",
+    "npiSubjectHeading" : "ybQPMahxgsWtVKOuKZv",
+    "tags" : [ "l3K6Fu6k1NLe" ],
+    "description" : "6ZDBAlEFetTVXXJE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "TV"
+          "type" : "Internet"
         },
         "format" : "Video",
-        "disseminationChannel" : "BnUPgwLKbr",
+        "disseminationChannel" : "nBxG6ijX0zTBHfsZ",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "bkosP3iTui",
-          "seriesPart" : "rl6O6HRrUsl192c83"
+          "seriesName" : "LZnLr2bMKscf21",
+          "seriesPart" : "VMytdRkofgVdi21TdSF"
         }
       },
-      "doi" : "https://www.example.org/aa8e491b-ddb0-4a14-9f2c-6cfd340007b1",
+      "doi" : "https://www.example.org/1d082222-c886-48c1-bc32-ff8dab40eb80",
       "publicationInstance" : {
         "type" : "MediaParticipationInRadioOrTv",
         "pages" : {
@@ -116,89 +116,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/bfd8c14d-7b9e-4665-a521-1ae8ba329184",
-    "abstract" : "xAZTLnEzPpmxna"
+    "metadataSource" : "https://www.example.org/3cef36ea-51c8-4bc9-8f60-2815214ec699",
+    "abstract" : "Rs3yf7MLlCnU6"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/38a5bab2-dd30-4c03-baeb-6a0abf50dd13",
-    "name" : "pAzh48utG71k7vza",
+    "id" : "https://www.example.org/7a761a5d-4aff-4711-b00e-9f49f09cb066",
+    "name" : "4ilfsls5JFYJGY3t",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-03-02T19:47:00.564Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "sHiTHLu0urFXcKrh"
+      "approvalDate" : "2000-12-25T20:37:14.568Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "zH9k0Wtpnl8UHDr"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/19aefadd-9ac4-40a8-8a18-d2c8a4166610",
-    "identifier" : "1PrnVgOZhm",
+    "source" : "https://www.example.org/973e0083-bab7-4a44-a5ac-697924dcb732",
+    "identifier" : "v4ExfUBVt9IbgB0D06t",
     "labels" : {
-      "nl" : "GqPpXB2Rh8zD"
+      "en" : "uRpOvua0KvGt"
+    },
+    "fundingAmount" : {
+      "currency" : "EUR",
+      "amount" : 780753120
+    },
+    "activeFrom" : "1983-07-17T07:29:53.732Z",
+    "activeTo" : "1989-08-04T00:21:19.208Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/40f28b15-03a6-43db-b564-419a9526e48d",
+    "id" : "https://www.example.org/32d38aaa-cfb7-4f74-9a91-9fae48f2c6bb",
+    "identifier" : "fJiwa471Ce7",
+    "labels" : {
+      "af" : "hS1VBWBoFhh2FoAPz"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 374833833
+      "amount" : 547451931
     },
-    "activeFrom" : "1979-03-05T17:49:38.300Z",
-    "activeTo" : "2023-03-13T10:44:44.568Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1c20264d-c5f5-4df3-9b64-a1f53a7b1e99",
-    "id" : "https://www.example.org/79f3d0e8-28c4-44b7-84d5-6d5c93a70557",
-    "identifier" : "PiOJEuZ8xBaIVEgs",
-    "labels" : {
-      "nn" : "Ufl8iIVz5CusgrZV"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1969581965
-    },
-    "activeFrom" : "2023-06-21T17:27:05.688Z",
-    "activeTo" : "2024-01-24T21:14:34.933Z"
+    "activeFrom" : "2002-03-21T12:09:45.522Z",
+    "activeTo" : "2015-07-20T09:56:26.726Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2bb458ac-7b76-4f81-9f16-59aa8476fbd1" ],
+  "subjects" : [ "https://www.example.org/2dbce39b-77b8-4dc4-b8b0-6fca84ca9fe2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "71d62ff9-3d8f-491f-9391-1a6ee242e483",
-    "name" : "1DXTfrPSE2m",
-    "mimeType" : "Teu3KkPe66H2",
-    "size" : 1200229581,
-    "license" : "https://www.example.com/e6zxkalpmrnmz",
+    "identifier" : "3a2afb23-b665-4bc5-b77f-ada771655a15",
+    "name" : "RT6Hicb7qqgvl",
+    "mimeType" : "2wY5d7lDhuAE1V2L",
+    "size" : 946484211,
+    "license" : "https://www.example.com/egahx1spbhhemmt6m",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "cogseB4xAXMOKYN7l2w"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "On8fkvgpgbLB1B2LL",
-    "publishedDate" : "1998-01-17T20:18:24.800Z",
+    "legalNote" : "Ct1IPboVqXVQIiz8C6",
+    "publishedDate" : "2012-03-20T20:23:40.998Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/J2YNnUTFe3rggs",
-    "name" : "04bImExDSa28",
-    "description" : "N3BE3m3Xg64y"
+    "id" : "https://www.example.com/9hzQCNTWX4T",
+    "name" : "8S0pNJ3eTRtsK",
+    "description" : "gTWC0hspXP"
   } ],
-  "rightsHolder" : "1MHk74BasD",
-  "duplicateOf" : "https://www.example.org/411dcb23-1031-489a-81f5-3ea1fb03301f",
+  "rightsHolder" : "igVZM2Lhyi",
+  "duplicateOf" : "https://www.example.org/571da686-6615-4dfe-99c1-085d7d502374",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "Hi1UBCEDkBiu3"
+    "note" : "CJT35Wpau1J1r8AcY"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fuG7EjpOM8HfZJDv",
-    "createdBy" : "FICYxZU3AZit40uTO",
-    "createdDate" : "1981-01-28T04:26:25.713Z"
+    "note" : "A4BC0Mt9jKVvjZj0",
+    "createdBy" : "x76mGOgqLy3382",
+    "createdDate" : "2004-04-13T19:23:46.502Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d8555e7d-b62b-4b5c-b595-648169daec79" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/a88d7f07-6cb0-43d5-bce1-ee8de27367c4" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "KoKCQSJBVKItH",
-    "ownerAffiliation" : "https://www.example.org/a19a1673-18f2-480a-a8bf-dd53e819e43c"
+    "owner" : "IE3N1P8q6xyJFF",
+    "ownerAffiliation" : "https://www.example.org/27de7f8f-66a3-4520-9c5b-9dd539c3e303"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/7737a7a2-bfe5-4f27-b1b9-5c02c1aa5026"
+    "id" : "https://www.example.org/077f979a-1237-40b0-9938-2a9603d588cc"
   },
-  "createdDate" : "1983-11-06T15:59:00.094Z",
-  "modifiedDate" : "1988-06-19T18:15:05.068Z",
-  "publishedDate" : "2018-04-10T08:34:49.048Z",
-  "indexedDate" : "1982-06-28T11:25:15.422Z",
-  "handle" : "https://www.example.org/a63317a2-49e6-457f-afbf-53c903f817af",
-  "doi" : "https://doi.org/10.1234/ut",
-  "link" : "https://www.example.org/5000e49e-67ec-46a0-b21a-57ced0f1c865",
+  "createdDate" : "1987-07-24T21:18:16.971Z",
+  "modifiedDate" : "1997-07-26T21:35:22.017Z",
+  "publishedDate" : "1976-12-27T13:00:46.221Z",
+  "indexedDate" : "1994-11-26T05:25:38.962Z",
+  "handle" : "https://www.example.org/6059063a-0fb9-4ce6-a881-4990b98886e1",
+  "doi" : "https://doi.org/10.1234/rerum",
+  "link" : "https://www.example.org/2d02581c-727d-4bbb-9ef0-0ce4ac45d82b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "HtYsUV52kf9",
+    "mainTitle" : "0bzgldumWATcROn",
     "alternativeTitles" : {
-      "nb" : "bGGDV7VOb3OTAQGTa"
+      "af" : "R8vNHnPNBNTKdEc5"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xLebr4ZjNMVDiQvh",
-      "month" : "Poe5EjdFM7Sls",
-      "day" : "zRQD2ngmqzfjFg4U"
+      "year" : "ArPcPcJ6nci4El",
+      "month" : "ARZgRfKWGWSZOzAE",
+      "day" : "afcLgjDqGzaLC14Rv"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5c635216-0137-4c55-841d-d47612a41c82",
-        "name" : "BPQq9U0vs8m",
-        "nameType" : "Personal",
-        "orcId" : "muaYQzrBsedPb4F",
+        "id" : "https://www.example.org/1cc33bf3-814e-429e-af4a-64fd9afd82c0",
+        "name" : "0bzcVt3psZ9nR3lvd",
+        "nameType" : "Organizational",
+        "orcId" : "dDsOjP1TeaRtnB",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "EaLHovtCZa",
-          "value" : "gvrfv7MDjxT9KUXN"
+          "sourceName" : "JGS1ypn3z0cgMZxf6XM",
+          "value" : "xzj81KIAtBHRrVekk3R"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BsKKPgDaXz",
-          "value" : "N6EUBHUBJFPxIJJ"
+          "sourceName" : "0Hd6kjneKMYeQE",
+          "value" : "jqaeM2OAwY8aAnZrW5b"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4d86ba35-20ed-4725-bab3-8f6030be68f2"
+        "id" : "https://www.example.org/c49a8647-aa0f-4dc8-9faf-fe236ea6df43"
       } ],
       "role" : {
-        "type" : "Scenographer"
+        "type" : "LightDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,53 +62,54 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7b443c49-94ab-418b-ae61-faa92952c973",
-        "name" : "FXkhJM8pRifnpP1",
-        "nameType" : "Organizational",
-        "orcId" : "k9tYGdJjlk",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/51f5025d-bb31-478b-8e69-b4441050d1dc",
+        "name" : "fHysKhBDZMWOGoZhxkt",
+        "nameType" : "Personal",
+        "orcId" : "1wj7GEfpM3D",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nIBYYYgBJxyG59ZAY3",
-          "value" : "V2mqhncKoSrGnRb"
+          "sourceName" : "U6LbWAyq45Z8s",
+          "value" : "i2Kvcn1qsMcBhsgvmp3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vMu70SnLFE",
-          "value" : "oenXjuDhz9s9FHQ"
+          "sourceName" : "6ZDwDo6CTFsHDZkIv",
+          "value" : "Ikzbca0cm28kPBm"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4ea2e55-0953-4df6-8c23-2a14d31cd92f"
+        "id" : "https://www.example.org/d60b295a-7b16-4605-bc8c-1d2227a6ec10"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "jyIUASYf5bGHRrgn98E"
+      "pl" : "WjBNrmtFXC7dDr0g"
     },
-    "npiSubjectHeading" : "ownfk4erLZ8CBv",
-    "tags" : [ "9JL44zTIc2csS" ],
-    "description" : "vfNevedXjHxqdOPtm",
+    "npiSubjectHeading" : "Z56JUa0ImzmI3v",
+    "tags" : [ "SLP6RISN8z0Do" ],
+    "description" : "F9MeDbZDce",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "Journal"
+          "type" : "MediaTypeOther",
+          "description" : "XJqVLYh8rKkN"
         },
-        "format" : "Sound",
-        "disseminationChannel" : "8nQXzvKRliza793ai07",
+        "format" : "Video",
+        "disseminationChannel" : "8xd5wL9wJMvtFd",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "OfwU6rmP7AT",
-          "seriesPart" : "uoAld8jLmH2IyDKH4"
+          "seriesName" : "53roJI16PJ",
+          "seriesPart" : "oGRHQjAXtMb7cBSFSNd"
         }
       },
-      "doi" : "https://www.example.org/a4dccadc-3c62-4f6f-91f8-3f84d6c9c311",
+      "doi" : "https://www.example.org/cfa7537c-12c4-4f66-bd27-4d7602280ad4",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -116,88 +117,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ffba5cb8-5c93-4489-b809-086aab0b138f",
-    "abstract" : "zvMPlaCofZ"
+    "metadataSource" : "https://www.example.org/ced9bf87-13e4-4df2-bbb4-64ae93979374",
+    "abstract" : "NRE8b75QgT78"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7f8d72af-8654-4521-aa00-604d4efae485",
-    "name" : "olpNQSVso0pgC7p",
+    "id" : "https://www.example.org/c515aaa2-d596-4352-9325-7fa5745a0e04",
+    "name" : "eU1Hw3sIAV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1999-10-23T16:49:06.085Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "pJk9etM3IszS2z"
+      "approvalDate" : "2004-05-11T07:45:45.132Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "L9DbhHIn2xu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/10ebb35f-d866-4c81-a140-4c4401a3e85a",
-    "identifier" : "gdCmUSmvFp7m",
+    "source" : "https://www.example.org/094e530d-ded8-4dba-8d0b-91a9568fe5b2",
+    "identifier" : "uSI8fWnS7VHQ9246",
     "labels" : {
-      "pl" : "5ma4wNZHZ8FwZ9T09"
+      "da" : "wEk39CewYhrze"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 374487709
+      "currency" : "EUR",
+      "amount" : 1655804434
     },
-    "activeFrom" : "2015-08-20T12:31:28.540Z",
-    "activeTo" : "2015-10-18T06:03:00.037Z"
+    "activeFrom" : "1972-05-30T06:43:57.041Z",
+    "activeTo" : "1993-12-04T00:28:14.696Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/99ce0076-e032-4fe6-a394-7ea222b6f6f7",
-    "id" : "https://www.example.org/a350d48f-6ad1-4f9e-8bd3-0f6564926907",
-    "identifier" : "jNemXjzsd3",
+    "source" : "https://www.example.org/63a1ac57-e825-48aa-9053-1f7fcaca9d15",
+    "id" : "https://www.example.org/9e44d065-5e0c-4d06-8911-9f56ce5bcdad",
+    "identifier" : "sQBV8XRxVajSL",
     "labels" : {
-      "hu" : "VvzfuBDezI0c"
+      "ru" : "udCLwYcvKGa"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 645957825
+      "currency" : "USD",
+      "amount" : 370728710
     },
-    "activeFrom" : "1997-01-14T21:08:41.076Z",
-    "activeTo" : "2022-04-22T07:11:56.831Z"
+    "activeFrom" : "1991-07-23T05:24:37.524Z",
+    "activeTo" : "2006-03-02T20:53:13.399Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/96908e33-e810-41df-bfcc-a1ae4b29c638" ],
+  "subjects" : [ "https://www.example.org/7e235c06-4919-4c2c-96b4-406b14deb7df" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "bf919fd5-f529-4438-9db8-31440b258e32",
-    "name" : "Qh8SxqRTw0KUJCMY6t",
-    "mimeType" : "U4eHUoVmkHoeA68eBt",
-    "size" : 461263345,
-    "license" : "https://www.example.com/tjchdra440xv",
+    "identifier" : "ea778ab0-7990-4428-9cf4-f8d2edaced5e",
+    "name" : "lF84mlH0Mafy7IQ",
+    "mimeType" : "Ra00V8tqQXPFnDqP0",
+    "size" : 212613768,
+    "license" : "https://www.example.com/iflux7jtvco",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "mE5q4auvPMFDZ",
-    "publishedDate" : "1982-12-26T22:13:18.010Z",
+    "legalNote" : "4nvciGVLIXneN8pvSHm",
+    "publishedDate" : "1984-11-17T13:17:40.378Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/IdUSb1ake9S",
-    "name" : "nbAq7MAWCIE",
-    "description" : "1Tzh11ngWpPXuiYLHX"
+    "id" : "https://www.example.com/Fs6qFdHIsNtbnPVKhQ9",
+    "name" : "pz9jK5Zr9dlEmyrns",
+    "description" : "9xM7Yf8i7I1oaIh"
   } ],
-  "rightsHolder" : "LlLpFcByWrOBL",
-  "duplicateOf" : "https://www.example.org/4a6f86cc-0618-4efd-a7b2-5bf82cd13296",
+  "rightsHolder" : "vBMtSXw9OXINTVD6",
+  "duplicateOf" : "https://www.example.org/51a6876e-676d-4f93-a8e7-7e32b4dccdc6",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "pI0XWlRVVb"
+    "note" : "utCuZreNXGbz7J"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "OtJwhSX7duXE",
-    "createdBy" : "kerUBmRLEBiU586H0RF",
-    "createdDate" : "2011-10-31T18:00:51.198Z"
+    "note" : "RvmC7BM7LgO8JJ",
+    "createdBy" : "MN7H9DS5uJ0",
+    "createdDate" : "1978-07-03T21:19:57.325Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5211cc94-4802-4d55-9e2d-93b3d4f8dca9" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/87ac6f27-ba27-4d9f-99fe-ac4cb2e50f78" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaPodcast.json
+++ b/documentation/MediaPodcast.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "IE3N1P8q6xyJFF",
-    "ownerAffiliation" : "https://www.example.org/27de7f8f-66a3-4520-9c5b-9dd539c3e303"
+    "owner" : "88Iyzr4DXG32AFA2i",
+    "ownerAffiliation" : "https://www.example.org/25cb3a3e-bb77-4d88-9a90-57515f62baaa"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/077f979a-1237-40b0-9938-2a9603d588cc"
+    "id" : "https://www.example.org/92fb3ad2-b995-4076-a724-26aeb91461fb"
   },
-  "createdDate" : "1987-07-24T21:18:16.971Z",
-  "modifiedDate" : "1997-07-26T21:35:22.017Z",
-  "publishedDate" : "1976-12-27T13:00:46.221Z",
-  "indexedDate" : "1994-11-26T05:25:38.962Z",
-  "handle" : "https://www.example.org/6059063a-0fb9-4ce6-a881-4990b98886e1",
-  "doi" : "https://doi.org/10.1234/rerum",
-  "link" : "https://www.example.org/2d02581c-727d-4bbb-9ef0-0ce4ac45d82b",
+  "createdDate" : "1980-11-29T04:43:20.873Z",
+  "modifiedDate" : "1990-08-18T18:22:28.429Z",
+  "publishedDate" : "2002-08-23T18:22:44.117Z",
+  "indexedDate" : "1982-11-09T16:20:20.671Z",
+  "handle" : "https://www.example.org/0977c13f-516f-4ec8-9ae6-91538bfb3cfe",
+  "doi" : "https://doi.org/10.1234/exercitationem",
+  "link" : "https://www.example.org/b50c70cd-c2e7-45ef-9ed3-f0a1f761601e",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "0bzgldumWATcROn",
+    "mainTitle" : "u42vwqhvMXn",
     "alternativeTitles" : {
-      "af" : "R8vNHnPNBNTKdEc5"
+      "pt" : "bbdpLoI6deggL2pnX"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ArPcPcJ6nci4El",
-      "month" : "ARZgRfKWGWSZOzAE",
-      "day" : "afcLgjDqGzaLC14Rv"
+      "year" : "4aGKtY4sb4b0",
+      "month" : "Z5JobVNEIfgm",
+      "day" : "P0GRCUHMTgrMT"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1cc33bf3-814e-429e-af4a-64fd9afd82c0",
-        "name" : "0bzcVt3psZ9nR3lvd",
-        "nameType" : "Organizational",
-        "orcId" : "dDsOjP1TeaRtnB",
+        "id" : "https://www.example.org/e7b93f74-4cf7-42c8-982e-4a4e2ffe61b9",
+        "name" : "OqRVfVPMSi",
+        "nameType" : "Personal",
+        "orcId" : "maa6GFY0gIOl",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JGS1ypn3z0cgMZxf6XM",
-          "value" : "xzj81KIAtBHRrVekk3R"
+          "sourceName" : "Y28Fj15Py1tzbcFSbDm",
+          "value" : "DcnDx2YF2nxrj27Xj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "0Hd6kjneKMYeQE",
-          "value" : "jqaeM2OAwY8aAnZrW5b"
+          "sourceName" : "Ku80TSsJRDx",
+          "value" : "21YEEheefi"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c49a8647-aa0f-4dc8-9faf-fe236ea6df43"
+        "id" : "https://www.example.org/08eee3cf-ea6c-4458-83d6-3aca50a74b34"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Artist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,54 +62,53 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/51f5025d-bb31-478b-8e69-b4441050d1dc",
-        "name" : "fHysKhBDZMWOGoZhxkt",
-        "nameType" : "Personal",
-        "orcId" : "1wj7GEfpM3D",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/40761956-83ec-4297-ad4a-50ffa404b300",
+        "name" : "vD29HtHaoi",
+        "nameType" : "Organizational",
+        "orcId" : "4dGu1vjVlTRA3Z7Y",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "U6LbWAyq45Z8s",
-          "value" : "i2Kvcn1qsMcBhsgvmp3"
+          "sourceName" : "AVqt9t1bldoN8",
+          "value" : "BRcM1Bp9Q8LTe2V"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6ZDwDo6CTFsHDZkIv",
-          "value" : "Ikzbca0cm28kPBm"
+          "sourceName" : "HwDgnmEEs5gM5dq",
+          "value" : "oy5gL3IFdhiUrUfp"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d60b295a-7b16-4605-bc8c-1d2227a6ec10"
+        "id" : "https://www.example.org/ff6cbd83-30e8-4da3-90c7-694300a5e6a6"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "WjBNrmtFXC7dDr0g"
+      "pl" : "pqfzgy4OJQllg"
     },
-    "npiSubjectHeading" : "Z56JUa0ImzmI3v",
-    "tags" : [ "SLP6RISN8z0Do" ],
-    "description" : "F9MeDbZDce",
+    "npiSubjectHeading" : "JxF10U0AIK6tbDAcFwo",
+    "tags" : [ "RSR3YCh95UVmnMewyQt" ],
+    "description" : "lUaC0CXLZE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContribution",
         "medium" : {
-          "type" : "MediaTypeOther",
-          "description" : "XJqVLYh8rKkN"
+          "type" : "TV"
         },
-        "format" : "Video",
-        "disseminationChannel" : "8xd5wL9wJMvtFd",
+        "format" : "Sound",
+        "disseminationChannel" : "tHdYmEPrJ0t5i15nZt",
         "partOf" : {
           "type" : "SeriesEpisode",
-          "seriesName" : "53roJI16PJ",
-          "seriesPart" : "oGRHQjAXtMb7cBSFSNd"
+          "seriesName" : "HW7bqXUbT6v",
+          "seriesPart" : "5qoB0Dfe9c0DvaOq"
         }
       },
-      "doi" : "https://www.example.org/cfa7537c-12c4-4f66-bd27-4d7602280ad4",
+      "doi" : "https://www.example.org/e1b60549-b9cf-4cd6-bddb-df1df1b0080c",
       "publicationInstance" : {
         "type" : "MediaPodcast",
         "pages" : {
@@ -117,89 +116,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/ced9bf87-13e4-4df2-bbb4-64ae93979374",
-    "abstract" : "NRE8b75QgT78"
+    "metadataSource" : "https://www.example.org/b136d605-4a8b-4244-b387-1f090f966ed4",
+    "abstract" : "Z6CEpdrR0Y2sR"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c515aaa2-d596-4352-9325-7fa5745a0e04",
-    "name" : "eU1Hw3sIAV",
+    "id" : "https://www.example.org/8f2b35b7-4ed0-4822-8521-e6a99b5a60c0",
+    "name" : "GdInf5rPTsf5Y4qu9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2004-05-11T07:45:45.132Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "L9DbhHIn2xu"
+      "approvalDate" : "2019-08-26T16:32:34.778Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "zCxt3xRUtfQai"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/094e530d-ded8-4dba-8d0b-91a9568fe5b2",
-    "identifier" : "uSI8fWnS7VHQ9246",
+    "source" : "https://www.example.org/24e2965c-01d7-4d34-b6b9-7555d7bf47f3",
+    "identifier" : "BGd5d5g2P5ZD0nmm3M",
     "labels" : {
-      "da" : "wEk39CewYhrze"
+      "es" : "PtnU16MvPJzIJiC9c"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1655804434
+      "amount" : 1587367673
     },
-    "activeFrom" : "1972-05-30T06:43:57.041Z",
-    "activeTo" : "1993-12-04T00:28:14.696Z"
+    "activeFrom" : "1978-07-14T09:22:49.825Z",
+    "activeTo" : "1988-12-03T08:41:26.374Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/63a1ac57-e825-48aa-9053-1f7fcaca9d15",
-    "id" : "https://www.example.org/9e44d065-5e0c-4d06-8911-9f56ce5bcdad",
-    "identifier" : "sQBV8XRxVajSL",
+    "source" : "https://www.example.org/6732c316-027c-4caf-b53d-8004ec2987a7",
+    "id" : "https://www.example.org/68567dc6-c3ad-409f-8a37-5464fce2ba8c",
+    "identifier" : "quM2kOY25Nv",
     "labels" : {
-      "ru" : "udCLwYcvKGa"
+      "pl" : "RO0Sm8DTKxu3xU7nl"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 370728710
+      "currency" : "GBP",
+      "amount" : 2041521775
     },
-    "activeFrom" : "1991-07-23T05:24:37.524Z",
-    "activeTo" : "2006-03-02T20:53:13.399Z"
+    "activeFrom" : "1979-02-19T22:38:50.876Z",
+    "activeTo" : "2005-06-08T07:05:44.845Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7e235c06-4919-4c2c-96b4-406b14deb7df" ],
+  "subjects" : [ "https://www.example.org/b8200707-110b-4bfe-96bd-81f8bf6e5c5e" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "ea778ab0-7990-4428-9cf4-f8d2edaced5e",
-    "name" : "lF84mlH0Mafy7IQ",
-    "mimeType" : "Ra00V8tqQXPFnDqP0",
-    "size" : 212613768,
-    "license" : "https://www.example.com/iflux7jtvco",
+    "identifier" : "ea2d669f-9881-47b4-90cf-654ecab27580",
+    "name" : "lPSMQ55vHkjNz55t",
+    "mimeType" : "WO5m1l98T2S6SORYwym",
+    "size" : 125532610,
+    "license" : "https://www.example.com/lvpxjur0e6xr",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "4nvciGVLIXneN8pvSHm",
-    "publishedDate" : "1984-11-17T13:17:40.378Z",
+    "legalNote" : "hFmR1QJqcC",
+    "publishedDate" : "1988-12-06T04:26:40.415Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "MeCdUqcFZRUY",
+      "uploadedDate" : "2003-01-08T08:08:53.659Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Fs6qFdHIsNtbnPVKhQ9",
-    "name" : "pz9jK5Zr9dlEmyrns",
-    "description" : "9xM7Yf8i7I1oaIh"
+    "id" : "https://www.example.com/04bgVutBrVZ",
+    "name" : "Zt6rNbriLSbSrcEPt",
+    "description" : "zolhEVNEoP9ca4zd"
   } ],
-  "rightsHolder" : "vBMtSXw9OXINTVD6",
-  "duplicateOf" : "https://www.example.org/51a6876e-676d-4f93-a8e7-7e32b4dccdc6",
+  "rightsHolder" : "K5LxFfPVkZoSAXT2ibI",
+  "duplicateOf" : "https://www.example.org/b558247d-0979-4c6d-93b4-79242ff3e70c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "utCuZreNXGbz7J"
+    "note" : "895R9pY2EK20mzw"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RvmC7BM7LgO8JJ",
-    "createdBy" : "MN7H9DS5uJ0",
-    "createdDate" : "1978-07-03T21:19:57.325Z"
+    "note" : "XCN3QSGs7WFsrcAR",
+    "createdBy" : "fmOdOiSgyvlXLHI",
+    "createdDate" : "1974-03-28T13:37:41.418Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/87ac6f27-ba27-4d9f-99fe-ac4cb2e50f78" ],
+  "curatingInstitutions" : [ "https://www.example.org/ada98264-2030-4790-bd7b-d14ed10024dd" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "Hzq2odK3O9",
-    "ownerAffiliation" : "https://www.example.org/5c715452-a89f-4aa6-85bb-d8c316ced847"
+    "owner" : "VVqDxFGStoWpMs2G",
+    "ownerAffiliation" : "https://www.example.org/243b6ac0-180e-4024-a81a-31421b9b5f7a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c995dadc-f9e3-4975-98b2-36042c39a718"
+    "id" : "https://www.example.org/1538b230-1f08-42da-bd4e-924694b23369"
   },
-  "createdDate" : "2014-07-29T00:06:34.018Z",
-  "modifiedDate" : "2011-11-08T16:31:17.446Z",
-  "publishedDate" : "2007-09-03T23:10:11.190Z",
-  "indexedDate" : "2013-04-04T20:12:12.125Z",
-  "handle" : "https://www.example.org/fb999ea2-9730-4e09-83f3-b3f8f2dea4eb",
-  "doi" : "https://doi.org/10.1234/minima",
-  "link" : "https://www.example.org/5f83b628-3677-43d6-ba43-4b357e835922",
+  "createdDate" : "1998-11-22T07:44:47.080Z",
+  "modifiedDate" : "2009-03-11T06:44:35.120Z",
+  "publishedDate" : "1989-04-24T04:53:48.294Z",
+  "indexedDate" : "1994-08-19T08:53:11.761Z",
+  "handle" : "https://www.example.org/4050606a-597d-4d4e-92a9-25f1a51adce0",
+  "doi" : "https://doi.org/10.1234/accusamus",
+  "link" : "https://www.example.org/af000c43-8fee-4d0b-aa0a-7ba37ae1b540",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "y5wdyrbKkoWyoI29Je",
+    "mainTitle" : "9xIV9zO86Wai",
     "alternativeTitles" : {
-      "sv" : "CUKG78M9amCe5aiye"
+      "ru" : "DtVTG6ITx7amk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1SoJoTuBeBgy3YO",
-      "month" : "bnTh23sbwAM8t",
-      "day" : "AIhnl9ShrdZsEgcIc"
+      "year" : "dFebrPIshcnoQhN8H",
+      "month" : "7QDbhyNWtjPYUmMyyE8",
+      "day" : "j4r32wy1Jz7cy1aK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c4527b85-92d3-4007-bc3a-a9a92ac46c9a",
-        "name" : "vnTWMRbE2hy",
-        "nameType" : "Organizational",
-        "orcId" : "YMJg1DozZeSDg",
+        "id" : "https://www.example.org/59d2e48d-5b02-4121-b530-ad022e5b058d",
+        "name" : "qbSy8uJCiMD6",
+        "nameType" : "Personal",
+        "orcId" : "lKj6CTKTZTfgtn2Dyy6",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wH6U1fmgczs",
-          "value" : "8ymH8oY7BqTvtnVE80"
+          "sourceName" : "jzbio8inaOOP",
+          "value" : "zy2yl1JN1SspVoEmWFF"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V3hkVKFAAW",
-          "value" : "L6mQEu6qzojuf18bB6I"
+          "sourceName" : "zQuPX0aUb9f7vIC70",
+          "value" : "G8A0wIAs4GD"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0f0b6a61-2163-4908-b16b-2c562514ab2c"
+        "id" : "https://www.example.org/58390025-bbfe-4237-b9b1-c94c8fc3f578"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/770931b0-fce9-43d9-822d-1ad336d330c1",
-        "name" : "p2auxFpKzayM0SHFR",
+        "id" : "https://www.example.org/0cf09ddd-f022-4f90-9766-dba867eae525",
+        "name" : "DqhSd93z9aa7xh",
         "nameType" : "Organizational",
-        "orcId" : "0oiLY5Jws38sKn",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "rdJoZ4BS734",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3SSwOxZB15Kz",
-          "value" : "2hEY9ZGMQlStxi3eL"
+          "sourceName" : "gKVFydGRPh",
+          "value" : "w1CuYUE7vhb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7qlAj4b9hK0otV",
-          "value" : "vLd4gMp7IZl0"
+          "sourceName" : "a1WRJyTZibTAhQk",
+          "value" : "PZp2tt31Fks7g"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8c963868-874b-4d71-98ab-65503b1dfd5f"
+        "id" : "https://www.example.org/5570fd90-a31d-46ad-ab7d-3b6293a88a61"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "EMxoDqs50k9aC4"
+      "nl" : "yGvw6MDCxPgwhK68"
     },
-    "npiSubjectHeading" : "n3SXfcZJjq52334",
-    "tags" : [ "GWDhZoKT1ET3g" ],
-    "description" : "K0VKeMej7az",
+    "npiSubjectHeading" : "hFtIL7GfJF6Zk",
+    "tags" : [ "fdnqZGN3Wl6k" ],
+    "description" : "J0tW37LxfYK0W49",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8bcbf03a-09f0-45cd-a9ed-74657094eca9"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/45e22ca2-282c-4308-bee2-9817cbfa09e8"
       },
-      "doi" : "https://www.example.org/30c3f9e8-d993-4e37-98c5-94b616e982a6",
+      "doi" : "https://www.example.org/a1f5c812-a33a-4772-8f3b-29299e94ff9e",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "wrXf7fGLZAf",
-        "issue" : "fmCoMLuV2AOmE",
-        "articleNumber" : "298bDbPOWQO",
+        "volume" : "JRjmwpHEBE0",
+        "issue" : "X59A8EpYI9k",
+        "articleNumber" : "S4EfnvjUjPm",
         "pages" : {
           "type" : "Range",
-          "begin" : "58uSKqyY155jxu",
-          "end" : "fYylDbV9vaPyxax6"
+          "begin" : "wDonTRJ7y5H8U0HYn02",
+          "end" : "nAhB8Rz1XWWFj8GVu7"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/52efac27-df22-4172-913f-39eae2f7858d",
-    "abstract" : "jhdL9JAUuqHpcXm"
+    "metadataSource" : "https://www.example.org/38d71933-50ed-48ad-a9af-9596467e6531",
+    "abstract" : "K7ZzwUyffHY"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ccc28b8d-6d3f-487a-99ad-1d51e61f6ac4",
-    "name" : "DdtfCfrAI4cIeAkJCh",
+    "id" : "https://www.example.org/2b44204b-a594-4a5b-a3fc-400e818c7977",
+    "name" : "ojAipuzztVU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2016-10-12T10:56:56.871Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1979-01-02T07:16:56.987Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "7thjxi0ilOLSN"
+      "applicationCode" : "Aq4abC2wf48QSo"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cf577b16-ace2-4ed0-b19c-80a5727f9b29",
-    "identifier" : "Vu1QHX0Si2vSpa",
+    "source" : "https://www.example.org/b675cc92-f495-42a7-b513-a648f7725713",
+    "identifier" : "48tTVbsfjdBhWzQU6",
     "labels" : {
-      "de" : "bdVwkTwX6PQzCwQLH"
+      "sv" : "zRu4bUr3WtMhD"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1078933551
+      "currency" : "NOK",
+      "amount" : 482277241
     },
-    "activeFrom" : "2000-04-25T19:29:59.591Z",
-    "activeTo" : "2013-01-28T14:26:43.796Z"
+    "activeFrom" : "2001-07-13T12:23:08.863Z",
+    "activeTo" : "2014-02-02T14:34:08.684Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d5000830-43bb-4cda-8a45-2fb61cf5a66d",
-    "id" : "https://www.example.org/5dfa2237-3989-459f-8bf3-cfed09f6ff0e",
-    "identifier" : "4KOFT7gm9Y0",
+    "source" : "https://www.example.org/46496582-0684-42aa-9b84-79c7f040a68a",
+    "id" : "https://www.example.org/6ce5b9b4-e245-4019-b6b3-239af8378f04",
+    "identifier" : "M9UzmDJG8Dse",
     "labels" : {
-      "nl" : "ez9yel4YseJe8az4hC9"
+      "da" : "7bOCL5SdGhIsdD6W7"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 453466205
+      "currency" : "EUR",
+      "amount" : 1276971450
     },
-    "activeFrom" : "2020-07-22T06:05:03.890Z",
-    "activeTo" : "2023-12-09T09:26:51.192Z"
+    "activeFrom" : "1974-11-27T07:53:56.373Z",
+    "activeTo" : "2021-06-03T17:38:10.935Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/855f849c-dc9e-40ff-8fd3-e6e4f604b40f" ],
+  "subjects" : [ "https://www.example.org/45474c43-07a2-4e59-a77e-fe4c6c44bcc5" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5c08e3e3-194e-4ac5-9cf0-5afb999b5e75",
-    "name" : "4Wrwp94i6EYzYs1Ufhh",
-    "mimeType" : "35cxQGYptUl",
-    "size" : 58929487,
-    "license" : "https://www.example.com/apfpcvojn8",
+    "identifier" : "4d77e76c-16d4-432b-96b9-dd4d7802e757",
+    "name" : "jfGMmiYL6OjLhnqDyJq",
+    "mimeType" : "ga3FlTk4ZOqcCgW",
+    "size" : 1916814803,
+    "license" : "https://www.example.com/wsitkv1bdsqarlm8",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "5Vx8nsCNRkJlO",
-    "publishedDate" : "1984-07-30T20:19:40.058Z",
+    "legalNote" : "ARpYTZwZPa4IL",
+    "publishedDate" : "1991-12-17T07:38:05.653Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/o9ODD85QRBnlCb",
-    "name" : "hPSNeTgSpQfr63oPy7c",
-    "description" : "Qi8OFgLgM6eoCuFc"
+    "id" : "https://www.example.com/Bkfh1uc8Qd1634",
+    "name" : "KM2rQp1H13d6",
+    "description" : "KWrD9618kX9"
   } ],
-  "rightsHolder" : "5AYzxnSGtfws",
-  "duplicateOf" : "https://www.example.org/3262a83c-b21a-4321-a023-19c9df0b7f79",
+  "rightsHolder" : "IRGktziXrIHaE",
+  "duplicateOf" : "https://www.example.org/c4579af9-6e97-4e65-9dad-6d98d31beef4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "gDY2vhjMUlk0VI"
+    "note" : "hGhASI0S2KcX8G7qIr"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "1MaQzPExe4GvB21au",
-    "createdBy" : "p0sKgMC9qt",
-    "createdDate" : "2022-08-23T11:01:00.728Z"
+    "note" : "eK3UqmldiNQYvoApb",
+    "createdBy" : "ubCWFmxuvh",
+    "createdDate" : "1981-12-15T23:43:06.245Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6c94dda7-b06f-4e43-9b43-199f452e7b85" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/6dee630e-89c4-4d54-8ef8-b3be1d73dbfb" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MediaReaderOpinion.json
+++ b/documentation/MediaReaderOpinion.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "VVqDxFGStoWpMs2G",
-    "ownerAffiliation" : "https://www.example.org/243b6ac0-180e-4024-a81a-31421b9b5f7a"
+    "owner" : "IYDBZ0UuN9Mq",
+    "ownerAffiliation" : "https://www.example.org/7f6022b0-ae25-48e3-950e-33d36d6e0944"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1538b230-1f08-42da-bd4e-924694b23369"
+    "id" : "https://www.example.org/00836b23-963c-458b-9ea1-4d12b033e1bd"
   },
-  "createdDate" : "1998-11-22T07:44:47.080Z",
-  "modifiedDate" : "2009-03-11T06:44:35.120Z",
-  "publishedDate" : "1989-04-24T04:53:48.294Z",
-  "indexedDate" : "1994-08-19T08:53:11.761Z",
-  "handle" : "https://www.example.org/4050606a-597d-4d4e-92a9-25f1a51adce0",
-  "doi" : "https://doi.org/10.1234/accusamus",
-  "link" : "https://www.example.org/af000c43-8fee-4d0b-aa0a-7ba37ae1b540",
+  "createdDate" : "1982-02-14T20:42:09.696Z",
+  "modifiedDate" : "2001-06-09T01:28:34.507Z",
+  "publishedDate" : "1983-03-26T06:44:50.284Z",
+  "indexedDate" : "1986-06-05T22:12:44.945Z",
+  "handle" : "https://www.example.org/86129e7d-3c60-41b2-b088-e6d4422e68cd",
+  "doi" : "https://doi.org/10.1234/laudantium",
+  "link" : "https://www.example.org/59632219-a1c4-4ea4-b86d-e8265c3538bc",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9xIV9zO86Wai",
+    "mainTitle" : "0Ht7CUfSqZj5AH7aXpk",
     "alternativeTitles" : {
-      "ru" : "DtVTG6ITx7amk"
+      "nb" : "epptJc5Q1mqLimu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "dFebrPIshcnoQhN8H",
-      "month" : "7QDbhyNWtjPYUmMyyE8",
-      "day" : "j4r32wy1Jz7cy1aK"
+      "year" : "DjVJb7Q2vXSbaj",
+      "month" : "yZbUR77JncRSScax",
+      "day" : "tIW5yk8HC49xR"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/59d2e48d-5b02-4121-b530-ad022e5b058d",
-        "name" : "qbSy8uJCiMD6",
-        "nameType" : "Personal",
-        "orcId" : "lKj6CTKTZTfgtn2Dyy6",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/3763f27c-6f65-43f0-a44b-b0c3c0a99768",
+        "name" : "NfvFtJAF2CIow",
+        "nameType" : "Organizational",
+        "orcId" : "42yGU0u29jhSY51mgQ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jzbio8inaOOP",
-          "value" : "zy2yl1JN1SspVoEmWFF"
+          "sourceName" : "JoIJvfiAGFkL",
+          "value" : "lm7rcz62ZBDaG2"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zQuPX0aUb9f7vIC70",
-          "value" : "G8A0wIAs4GD"
+          "sourceName" : "tUAUx2dKZgA",
+          "value" : "RdNkuOfndlI"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/58390025-bbfe-4237-b9b1-c94c8fc3f578"
+        "id" : "https://www.example.org/22cd9842-924a-48d0-96b1-b39141d0e002"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Dramatist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0cf09ddd-f022-4f90-9766-dba867eae525",
-        "name" : "DqhSd93z9aa7xh",
+        "id" : "https://www.example.org/088ebe99-3fde-457e-83cd-b1fe2bd5f023",
+        "name" : "Kl69CL9t6mWNwqhz",
         "nameType" : "Organizational",
-        "orcId" : "rdJoZ4BS734",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "GJcs8zPZuyYminiZV",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gKVFydGRPh",
-          "value" : "w1CuYUE7vhb"
+          "sourceName" : "3YDq46GpUOwzZsaYde6",
+          "value" : "ZeU6wvUQ3A4Gn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "a1WRJyTZibTAhQk",
-          "value" : "PZp2tt31Fks7g"
+          "sourceName" : "Vcc8mOjpC30pJ19PKNj",
+          "value" : "a4C6wU5KwryIK84zLrq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5570fd90-a31d-46ad-ab7d-3b6293a88a61"
+        "id" : "https://www.example.org/288a710e-fe2f-4458-9e2e-3ca05f8e8a07"
       } ],
       "role" : {
-        "type" : "ProjectMember"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "yGvw6MDCxPgwhK68"
+      "pl" : "pbYpdr8Oz2XSMj"
     },
-    "npiSubjectHeading" : "hFtIL7GfJF6Zk",
-    "tags" : [ "fdnqZGN3Wl6k" ],
-    "description" : "J0tW37LxfYK0W49",
+    "npiSubjectHeading" : "9Ts06KiaUWw35ipD",
+    "tags" : [ "YOePfhCSmIpe7N" ],
+    "description" : "ZkpV3t8HVyQzVsOuE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "MediaContributionPeriodical",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/45e22ca2-282c-4308-bee2-9817cbfa09e8"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1a4c1802-c3c3-4bb2-858c-79d91f963d7e"
       },
-      "doi" : "https://www.example.org/a1f5c812-a33a-4772-8f3b-29299e94ff9e",
+      "doi" : "https://www.example.org/48363eb6-c27e-42f6-9080-8c1e52940abd",
       "publicationInstance" : {
         "type" : "MediaReaderOpinion",
-        "volume" : "JRjmwpHEBE0",
-        "issue" : "X59A8EpYI9k",
-        "articleNumber" : "S4EfnvjUjPm",
+        "volume" : "AYB6vo7BP4NUFX",
+        "issue" : "VlOCD9keLeJLmZ",
+        "articleNumber" : "23vZkgYWd6QpCbYsoKv",
         "pages" : {
           "type" : "Range",
-          "begin" : "wDonTRJ7y5H8U0HYn02",
-          "end" : "nAhB8Rz1XWWFj8GVu7"
+          "begin" : "8m2pZu50F81GUt",
+          "end" : "JUZC9SmoBYfIEe3ZfF"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/38d71933-50ed-48ad-a9af-9596467e6531",
-    "abstract" : "K7ZzwUyffHY"
+    "metadataSource" : "https://www.example.org/aaf2d192-ebf1-4c72-ae40-c6eafcd1eb5f",
+    "abstract" : "CSo0uiDyd5G7yrHMmk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2b44204b-a594-4a5b-a3fc-400e818c7977",
-    "name" : "ojAipuzztVU",
+    "id" : "https://www.example.org/77df328f-7828-41e8-80b6-5c2b73ce75dd",
+    "name" : "ov4cyhj57PJmb5Ffo",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1979-01-02T07:16:56.987Z",
+      "approvalDate" : "2018-04-19T00:18:18.710Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Aq4abC2wf48QSo"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "Lg0EqiThkyH3no"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b675cc92-f495-42a7-b513-a648f7725713",
-    "identifier" : "48tTVbsfjdBhWzQU6",
+    "source" : "https://www.example.org/cbfa8400-e8bc-4b38-bac9-afbaae5fa1fb",
+    "identifier" : "taYRl1jP909CmMa1",
     "labels" : {
-      "sv" : "zRu4bUr3WtMhD"
+      "ru" : "Bgijsjfic1"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 482277241
+      "amount" : 1653323047
     },
-    "activeFrom" : "2001-07-13T12:23:08.863Z",
-    "activeTo" : "2014-02-02T14:34:08.684Z"
+    "activeFrom" : "2021-07-06T05:14:47.482Z",
+    "activeTo" : "2023-03-08T16:03:01.851Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/46496582-0684-42aa-9b84-79c7f040a68a",
-    "id" : "https://www.example.org/6ce5b9b4-e245-4019-b6b3-239af8378f04",
-    "identifier" : "M9UzmDJG8Dse",
+    "source" : "https://www.example.org/df68c4ca-e250-42ec-8c43-c91f53a7285f",
+    "id" : "https://www.example.org/92df0942-7c47-494e-9c0a-bd2e1aa0b59c",
+    "identifier" : "J1XbkB5CG0c3WdU",
     "labels" : {
-      "da" : "7bOCL5SdGhIsdD6W7"
+      "nn" : "wJxElUY5buAOF"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1276971450
+      "currency" : "USD",
+      "amount" : 793956806
     },
-    "activeFrom" : "1974-11-27T07:53:56.373Z",
-    "activeTo" : "2021-06-03T17:38:10.935Z"
+    "activeFrom" : "2021-05-07T23:50:43.018Z",
+    "activeTo" : "2023-07-24T06:57:28.532Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/45474c43-07a2-4e59-a77e-fe4c6c44bcc5" ],
+  "subjects" : [ "https://www.example.org/5fa57a3c-7d21-4349-9d89-5bb0ba152dd3" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4d77e76c-16d4-432b-96b9-dd4d7802e757",
-    "name" : "jfGMmiYL6OjLhnqDyJq",
-    "mimeType" : "ga3FlTk4ZOqcCgW",
-    "size" : 1916814803,
-    "license" : "https://www.example.com/wsitkv1bdsqarlm8",
+    "identifier" : "33b427cf-6f37-4931-8ef9-8c9fec1edd00",
+    "name" : "nRbg3AicSMr24Qnwx",
+    "mimeType" : "PA7IDQ1ZQQQkd0vlNMM",
+    "size" : 130612353,
+    "license" : "https://www.example.com/f77leh8kkwp4k67",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "ARpYTZwZPa4IL",
-    "publishedDate" : "1991-12-17T07:38:05.653Z",
+    "legalNote" : "ZW2ybTOtLRJuwZG",
+    "publishedDate" : "1985-03-29T07:45:25.173Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "03EtOUQjizlxDeyU5",
+      "uploadedDate" : "2021-09-04T11:09:10.548Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Bkfh1uc8Qd1634",
-    "name" : "KM2rQp1H13d6",
-    "description" : "KWrD9618kX9"
+    "id" : "https://www.example.com/j1t6goTl5T156R",
+    "name" : "0I7uu41LMOu7d9n4hFe",
+    "description" : "Fe0HU29qqeGp"
   } ],
-  "rightsHolder" : "IRGktziXrIHaE",
-  "duplicateOf" : "https://www.example.org/c4579af9-6e97-4e65-9dad-6d98d31beef4",
+  "rightsHolder" : "K59uUEEyh6ySgdy6",
+  "duplicateOf" : "https://www.example.org/248af2bc-650a-4312-bc22-d1b0efd5d96e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "hGhASI0S2KcX8G7qIr"
+    "note" : "M9dPdJ6NNpl"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "eK3UqmldiNQYvoApb",
-    "createdBy" : "ubCWFmxuvh",
-    "createdDate" : "1981-12-15T23:43:06.245Z"
+    "note" : "t5HdilvjkpkEr",
+    "createdBy" : "JSv5YGfMWU",
+    "createdDate" : "1975-05-27T14:12:15.700Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/6dee630e-89c4-4d54-8ef8-b3be1d73dbfb" ],
+  "curatingInstitutions" : [ "https://www.example.org/96bd8146-8120-4b57-ad22-78dc1048d732" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "4LsxEhB99l1A",
-    "ownerAffiliation" : "https://www.example.org/90c2a1cb-61bd-4997-908f-a5862f915fc9"
+    "owner" : "fdzYv9kVTUnfGfIb",
+    "ownerAffiliation" : "https://www.example.org/16cd0e64-1516-4f23-a5b4-60d0886d01c4"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/45396a5b-0cbb-475c-8370-f2049eeddce5"
+    "id" : "https://www.example.org/09fa196f-0067-4084-a4da-bf5bcdc4962c"
   },
-  "createdDate" : "1999-01-04T10:49:47.057Z",
-  "modifiedDate" : "1983-05-27T14:07:59.067Z",
-  "publishedDate" : "2000-10-25T10:08:56.365Z",
-  "indexedDate" : "1973-05-31T00:13:48.059Z",
-  "handle" : "https://www.example.org/69d53a09-e559-4a8b-8b68-e4d1ff4b0849",
-  "doi" : "https://doi.org/10.1234/voluptas",
-  "link" : "https://www.example.org/a1f7dcd0-a6b8-4e02-a6ef-b9047b1b36bd",
+  "createdDate" : "2005-08-19T08:01:29.068Z",
+  "modifiedDate" : "1984-08-31T03:51:37.812Z",
+  "publishedDate" : "2015-10-25T18:08:12.842Z",
+  "indexedDate" : "2003-01-07T00:11:38.676Z",
+  "handle" : "https://www.example.org/a96ac6cb-5f06-4dee-a476-e888a4f0b1cf",
+  "doi" : "https://doi.org/10.1234/doloribus",
+  "link" : "https://www.example.org/8c3d0538-8236-434d-ba9c-8e9f022c77f6",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "g4e3gCcEPKKr",
+    "mainTitle" : "vJutXFrvoUisoRMshj",
     "alternativeTitles" : {
-      "nl" : "DbGMqhDh2JJiKfovM"
+      "ru" : "jpmDIqSZXOvgU"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "yqZlIAEFyr3rvxWWzn",
-      "month" : "omuuiAIC1BGyltJ",
-      "day" : "nVmB7zbmla2DrxVGm"
+      "year" : "Bd6PpJhHzl8NOoX",
+      "month" : "GVODZbLray7ADfg2Qbr",
+      "day" : "JSTSQYDCTfTby4fK"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ff538662-455c-4d48-8802-2e5982dfb62c",
-        "name" : "wgLKujm7CtDRDGJH9m",
-        "nameType" : "Personal",
-        "orcId" : "zHwGY0UJWu",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/51dfa6a8-0b43-4a81-a1cd-a8f6ac01aaf0",
+        "name" : "Aoalfh2ZSq",
+        "nameType" : "Organizational",
+        "orcId" : "86g1kQiimr",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "arsYJECa1fnMsqcy",
-          "value" : "QfRRRjlWs2Sv"
+          "sourceName" : "U4w2vf3bLL5tLxTgnTX",
+          "value" : "7hzesRI0pEhQKYw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "z5Kclk59oyksHl4l",
-          "value" : "hJkRrNz33ECQ4lY0OMa"
+          "sourceName" : "vlhcBfKSbW7HERS8F0F",
+          "value" : "GxJQwxfH6Xo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/131e9921-55fe-4cbf-a965-39d8be395100"
+        "id" : "https://www.example.org/e0f31a54-8bb7-4bb3-b877-5fad1240960f"
       } ],
       "role" : {
-        "type" : "Journalist"
+        "type" : "Dancer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,180 +62,188 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b91fe830-695a-47cf-94f7-099f4980d8d6",
-        "name" : "sMLYFtMOxNsV",
+        "id" : "https://www.example.org/ae0fdf0b-25d1-4674-b5f0-63f0401f5763",
+        "name" : "eKMdFoUperoMgr5Sbt",
         "nameType" : "Organizational",
-        "orcId" : "uQtiTqNsYmhOZMhUNTp",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "KPxAIGw9nqDlGtCsFa",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MzOaqfhReFoyovnbp",
-          "value" : "Pp9phRQIsP"
+          "sourceName" : "JAcuW3nKQJ",
+          "value" : "j1sMD8IlAg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kcMwUMbIFhF",
-          "value" : "aAePuoT2Yt"
+          "sourceName" : "jcp93H7ZF7qLgXjH",
+          "value" : "sSa4m71c10FUb8lA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1bd600aa-9e1b-4969-bf23-178be14c5527"
+        "id" : "https://www.example.org/652c3864-c572-411c-807a-ff531edfbcc0"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "Screenwriter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "174bufYMLsxvA"
+      "fr" : "ljqi6OcjT3Mf"
     },
-    "npiSubjectHeading" : "AMHUUArHeGr7Q3r",
-    "tags" : [ "tabeb9G3VSxJ539l" ],
-    "description" : "SOxsBTcitdn",
+    "npiSubjectHeading" : "hEMf8yNRlTX79jLscoc",
+    "tags" : [ "O5XSi2Wb7BYaF" ],
+    "description" : "fGejUYg4YErtjdSJ6",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/746146cf-7421-4b62-85a0-2afa981f4967",
+      "doi" : "https://www.example.org/952dc16e-6d14-4191-87ea-40970faca598",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
           "type" : "AugmentedVirtualRealityFilm"
         },
-        "description" : "PJsqLZRFxV8Khdkl",
+        "description" : "3FLDGYw64XJYyB",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "mxB6GFXsiw",
+            "name" : "8xDSZ8yTQ8OL",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2011-02-10T07:54:12.340Z"
+            "value" : "1987-06-12T16:44:05.953Z"
           },
-          "sequence" : 289133345
+          "sequence" : 1825720153
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "Hud7KcjD2idjTAVXJE",
-            "country" : "vxWtXzm830qhw6VyP"
+            "label" : "4xd0uCYE82dD",
+            "country" : "HnM26HtZobDUGMp"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1982-12-22T05:14:12.263Z"
+            "value" : "2015-03-27T21:47:32.361Z"
           },
-          "sequence" : 599118157
+          "sequence" : 424645257
         }, {
           "type" : "OtherRelease",
-          "description" : "Bh6ugGqDj4",
+          "description" : "pcL3aZpX2o",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "28nTA5yX5Lfc44vWmD",
-            "country" : "WNQ7CipZJdBM2c"
+            "label" : "ysnVQnQibymRKe",
+            "country" : "hwgqsKvS6MZyjeOp6"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "NzIXosmIRm3egbav6BJ",
+            "name" : "IoJ1rxi7l1uSOtzx5j",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1984-11-19T23:37:13.641Z"
+            "value" : "2004-02-28T08:13:13.146Z"
           },
-          "sequence" : 1543096310
+          "sequence" : 1967181636
         } ],
+        "duration" : {
+          "type" : "NullDuration"
+        },
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/0f50b021-e399-43ec-bfde-e5a7f472c04a",
-    "abstract" : "5AsXYeiYiUGi7x1UJb3"
+    "metadataSource" : "https://www.example.org/c3cd2ec4-c640-4136-bf4a-bf933b0152b1",
+    "abstract" : "Wq8pb7l4jlKg6C"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/471980fb-ab22-4126-aa7a-683b5174ce22",
-    "name" : "u43TlsA8CTwhFO7qRM",
+    "id" : "https://www.example.org/d3fab5e1-1aba-41c9-86c8-f3c7df1a18b7",
+    "name" : "ROk4QiOeNp0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2017-02-08T17:09:47.464Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "uhXpWOQoenWzmHjos"
+      "approvalDate" : "2011-07-29T14:23:36.528Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "vG3L1vyZDZu"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1f971d08-ec6e-4843-bc4b-b7848b8f3f18",
-    "identifier" : "wjlXsR5h3U7",
+    "source" : "https://www.example.org/90bc3374-59d7-42df-94dc-aa525da17ea4",
+    "identifier" : "MqDECIlt47GqOxm1E",
     "labels" : {
-      "bg" : "89jsvcbkFxVqEweY0IF"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1559720206
-    },
-    "activeFrom" : "2017-01-18T19:02:23.081Z",
-    "activeTo" : "2021-06-29T19:42:53.025Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ca2bd731-7d09-4300-9027-8ee5398d3528",
-    "id" : "https://www.example.org/c99a95ae-5170-4020-b258-1ecfc4226bef",
-    "identifier" : "EzncOPvQsY9e4",
-    "labels" : {
-      "af" : "r1ElHT9lruRQvB"
+      "af" : "WVwWt0zwmLIOYwZl8f"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1326758982
+      "amount" : 1854232630
     },
-    "activeFrom" : "1980-10-27T20:36:18.440Z",
-    "activeTo" : "1992-01-29T08:22:21.539Z"
+    "activeFrom" : "1982-09-19T03:31:40.111Z",
+    "activeTo" : "2015-07-16T15:48:18.931Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/cb055af8-f004-4061-9d3a-3529dbcef488",
+    "id" : "https://www.example.org/65e9b403-4080-4824-9683-f2c60cf53f6b",
+    "identifier" : "0OHVQw0jCJjBC0uuyCl",
+    "labels" : {
+      "sv" : "ENkqlPc6w94DY"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1006514576
+    },
+    "activeFrom" : "1998-02-03T04:12:19.548Z",
+    "activeTo" : "2005-12-13T20:27:37.329Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/30ebaafb-5e88-45d3-a8bb-b8be6f725a78" ],
+  "subjects" : [ "https://www.example.org/ab996259-da44-4c59-8d50-d50e9bf51fb9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "10f06808-02b5-4ab0-aacd-ada29d2a344e",
-    "name" : "wcDRS1Sybu",
-    "mimeType" : "WUcbnykj9YX2Jt4yOkR",
-    "size" : 1303157300,
-    "license" : "https://www.example.com/omb2of3cfpusjedzi",
+    "identifier" : "26de6562-6b1f-4438-a67d-17265ebd2f60",
+    "name" : "TOuxCkRnKvlj0FdaHE",
+    "mimeType" : "tPB6U2Dk4eSKTEyGT",
+    "size" : 826788715,
+    "license" : "https://www.example.com/s2sgmzlz7tkkiarwd",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "fTORNMmJfA",
-    "publishedDate" : "1982-07-15T16:40:55.365Z",
+    "legalNote" : "Kmc2YCppFPiA6wH",
+    "publishedDate" : "1997-01-02T22:19:55.058Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "3DWaSaDtfGihIaxds6",
+      "uploadedDate" : "1971-09-22T01:07:16.841Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/JGtzmGDh1rpl",
-    "name" : "R8pnbVEBwYMa8kGK",
-    "description" : "GWyCxXcvkLTUSlpHLu"
+    "id" : "https://www.example.com/4g4fHrryMl",
+    "name" : "1xDuMnCUrHP1",
+    "description" : "SqKuVmPxDDrMHo2pGh"
   } ],
-  "rightsHolder" : "Tuwbylg63lRK0",
-  "duplicateOf" : "https://www.example.org/236cac4d-74d4-4dd4-ae36-a44bbe99db2e",
+  "rightsHolder" : "GNofpEGKFPBYHx",
+  "duplicateOf" : "https://www.example.org/6917efd8-ad06-4fd9-8338-b2f292d1985b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "bmv7Q0tcF9KMUg"
+    "note" : "dFDgDTQChOuvPEv7"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "scziGKiQfK8rrA",
-    "createdBy" : "EUIqSfLK2ViPJ",
-    "createdDate" : "1981-08-18T19:33:25.469Z"
+    "note" : "dMz8cnuWxgrLU",
+    "createdBy" : "VD1FIl4Tpwkh",
+    "createdDate" : "2013-02-12T19:48:02.337Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/07a53943-8cf2-40fa-b965-5a6d607a5573" ],
+  "curatingInstitutions" : [ "https://www.example.org/ac161d35-62cb-4fbc-ae93-3959dca006a5" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/MovingPicture.json
+++ b/documentation/MovingPicture.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "3N5ZVdtEFQzLeO",
-    "ownerAffiliation" : "https://www.example.org/c6bdeefd-5832-4846-995f-133027cb89bd"
+    "owner" : "4LsxEhB99l1A",
+    "ownerAffiliation" : "https://www.example.org/90c2a1cb-61bd-4997-908f-a5862f915fc9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/8c231509-b5a4-4227-bb34-e35dd8a681eb"
+    "id" : "https://www.example.org/45396a5b-0cbb-475c-8370-f2049eeddce5"
   },
-  "createdDate" : "1988-03-17T13:53:13.981Z",
-  "modifiedDate" : "1987-11-17T03:52:27.021Z",
-  "publishedDate" : "2022-02-24T16:16:33.667Z",
-  "indexedDate" : "2011-08-11T02:52:58.548Z",
-  "handle" : "https://www.example.org/30702d28-6c25-4670-818e-646c031c9a79",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/994dcc40-56e4-4430-af8e-563917256d4d",
+  "createdDate" : "1999-01-04T10:49:47.057Z",
+  "modifiedDate" : "1983-05-27T14:07:59.067Z",
+  "publishedDate" : "2000-10-25T10:08:56.365Z",
+  "indexedDate" : "1973-05-31T00:13:48.059Z",
+  "handle" : "https://www.example.org/69d53a09-e559-4a8b-8b68-e4d1ff4b0849",
+  "doi" : "https://doi.org/10.1234/voluptas",
+  "link" : "https://www.example.org/a1f7dcd0-a6b8-4e02-a6ef-b9047b1b36bd",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rlxvNyVF34KFHJiwgDv",
+    "mainTitle" : "g4e3gCcEPKKr",
     "alternativeTitles" : {
-      "ru" : "nB5IB30vK9Fh"
+      "nl" : "DbGMqhDh2JJiKfovM"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "1TsjHwdcUL5o9WYHT",
-      "month" : "SHjUBWNcN9c1MHs",
-      "day" : "1dwdxo4XfFtXdf"
+      "year" : "yqZlIAEFyr3rvxWWzn",
+      "month" : "omuuiAIC1BGyltJ",
+      "day" : "nVmB7zbmla2DrxVGm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/927410c4-02b8-4db2-aabd-9c56194dc5a3",
-        "name" : "474WqDXkgvf6T",
+        "id" : "https://www.example.org/ff538662-455c-4d48-8802-2e5982dfb62c",
+        "name" : "wgLKujm7CtDRDGJH9m",
         "nameType" : "Personal",
-        "orcId" : "9tpkG2ncE2Y5hwR28HG",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "zHwGY0UJWu",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "MU1adkZyCzz2BBPA",
-          "value" : "KHaJLYIhQwS2B"
+          "sourceName" : "arsYJECa1fnMsqcy",
+          "value" : "QfRRRjlWs2Sv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KFoAMHGZQRbvB6wJ",
-          "value" : "h0QIeJ0Sn5bB9W2Y3LM"
+          "sourceName" : "z5Kclk59oyksHl4l",
+          "value" : "hJkRrNz33ECQ4lY0OMa"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/01235ebb-4a45-429d-8cf8-84a53e5ca8bf"
+        "id" : "https://www.example.org/131e9921-55fe-4cbf-a965-39d8be395100"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "Journalist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,179 +62,180 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/80fae97a-0783-44a6-9fda-f0ab27be03fa",
-        "name" : "3XbYFbkmqHyKyDxKX",
-        "nameType" : "Personal",
-        "orcId" : "GYoFv1zNDvjBhq",
+        "id" : "https://www.example.org/b91fe830-695a-47cf-94f7-099f4980d8d6",
+        "name" : "sMLYFtMOxNsV",
+        "nameType" : "Organizational",
+        "orcId" : "uQtiTqNsYmhOZMhUNTp",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "p6QdCnWpGe0OB5n",
-          "value" : "KMw1Rrq3Rpg9i"
+          "sourceName" : "MzOaqfhReFoyovnbp",
+          "value" : "Pp9phRQIsP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "OeoMJPceeByin4rgFpc",
-          "value" : "Dk9MM6evQXIE"
+          "sourceName" : "kcMwUMbIFhF",
+          "value" : "aAePuoT2Yt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/23ea7ee4-5cbd-4a39-b33b-4be598c5972f"
+        "id" : "https://www.example.org/1bd600aa-9e1b-4969-bf23-178be14c5527"
       } ],
       "role" : {
-        "type" : "Editor"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "af" : "mNsTO9EYgXMSr"
+      "pt" : "174bufYMLsxvA"
     },
-    "npiSubjectHeading" : "L1wemIUt4xUkxi7Op",
-    "tags" : [ "MTsxDSaJcJ" ],
-    "description" : "RP1w3rw63J",
+    "npiSubjectHeading" : "AMHUUArHeGr7Q3r",
+    "tags" : [ "tabeb9G3VSxJ539l" ],
+    "description" : "SOxsBTcitdn",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/6882e2fc-35b4-4a58-affe-278a4048b3a0",
+      "doi" : "https://www.example.org/746146cf-7421-4b62-85a0-2afa981f4967",
       "publicationInstance" : {
         "type" : "MovingPicture",
         "subtype" : {
-          "type" : "SerialFilmProduction"
+          "type" : "AugmentedVirtualRealityFilm"
         },
-        "description" : "cdLAzMaRfkMQ4vQrv",
+        "description" : "PJsqLZRFxV8Khdkl",
         "outputs" : [ {
           "type" : "Broadcast",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "vn6QJcHe52c",
+            "name" : "mxB6GFXsiw",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "2001-01-21T01:00:49.728Z"
+            "value" : "2011-02-10T07:54:12.340Z"
           },
-          "sequence" : 961619499
+          "sequence" : 289133345
         }, {
           "type" : "CinematicRelease",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "pUlwBem4kc",
-            "country" : "bNFUPFpvEF0dHVJ"
+            "label" : "Hud7KcjD2idjTAVXJE",
+            "country" : "vxWtXzm830qhw6VyP"
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1996-11-09T12:28:38.163Z"
+            "value" : "1982-12-22T05:14:12.263Z"
           },
-          "sequence" : 1572573585
+          "sequence" : 599118157
         }, {
           "type" : "OtherRelease",
-          "description" : "WnRrtAFcon",
+          "description" : "Bh6ugGqDj4",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "KF7DDskMeedXFOaj",
-            "country" : "Vfh1eo4QFh1vjCi"
+            "label" : "28nTA5yX5Lfc44vWmD",
+            "country" : "WNQ7CipZJdBM2c"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "H00sFKCHwwvW0",
+            "name" : "NzIXosmIRm3egbav6BJ",
             "valid" : true
           },
           "date" : {
             "type" : "Instant",
-            "value" : "1977-12-03T23:50:27.364Z"
+            "value" : "1984-11-19T23:37:13.641Z"
           },
-          "sequence" : 1995316963
+          "sequence" : 1543096310
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/7a879bbf-8682-484b-b527-5e99fdf6f26b",
-    "abstract" : "KyX5t4ScMhxVKh"
+    "metadataSource" : "https://www.example.org/0f50b021-e399-43ec-bfde-e5a7f472c04a",
+    "abstract" : "5AsXYeiYiUGi7x1UJb3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/383c29a8-0f5a-436b-b3ac-b1d7d23d5657",
-    "name" : "A26D6VzZaZg7r0QZ",
+    "id" : "https://www.example.org/471980fb-ab22-4126-aa7a-683b5174ce22",
+    "name" : "u43TlsA8CTwhFO7qRM",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1991-10-20T23:43:28.575Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "D4wdcotdH0LS1gVB"
+      "approvalDate" : "2017-02-08T17:09:47.464Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "uhXpWOQoenWzmHjos"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/528e7a7b-1978-4479-8664-111b5e01b00d",
-    "identifier" : "w9sR19Uj8ar",
+    "source" : "https://www.example.org/1f971d08-ec6e-4843-bc4b-b7848b8f3f18",
+    "identifier" : "wjlXsR5h3U7",
     "labels" : {
-      "is" : "0UGk6KtNl7wL"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 330925385
-    },
-    "activeFrom" : "1971-07-25T06:39:49.019Z",
-    "activeTo" : "1985-12-08T11:49:48.245Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/93c8a9e9-b92d-4420-88f3-acda5098e3cc",
-    "id" : "https://www.example.org/3ba1822e-619d-47e3-b03b-46cc9375d2c7",
-    "identifier" : "A5gnP3vRNYs31J3gen",
-    "labels" : {
-      "es" : "RxUMs2a9AT"
+      "bg" : "89jsvcbkFxVqEweY0IF"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1987604365
+      "amount" : 1559720206
     },
-    "activeFrom" : "2004-06-04T17:37:56.524Z",
-    "activeTo" : "2019-09-08T01:24:04.097Z"
+    "activeFrom" : "2017-01-18T19:02:23.081Z",
+    "activeTo" : "2021-06-29T19:42:53.025Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/ca2bd731-7d09-4300-9027-8ee5398d3528",
+    "id" : "https://www.example.org/c99a95ae-5170-4020-b258-1ecfc4226bef",
+    "identifier" : "EzncOPvQsY9e4",
+    "labels" : {
+      "af" : "r1ElHT9lruRQvB"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 1326758982
+    },
+    "activeFrom" : "1980-10-27T20:36:18.440Z",
+    "activeTo" : "1992-01-29T08:22:21.539Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/0e7b9a6b-203c-460c-bec5-3a45a1b88d1c" ],
+  "subjects" : [ "https://www.example.org/30ebaafb-5e88-45d3-a8bb-b8be6f725a78" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "6ad45537-e338-4c8c-9a90-f4de18f55b1a",
-    "name" : "m5m16ONnQ9",
-    "mimeType" : "p6cZngLQyU26Hfzl0",
-    "size" : 747129952,
-    "license" : "https://www.example.com/ev0cey6qq0zffgerv",
+    "identifier" : "10f06808-02b5-4ab0-aacd-ada29d2a344e",
+    "name" : "wcDRS1Sybu",
+    "mimeType" : "WUcbnykj9YX2Jt4yOkR",
+    "size" : 1303157300,
+    "license" : "https://www.example.com/omb2of3cfpusjedzi",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "XPFDNatz9HDV8gIq3m",
-    "publishedDate" : "1991-01-18T03:26:27.354Z",
+    "legalNote" : "fTORNMmJfA",
+    "publishedDate" : "1982-07-15T16:40:55.365Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/MQP7boiuwrkJoE",
-    "name" : "6MQNXT8XmYTTkSlDA",
-    "description" : "L3dl3t8ToliEPAO4hMF"
+    "id" : "https://www.example.com/JGtzmGDh1rpl",
+    "name" : "R8pnbVEBwYMa8kGK",
+    "description" : "GWyCxXcvkLTUSlpHLu"
   } ],
-  "rightsHolder" : "aUVlrSwt65UXUb953o",
-  "duplicateOf" : "https://www.example.org/0a765ba4-fe29-442f-8cc2-71d446e57b16",
+  "rightsHolder" : "Tuwbylg63lRK0",
+  "duplicateOf" : "https://www.example.org/236cac4d-74d4-4dd4-ae36-a44bbe99db2e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ovGDRB3hnx4nDdX"
+    "note" : "bmv7Q0tcF9KMUg"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CrZE9NNAu0iPNfqqA",
-    "createdBy" : "qgA5C5WPwqHUgw",
-    "createdDate" : "2012-09-25T16:19:34.410Z"
+    "note" : "scziGKiQfK8rrA",
+    "createdBy" : "EUIqSfLK2ViPJ",
+    "createdDate" : "1981-08-18T19:33:25.469Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3ed64789-d2fd-4fde-81d9-8446d9716e09" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/07a53943-8cf2-40fa-b965-5a6d607a5573" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "z3s5ZUXVGZrwpxjE",
-    "ownerAffiliation" : "https://www.example.org/8549a52b-feba-46ea-8d5b-83c163bed19f"
+    "owner" : "ZTAOp0f2tMGHo85ST",
+    "ownerAffiliation" : "https://www.example.org/78ee70ae-1746-4e14-ae72-f4cf428aecc9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/91f33017-6e34-4383-ac91-18df1bf80f01"
+    "id" : "https://www.example.org/59bf4844-16d9-41d6-9868-e23404d8b0fb"
   },
-  "createdDate" : "1992-02-12T14:57:28.838Z",
-  "modifiedDate" : "2001-08-20T21:21:14.038Z",
-  "publishedDate" : "2003-01-18T09:19:29.470Z",
-  "indexedDate" : "2003-03-27T00:38:16.061Z",
-  "handle" : "https://www.example.org/cf5299b1-5a87-4fe6-ab52-e08e79377e96",
-  "doi" : "https://doi.org/10.1234/dolore",
-  "link" : "https://www.example.org/daaa70e9-63db-4c6e-95e7-5ea213e40719",
+  "createdDate" : "1997-11-05T08:32:07.041Z",
+  "modifiedDate" : "1989-05-19T13:08:35.449Z",
+  "publishedDate" : "1976-02-12T14:42:47.714Z",
+  "indexedDate" : "2000-11-12T01:31:09.247Z",
+  "handle" : "https://www.example.org/17db6b9d-4f00-4487-b330-aed10e7f393b",
+  "doi" : "https://doi.org/10.1234/culpa",
+  "link" : "https://www.example.org/e747997f-0946-48bd-b0ab-a70cc188bd2b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "s73r9hqveTBlnF",
+    "mainTitle" : "GvpphuixrOX",
     "alternativeTitles" : {
-      "ru" : "W46HJhBebAEzgeLX4T"
+      "ca" : "IkSpRDlqm6jYkp0UJdj"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "0kAEtT0IAh3iTZ",
-      "month" : "HVPal5mTVyf",
-      "day" : "v7G4q2UtAfIhn56p"
+      "year" : "bR1xTPly53t0f",
+      "month" : "CRtgcSY17kVisJ",
+      "day" : "EKtvU9Tuq6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6990ebea-2e6a-4540-ad76-aac4b03f5553",
-        "name" : "qh5GKxyq4IukGNL",
+        "id" : "https://www.example.org/728476b7-6003-4720-972b-189be9fa6b81",
+        "name" : "i3szAhDMQRvupr",
         "nameType" : "Personal",
-        "orcId" : "BGzgvI67V4",
-        "verificationStatus" : "Verified",
+        "orcId" : "EYcoqw9louDG",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HpLrIWMqThmBuP0W7S",
-          "value" : "jbF472yXYzX"
+          "sourceName" : "JawnFfhLbtmSb",
+          "value" : "HwAxA3aN4cGhxg3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ka5TKfxqcWgHil",
-          "value" : "jxincuSuHp"
+          "sourceName" : "xgXtPtR4g8J4",
+          "value" : "bNbNYaOvlnT8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f40a2753-b8e4-46a3-afb1-8e73bbb345dc"
+        "id" : "https://www.example.org/ff1ebd05-89ef-4ac0-8c21-90384fb1be7a"
       } ],
       "role" : {
         "type" : "MuseumEducator"
@@ -62,61 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9699bf14-d022-4fae-8c19-70288d2bb1af",
-        "name" : "Kpq6bNlIjMDqYZNvMC",
-        "nameType" : "Organizational",
-        "orcId" : "xluTJ4p7oWO",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/c15e5ff0-3214-4626-9edc-df7a0040155d",
+        "name" : "kBR2e43GuWW0TKuNgP",
+        "nameType" : "Personal",
+        "orcId" : "8NydSDGLa7",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VWPptghKZHi",
-          "value" : "MevMgyQaBDToh8c"
+          "sourceName" : "4k5h5AQePU1JzPJc7Ut",
+          "value" : "FriGYATsrQV7RYLKdFu"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o0JplWvR1ZUtP",
-          "value" : "9M0q68ASxrvuufJp"
+          "sourceName" : "bIfVP38wo2hpkJUl",
+          "value" : "iYYKbURFCaQe2vytFz"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fc3b3b6a-16a3-465f-91b7-24950a3c6663"
+        "id" : "https://www.example.org/8289c3e4-b38b-4727-8f10-514ebcf6a2ef"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Dramaturge"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "SC5QLjurX4"
+      "cs" : "SkwMPMpryhC"
     },
-    "npiSubjectHeading" : "9ICPOA5UlsMmz5f",
-    "tags" : [ "IYaOGG08ZgvgF" ],
-    "description" : "gqze2ogc8mtEwNDNweg",
+    "npiSubjectHeading" : "PxwC2ZiKCfnOHV",
+    "tags" : [ "NUyCoZyO67f9" ],
+    "description" : "b6CCKQYFvn5SZC",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/70489096-bf4d-47e6-89fb-e061a15f1bfa",
+      "doi" : "https://www.example.org/fb8b2565-4eb3-4601-ac77-46dde61f0b70",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "Vinyl"
+            "type" : "DigitalFile"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "CAndEt03NIu",
+            "name" : "VWVzflej5isteiV",
             "valid" : true
           },
-          "catalogueNumber" : "vymV5NezqGtgZfRrc",
+          "catalogueNumber" : "X50TBJZATaEN9s",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "EX2TWBR2MP9AwoTR5",
-            "composer" : "t2XYjs1aP4KAs1P",
-            "extent" : "pDYJ1cbqifnF6noyeyj"
+            "title" : "HlBVfgpt7R9AK8EA58",
+            "composer" : "RlZlchpOoE5if0mZs",
+            "extent" : "C1uTfHpjsMkCQ8Z"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,30 +126,29 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "jI8QjOfzdzV9SMgRm",
-            "country" : "faPPrHJeNthJeCt00d"
+            "label" : "yiuPPkI2yd7",
+            "country" : "IepwzGjHP56MHIB8m"
           },
           "time" : {
-            "type" : "Period",
-            "from" : "1999-05-14T00:19:55.247Z",
-            "to" : "2001-06-02T11:14:52.468Z"
+            "type" : "Instant",
+            "value" : "1974-09-29T18:40:31.619Z"
           },
-          "extent" : "t6vGNscang",
+          "extent" : "drEiSRRrAg",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "l4eW04TnXzy3s",
-            "composer" : "OnFPzRRJ2PwPNGhfZ",
+            "title" : "REWT4PoktuLkHlRS566",
+            "composer" : "8i0XB2uvBRxQ3M1",
             "premiere" : false
           } ],
-          "concertSeries" : "vxQJNydvBCY5kJftT"
+          "concertSeries" : "wslHyP8D7yUEbzhfb"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "iFRHLwS70zcd7Sl",
-          "movements" : "ZOmh2xcIuYFJzQUvHs",
-          "extent" : "YMIzFgFPfQX",
+          "ensemble" : "TcpKFaIbIKtYBy",
+          "movements" : "l7EJ1wV5KKmELePzQ7",
+          "extent" : "TBU3HgAFL1BjGj",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "LxOi7uRiA2L",
+            "name" : "puKflEvubFfDvHfpMOS",
             "valid" : true
           },
           "ismn" : {
@@ -159,17 +158,17 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "jByGfI2Rvzzu4Qt",
+          "performanceType" : "aL1VTLgz1oY",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "JZXI6s8XTa",
-            "country" : "bmRqsB3OCZI18"
+            "label" : "zdtZCkH38pgu1kE",
+            "country" : "zxBiXjDfElnsM4oP"
           },
-          "extent" : "nwhBlJh1i6s0",
+          "extent" : "NBquLvEJ57DryD5",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "Zx3dtSH8I1nHN",
-            "composer" : "fau0X3uHkA5uIeQh5Y"
+            "title" : "0f964ik2fjCm",
+            "composer" : "xZbJk70HIw"
           } ]
         } ],
         "pages" : {
@@ -177,88 +176,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/d6fa0293-3d6f-466c-9153-0bb0ea503d70",
-    "abstract" : "cGICwLDjNvyXcPcI"
+    "metadataSource" : "https://www.example.org/590c2e11-cc79-46a7-944f-d14c1fea69e5",
+    "abstract" : "zKAlks1nUY8k8ZAW"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e8ed88c4-25af-4d41-a510-3ddbf4215082",
-    "name" : "njhAIQCfF7",
+    "id" : "https://www.example.org/0cf455c3-9b8c-40fc-9396-8c1b87df7a80",
+    "name" : "MmaaS7U2BeQsdA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-06-20T05:47:02.739Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "XKyeaigZwza"
+      "approvalDate" : "1980-02-13T20:17:13.584Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "J2oKXBJKqHsD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b75f1bc2-9f2a-4dbb-895b-b5e1ed2df7ea",
-    "identifier" : "19OucOpDiHT",
+    "source" : "https://www.example.org/37d0accf-16d3-4524-81bf-50e61204bc54",
+    "identifier" : "umy19o02VrChsLx",
     "labels" : {
-      "es" : "CM0ECLR0jougX"
+      "de" : "YxCrewNi4cIO2ks"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 9695325
+      "currency" : "USD",
+      "amount" : 1935762626
     },
-    "activeFrom" : "1971-06-26T00:22:03.306Z",
-    "activeTo" : "2009-01-11T13:30:14.693Z"
+    "activeFrom" : "1998-04-02T14:19:24.532Z",
+    "activeTo" : "2022-08-11T02:25:25.682Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/243b7252-7449-4172-892d-79e2226c77f7",
-    "id" : "https://www.example.org/413b4abc-1b52-4b7e-88e4-3a4072f849d6",
-    "identifier" : "EosyS0zSNzNl",
+    "source" : "https://www.example.org/1c959ce1-ce36-4193-8ef0-6a16d46bcfbf",
+    "id" : "https://www.example.org/62e49dbc-30db-4cc4-8a16-7acf858e20e9",
+    "identifier" : "hdmLebYV0dBNLOAlW",
     "labels" : {
-      "zh" : "BRy0MtJZ5SxaNKic"
+      "da" : "sD3MFlOgAj9i5g"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1758846036
+      "currency" : "USD",
+      "amount" : 486256345
     },
-    "activeFrom" : "2001-04-11T05:54:45.516Z",
-    "activeTo" : "2006-12-17T00:15:55.389Z"
+    "activeFrom" : "1991-06-10T23:21:09.254Z",
+    "activeTo" : "2018-06-07T16:31:44.829Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/2d8581f9-a08c-4500-9d25-e142317ba4b5" ],
+  "subjects" : [ "https://www.example.org/5b2752ad-2aa4-4bab-835f-49015b7d6ba0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "45a4c2ed-08ed-41d6-a4f5-8b37e47ff84d",
-    "name" : "pLqOCEllnNWmoMpirFc",
-    "mimeType" : "ge0hoqcO9X36U",
-    "size" : 1176538915,
-    "license" : "https://www.example.com/ncbglkbiftpjcjkilb",
+    "identifier" : "9247ab32-a1ee-45c1-bcca-def23169a588",
+    "name" : "Rk4c1RDuRpUCiLFu",
+    "mimeType" : "uUJaMZMtD1DiOaphM",
+    "size" : 1119905134,
+    "license" : "https://www.example.com/nyu7pezjrh",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Wh5fX7lAUBMCAbQ4m0",
-    "publishedDate" : "1981-03-18T18:31:09.216Z",
+    "legalNote" : "esuIO058Dr7GxxnM",
+    "publishedDate" : "1994-09-28T19:58:11.417Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/9b01Uxq2JJISwq",
-    "name" : "4sOX99qtNNY9OWL4hqt",
-    "description" : "50lEBtO5Ck49ZKeFPd"
+    "id" : "https://www.example.com/SFtAtQgusdg",
+    "name" : "sQrxKW51JCRjR07a6",
+    "description" : "YPX3EweS5pg"
   } ],
-  "rightsHolder" : "BeDYf1c8Vx0OMV2",
-  "duplicateOf" : "https://www.example.org/0cc00ebb-d288-4fff-8bc5-36318f9a8fcd",
+  "rightsHolder" : "PI0A2LqmB16",
+  "duplicateOf" : "https://www.example.org/b8db1cd4-16c5-4b07-a500-5c19e6f648c4",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kbbTD1pnf90Ko"
+    "note" : "466gSIzR1U"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "oTUpWmoq4yrngbSYnY",
-    "createdBy" : "TAIhjykHYm3",
-    "createdDate" : "1981-10-18T18:50:03.541Z"
+    "note" : "mg7W9SoxORPE1Vp3",
+    "createdBy" : "RHOaohS2LX",
+    "createdDate" : "1972-03-18T07:15:38.328Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a1a4bff0-43d3-4411-9f6d-f6278d1f1ce4" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/2b4f8578-b9be-4dad-8132-62df3c312ff2" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/MusicPerformance.json
+++ b/documentation/MusicPerformance.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "ZTAOp0f2tMGHo85ST",
-    "ownerAffiliation" : "https://www.example.org/78ee70ae-1746-4e14-ae72-f4cf428aecc9"
+    "owner" : "tcCJhqlyNrbZucw",
+    "ownerAffiliation" : "https://www.example.org/f903dc8f-09f3-4eed-ae65-eac15da93d80"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/59bf4844-16d9-41d6-9868-e23404d8b0fb"
+    "id" : "https://www.example.org/9ad1b67e-d481-4b84-bdbc-fe6481fae963"
   },
-  "createdDate" : "1997-11-05T08:32:07.041Z",
-  "modifiedDate" : "1989-05-19T13:08:35.449Z",
-  "publishedDate" : "1976-02-12T14:42:47.714Z",
-  "indexedDate" : "2000-11-12T01:31:09.247Z",
-  "handle" : "https://www.example.org/17db6b9d-4f00-4487-b330-aed10e7f393b",
-  "doi" : "https://doi.org/10.1234/culpa",
-  "link" : "https://www.example.org/e747997f-0946-48bd-b0ab-a70cc188bd2b",
+  "createdDate" : "1990-02-24T10:16:16.361Z",
+  "modifiedDate" : "1972-03-06T21:17:15.952Z",
+  "publishedDate" : "1972-04-28T22:37:09.689Z",
+  "indexedDate" : "1974-07-13T08:35:14.239Z",
+  "handle" : "https://www.example.org/dcd9c012-2ad5-42a5-8138-02dfe9ce4508",
+  "doi" : "https://doi.org/10.1234/totam",
+  "link" : "https://www.example.org/70c1d186-8e83-4b55-8c2c-749b94380a9b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "GvpphuixrOX",
+    "mainTitle" : "hO8fvlPB0D",
     "alternativeTitles" : {
-      "ca" : "IkSpRDlqm6jYkp0UJdj"
+      "nl" : "FBhQ2dpGmEAFwDw6"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bR1xTPly53t0f",
-      "month" : "CRtgcSY17kVisJ",
-      "day" : "EKtvU9Tuq6"
+      "year" : "8g25cEtM5h",
+      "month" : "32Ptf8jdxne",
+      "day" : "8n1kl0H8Q3ZA"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/728476b7-6003-4720-972b-189be9fa6b81",
-        "name" : "i3szAhDMQRvupr",
-        "nameType" : "Personal",
-        "orcId" : "EYcoqw9louDG",
+        "id" : "https://www.example.org/b93e6e26-b6e1-4153-b4fe-259cc4efc6ee",
+        "name" : "hXMDdCoG6TcC",
+        "nameType" : "Organizational",
+        "orcId" : "D44y1ph52GTgM0",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "JawnFfhLbtmSb",
-          "value" : "HwAxA3aN4cGhxg3"
+          "sourceName" : "97b7dqBS83c",
+          "value" : "MA8g3poJgzw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xgXtPtR4g8J4",
-          "value" : "bNbNYaOvlnT8"
+          "sourceName" : "yj2XPrjMgqSV",
+          "value" : "K3jBpwTDm7lH5CZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ff1ebd05-89ef-4ac0-8c21-90384fb1be7a"
+        "id" : "https://www.example.org/86b111b3-784a-427f-aa27-afce0bd4e410"
       } ],
       "role" : {
-        "type" : "MuseumEducator"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,61 +62,61 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c15e5ff0-3214-4626-9edc-df7a0040155d",
-        "name" : "kBR2e43GuWW0TKuNgP",
+        "id" : "https://www.example.org/d5f0c2f7-57bb-458d-97b2-5c3e1ae31713",
+        "name" : "GJ7qpWCIv345G",
         "nameType" : "Personal",
-        "orcId" : "8NydSDGLa7",
+        "orcId" : "T3xP1mQcreTGB96c",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4k5h5AQePU1JzPJc7Ut",
-          "value" : "FriGYATsrQV7RYLKdFu"
+          "sourceName" : "5n4ynOHNo8727Gh05br",
+          "value" : "9RPEDJwrVu12RxZRh"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bIfVP38wo2hpkJUl",
-          "value" : "iYYKbURFCaQe2vytFz"
+          "sourceName" : "hTzly1SQCWBDR",
+          "value" : "eoJbArg3BvhbTaA24"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8289c3e4-b38b-4727-8f10-514ebcf6a2ef"
+        "id" : "https://www.example.org/cfc9b7e5-5753-421d-83f6-52d707718e37"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "Screenwriter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "SkwMPMpryhC"
+      "pl" : "emvPiLSlbO26SiqYRju"
     },
-    "npiSubjectHeading" : "PxwC2ZiKCfnOHV",
-    "tags" : [ "NUyCoZyO67f9" ],
-    "description" : "b6CCKQYFvn5SZC",
+    "npiSubjectHeading" : "iZSFMcy0wXfgP",
+    "tags" : [ "0u2wEkg6CObYE9" ],
+    "description" : "EmkYClxBiJDdLi",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/fb8b2565-4eb3-4601-ac77-46dde61f0b70",
+      "doi" : "https://www.example.org/bb5966ea-1af4-424c-ae8d-76f263c68105",
       "publicationInstance" : {
         "type" : "MusicPerformance",
         "manifestations" : [ {
           "type" : "AudioVisualPublication",
           "mediaType" : {
-            "type" : "DigitalFile"
+            "type" : "Streaming"
           },
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "VWVzflej5isteiV",
+            "name" : "PlxYNQBJc6Y",
             "valid" : true
           },
-          "catalogueNumber" : "X50TBJZATaEN9s",
+          "catalogueNumber" : "43Qj6njbrxwBZunJA",
           "trackList" : [ {
             "type" : "MusicTrack",
-            "title" : "HlBVfgpt7R9AK8EA58",
-            "composer" : "RlZlchpOoE5if0mZs",
-            "extent" : "C1uTfHpjsMkCQ8Z"
+            "title" : "fDYohwilTMeIARsk",
+            "composer" : "wFgQyVyfABW",
+            "extent" : "1lV72fnxt9tSt1y34o"
           } ],
           "isrc" : {
             "type" : "Isrc",
@@ -126,29 +126,30 @@
           "type" : "Concert",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "yiuPPkI2yd7",
-            "country" : "IepwzGjHP56MHIB8m"
+            "label" : "YkWPs9Wc3Jw14nCI",
+            "country" : "L4NXclrAgdtzjudM6V"
           },
           "time" : {
-            "type" : "Instant",
-            "value" : "1974-09-29T18:40:31.619Z"
+            "type" : "Period",
+            "from" : "1981-02-25T18:45:11.333Z",
+            "to" : "1990-07-29T19:41:56.128Z"
           },
-          "extent" : "drEiSRRrAg",
+          "extent" : "ts86yPwH2BE",
           "concertProgramme" : [ {
             "type" : "MusicalWorkPerformance",
-            "title" : "REWT4PoktuLkHlRS566",
-            "composer" : "8i0XB2uvBRxQ3M1",
+            "title" : "lGiUutqtUjW24Xt",
+            "composer" : "cfzB6vlgJWkPY",
             "premiere" : false
           } ],
-          "concertSeries" : "wslHyP8D7yUEbzhfb"
+          "concertSeries" : "U7gLVoqnJyTVU5d"
         }, {
           "type" : "MusicScore",
-          "ensemble" : "TcpKFaIbIKtYBy",
-          "movements" : "l7EJ1wV5KKmELePzQ7",
-          "extent" : "TBU3HgAFL1BjGj",
+          "ensemble" : "WhpG5DIl4qKr8n",
+          "movements" : "PC22jXuLsZVSPCYQpwj",
+          "extent" : "N7qGxHxbQ85Lhmb4dx",
           "publisher" : {
             "type" : "UnconfirmedPublisher",
-            "name" : "puKflEvubFfDvHfpMOS",
+            "name" : "x1v2XsldO4qJRa0k",
             "valid" : true
           },
           "ismn" : {
@@ -158,107 +159,115 @@
           }
         }, {
           "type" : "OtherPerformance",
-          "performanceType" : "aL1VTLgz1oY",
+          "performanceType" : "7b9sAnqZUr",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "zdtZCkH38pgu1kE",
-            "country" : "zxBiXjDfElnsM4oP"
+            "label" : "WB68qimx8UEzO7qtk0",
+            "country" : "3U1Uxnuuga"
           },
-          "extent" : "NBquLvEJ57DryD5",
+          "extent" : "TzvvfbZImxjuw",
           "musicalWorks" : [ {
             "type" : "MusicalWork",
-            "title" : "0f964ik2fjCm",
-            "composer" : "xZbJk70HIw"
+            "title" : "7jfMB55OgYr6h7RDs5",
+            "composer" : "iVk9WnurEIarO3F6"
           } ]
         } ],
+        "duration" : {
+          "type" : "NullDuration"
+        },
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/590c2e11-cc79-46a7-944f-d14c1fea69e5",
-    "abstract" : "zKAlks1nUY8k8ZAW"
+    "metadataSource" : "https://www.example.org/3e88c6c0-7ce3-440a-8b58-ceaec9c2ee9b",
+    "abstract" : "HQz78U9Bbdie"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/0cf455c3-9b8c-40fc-9396-8c1b87df7a80",
-    "name" : "MmaaS7U2BeQsdA",
+    "id" : "https://www.example.org/bf6da441-b941-4969-bf47-211cd49b5173",
+    "name" : "fJGVOXFWt7a4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1980-02-13T20:17:13.584Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "J2oKXBJKqHsD"
+      "approvalDate" : "1977-12-01T19:10:59.607Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "T0AQPFxc6b5yHoEfN"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/37d0accf-16d3-4524-81bf-50e61204bc54",
-    "identifier" : "umy19o02VrChsLx",
+    "source" : "https://www.example.org/f66d9c1c-6518-426c-b955-2d9e6f7b0c31",
+    "identifier" : "sWSLt0ob9WipQh",
     "labels" : {
-      "de" : "YxCrewNi4cIO2ks"
+      "sv" : "un44NT8BzLOoB"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1935762626
+      "currency" : "EUR",
+      "amount" : 673495710
     },
-    "activeFrom" : "1998-04-02T14:19:24.532Z",
-    "activeTo" : "2022-08-11T02:25:25.682Z"
+    "activeFrom" : "1978-06-06T12:06:43.565Z",
+    "activeTo" : "1986-03-13T14:48:39.241Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/1c959ce1-ce36-4193-8ef0-6a16d46bcfbf",
-    "id" : "https://www.example.org/62e49dbc-30db-4cc4-8a16-7acf858e20e9",
-    "identifier" : "hdmLebYV0dBNLOAlW",
+    "source" : "https://www.example.org/5b538fe1-c0b7-478c-a59f-231e8b870e3f",
+    "id" : "https://www.example.org/a1a31fdc-bd28-46c1-894d-e7d1e2db11a1",
+    "identifier" : "xEoTogtGxv",
     "labels" : {
-      "da" : "sD3MFlOgAj9i5g"
+      "da" : "rF6XGgyPkcV"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 486256345
+      "amount" : 1419345058
     },
-    "activeFrom" : "1991-06-10T23:21:09.254Z",
-    "activeTo" : "2018-06-07T16:31:44.829Z"
+    "activeFrom" : "1994-09-07T07:12:02.789Z",
+    "activeTo" : "2016-09-03T01:19:00.291Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/5b2752ad-2aa4-4bab-835f-49015b7d6ba0" ],
+  "subjects" : [ "https://www.example.org/6afba5d9-1680-47a3-827f-64b3fc0f4b83" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9247ab32-a1ee-45c1-bcca-def23169a588",
-    "name" : "Rk4c1RDuRpUCiLFu",
-    "mimeType" : "uUJaMZMtD1DiOaphM",
-    "size" : 1119905134,
-    "license" : "https://www.example.com/nyu7pezjrh",
+    "identifier" : "d2cf2bcd-63f4-460a-bcb6-a27a0148bd6f",
+    "name" : "jdmnaO8eLy08QEWD",
+    "mimeType" : "GBPY1yrgJt9eIVTni",
+    "size" : 1101407718,
+    "license" : "https://www.example.com/muzkovqbl6ftif",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "esuIO058Dr7GxxnM",
-    "publishedDate" : "1994-09-28T19:58:11.417Z",
+    "legalNote" : "QNT9uXMTlhupB57StJ",
+    "publishedDate" : "1972-09-24T17:16:00.396Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "20B3Fh3amNebnpJoo",
+      "uploadedDate" : "1980-07-22T14:30:27.657Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/SFtAtQgusdg",
-    "name" : "sQrxKW51JCRjR07a6",
-    "description" : "YPX3EweS5pg"
+    "id" : "https://www.example.com/TMZjfmblASKGZ5hdbi",
+    "name" : "K5VvmTA6C4It3H",
+    "description" : "IHWVM9pZgofb"
   } ],
-  "rightsHolder" : "PI0A2LqmB16",
-  "duplicateOf" : "https://www.example.org/b8db1cd4-16c5-4b07-a500-5c19e6f648c4",
+  "rightsHolder" : "3KadAxykNliHG6",
+  "duplicateOf" : "https://www.example.org/cf1a1e48-4a34-4d6c-a8e7-b9d890fdc276",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "466gSIzR1U"
+    "note" : "9YArCHmJBn4kE"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "mg7W9SoxORPE1Vp3",
-    "createdBy" : "RHOaohS2LX",
-    "createdDate" : "1972-03-18T07:15:38.328Z"
+    "note" : "AI7wZ9TDD66",
+    "createdBy" : "Z7dT5JhfhFpQ",
+    "createdDate" : "1992-03-04T09:29:52.769Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2b4f8578-b9be-4dad-8132-62df3c312ff2" ],
+  "curatingInstitutions" : [ "https://www.example.org/7c346d5e-5898-49bf-ac44-4c25800388fd" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "w5DPDfVlrVn9D5rz7sO",
-    "ownerAffiliation" : "https://www.example.org/5e4b8844-24d0-4888-846d-0b51b858e7fa"
+    "owner" : "OuBf77jxFxW",
+    "ownerAffiliation" : "https://www.example.org/b5fda9b0-24cf-4898-98d4-9fbfbdc3da70"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/0c1d49a2-3b31-4536-aa5a-7bc490c2e411"
+    "id" : "https://www.example.org/871a308b-7069-4d27-9af9-0365957ca988"
   },
-  "createdDate" : "1972-08-28T16:50:46.966Z",
-  "modifiedDate" : "2005-04-20T06:40:18.282Z",
-  "publishedDate" : "2022-10-09T07:40:25.831Z",
-  "indexedDate" : "2019-09-13T10:20:04.566Z",
-  "handle" : "https://www.example.org/474d443d-4698-4e92-92b1-8c38fc162d40",
-  "doi" : "https://doi.org/10.1234/amet",
-  "link" : "https://www.example.org/d998e342-9ecf-406e-8b8f-72cffcea44ba",
+  "createdDate" : "1978-02-09T02:42:39.678Z",
+  "modifiedDate" : "1992-02-22T08:53:59.878Z",
+  "publishedDate" : "1993-12-24T20:09:24.227Z",
+  "indexedDate" : "2013-09-10T03:16:33.719Z",
+  "handle" : "https://www.example.org/e81e38d1-b4f0-4a1e-9269-937799a57212",
+  "doi" : "https://doi.org/10.1234/pariatur",
+  "link" : "https://www.example.org/b5535644-5985-4b1a-a393-4c20bf56c13b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "vdAVPpNIzrv1yq3yhQ",
+    "mainTitle" : "RRVEFJkbUUvfimT8FRc",
     "alternativeTitles" : {
-      "pt" : "vzqnUMiltJhz1o0"
+      "de" : "LNE84ryxNk"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bGLeGJivsD",
-      "month" : "SW6LLimi877",
-      "day" : "bJ8Hb0EMnLw16o"
+      "year" : "kYDZJDegcHq56iCV1",
+      "month" : "bEFxnC4CUdtSG",
+      "day" : "SgClbttYNJZza"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/987e372d-708c-40e5-8362-4d8e13108d83",
-        "name" : "gSH5TsqFYBP",
+        "id" : "https://www.example.org/e8edeb17-560f-4db3-8bc3-54c3cfcbed76",
+        "name" : "iOzWSXmXLLB0",
         "nameType" : "Personal",
-        "orcId" : "edPZuLyE7Y3CETfqw",
+        "orcId" : "l0vOIDop4tkzCaU",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HwRaZqeExQBM",
-          "value" : "e6AzeyCUaUiXwOLf"
+          "sourceName" : "V1ID29RI3BnXbkTxw3D",
+          "value" : "jsRPiBgB4OLbfNKxcc"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ohky9OxWB0",
-          "value" : "5phGWRp0N0F"
+          "sourceName" : "sExrq1PoDfNZS5",
+          "value" : "CUqnTJOsOyf6H6R3s"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/450180fb-cf24-437f-ba7e-d58550bf38ad"
+        "id" : "https://www.example.org/3f61ee17-fac1-4a29-963a-f95db252d086"
       } ],
       "role" : {
         "type" : "ProjectLeader"
@@ -62,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/00a07cad-23aa-45ef-aa45-96a91ed48556",
-        "name" : "PuJaw9oX6E",
-        "nameType" : "Organizational",
-        "orcId" : "D9GxB15FxIjhf1KgzzN",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/fff06cc7-824b-4ac9-9f91-84922cd7341a",
+        "name" : "Dti9auVLgJeAh8E2lv",
+        "nameType" : "Personal",
+        "orcId" : "Vb3cMjkm71",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rNbPie1KKGCwqCD",
-          "value" : "9gArsvIdodBK"
+          "sourceName" : "iraGmeABnwN",
+          "value" : "LSZ9UXPUxM2O"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2ffFbo5KQV3tyCSS",
-          "value" : "LR2ZYuk9HOvn"
+          "sourceName" : "tTvc4QElGvODkIwG",
+          "value" : "rZFiGYH7KE12kvg4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6a74ba52-e9e4-464e-b485-a06faf9e9624"
+        "id" : "https://www.example.org/f0445ec6-0333-49c8-ae37-13a50e3054c5"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "blH9C0vNH4RWwhVBP"
+      "de" : "6PuuzLzV24g"
     },
-    "npiSubjectHeading" : "nvHD75pZvC",
-    "tags" : [ "J3ppH3ypNo" ],
-    "description" : "a2Lg2YEqZnrGGurn8b",
+    "npiSubjectHeading" : "SGFpULG72whytn1q",
+    "tags" : [ "jSEVGWZJtl8h7L" ],
+    "description" : "rUGms43jD50YXrQKI2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/3pk8kaKpsoN"
+        "id" : "https://www.example.com/VrofSSRhON"
       },
-      "doi" : "https://www.example.org/bd78f806-2edc-49a0-a020-af53a3ead2bf",
+      "doi" : "https://www.example.org/0cb75d12-3e67-4a49-915f-cf5e4eb604df",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "KzsvDWzR5d9rDD",
-          "end" : "r1PBtoUVgoL"
+          "begin" : "X4iJhwkJIVeN",
+          "end" : "Q3E17913Bcg2hUvP"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/628fcde7-565a-4041-bc4e-0e6269e691cc",
-    "abstract" : "p5Uly37qqubn"
+    "metadataSource" : "https://www.example.org/b91cad14-3a9e-4016-b7bf-94a04d143182",
+    "abstract" : "3XWUv7EXVgTcC9D"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/65061c95-e05a-4c8e-853a-2eb30de20fc5",
-    "name" : "SprZ9Mne30WfBNP",
+    "id" : "https://www.example.org/07c066b8-d58d-4b50-b738-8a7ef13118df",
+    "name" : "WVELUl0zulEEhKj7",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-11-15T09:32:34.102Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "gVZC0Q9A8VGwuD"
+      "approvalDate" : "1976-03-25T21:47:55.434Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ofSxdrdcW0gIGVwj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e87c3f33-4942-4d40-a27e-6079f471b69b",
-    "identifier" : "4uN5VAmbghj7zHw",
+    "source" : "https://www.example.org/09a8081d-f7f3-4349-9c26-947b64b285b6",
+    "identifier" : "pE9socop1AkJjlQyy2",
     "labels" : {
-      "zh" : "Pt73xVOISN8y"
+      "fi" : "eV4VUjDA7kCKzNct6C"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1232947696
+      "currency" : "GBP",
+      "amount" : 671126782
     },
-    "activeFrom" : "1979-01-30T21:38:25.729Z",
-    "activeTo" : "1987-05-06T10:15:43.201Z"
+    "activeFrom" : "1985-06-24T14:24:59.504Z",
+    "activeTo" : "2014-04-07T02:54:29.309Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/939eb936-01cc-4528-9ef3-91c77e1008fa",
-    "id" : "https://www.example.org/57b11a6e-cb1e-4ad0-ba04-2968cf729679",
-    "identifier" : "FtvkJhYszva2QVSmClP",
+    "source" : "https://www.example.org/dca65b0e-15f2-4926-9840-d028754fa1d7",
+    "id" : "https://www.example.org/d6b320cf-8825-4888-861a-0b15e2554a57",
+    "identifier" : "qEbMyBJ1dSdMZFHIl",
     "labels" : {
-      "it" : "4pzuLZdT4S4Om"
+      "pt" : "rEZkOIWjes5PwpvevAV"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 322286898
+      "currency" : "EUR",
+      "amount" : 639718778
     },
-    "activeFrom" : "2017-07-01T12:47:23.494Z",
-    "activeTo" : "2023-12-21T19:29:28.001Z"
+    "activeFrom" : "1974-07-26T06:33:22.144Z",
+    "activeTo" : "1995-02-05T07:28:55.440Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b3fb6255-dd96-477e-946a-b359d453059d" ],
+  "subjects" : [ "https://www.example.org/64a24ba1-d2f3-45c1-ba9e-fbc6b0ae7f2c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5338a21e-3d9a-40d0-8e08-80ddb250b76d",
-    "name" : "jOtwj8VMpPKo5s",
-    "mimeType" : "rqF32uwiKtQzJx",
-    "size" : 753528888,
-    "license" : "https://www.example.com/05lwhbsgropqsgljz0",
+    "identifier" : "f1cfb1bf-836b-4811-bb2a-5e88806bc87b",
+    "name" : "EojHsIc6BV4F4L0s",
+    "mimeType" : "733zTvI3lGNV",
+    "size" : 63942176,
+    "license" : "https://www.example.com/r1cxayxpgzn76gpi3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "BjM0HADifbhR3",
-    "publishedDate" : "2022-05-21T17:41:16.248Z",
+    "legalNote" : "HnXUKIQjIxCFTw",
+    "publishedDate" : "1974-10-21T20:55:59.550Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VVlCs7wtBeJ6wFzZ0b",
-    "name" : "hyJwLAWAmbzYav",
-    "description" : "w789dL2DS6Z"
+    "id" : "https://www.example.com/NSxcuyUbQ1qav06",
+    "name" : "lFAcIZfBSVltJrt",
+    "description" : "RHEfPUJACtaFHS8DT"
   } ],
-  "rightsHolder" : "ineYveYtIueBaiFcyt",
-  "duplicateOf" : "https://www.example.org/5bd3b6af-bd43-4f3e-acc4-c09ff571869e",
+  "rightsHolder" : "DCkcxyc8zaS5DL7IdIN",
+  "duplicateOf" : "https://www.example.org/25f3cc53-1f23-4619-8a45-a20d2cb91c51",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ECVf8MhHFe1eD"
+    "note" : "sBLz9lT6hp6OFXxwC"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "hwNRF7zC4Rwm",
-    "createdBy" : "THilChyVaHPmeUm3Xps",
-    "createdDate" : "1997-04-11T07:57:23.647Z"
+    "note" : "6BMG6BMVbF8n7Rk2w5",
+    "createdBy" : "XZm39rWuKM8qQ5wVzi",
+    "createdDate" : "2003-11-04T20:00:11.329Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a9e351c6-1984-4111-b437-51cb60f332c7" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/8dc66f1c-9693-471e-8f33-265465c9298a" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/NonFictionChapter.json
+++ b/documentation/NonFictionChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "OuBf77jxFxW",
-    "ownerAffiliation" : "https://www.example.org/b5fda9b0-24cf-4898-98d4-9fbfbdc3da70"
+    "owner" : "jUjTuMex9l",
+    "ownerAffiliation" : "https://www.example.org/7c53484f-be7e-4f59-854e-1d07621dc7a6"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/871a308b-7069-4d27-9af9-0365957ca988"
+    "id" : "https://www.example.org/6c054c76-a21b-430c-bdf3-d799bfaecc26"
   },
-  "createdDate" : "1978-02-09T02:42:39.678Z",
-  "modifiedDate" : "1992-02-22T08:53:59.878Z",
-  "publishedDate" : "1993-12-24T20:09:24.227Z",
-  "indexedDate" : "2013-09-10T03:16:33.719Z",
-  "handle" : "https://www.example.org/e81e38d1-b4f0-4a1e-9269-937799a57212",
-  "doi" : "https://doi.org/10.1234/pariatur",
-  "link" : "https://www.example.org/b5535644-5985-4b1a-a393-4c20bf56c13b",
+  "createdDate" : "2017-11-08T12:45:36.308Z",
+  "modifiedDate" : "2018-03-10T11:11:45.829Z",
+  "publishedDate" : "1995-05-20T11:33:02.998Z",
+  "indexedDate" : "1976-10-17T03:17:37.336Z",
+  "handle" : "https://www.example.org/f88a42b3-6d41-4a58-86c7-504118b18ed3",
+  "doi" : "https://doi.org/10.1234/expedita",
+  "link" : "https://www.example.org/1880692f-f841-4879-9682-489f2bc9d2e4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "RRVEFJkbUUvfimT8FRc",
+    "mainTitle" : "iFY3YGQIvMKZIfi",
     "alternativeTitles" : {
-      "de" : "LNE84ryxNk"
+      "is" : "drk7O57MqWC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "kYDZJDegcHq56iCV1",
-      "month" : "bEFxnC4CUdtSG",
-      "day" : "SgClbttYNJZza"
+      "year" : "H4C3QdLhjJsQKL7qsu",
+      "month" : "T46zQHevRZC8",
+      "day" : "cyg046HkSS5ooV"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e8edeb17-560f-4db3-8bc3-54c3cfcbed76",
-        "name" : "iOzWSXmXLLB0",
-        "nameType" : "Personal",
-        "orcId" : "l0vOIDop4tkzCaU",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/1593b8ab-4c65-4e77-8067-5a25d18415c8",
+        "name" : "2nX851nxWGih37",
+        "nameType" : "Organizational",
+        "orcId" : "ndtoCWVg7cyRxJje5Y",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "V1ID29RI3BnXbkTxw3D",
-          "value" : "jsRPiBgB4OLbfNKxcc"
+          "sourceName" : "hfL6Dm5TNIIYrIw",
+          "value" : "LYSGB2cLaaGq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sExrq1PoDfNZS5",
-          "value" : "CUqnTJOsOyf6H6R3s"
+          "sourceName" : "lGv84KTXBPMMU189v93",
+          "value" : "XnL1gDyXNUbiXu39gHk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3f61ee17-fac1-4a29-963a-f95db252d086"
+        "id" : "https://www.example.org/ca251775-40d1-4ce2-a953-e601c6cdc4ef"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "AcademicCoordinator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fff06cc7-824b-4ac9-9f91-84922cd7341a",
-        "name" : "Dti9auVLgJeAh8E2lv",
-        "nameType" : "Personal",
-        "orcId" : "Vb3cMjkm71",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ad53be13-5856-49c5-b9ff-a41f9ce7123a",
+        "name" : "StTos4ucIzl7",
+        "nameType" : "Organizational",
+        "orcId" : "k3bMtCU0uK",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iraGmeABnwN",
-          "value" : "LSZ9UXPUxM2O"
+          "sourceName" : "6hk2rPMyIYAw",
+          "value" : "pfPwHKdlDVQcG1KgC"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tTvc4QElGvODkIwG",
-          "value" : "rZFiGYH7KE12kvg4"
+          "sourceName" : "iIGpAMbLgeCYorY9mF",
+          "value" : "q6UJtRCTAvr0mu7Xq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/f0445ec6-0333-49c8-ae37-13a50e3054c5"
+        "id" : "https://www.example.org/ae903459-336f-46dc-94f6-c627728636cf"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "6PuuzLzV24g"
+      "pl" : "uZZAsnpbrzYqP"
     },
-    "npiSubjectHeading" : "SGFpULG72whytn1q",
-    "tags" : [ "jSEVGWZJtl8h7L" ],
-    "description" : "rUGms43jD50YXrQKI2",
+    "npiSubjectHeading" : "SK7ollfF6p8c7hAn",
+    "tags" : [ "sfo01v0F5ap72FCA" ],
+    "description" : "2kBkRCcy2xqRYcLhg",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/VrofSSRhON"
+        "id" : "https://www.example.com/YssAbtQJeXfNvRQT4"
       },
-      "doi" : "https://www.example.org/0cb75d12-3e67-4a49-915f-cf5e4eb604df",
+      "doi" : "https://www.example.org/69533ad4-7147-48a9-8ae5-082ff24802f5",
       "publicationInstance" : {
         "type" : "NonFictionChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "X4iJhwkJIVeN",
-          "end" : "Q3E17913Bcg2hUvP"
+          "begin" : "uitO6iAN9rDpWdF75H",
+          "end" : "phlzH67Ujlb12"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b91cad14-3a9e-4016-b7bf-94a04d143182",
-    "abstract" : "3XWUv7EXVgTcC9D"
+    "metadataSource" : "https://www.example.org/3ff142ab-6bc4-42bd-a774-52922183c4fa",
+    "abstract" : "4RqVaXxU3sxk"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/07c066b8-d58d-4b50-b738-8a7ef13118df",
-    "name" : "WVELUl0zulEEhKj7",
+    "id" : "https://www.example.org/cf07eeff-d05d-4b56-85bb-e5b82c378cc6",
+    "name" : "qtKOkSgcqfZMm6Sl",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-03-25T21:47:55.434Z",
+      "approvalDate" : "2020-10-05T20:56:55.828Z",
       "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "ofSxdrdcW0gIGVwj"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "fDvsUWuaXkAzaqD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/09a8081d-f7f3-4349-9c26-947b64b285b6",
-    "identifier" : "pE9socop1AkJjlQyy2",
+    "source" : "https://www.example.org/56069178-c827-47f6-835d-3855f1ebaa97",
+    "identifier" : "DYLjAtzLBO1My0rA",
     "labels" : {
-      "fi" : "eV4VUjDA7kCKzNct6C"
+      "af" : "MqpZLbkgMDCoeHGeCj4"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 671126782
+      "currency" : "NOK",
+      "amount" : 1285810857
     },
-    "activeFrom" : "1985-06-24T14:24:59.504Z",
-    "activeTo" : "2014-04-07T02:54:29.309Z"
+    "activeFrom" : "2018-11-11T02:06:05.045Z",
+    "activeTo" : "2019-03-21T20:39:37.267Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/dca65b0e-15f2-4926-9840-d028754fa1d7",
-    "id" : "https://www.example.org/d6b320cf-8825-4888-861a-0b15e2554a57",
-    "identifier" : "qEbMyBJ1dSdMZFHIl",
+    "source" : "https://www.example.org/a3aca31a-e4da-41b0-920d-7881dee61c81",
+    "id" : "https://www.example.org/7e579ea0-6ed3-4bbc-bd04-6670c69a23ba",
+    "identifier" : "tA4liIzVuN3",
     "labels" : {
-      "pt" : "rEZkOIWjes5PwpvevAV"
+      "is" : "AhSnnuQ80Pmy4XU7Y7"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 639718778
+      "amount" : 451520732
     },
-    "activeFrom" : "1974-07-26T06:33:22.144Z",
-    "activeTo" : "1995-02-05T07:28:55.440Z"
+    "activeFrom" : "2015-11-19T03:35:14.718Z",
+    "activeTo" : "2017-11-05T21:38:12.699Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/64a24ba1-d2f3-45c1-ba9e-fbc6b0ae7f2c" ],
+  "subjects" : [ "https://www.example.org/4c58221c-d4e4-4429-a52c-608bf4b8b373" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "f1cfb1bf-836b-4811-bb2a-5e88806bc87b",
-    "name" : "EojHsIc6BV4F4L0s",
-    "mimeType" : "733zTvI3lGNV",
-    "size" : 63942176,
-    "license" : "https://www.example.com/r1cxayxpgzn76gpi3",
+    "identifier" : "753b9a64-61b4-4936-90ad-eded4f10178a",
+    "name" : "fjBrSe6ahc",
+    "mimeType" : "GXjFikwiOv",
+    "size" : 101759005,
+    "license" : "https://www.example.com/fbt2t4h0ng1yizq",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "HnXUKIQjIxCFTw",
-    "publishedDate" : "1974-10-21T20:55:59.550Z",
+    "legalNote" : "xlVoehJln1Bi",
+    "publishedDate" : "2022-07-12T05:25:44.744Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "JhZ5LxLuOtHi23RTq",
+      "uploadedDate" : "2020-11-06T12:20:07.007Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/NSxcuyUbQ1qav06",
-    "name" : "lFAcIZfBSVltJrt",
-    "description" : "RHEfPUJACtaFHS8DT"
+    "id" : "https://www.example.com/3o23G8WcICgUHsezrH3",
+    "name" : "v40cYC197PfQ6sm",
+    "description" : "v8HUdJYHzz5fD"
   } ],
-  "rightsHolder" : "DCkcxyc8zaS5DL7IdIN",
-  "duplicateOf" : "https://www.example.org/25f3cc53-1f23-4619-8a45-a20d2cb91c51",
+  "rightsHolder" : "aQw6wh8tRfVKYp93B",
+  "duplicateOf" : "https://www.example.org/d85f0220-51de-4c7d-b2c2-3cc23db14e86",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "sBLz9lT6hp6OFXxwC"
+    "note" : "KTG7LKHwb2rHZV5Ou"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "6BMG6BMVbF8n7Rk2w5",
-    "createdBy" : "XZm39rWuKM8qQ5wVzi",
-    "createdDate" : "2003-11-04T20:00:11.329Z"
+    "note" : "3rRewEEBni84YR4f",
+    "createdBy" : "k6RaOt2bPyCHGK",
+    "createdDate" : "1994-09-22T21:44:03.734Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/8dc66f1c-9693-471e-8f33-265465c9298a" ],
+  "curatingInstitutions" : [ "https://www.example.org/8c12fc22-2bd1-401d-9e7f-43271cc49c6f" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "1OCav88F0ZngRN",
-    "ownerAffiliation" : "https://www.example.org/dce5d277-431c-494c-946c-abd49d8620cc"
+    "owner" : "LZ96AfZZwAP4X8QWIp6",
+    "ownerAffiliation" : "https://www.example.org/a6f2735c-cd34-462c-8483-72c8a27b935c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/500206bd-0981-42e4-a0cf-4cd8c8e3a34a"
+    "id" : "https://www.example.org/23c107bf-d917-457a-8996-5b4fb4194733"
   },
-  "createdDate" : "1990-09-20T07:09:53.723Z",
-  "modifiedDate" : "1982-03-21T05:22:11.446Z",
-  "publishedDate" : "1998-05-11T16:47:21.483Z",
-  "indexedDate" : "2022-12-14T11:27:51.456Z",
-  "handle" : "https://www.example.org/6c9f63f5-4669-4412-be2a-61a7dd126cd0",
-  "doi" : "https://doi.org/10.1234/laborum",
-  "link" : "https://www.example.org/8e0630d1-e3b7-4032-bcbc-7a3ff6dbc8b4",
+  "createdDate" : "2022-08-12T02:42:57.457Z",
+  "modifiedDate" : "1998-02-02T00:20:29.713Z",
+  "publishedDate" : "1982-03-09T06:13:16.038Z",
+  "indexedDate" : "1978-02-21T13:45:10.409Z",
+  "handle" : "https://www.example.org/333a75e6-93f7-4967-a0d0-e10e52e34170",
+  "doi" : "https://doi.org/10.1234/quaerat",
+  "link" : "https://www.example.org/bee0aceb-cb8d-4ce7-8b5c-a48816399a45",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ioqf1bwjpCRCI22UjN2",
+    "mainTitle" : "CkpXVxhVx8",
     "alternativeTitles" : {
-      "fi" : "iNutYXatymRP3"
+      "pl" : "vmjEb9wsgmkc8MiZu"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cC244sxXcpv9DtJDKx3",
-      "month" : "41BvoBhtrXHpC3p5BU",
-      "day" : "HzpYveuoYhZbsOLj"
+      "year" : "Lzc5BKXTRL",
+      "month" : "TxyepkXcK9",
+      "day" : "70MZKvfRN0EpKyI5mb"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4b5fe155-2117-4e5c-9243-77012a15a562",
-        "name" : "Fqt4NN4PTp",
+        "id" : "https://www.example.org/ea605477-be5d-4e1d-abaf-149dff3b24b2",
+        "name" : "NNj6Hd1LwWIV",
         "nameType" : "Personal",
-        "orcId" : "GQP4uPXgfYj8UkJ",
-        "verificationStatus" : "Verified",
+        "orcId" : "EaEf7nxBoNuKUSm5F",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qhGqy95CMNu7Mz0bQ",
-          "value" : "5I66DFKVnyh0"
+          "sourceName" : "5nJ9ctwFj642fFg9p",
+          "value" : "MElZgxv4pfxE"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "80G9N66VV6qv60C",
-          "value" : "WJamRLNOifq2TrwNA6"
+          "sourceName" : "1CMbA3awfntp",
+          "value" : "ZAQ3efJpFWn"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ab54ee1f-d746-441c-8baf-9680fb594157"
+        "id" : "https://www.example.org/ff7d488a-f8b6-43f2-8c4e-d9519edd43e4"
       } ],
       "role" : {
-        "type" : "Funder"
+        "type" : "DataCollector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6a8dc8a9-6504-4bd4-ad6c-7912f060aa34",
-        "name" : "1iD75DhToQ",
-        "nameType" : "Personal",
-        "orcId" : "Ief5Eb8d2eOqM8zSq",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/9dbb3569-9067-4bc7-a385-b51cc864bd51",
+        "name" : "p1YxqUOLiP5YLlaU",
+        "nameType" : "Organizational",
+        "orcId" : "mpOMqMMHQUggCIsr",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9xPpXGaHyKNQcx",
-          "value" : "ut95a2tdM8QXn08d"
+          "sourceName" : "9fGwgX7nJQEP",
+          "value" : "oJgHcaMaWd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gGAmYppAXR",
-          "value" : "LxZCCANuCPtN2jA"
+          "sourceName" : "B6dm8RrBOxViBk",
+          "value" : "HppvjJdf98m"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a48603b8-cb1d-4009-af4c-51d94d675452"
+        "id" : "https://www.example.org/d1e6ffdd-f425-49d1-ac42-aa2dd7e2b193"
       } ],
       "role" : {
-        "type" : "Director"
+        "type" : "ProjectMember"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "qyQn6hObU09"
+      "el" : "RDjkNRAckRrR5XOZr"
     },
-    "npiSubjectHeading" : "mSbXczeyuBxYkDXpU",
-    "tags" : [ "CYerqF3cAbkbC8b2" ],
-    "description" : "4FXTdsgM4iotmX",
+    "npiSubjectHeading" : "Vd0xHi9YP2J0xgWXG",
+    "tags" : [ "E2pnWRMMXXff" ],
+    "description" : "djjRMs1QpfE4qpOcXW",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e25d1b4c-47ae-4413-9432-90548d4442b3"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/706f1344-2111-48df-a7e6-8b18b3c69676"
         },
-        "seriesNumber" : "NIWInW1puwui",
+        "seriesNumber" : "Y2J9RBs0s8scM",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4289b62e-1166-4be0-aaef-028fad59322c",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/24ff9195-c81e-47f6-8e86-aeed2b583c9e",
           "valid" : true
         },
-        "isbnList" : [ "9781931216944" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9781482744217", "9781862963603" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "YFuOKDZ8v4zz"
+          "value" : "1862963606"
         } ]
       },
-      "doi" : "https://www.example.org/b5076771-1318-40a9-aef0-ccd7c479eb63",
+      "doi" : "https://www.example.org/bd8c0ce4-bb55-4b07-9de3-7692a8084469",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Kl1qJE3mrlwfTuQ",
-            "end" : "hkTy4H9KoeA"
+            "begin" : "Jjv6zi3ICbq06PoW",
+            "end" : "40Yqy5FADoCS2oo"
           },
-          "pages" : "f4WNBvycS1Gpb4VJ9r",
-          "illustrated" : false
+          "pages" : "ziw5QwhmDMJF",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/65a0efa5-3424-4e9b-a7c8-6da762a5c1f0",
-    "abstract" : "4hGimzQbTNgwPbUI"
+    "metadataSource" : "https://www.example.org/51b39cee-b3ea-41c2-a77d-ef473aa4738e",
+    "abstract" : "tjeZo9YLLyISGVtFgx9"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f44bf34e-f207-4f9c-a8c6-ab647deb5b2a",
-    "name" : "VHqrNAprcQKia07vbW9",
+    "id" : "https://www.example.org/ef60d8af-da06-49d5-8446-ed1409ed35b4",
+    "name" : "UCFLfqmSi4toLG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-06-04T07:25:31.362Z",
+      "approvalDate" : "1999-05-09T22:33:12.890Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "iW85b6bxhOI"
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "UcgbF1Ks0SKdkIuH"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/fa6d5a19-ce5d-45f4-abce-9e2bdb50ac23",
-    "identifier" : "oXqvZXJcjYWwQBsAqs",
+    "source" : "https://www.example.org/d90e5c26-a631-494c-8c74-b81831ff54f2",
+    "identifier" : "jgOEhCQSMx61yL2Y",
     "labels" : {
-      "sv" : "4xyEHwfjvIU6PHd9Qp"
+      "zh" : "QyejQNYpH0g"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 694421007
+      "amount" : 1101493501
     },
-    "activeFrom" : "1985-07-03T04:05:21.928Z",
-    "activeTo" : "2019-10-06T06:50:16.929Z"
+    "activeFrom" : "1978-09-17T14:49:45.238Z",
+    "activeTo" : "1982-10-26T06:45:52.595Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0f0aeacc-0218-45e5-8feb-88fd7d3fa333",
-    "id" : "https://www.example.org/5c98ead5-bf9b-4bb4-bb58-4682b35a0756",
-    "identifier" : "6PRr4ZuYYqNZVZ",
+    "source" : "https://www.example.org/562b599b-c4ea-4ba5-910f-b7f6b8c66ae3",
+    "id" : "https://www.example.org/6feb04ff-284f-443e-b953-6f91a5d84255",
+    "identifier" : "k4QXcTTgCyR2PSTRFA",
     "labels" : {
-      "fi" : "VJLBNLvMkXoxiSvi"
+      "cs" : "XFCR7P9guE"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 2124678541
+      "amount" : 612253042
     },
-    "activeFrom" : "1980-05-06T19:34:15.174Z",
-    "activeTo" : "1997-11-08T20:26:58.224Z"
+    "activeFrom" : "1981-10-23T17:38:27.914Z",
+    "activeTo" : "2001-01-22T20:46:00.162Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/40922b26-2230-4da3-8399-b78255e2dc0c" ],
+  "subjects" : [ "https://www.example.org/edf4e46f-c960-4422-abe7-6c6c754a6412" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "87eb1169-095a-4113-a889-2b04c6800736",
-    "name" : "vmujBbueQZ5hks0K",
-    "mimeType" : "b9mwH3s8cQXyVj7km",
-    "size" : 797657599,
-    "license" : "https://www.example.com/x81llcre1ccc",
+    "identifier" : "154f04da-0a89-4206-a292-ee4b7b511571",
+    "name" : "VGWunhYbUaN9nN",
+    "mimeType" : "YK8WsD8vKNyzl",
+    "size" : 336370663,
+    "license" : "https://www.example.com/meenfcringaoaub",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "AcAwVvKXLmphkCl",
-    "publishedDate" : "1982-08-25T00:19:16.918Z",
+    "legalNote" : "q5yxo1VFyg",
+    "publishedDate" : "2020-06-08T05:42:18.699Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "3bHFiqUhRmX",
+      "uploadedDate" : "1999-11-09T15:10:54.297Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/m1HzAsWRrezvleTt",
-    "name" : "xDfMIpwjeyALB7M1",
-    "description" : "MZeddqdAYtrop2sYb88"
+    "id" : "https://www.example.com/dOLqFFcxxB5erL1",
+    "name" : "QHcBr9tLo5H",
+    "description" : "ofXDHSzbh3mYyv0"
   } ],
-  "rightsHolder" : "QBLLYQO0YrmD7CFMblN",
-  "duplicateOf" : "https://www.example.org/82a27523-735b-4a86-aace-468a7e198f0b",
+  "rightsHolder" : "g1t3GoU0fdU117d78X",
+  "duplicateOf" : "https://www.example.org/c2dd425f-ddbc-4ec0-ba09-b711f45dcab5",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "w3nPgcIn0zjgu"
+    "note" : "HeNL2VQNqGd9jjA9NBi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "QihEHGvssvPB",
-    "createdBy" : "CwjtAuEUkvAK7WXo",
-    "createdDate" : "1976-03-01T13:07:24.060Z"
+    "note" : "Q1MJFFRrYov6qAM",
+    "createdBy" : "iw49XflHEeZrw66P",
+    "createdDate" : "1979-12-19T14:08:15.527Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/02bdc724-4d7f-4e66-9bbd-3b26014c3e7f" ],
+  "curatingInstitutions" : [ "https://www.example.org/57523f7f-226f-4255-9953-29a0da2816fb" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/NonFictionMonograph.json
+++ b/documentation/NonFictionMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "GJmfYw511OxTXHdxzou",
-    "ownerAffiliation" : "https://www.example.org/aec9da3e-181e-4710-bd9a-4cbc7ff8d2e5"
+    "owner" : "1OCav88F0ZngRN",
+    "ownerAffiliation" : "https://www.example.org/dce5d277-431c-494c-946c-abd49d8620cc"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/31bcd1b7-abbc-4611-bf51-baccf58def84"
+    "id" : "https://www.example.org/500206bd-0981-42e4-a0cf-4cd8c8e3a34a"
   },
-  "createdDate" : "2012-11-13T11:28:32.747Z",
-  "modifiedDate" : "1993-05-13T08:48:08.533Z",
-  "publishedDate" : "2001-03-18T18:42:18.826Z",
-  "indexedDate" : "2010-09-28T07:18:39.336Z",
-  "handle" : "https://www.example.org/7735ab71-427c-4555-8f0e-efea36c7bef4",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/1dc6580e-2f8e-40ac-a8c3-edef5a5086e8",
+  "createdDate" : "1990-09-20T07:09:53.723Z",
+  "modifiedDate" : "1982-03-21T05:22:11.446Z",
+  "publishedDate" : "1998-05-11T16:47:21.483Z",
+  "indexedDate" : "2022-12-14T11:27:51.456Z",
+  "handle" : "https://www.example.org/6c9f63f5-4669-4412-be2a-61a7dd126cd0",
+  "doi" : "https://doi.org/10.1234/laborum",
+  "link" : "https://www.example.org/8e0630d1-e3b7-4032-bcbc-7a3ff6dbc8b4",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "A5tsCOV90q",
+    "mainTitle" : "ioqf1bwjpCRCI22UjN2",
     "alternativeTitles" : {
-      "pt" : "wte7KWbHamDOe"
+      "fi" : "iNutYXatymRP3"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "TUqcIAEsxbUuKQhRNP",
-      "month" : "UrXeHunZ0ZtMkhbphh6",
-      "day" : "0JcwbmjjzPDDKfNY"
+      "year" : "cC244sxXcpv9DtJDKx3",
+      "month" : "41BvoBhtrXHpC3p5BU",
+      "day" : "HzpYveuoYhZbsOLj"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/698d3459-a48a-451e-8548-c5d2131a0242",
-        "name" : "HVZlAwTV6j",
+        "id" : "https://www.example.org/4b5fe155-2117-4e5c-9243-77012a15a562",
+        "name" : "Fqt4NN4PTp",
         "nameType" : "Personal",
-        "orcId" : "clCwYFRlIrCqFnDgL",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "GQP4uPXgfYj8UkJ",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "WpiA1Q57W3CDkVgO8Vr",
-          "value" : "HomfStIGieFng8jeF"
+          "sourceName" : "qhGqy95CMNu7Mz0bQ",
+          "value" : "5I66DFKVnyh0"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gIen4FOVcI1tN",
-          "value" : "qNmXM4L4p809glFfo"
+          "sourceName" : "80G9N66VV6qv60C",
+          "value" : "WJamRLNOifq2TrwNA6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/14641f8a-d2ab-4b4c-9a45-7147d6aeeeac"
+        "id" : "https://www.example.org/ab54ee1f-d746-441c-8baf-9680fb594157"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/614f1499-bf24-4e2c-bce8-82695bc561f2",
-        "name" : "YVYZDw3kKJViT9U5",
+        "id" : "https://www.example.org/6a8dc8a9-6504-4bd4-ad6c-7912f060aa34",
+        "name" : "1iD75DhToQ",
         "nameType" : "Personal",
-        "orcId" : "q1zCHc9P8UxyDL",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "Ief5Eb8d2eOqM8zSq",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vGN5F1GBWTZ6kAofZ9d",
-          "value" : "SJX3sToWivaHnn3"
+          "sourceName" : "9xPpXGaHyKNQcx",
+          "value" : "ut95a2tdM8QXn08d"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "pZbAPU0VTNuVW5s8Jpy",
-          "value" : "sPwXgbDIMbz3eicj4"
+          "sourceName" : "gGAmYppAXR",
+          "value" : "LxZCCANuCPtN2jA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5a6482e7-1161-41d8-a32b-100c5657b887"
+        "id" : "https://www.example.org/a48603b8-cb1d-4009-af4c-51d94d675452"
       } ],
       "role" : {
-        "type" : "ProjectLeader"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "o8pbT7MDojH"
+      "sv" : "qyQn6hObU09"
     },
-    "npiSubjectHeading" : "yb5F5emjyI3",
-    "tags" : [ "7pbsHqH24Uci5jTG" ],
-    "description" : "uNfG5jNu6Tvt5KfDJH",
+    "npiSubjectHeading" : "mSbXczeyuBxYkDXpU",
+    "tags" : [ "CYerqF3cAbkbC8b2" ],
+    "description" : "4FXTdsgM4iotmX",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/85f099b4-3585-4777-8943-96823efd3e61"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e25d1b4c-47ae-4413-9432-90548d4442b3"
         },
-        "seriesNumber" : "te0b2wYQogycU84K",
+        "seriesNumber" : "NIWInW1puwui",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/21112549-c4a5-4fb5-ae95-8d8664962e68",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4289b62e-1166-4be0-aaef-028fad59322c",
           "valid" : true
         },
-        "isbnList" : [ "9781908416124" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9781931216944" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "YSVkNTHQTNDsOf5jkpe"
+          "value" : "YFuOKDZ8v4zz"
         } ]
       },
-      "doi" : "https://www.example.org/899c3e81-559e-4dba-ae12-18b3447c63cc",
+      "doi" : "https://www.example.org/b5076771-1318-40a9-aef0-ccd7c479eb63",
       "publicationInstance" : {
         "type" : "NonFictionMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7a13WYCKaXdsZxwZ0B",
-            "end" : "NCfGsiZwQVAq7ZbKpgA"
+            "begin" : "Kl1qJE3mrlwfTuQ",
+            "end" : "hkTy4H9KoeA"
           },
-          "pages" : "ofyp5oRrHxlA",
-          "illustrated" : true
+          "pages" : "f4WNBvycS1Gpb4VJ9r",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8b78f47a-57db-4a87-a945-84e0d3b1c77e",
-    "abstract" : "GEeLgTGdk7R"
+    "metadataSource" : "https://www.example.org/65a0efa5-3424-4e9b-a7c8-6da762a5c1f0",
+    "abstract" : "4hGimzQbTNgwPbUI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/65341fa4-1b8e-4c1a-8509-b6cf8fa1064f",
-    "name" : "q29TqEgD4rd",
+    "id" : "https://www.example.org/f44bf34e-f207-4f9c-a8c6-ab647deb5b2a",
+    "name" : "VHqrNAprcQKia07vbW9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2014-02-18T03:28:30.916Z",
+      "approvalDate" : "1984-06-04T07:25:31.362Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "voKSBbtk12"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "iW85b6bxhOI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1d8416a9-a0da-4107-9b4e-db0da3bf9ebd",
-    "identifier" : "iGLP1CZHrdvUT7377F",
+    "source" : "https://www.example.org/fa6d5a19-ce5d-45f4-abce-9e2bdb50ac23",
+    "identifier" : "oXqvZXJcjYWwQBsAqs",
     "labels" : {
-      "de" : "XczeARCgyygbIi"
+      "sv" : "4xyEHwfjvIU6PHd9Qp"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1198031458
+      "amount" : 694421007
     },
-    "activeFrom" : "2015-02-13T22:11:25.560Z",
-    "activeTo" : "2022-04-13T06:03:20.361Z"
+    "activeFrom" : "1985-07-03T04:05:21.928Z",
+    "activeTo" : "2019-10-06T06:50:16.929Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/61765bae-23fe-425a-8aa8-57b95a6493bc",
-    "id" : "https://www.example.org/fa133297-297a-4314-a5a3-29d054727c95",
-    "identifier" : "U9ORRxBvmV",
+    "source" : "https://www.example.org/0f0aeacc-0218-45e5-8feb-88fd7d3fa333",
+    "id" : "https://www.example.org/5c98ead5-bf9b-4bb4-bb58-4682b35a0756",
+    "identifier" : "6PRr4ZuYYqNZVZ",
     "labels" : {
-      "de" : "iFBvoJkdcxV3Kz"
+      "fi" : "VJLBNLvMkXoxiSvi"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1033840953
+      "currency" : "EUR",
+      "amount" : 2124678541
     },
-    "activeFrom" : "1971-01-06T00:48:11.835Z",
-    "activeTo" : "2008-06-16T17:54:39.308Z"
+    "activeFrom" : "1980-05-06T19:34:15.174Z",
+    "activeTo" : "1997-11-08T20:26:58.224Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/29453280-18dd-41dd-9cc8-5a3e43283b83" ],
+  "subjects" : [ "https://www.example.org/40922b26-2230-4da3-8399-b78255e2dc0c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "80aee361-963a-44bf-89f3-cbf01b77cd7c",
-    "name" : "9C8MaysWTrF1X",
-    "mimeType" : "IjVqrAzO9vS",
-    "size" : 263330762,
-    "license" : "https://www.example.com/quhdgyziresxh",
+    "identifier" : "87eb1169-095a-4113-a889-2b04c6800736",
+    "name" : "vmujBbueQZ5hks0K",
+    "mimeType" : "b9mwH3s8cQXyVj7km",
+    "size" : 797657599,
+    "license" : "https://www.example.com/x81llcre1ccc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "9ih416tvFlIH",
-    "publishedDate" : "2019-06-06T06:30:48.611Z",
+    "legalNote" : "AcAwVvKXLmphkCl",
+    "publishedDate" : "1982-08-25T00:19:16.918Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/TeBqMlkLVp5",
-    "name" : "B5kfZHqdTdwpzIMYlg",
-    "description" : "ExaZ9wabUlh55OD"
+    "id" : "https://www.example.com/m1HzAsWRrezvleTt",
+    "name" : "xDfMIpwjeyALB7M1",
+    "description" : "MZeddqdAYtrop2sYb88"
   } ],
-  "rightsHolder" : "BKrXJ8FxiIhSrch",
-  "duplicateOf" : "https://www.example.org/c5777705-491f-4424-9796-1385e8729448",
+  "rightsHolder" : "QBLLYQO0YrmD7CFMblN",
+  "duplicateOf" : "https://www.example.org/82a27523-735b-4a86-aace-468a7e198f0b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ibDZLstnbtnsF"
+    "note" : "w3nPgcIn0zjgu"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "sukhYw3UkNL0tJROk",
-    "createdBy" : "sP4hjUGwTcyAjBjOWo",
-    "createdDate" : "1996-06-14T06:42:03.461Z"
+    "note" : "QihEHGvssvPB",
+    "createdBy" : "CwjtAuEUkvAK7WXo",
+    "createdDate" : "1976-03-01T13:07:24.060Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/7d9d3a49-3de0-40c0-9d90-a5df8d59e494" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/02bdc724-4d7f-4e66-9bbd-3b26014c3e7f" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "XlNK7WnY2xQcF84h",
-    "ownerAffiliation" : "https://www.example.org/010541fc-0881-4fdc-a400-05321b9b4c27"
+    "owner" : "rtzFF1q3gIsRB",
+    "ownerAffiliation" : "https://www.example.org/b1629035-e75f-4422-b8ca-99ee53c0b55c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ec159a12-afff-4cbe-a1e5-2e9f19fcbb45"
+    "id" : "https://www.example.org/9fc01612-cd03-4920-a8d4-319b99dc6fbd"
   },
-  "createdDate" : "1980-11-15T00:50:09.497Z",
-  "modifiedDate" : "1978-07-22T22:35:21.977Z",
-  "publishedDate" : "2008-03-09T12:58:36.072Z",
-  "indexedDate" : "1975-10-04T15:46:17.230Z",
-  "handle" : "https://www.example.org/ddc787d9-719c-42cc-961b-23cd8adafb2d",
-  "doi" : "https://doi.org/10.1234/quas",
-  "link" : "https://www.example.org/782d7724-b1b7-4dcc-9480-1b84661b6d23",
+  "createdDate" : "2012-11-11T17:18:11.538Z",
+  "modifiedDate" : "1990-11-09T22:32:19.589Z",
+  "publishedDate" : "1977-07-10T05:50:22.436Z",
+  "indexedDate" : "2017-12-18T01:02:38.104Z",
+  "handle" : "https://www.example.org/92456a8a-e3cf-4629-94ec-bed5645cd270",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/8d7c2edf-82ca-4e64-803c-32d84408aa35",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Qw1OoiVemR3hXl",
+    "mainTitle" : "ErfSo3IegF45",
     "alternativeTitles" : {
-      "pt" : "2wCdqeVfU5r5gePnxoY"
+      "it" : "FxS51VcMyCVKQD6K"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "J4in74zmh33A",
-      "month" : "7zpWDbZz1roXBMqE",
-      "day" : "mGxyyG4oQu2zH"
+      "year" : "iTAnhxXjUJ19M8E6twn",
+      "month" : "cSQ3J2YtugPdY",
+      "day" : "STXHsrFzXF6G1VLeXZN"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5237e62c-a531-4396-bfdb-ff60d9816ec7",
-        "name" : "QUNzPk8LeLo3pDLVjPw",
+        "id" : "https://www.example.org/54e412cf-d9af-4454-bace-4b8b8e7aabf7",
+        "name" : "y0CsceXw5GX",
         "nameType" : "Personal",
-        "orcId" : "qgle0kFUTRAC",
-        "verificationStatus" : "Verified",
+        "orcId" : "wgXmwFvC96q1ydM6M",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "df7fzro2jOhCJ1n",
-          "value" : "XFh2ZegEZbltTJlKP"
+          "sourceName" : "3MIp80DQmNw4vWnb",
+          "value" : "guEKMUF3gm8tpuhJlwv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jwUNwB0awUe7giQ",
-          "value" : "Owm1RdrIgC6gBj"
+          "sourceName" : "8CiGIp7s1PUghvo",
+          "value" : "frPLfMRjWANyR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b7c02786-af39-476b-ab3f-957c8fd7989d"
+        "id" : "https://www.example.org/ec0469b6-6933-4a21-98be-a3defe6d5aaa"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "Actor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,58 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b60de7f6-592d-4c7d-ae1f-50ad53c3ba91",
-        "name" : "8BUrXi95oQGUEHbMLl",
+        "id" : "https://www.example.org/006c591e-47a5-4e84-85bf-076c1b1c1d0a",
+        "name" : "ZBkEh6tQXWN1OU8",
         "nameType" : "Organizational",
-        "orcId" : "XNjC0te83RM4p8gn",
-        "verificationStatus" : "Verified",
+        "orcId" : "57G5jCeyVfyKUww",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AX4KkLmOWsLHBEZi1YA",
-          "value" : "jVOHdw08fLBjPuyU"
+          "sourceName" : "jRS8km4GK2WICB2O",
+          "value" : "bkXzjuIr1YxSMhBstvv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9BoQTgWsrECNJxq4",
-          "value" : "bU4NriGcwnMIaQ"
+          "sourceName" : "vYfuZpAkjz",
+          "value" : "KMRHjmAF5HFOLVjxt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9c464c91-9cca-4350-a13e-8f4ac3f8d1f4"
+        "id" : "https://www.example.org/636973b7-3d75-4da2-a18e-288bd235b9cd"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "oD55QFsiC09vGzu"
+      "el" : "spQDKls24HAKvVSZKPy"
     },
-    "npiSubjectHeading" : "TaUvnai25VZTwJFUPo",
-    "tags" : [ "esYo9yNKRHR44pUzPNz" ],
-    "description" : "vQHIjnaKwBf2YEuEVsO",
+    "npiSubjectHeading" : "5XA4ZueKavoBF",
+    "tags" : [ "WpeFfiGjhAaDe2Asy" ],
+    "description" : "NiCsx3bEHG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "eMpvhsB48ZKZjw8ew",
+        "label" : "yBrM7SqA03RpjnK3rp",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "zIp1OxsFYgsxJt",
-          "country" : "1jU4jgpUAXtvZA3Lb"
+          "label" : "PTYw9HyaSlwNEG6v",
+          "country" : "NmPpaMqYmAzqSfwzt1q"
         },
         "time" : {
           "type" : "Instant",
-          "value" : "2003-07-16T20:19:11.782Z"
+          "value" : "1974-07-07T17:00:15.793Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/0i7UlZZdaVf1uiTzK"
+          "id" : "https://www.example.com/9CjfddJox07R9CGCF1W"
         },
-        "product" : "https://www.example.com/S1RT91I8XeoHQ7lRODP"
+        "product" : "https://www.example.com/Dr7rpSFgeKk3w"
       },
-      "doi" : "https://www.example.org/ba6b4417-9deb-4583-afb6-c689a6d1b1e7",
+      "doi" : "https://www.example.org/d3cb594f-2eae-4701-9076-f4dfcf41d8ef",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -121,88 +121,89 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b8a0db5a-9655-40fd-ae05-9ba5afabfa78",
-    "abstract" : "P0DYsHh1GPJ8fxQJ"
+    "metadataSource" : "https://www.example.org/96a65525-b73d-4c83-8475-dc42080b1298",
+    "abstract" : "F53qbmENtj3qvq"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/51a8fe79-6ec6-432f-9141-7234995af77d",
-    "name" : "gfmOVe3Sj9cdG",
+    "id" : "https://www.example.org/cec6eb25-3a68-4a20-9487-1cf29e16928a",
+    "name" : "6iGWsLWeRiQo",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-04-25T20:13:50.865Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "N753fGpCWVjHOFc"
+      "approvalDate" : "1987-05-17T05:25:34.313Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "rqfWqMV1ZZ0WzZ19AU"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/c62ef691-27a0-4667-9478-d8959bf8155a",
-    "identifier" : "MtGKoeSpv55NebS",
+    "source" : "https://www.example.org/00bc4a0f-7214-4c4c-82fc-eb63b3466380",
+    "identifier" : "MTfJdq5EoTdlvIO3vg",
     "labels" : {
-      "sv" : "wn6NWLCMurN63"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 984912770
-    },
-    "activeFrom" : "2017-09-24T21:37:10.075Z",
-    "activeTo" : "2023-04-09T22:43:44.172Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/01b2cc45-5850-461a-bbbe-fe5e26c4c5b4",
-    "id" : "https://www.example.org/a6e10907-6543-4e0f-87b6-fe3f5ff62857",
-    "identifier" : "WP9G8tuYiDp5FU7AMqx",
-    "labels" : {
-      "bg" : "GxKojM2Ka1GxWVp1UI"
+      "sv" : "XI5PubaOMC00oEw8vW"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 611541829
+      "amount" : 1761359458
     },
-    "activeFrom" : "1990-12-02T06:13:53.278Z",
-    "activeTo" : "2018-08-16T14:39:07.440Z"
+    "activeFrom" : "2002-12-31T11:28:52.277Z",
+    "activeTo" : "2018-07-26T14:12:55.243Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/480d4275-1b22-4ba9-8047-6d07fc3346ef",
+    "id" : "https://www.example.org/ba366fc3-7c8a-4cfc-b668-48cff1c48695",
+    "identifier" : "f8PCNPwyf27IsY0CY7",
+    "labels" : {
+      "fi" : "b9ZauWgYMKhgIB"
+    },
+    "fundingAmount" : {
+      "currency" : "USD",
+      "amount" : 2030905495
+    },
+    "activeFrom" : "1997-09-19T23:48:02.039Z",
+    "activeTo" : "2005-05-11T11:37:45.407Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b0ce7f3f-b007-4166-83af-6fb23ece8c28" ],
+  "subjects" : [ "https://www.example.org/cba2356c-a71d-46bd-ab87-b8a46ce44638" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1f0ae224-7e05-43a1-b188-c4b3822aacb8",
-    "name" : "VIL9WP7XUQtISJkyCr",
-    "mimeType" : "fMn6Klv6yXsXVi",
-    "size" : 1308638541,
-    "license" : "https://www.example.com/b9y62qr67jddnpwlwk",
+    "identifier" : "4d2e4fc2-f355-435d-b1bb-c08dd0516245",
+    "name" : "azCvC0kccZnDIyu",
+    "mimeType" : "rwzWqOw3MBdK",
+    "size" : 2035938019,
+    "license" : "https://www.example.com/lhphiosgngtjnze",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "YDX3vsdhKuo",
-    "publishedDate" : "2011-01-28T08:05:10.250Z",
+    "legalNote" : "a2MMpSoSIjkDtjqEUT",
+    "publishedDate" : "1981-09-16T18:16:29.189Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FPUkiU6SJ55d3",
-    "name" : "DimBDcY39iOUfVPJ",
-    "description" : "UbqLa7Ozzvha1"
+    "id" : "https://www.example.com/g6P54r19Of8RWR",
+    "name" : "1z7gOmSmD6Kp5q",
+    "description" : "lfaHpWe0qi1a7tx"
   } ],
-  "rightsHolder" : "M9JwVVMsjyxXN",
-  "duplicateOf" : "https://www.example.org/fa5d3299-79e5-4197-b16c-69c42d6ff2b5",
+  "rightsHolder" : "trfn4XrC04UTuJ7mh",
+  "duplicateOf" : "https://www.example.org/df7a4226-28cf-4e84-aa80-45f4129d9b36",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "zNPjIwJoaY"
+    "note" : "7aW1HzOGUxvuKl"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RC7SJ559dL7",
-    "createdBy" : "zsTgamx4ixWxmd",
-    "createdDate" : "2012-03-04T04:37:05.618Z"
+    "note" : "ZTgP0GRMZNsOiAYLe",
+    "createdBy" : "KuJITAe7TAFo",
+    "createdDate" : "2008-02-09T21:28:16.995Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3bed1718-4163-4e14-8f1b-a76eb8094597" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/dd4baadb-12cd-456f-8811-fd31b8858412" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/OtherPresentation.json
+++ b/documentation/OtherPresentation.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "rtzFF1q3gIsRB",
-    "ownerAffiliation" : "https://www.example.org/b1629035-e75f-4422-b8ca-99ee53c0b55c"
+    "owner" : "knG0n20z1x6MTr",
+    "ownerAffiliation" : "https://www.example.org/9d416949-a8fc-497d-935d-8e34b30d8c11"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/9fc01612-cd03-4920-a8d4-319b99dc6fbd"
+    "id" : "https://www.example.org/49c1cc95-fb48-4ab3-bd95-14b548467cc9"
   },
-  "createdDate" : "2012-11-11T17:18:11.538Z",
-  "modifiedDate" : "1990-11-09T22:32:19.589Z",
-  "publishedDate" : "1977-07-10T05:50:22.436Z",
-  "indexedDate" : "2017-12-18T01:02:38.104Z",
-  "handle" : "https://www.example.org/92456a8a-e3cf-4629-94ec-bed5645cd270",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/8d7c2edf-82ca-4e64-803c-32d84408aa35",
+  "createdDate" : "1990-03-21T09:42:40.493Z",
+  "modifiedDate" : "1997-08-19T03:14:58.460Z",
+  "publishedDate" : "1990-05-01T19:31:07.024Z",
+  "indexedDate" : "2000-06-27T14:42:18.405Z",
+  "handle" : "https://www.example.org/4d622fc9-ae70-440f-a0da-2d31539c1d49",
+  "doi" : "https://doi.org/10.1234/ut",
+  "link" : "https://www.example.org/279bbeeb-9023-4a13-a4e2-67c74def9449",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ErfSo3IegF45",
+    "mainTitle" : "oCWFtak3ipdtc8F5N",
     "alternativeTitles" : {
-      "it" : "FxS51VcMyCVKQD6K"
+      "sv" : "k0vMqkTyupK0"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "iTAnhxXjUJ19M8E6twn",
-      "month" : "cSQ3J2YtugPdY",
-      "day" : "STXHsrFzXF6G1VLeXZN"
+      "year" : "EsW8m3yqFEQNU23J",
+      "month" : "rSW53XPjh1QbpLnxhrI",
+      "day" : "nRc4FNzIZVt7er3"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/54e412cf-d9af-4454-bace-4b8b8e7aabf7",
-        "name" : "y0CsceXw5GX",
+        "id" : "https://www.example.org/6b799e18-249e-4800-9854-f6e7969902ae",
+        "name" : "Tg52hQXq8S",
         "nameType" : "Personal",
-        "orcId" : "wgXmwFvC96q1ydM6M",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "2AxUXwV3mSBV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3MIp80DQmNw4vWnb",
-          "value" : "guEKMUF3gm8tpuhJlwv"
+          "sourceName" : "CTvOekXeO0mGPN1",
+          "value" : "fqzKFUlMgLZok7H"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "8CiGIp7s1PUghvo",
-          "value" : "frPLfMRjWANyR"
+          "sourceName" : "WFIjsbaLkd93X",
+          "value" : "PbNqueE72I6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ec0469b6-6933-4a21-98be-a3defe6d5aaa"
+        "id" : "https://www.example.org/259dacfe-dfe7-47a5-bc3c-8bcf229cf0c7"
       } ],
       "role" : {
-        "type" : "Actor"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,58 +62,59 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/006c591e-47a5-4e84-85bf-076c1b1c1d0a",
-        "name" : "ZBkEh6tQXWN1OU8",
-        "nameType" : "Organizational",
-        "orcId" : "57G5jCeyVfyKUww",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/25dd26b6-9f4d-4a37-852d-264e537c03ab",
+        "name" : "Qu1mNEkcW7Edc0oWpkk",
+        "nameType" : "Personal",
+        "orcId" : "1unK8oBt0zT",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "jRS8km4GK2WICB2O",
-          "value" : "bkXzjuIr1YxSMhBstvv"
+          "sourceName" : "FVtDQJnP69ms",
+          "value" : "t7MlGbCrZej4D1WbzYQ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vYfuZpAkjz",
-          "value" : "KMRHjmAF5HFOLVjxt"
+          "sourceName" : "sQ12ykPwNipHlwL",
+          "value" : "tcv0z3pNHST"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/636973b7-3d75-4da2-a18e-288bd235b9cd"
+        "id" : "https://www.example.org/66cc7b6e-7b9c-4edd-bec8-3e177fed5986"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "Dramatist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "spQDKls24HAKvVSZKPy"
+      "cs" : "7BQvXenkaqa"
     },
-    "npiSubjectHeading" : "5XA4ZueKavoBF",
-    "tags" : [ "WpeFfiGjhAaDe2Asy" ],
-    "description" : "NiCsx3bEHG",
+    "npiSubjectHeading" : "arQKDYjE2nXT",
+    "tags" : [ "iHC9SqoaIbdYAuq9j5" ],
+    "description" : "53U56GgaM1Bq5wvm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Event",
-        "label" : "yBrM7SqA03RpjnK3rp",
+        "label" : "S55Z2TFuwzCg1",
         "place" : {
           "type" : "UnconfirmedPlace",
-          "label" : "PTYw9HyaSlwNEG6v",
-          "country" : "NmPpaMqYmAzqSfwzt1q"
+          "label" : "LX7ZCPnLxaJe",
+          "country" : "VZLtqunzQozqO9MmhQ"
         },
         "time" : {
-          "type" : "Instant",
-          "value" : "1974-07-07T17:00:15.793Z"
+          "type" : "Period",
+          "from" : "2016-07-25T07:29:11.958Z",
+          "to" : "2020-10-16T07:32:56.837Z"
         },
         "agent" : {
           "type" : "Organization",
-          "id" : "https://www.example.com/9CjfddJox07R9CGCF1W"
+          "id" : "https://www.example.com/uKYlmyOEc8"
         },
-        "product" : "https://www.example.com/Dr7rpSFgeKk3w"
+        "product" : "https://www.example.com/NvdGBE9lJ533G"
       },
-      "doi" : "https://www.example.org/d3cb594f-2eae-4701-9076-f4dfcf41d8ef",
+      "doi" : "https://www.example.org/88d47af7-fbca-4deb-9699-7cba09af5488",
       "publicationInstance" : {
         "type" : "OtherPresentation",
         "pages" : {
@@ -121,89 +122,94 @@
         }
       }
     },
-    "metadataSource" : "https://www.example.org/96a65525-b73d-4c83-8475-dc42080b1298",
-    "abstract" : "F53qbmENtj3qvq"
+    "metadataSource" : "https://www.example.org/0a4ee7c1-2615-4f31-adcc-50431a2ec9d0",
+    "abstract" : "H6tggD8Bu6ewe"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cec6eb25-3a68-4a20-9487-1cf29e16928a",
-    "name" : "6iGWsLWeRiQo",
+    "id" : "https://www.example.org/c89cbdc1-7430-49a6-a8ef-917c3f154a2d",
+    "name" : "YgISdwyqCJA7Xvnz0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1987-05-17T05:25:34.313Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "rqfWqMV1ZZ0WzZ19AU"
+      "approvalDate" : "1974-02-25T17:41:31.074Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "0hAcCJ3oA5bW"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/00bc4a0f-7214-4c4c-82fc-eb63b3466380",
-    "identifier" : "MTfJdq5EoTdlvIO3vg",
+    "source" : "https://www.example.org/e1f60674-b050-4807-832e-627980611cec",
+    "identifier" : "07W5bQCPo7",
     "labels" : {
-      "sv" : "XI5PubaOMC00oEw8vW"
+      "en" : "zyNWISe6UHSefJF"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1761359458
+      "amount" : 1317531064
     },
-    "activeFrom" : "2002-12-31T11:28:52.277Z",
-    "activeTo" : "2018-07-26T14:12:55.243Z"
+    "activeFrom" : "1994-07-15T23:49:48.670Z",
+    "activeTo" : "2016-06-18T19:48:07.187Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/480d4275-1b22-4ba9-8047-6d07fc3346ef",
-    "id" : "https://www.example.org/ba366fc3-7c8a-4cfc-b668-48cff1c48695",
-    "identifier" : "f8PCNPwyf27IsY0CY7",
+    "source" : "https://www.example.org/7f62eaea-9efc-46f7-a865-dee705cbdf37",
+    "id" : "https://www.example.org/14f5bd84-eb2b-47b9-92f1-825297508fa5",
+    "identifier" : "eUdX1AP63QoIOw",
     "labels" : {
-      "fi" : "b9ZauWgYMKhgIB"
+      "ca" : "EEBko5OwREJVTQOFPaO"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2030905495
+      "currency" : "GBP",
+      "amount" : 432097652
     },
-    "activeFrom" : "1997-09-19T23:48:02.039Z",
-    "activeTo" : "2005-05-11T11:37:45.407Z"
+    "activeFrom" : "1989-01-01T02:54:46.795Z",
+    "activeTo" : "1993-04-25T01:44:18.897Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cba2356c-a71d-46bd-ab87-b8a46ce44638" ],
+  "subjects" : [ "https://www.example.org/36573253-8e7e-450c-a919-c7d2c574fe4d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4d2e4fc2-f355-435d-b1bb-c08dd0516245",
-    "name" : "azCvC0kccZnDIyu",
-    "mimeType" : "rwzWqOw3MBdK",
-    "size" : 2035938019,
-    "license" : "https://www.example.com/lhphiosgngtjnze",
+    "identifier" : "c2892174-b414-401a-b5d9-95dbac2a9acb",
+    "name" : "XOes7bkuio9x7",
+    "mimeType" : "NkSvYtFV4z",
+    "size" : 1889254370,
+    "license" : "https://www.example.com/hy11ftpwcmea",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "a2MMpSoSIjkDtjqEUT",
-    "publishedDate" : "1981-09-16T18:16:29.189Z",
+    "legalNote" : "BcUjatTJynYm",
+    "publishedDate" : "2022-07-28T21:31:19.401Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "bTF03VzGhBGf8JZE",
+      "uploadedDate" : "2012-06-08T14:01:14.959Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/g6P54r19Of8RWR",
-    "name" : "1z7gOmSmD6Kp5q",
-    "description" : "lfaHpWe0qi1a7tx"
+    "id" : "https://www.example.com/W49gJc8Jv1m",
+    "name" : "0bIqKZXH0saGcAaGD",
+    "description" : "B9qjPJIHUe7"
   } ],
-  "rightsHolder" : "trfn4XrC04UTuJ7mh",
-  "duplicateOf" : "https://www.example.org/df7a4226-28cf-4e84-aa80-45f4129d9b36",
+  "rightsHolder" : "f448Gm8E3o1ArLO4GD",
+  "duplicateOf" : "https://www.example.org/5b14d339-1b37-41f6-8dfd-7574a29edb7f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7aW1HzOGUxvuKl"
+    "note" : "e02Y0uLjski2FM"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ZTgP0GRMZNsOiAYLe",
-    "createdBy" : "KuJITAe7TAFo",
-    "createdDate" : "2008-02-09T21:28:16.995Z"
+    "note" : "B3eeCLStSNsIw",
+    "createdBy" : "da6f9rVxQza",
+    "createdDate" : "2022-10-02T19:52:23.404Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/dd4baadb-12cd-456f-8811-fd31b8858412" ],
+  "curatingInstitutions" : [ "https://www.example.org/dadfd10a-4af9-49d6-990f-7feed8bd3555" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "wkQMWIjKeGKyIDlOj",
-    "ownerAffiliation" : "https://www.example.org/8b89b7a6-7408-4754-b04e-74e4e4a22e7d"
+    "owner" : "evmlHrdMVOWxW",
+    "ownerAffiliation" : "https://www.example.org/55e9239a-05c2-4c89-8b25-498ef8ce96ce"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/c7e5355d-6583-490e-8e31-fe29cfe1ef62"
+    "id" : "https://www.example.org/54f7dc5e-2eee-4fd7-9cc9-d46416b4149e"
   },
-  "createdDate" : "1977-01-21T23:43:59.812Z",
-  "modifiedDate" : "1988-07-10T10:24:24.690Z",
-  "publishedDate" : "1993-09-27T13:51:18.066Z",
-  "indexedDate" : "1985-08-02T23:04:33.461Z",
-  "handle" : "https://www.example.org/45e33b36-a1c1-47be-8f81-8761a5b8a111",
-  "doi" : "https://doi.org/10.1234/qui",
-  "link" : "https://www.example.org/2a902d70-f214-4584-8f94-99b4f1c8fbff",
+  "createdDate" : "2012-03-24T01:43:20.883Z",
+  "modifiedDate" : "2004-02-05T01:16:10.933Z",
+  "publishedDate" : "1994-08-05T04:27:25.418Z",
+  "indexedDate" : "1981-06-21T14:49:13.219Z",
+  "handle" : "https://www.example.org/8ac1d468-9a87-41e8-b80f-d45ef9760114",
+  "doi" : "https://doi.org/10.1234/quod",
+  "link" : "https://www.example.org/8cebfee5-8637-4344-9999-4b872cb115f5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "YxRtCRrpQYke2",
+    "mainTitle" : "7ChZ3hlVWS",
     "alternativeTitles" : {
-      "is" : "yT3kwVjnYfkVBUl3"
+      "se" : "EwOLwHKvEix"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "qe6A06cDpgNxo3",
-      "month" : "S7gx143ikVxh",
-      "day" : "mxgXmZl6pmxhePrEzHx"
+      "year" : "sgBEiwXTmmfS1",
+      "month" : "qvvEaVdI9K",
+      "day" : "wAnE8WD1ofTHfFh7kr"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/39140471-b84c-4498-b14f-5fd8e6f1f957",
-        "name" : "yonWDpFpMM",
+        "id" : "https://www.example.org/d8d0ee69-7306-4e9d-af7b-c2edaf32ab0c",
+        "name" : "zXvpAlSftYfrYE",
         "nameType" : "Personal",
-        "orcId" : "IWcZzoEk0pQcPNfFZ",
+        "orcId" : "NastEnKM2u",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ycN02c9JTkvmJ9L1w",
-          "value" : "TOYeCGBNFTjfQYIX3a"
+          "sourceName" : "ElXksBoqkuuOHZ",
+          "value" : "ZJtADZnlcVlgD6x1qA"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NNVOmaoNwJqB",
-          "value" : "b9XKG1c3tCczF"
+          "sourceName" : "dx5Gl4UyycY",
+          "value" : "fhoyfyXoEASFzt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9f02f15d-08e2-400e-948a-ac277588612c"
+        "id" : "https://www.example.org/fc6cba48-baee-4787-95b6-9093244b0e9d"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "AudioVisualContributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,163 +62,169 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cb80c971-0b81-40b1-a786-881fccaca118",
-        "name" : "VBAaQA9Jy7F0j9KTirS",
+        "id" : "https://www.example.org/da8cae55-7dcc-41d7-9bc8-27ea9dcfbf51",
+        "name" : "OBvA8tlNf3Rn1hiE",
         "nameType" : "Personal",
-        "orcId" : "dwjeQafPMz",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "0cTUvzgjaV",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wEDeGmlQHoTrFELR5",
-          "value" : "ZX0GCosuLy"
+          "sourceName" : "DFdfUOG76f",
+          "value" : "joSUH7diezXx"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "feia15fk7g3oBOyBgP",
-          "value" : "8MFVB3LBnxH"
+          "sourceName" : "MCM5ut688G",
+          "value" : "uQPjLnE3FOgGiRF5v5u"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d866c2a0-9cfe-46e2-8d27-a1232b8ea3a8"
+        "id" : "https://www.example.org/961c4965-e5b7-4cc9-999e-334386b0a276"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "Photographer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "SdOYohTJOZedSb"
+      "sv" : "4kalsn711gn4Yi"
     },
-    "npiSubjectHeading" : "F3Fb3MtN4bzrByub6",
-    "tags" : [ "xYjC7oGopPktvWr" ],
-    "description" : "Ops4zI2vOsMKQ7",
+    "npiSubjectHeading" : "K3fCTNTHTr",
+    "tags" : [ "jtXuoeAVvsm" ],
+    "description" : "d19j05A3eyu",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b77ef923-adab-45f3-b99c-abc448e92b43"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b2efb730-c75d-4ecb-a35d-a254882f3654"
         },
-        "seriesNumber" : "q3v53vXgecwgIAKfg0h",
+        "seriesNumber" : "mYpkkuZcII",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e6e60045-a396-4b90-aaf5-06e6c38de51d",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4dcb21a3-3267-4d28-9d85-a53a2b1551fb",
           "valid" : true
         },
-        "isbnList" : [ "9790021863111" ],
+        "isbnList" : [ "9780258072653", "9781264855339" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "e4X42pPcSFcEvky"
+          "value" : "1264855338"
         } ]
       },
-      "doi" : "https://www.example.org/7845f8ea-7b76-401d-9e2a-8e0f7030767a",
+      "doi" : "https://www.example.org/86376d74-a8d5-488a-8ddd-5a1f7111534f",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "dDV4HW9J14",
-            "end" : "uyvt4VLqv9LcavUr"
+            "begin" : "5Qck4eRZGqRndt",
+            "end" : "NsLqxlWV6iT4Wrh"
           },
-          "pages" : "g8vBgmXEjDNwx",
+          "pages" : "KouHqoEsPba8",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "6Y603BVplL17VITt",
-          "month" : "9RPoDs6KmHS",
-          "day" : "QmxDB8eb665CG9K6n"
+          "year" : "WiJ559PC7v6DC7",
+          "month" : "g7GnKhJLNV8OB0HLQv",
+          "day" : "a2el3a19a7rtglmfk2o"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/6cd57094-7496-470f-bf75-f729e8fbf28a",
-    "abstract" : "BOvWKjANRTvpgVgqAQr"
+    "metadataSource" : "https://www.example.org/517edb3e-d167-490e-a3f9-566753d703d3",
+    "abstract" : "WiFJl8t2C1tO5enx"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cd7f5df7-eca6-4af4-9ac4-c0b203be4999",
-    "name" : "nnK2DyUPzo",
+    "id" : "https://www.example.org/4a5f7fd4-f10f-403c-bc83-f5640d0323c9",
+    "name" : "xbA0s1TAEIh8wc",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-02-19T12:38:20.208Z",
+      "approvalDate" : "1974-09-27T19:18:32.424Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "F0JlmUQGP3ilKgjo2b"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "IE3xDanGPpv"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/aa7555f5-1bef-4498-b9a9-132b332f941b",
-    "identifier" : "6iNT6q95QW",
+    "source" : "https://www.example.org/06fe91df-6a91-4078-886a-85dd5c22154d",
+    "identifier" : "EP1QMqZ4IrG",
     "labels" : {
-      "is" : "QASMacgXzaF0xZBqrl"
+      "af" : "hq67ZNaaVlskMgXWxJ"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 233958738
+      "currency" : "EUR",
+      "amount" : 471846023
     },
-    "activeFrom" : "1994-10-30T15:28:27.212Z",
-    "activeTo" : "2011-06-29T04:46:27.189Z"
+    "activeFrom" : "1996-02-25T14:59:03.468Z",
+    "activeTo" : "2021-11-26T05:03:59.434Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/64a96549-7f24-428c-8128-ab3d5028d3c5",
-    "id" : "https://www.example.org/7792383d-1c8f-49ee-b715-bb6282286d58",
-    "identifier" : "8Fur8kLBXeGgfZryt",
+    "source" : "https://www.example.org/1d3bc39c-5b43-4ca1-8b4a-326803af597f",
+    "id" : "https://www.example.org/b5889204-4288-411d-84aa-34df44fc549c",
+    "identifier" : "EvYiQpMX5pXB6",
     "labels" : {
-      "da" : "nAS189AvksIkWAy6"
+      "nl" : "rVMKM7TsOZGgN"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1301316785
+      "currency" : "EUR",
+      "amount" : 1314673931
     },
-    "activeFrom" : "1997-01-31T12:19:12.498Z",
-    "activeTo" : "2002-12-09T15:18:00.279Z"
+    "activeFrom" : "1980-10-12T00:08:33.481Z",
+    "activeTo" : "1990-04-15T05:53:21.157Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9130be07-ef47-46a3-a665-ac6c4d48a4f9" ],
+  "subjects" : [ "https://www.example.org/305aea40-ae65-43cd-9622-8ab4bf52f28b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8226a7e0-b3b5-4226-ba7d-0103da7667b6",
-    "name" : "tmJEPYCfPpWa6p",
-    "mimeType" : "rDzS8z8fI5Us8P",
-    "size" : 1611525421,
-    "license" : "https://www.example.com/qx00beoxgqgbemttep",
+    "identifier" : "666438c6-d448-4ccb-b604-298b33415772",
+    "name" : "h7GMTuA4KmTVSQ",
+    "mimeType" : "2RR92WcYHk0shN4u",
+    "size" : 487694756,
+    "license" : "https://www.example.com/ceafvutod1gculxtk0",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "7MW2kypbld9HZfwePiv"
     },
-    "legalNote" : "Q3MF5j28nfa",
-    "publishedDate" : "2016-11-10T09:56:24.853Z",
+    "legalNote" : "8UFf6Ohe78",
+    "publishedDate" : "1978-05-05T11:29:27.497Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "og7Pkby51Y1HlQow",
+      "uploadedDate" : "2012-10-19T04:04:44.888Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/9N15jeL3BlpO79hSDO0",
-    "name" : "oW2YjsDFPzn",
-    "description" : "r31g3tixB0KYSUOV"
+    "id" : "https://www.example.com/hVTsZuqQ3ovTN",
+    "name" : "fnAxp8bJ1S",
+    "description" : "lOnWh0jINv6p"
   } ],
-  "rightsHolder" : "xHrSEaNtg29GipkEn3Y",
-  "duplicateOf" : "https://www.example.org/0b97be59-a577-46c9-8b57-25400ddacf18",
+  "rightsHolder" : "eMeO8snEq9rO",
+  "duplicateOf" : "https://www.example.org/e5ec7c3e-7601-4bb1-80b5-10a41a54551c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "DkqM2BsBoG"
+    "note" : "CxSwmXmRsJcCJWlGk"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "Kf3wa8doqEAB",
-    "createdBy" : "3IyOLmroxm",
-    "createdDate" : "1987-09-05T05:11:10.339Z"
+    "note" : "QzKGwlhok9Tj91kzC4d",
+    "createdBy" : "rd7N41Wk6M",
+    "createdDate" : "2009-08-02T12:44:38.599Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/07eb0219-052a-49ef-b751-24912f52646e" ],
+  "curatingInstitutions" : [ "https://www.example.org/1c8b7aee-c1b5-47d2-8153-01ae8a9839dc" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/OtherStudentWork.json
+++ b/documentation/OtherStudentWork.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "bS8gle1k0u5nVUp",
-    "ownerAffiliation" : "https://www.example.org/b2ba1e32-76fc-407f-94d5-2421bd14de4e"
+    "owner" : "wkQMWIjKeGKyIDlOj",
+    "ownerAffiliation" : "https://www.example.org/8b89b7a6-7408-4754-b04e-74e4e4a22e7d"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/488454b0-bc59-460c-8ca9-cccf97b02c40"
+    "id" : "https://www.example.org/c7e5355d-6583-490e-8e31-fe29cfe1ef62"
   },
-  "createdDate" : "1973-11-08T06:21:36.216Z",
-  "modifiedDate" : "1993-01-20T15:55:13.580Z",
-  "publishedDate" : "1977-11-24T12:27:30.568Z",
-  "indexedDate" : "2006-05-02T16:03:13.226Z",
-  "handle" : "https://www.example.org/316263f0-aebd-42e3-87a8-6fdb767acd6f",
-  "doi" : "https://doi.org/10.1234/odio",
-  "link" : "https://www.example.org/49456cad-a378-4473-a8e0-eaee854e3fd3",
+  "createdDate" : "1977-01-21T23:43:59.812Z",
+  "modifiedDate" : "1988-07-10T10:24:24.690Z",
+  "publishedDate" : "1993-09-27T13:51:18.066Z",
+  "indexedDate" : "1985-08-02T23:04:33.461Z",
+  "handle" : "https://www.example.org/45e33b36-a1c1-47be-8f81-8761a5b8a111",
+  "doi" : "https://doi.org/10.1234/qui",
+  "link" : "https://www.example.org/2a902d70-f214-4584-8f94-99b4f1c8fbff",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "cCGqCghCYpdUiw0gD5",
+    "mainTitle" : "YxRtCRrpQYke2",
     "alternativeTitles" : {
-      "de" : "2fyYrpHTqZ"
+      "is" : "yT3kwVjnYfkVBUl3"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "ysdXyuksJkKdfqzf",
-      "month" : "diBQt6FEyXdBPGPmdHg",
-      "day" : "3EOjre3guRxTLVr3U5"
+      "year" : "qe6A06cDpgNxo3",
+      "month" : "S7gx143ikVxh",
+      "day" : "mxgXmZl6pmxhePrEzHx"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/b19b1c5f-021a-4f06-9979-f2170312b96c",
-        "name" : "LRzO4VkoHRwSuO1NZgz",
+        "id" : "https://www.example.org/39140471-b84c-4498-b14f-5fd8e6f1f957",
+        "name" : "yonWDpFpMM",
         "nameType" : "Personal",
-        "orcId" : "PBY3oNWH2nePKs",
+        "orcId" : "IWcZzoEk0pQcPNfFZ",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "vZnlAyAjpy1ahKU0p",
-          "value" : "Vcbku3BZtpu9"
+          "sourceName" : "ycN02c9JTkvmJ9L1w",
+          "value" : "TOYeCGBNFTjfQYIX3a"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BCrTZdtVWv",
-          "value" : "ITTJVBcNxsE"
+          "sourceName" : "NNVOmaoNwJqB",
+          "value" : "b9XKG1c3tCczF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/947ae42b-88ed-4bc3-9fa5-228085a1044b"
+        "id" : "https://www.example.org/9f02f15d-08e2-400e-948a-ac277588612c"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "Consultant"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,162 +62,163 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a583b401-1da5-4144-963b-e0314514698b",
-        "name" : "FJd5kMCWMf7JJP",
-        "nameType" : "Organizational",
-        "orcId" : "eqF8MC2QeHlXo",
+        "id" : "https://www.example.org/cb80c971-0b81-40b1-a786-881fccaca118",
+        "name" : "VBAaQA9Jy7F0j9KTirS",
+        "nameType" : "Personal",
+        "orcId" : "dwjeQafPMz",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AmT2rnFFWb5JUZf2Z1",
-          "value" : "kFY9WuD5CFLyTKWc2dN"
+          "sourceName" : "wEDeGmlQHoTrFELR5",
+          "value" : "ZX0GCosuLy"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "N2puoCQV9iCwd0yN",
-          "value" : "Xphc6jCHm9UwbhEWBF"
+          "sourceName" : "feia15fk7g3oBOyBgP",
+          "value" : "8MFVB3LBnxH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cea143f7-8986-4634-8ab4-94409f43e1ef"
+        "id" : "https://www.example.org/d866c2a0-9cfe-46e2-8d27-a1232b8ea3a8"
       } ],
       "role" : {
-        "type" : "Dramatist"
+        "type" : "Registrar"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "da" : "TOhopCaHydW4cFY"
+      "nn" : "SdOYohTJOZedSb"
     },
-    "npiSubjectHeading" : "MUHkNT2ue0Ejt9u",
-    "tags" : [ "9W02k2vAf6m" ],
-    "description" : "WpEWXvvquUA",
+    "npiSubjectHeading" : "F3Fb3MtN4bzrByub6",
+    "tags" : [ "xYjC7oGopPktvWr" ],
+    "description" : "Ops4zI2vOsMKQ7",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f6b0a7d3-20f4-4617-8356-0f368b62b2db"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b77ef923-adab-45f3-b99c-abc448e92b43"
         },
-        "seriesNumber" : "qU6BvNbItcdQ15z7",
+        "seriesNumber" : "q3v53vXgecwgIAKfg0h",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3cf8689a-e07f-4679-9bd3-912e69538f73",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e6e60045-a396-4b90-aaf5-06e6c38de51d",
           "valid" : true
         },
-        "isbnList" : [ "9780702313332" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9790021863111" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "vYtx17T7Cs597"
+          "value" : "e4X42pPcSFcEvky"
         } ]
       },
-      "doi" : "https://www.example.org/f330943d-8729-4f98-b75e-98f672532238",
+      "doi" : "https://www.example.org/7845f8ea-7b76-401d-9e2a-8e0f7030767a",
       "publicationInstance" : {
         "type" : "OtherStudentWork",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "05TpPbFdgpSfo",
-            "end" : "LEa1MLwz4lQwCiwap8"
+            "begin" : "dDV4HW9J14",
+            "end" : "uyvt4VLqv9LcavUr"
           },
-          "pages" : "P9occGpVJTFqBzGcrFO",
+          "pages" : "g8vBgmXEjDNwx",
           "illustrated" : true
         },
         "submittedDate" : {
           "type" : "PublicationDate",
-          "year" : "GYKN2IwnfIeu9",
-          "month" : "MG2VORz9SJQumFBE",
-          "day" : "uFS3YhkoQl"
+          "year" : "6Y603BVplL17VITt",
+          "month" : "9RPoDs6KmHS",
+          "day" : "QmxDB8eb665CG9K6n"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f11ea7fb-92b5-4fbd-bea5-18ab0a14cc1b",
-    "abstract" : "4z8KgYGYcSD"
+    "metadataSource" : "https://www.example.org/6cd57094-7496-470f-bf75-f729e8fbf28a",
+    "abstract" : "BOvWKjANRTvpgVgqAQr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9bcc4ee1-cdb6-445b-bb50-54eac4481382",
-    "name" : "X3Nkg3BEPX",
+    "id" : "https://www.example.org/cd7f5df7-eca6-4af4-9ac4-c0b203be4999",
+    "name" : "nnK2DyUPzo",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1990-10-20T12:23:44.941Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "8Cj2REfPlaZ"
+      "approvalDate" : "2008-02-19T12:38:20.208Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "F0JlmUQGP3ilKgjo2b"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b7311a4f-2390-49b1-9a38-67c4ed8c9090",
-    "identifier" : "dLl4APwYELQZ",
+    "source" : "https://www.example.org/aa7555f5-1bef-4498-b9a9-132b332f941b",
+    "identifier" : "6iNT6q95QW",
     "labels" : {
-      "pl" : "7CQQr7ZLAnzh022a"
+      "is" : "QASMacgXzaF0xZBqrl"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 441626609
+      "currency" : "NOK",
+      "amount" : 233958738
     },
-    "activeFrom" : "2009-05-06T11:28:19.320Z",
-    "activeTo" : "2023-07-11T16:54:42.063Z"
+    "activeFrom" : "1994-10-30T15:28:27.212Z",
+    "activeTo" : "2011-06-29T04:46:27.189Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/a04270b4-ae65-4c1a-ada6-2601d80ca9fb",
-    "id" : "https://www.example.org/d2a976c4-194e-4193-8fe2-fea084249d5d",
-    "identifier" : "TzB5HOi6YAZKqg4",
+    "source" : "https://www.example.org/64a96549-7f24-428c-8128-ab3d5028d3c5",
+    "id" : "https://www.example.org/7792383d-1c8f-49ee-b715-bb6282286d58",
+    "identifier" : "8Fur8kLBXeGgfZryt",
     "labels" : {
-      "en" : "L0axVXhp3HgzM39z"
+      "da" : "nAS189AvksIkWAy6"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 932644736
+      "currency" : "NOK",
+      "amount" : 1301316785
     },
-    "activeFrom" : "1979-01-27T10:52:43.561Z",
-    "activeTo" : "2000-12-07T13:35:57.261Z"
+    "activeFrom" : "1997-01-31T12:19:12.498Z",
+    "activeTo" : "2002-12-09T15:18:00.279Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/43c37a30-9e93-4d4d-a352-86a7a7d0b8ab" ],
+  "subjects" : [ "https://www.example.org/9130be07-ef47-46a3-a665-ac6c4d48a4f9" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "e6078829-3242-43c6-b633-f90eb149ba18",
-    "name" : "0kre8AXIPJJ",
-    "mimeType" : "Wd2eVAwMGC",
-    "size" : 563909508,
-    "license" : "https://www.example.com/0zzawgfdgtty0rs8yo",
+    "identifier" : "8226a7e0-b3b5-4226-ba7d-0103da7667b6",
+    "name" : "tmJEPYCfPpWa6p",
+    "mimeType" : "rDzS8z8fI5Us8P",
+    "size" : 1611525421,
+    "license" : "https://www.example.com/qx00beoxgqgbemttep",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "OTjkRPGx6YqfG",
-    "publishedDate" : "1999-10-20T12:38:08.394Z",
+    "legalNote" : "Q3MF5j28nfa",
+    "publishedDate" : "2016-11-10T09:56:24.853Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/mYUpsL2IfgSQr1C1Z2i",
-    "name" : "97vjXTsrrS",
-    "description" : "ippdyDb7lRV4TylD6y"
+    "id" : "https://www.example.com/9N15jeL3BlpO79hSDO0",
+    "name" : "oW2YjsDFPzn",
+    "description" : "r31g3tixB0KYSUOV"
   } ],
-  "rightsHolder" : "ToVZfoQtm3J8pFyU",
-  "duplicateOf" : "https://www.example.org/15893ee4-0690-4d04-977e-2dc09038d53e",
+  "rightsHolder" : "xHrSEaNtg29GipkEn3Y",
+  "duplicateOf" : "https://www.example.org/0b97be59-a577-46c9-8b57-25400ddacf18",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "40ixYlula0"
+    "note" : "DkqM2BsBoG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "gFp6a3NieHE1Ch7X",
-    "createdBy" : "ptf8QGlQMiA",
-    "createdDate" : "2018-07-09T10:17:29.023Z"
+    "note" : "Kf3wa8doqEAB",
+    "createdBy" : "3IyOLmroxm",
+    "createdDate" : "1987-09-05T05:11:10.339Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/d821cfd2-55e4-4bc0-9041-425bf34b26cc" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/07eb0219-052a-49ef-b751-24912f52646e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "W21HV7cnmEL",
-    "ownerAffiliation" : "https://www.example.org/f36f9fe3-74ee-4263-add8-02fc121726cd"
+    "owner" : "vDqmmFZC5Dh",
+    "ownerAffiliation" : "https://www.example.org/91e95e3e-2fa2-4cf3-b783-a7745493366a"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/6d90e84c-3eb8-49f1-baef-c2b4c7e540b4"
+    "id" : "https://www.example.org/e0cf6708-336f-4070-95ed-504df37c6c8d"
   },
-  "createdDate" : "1983-05-16T20:58:09.665Z",
-  "modifiedDate" : "1981-03-26T06:05:04.324Z",
-  "publishedDate" : "2016-11-30T22:14:49.175Z",
-  "indexedDate" : "2018-08-10T06:43:56.182Z",
-  "handle" : "https://www.example.org/a0fe4315-ba4a-45e1-8b54-9dd4d2a7955a",
-  "doi" : "https://doi.org/10.1234/animi",
-  "link" : "https://www.example.org/9e9d1721-3393-44a4-83a9-f80a457399f7",
+  "createdDate" : "2006-12-28T14:16:15.305Z",
+  "modifiedDate" : "1975-03-17T08:39:31.437Z",
+  "publishedDate" : "2009-06-20T05:21:45.583Z",
+  "indexedDate" : "1987-06-05T22:04:07.925Z",
+  "handle" : "https://www.example.org/3c36c3a5-f664-486b-9911-e0c9981c389a",
+  "doi" : "https://doi.org/10.1234/dolorem",
+  "link" : "https://www.example.org/b8205f63-762f-4cda-820b-a1f7a8ca569b",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "TgI6WZLupH2f9j",
+    "mainTitle" : "ZOugtjmK9Aib",
     "alternativeTitles" : {
-      "nb" : "CWwobHufhzkj"
+      "el" : "xvxPz8qcyNhM"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zp09ZdKLDreRhWdPram",
-      "month" : "9jxP8pNsGw7uget",
-      "day" : "Yb7rxIDoILHtdTKWg"
+      "year" : "cCEhPc82wBn2Ke",
+      "month" : "J7uW8tjEV8Rlqzaz",
+      "day" : "JuNv5wz3N8yRa2Cl3Wa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c3b3ed19-9873-4f73-9b17-ab489c3e36c1",
-        "name" : "5zEiug2Bl31w",
+        "id" : "https://www.example.org/ffc92e6e-b279-4db2-9b52-99ff957363d1",
+        "name" : "nbh2VvvwXUWOeJ",
         "nameType" : "Personal",
-        "orcId" : "9sTShop1dQOewMzjq",
+        "orcId" : "wASjnm9VDmRFJp4",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "s6HfUIqEqzFKbSs",
-          "value" : "QX6rhnDE29Rc0"
+          "sourceName" : "3oCFUC7uvw5dr2b",
+          "value" : "K8OSVuuv3UNFZjL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "TXC3HAxfFJyHhJG",
-          "value" : "IzxOdvg9cNDXEuO5H"
+          "sourceName" : "1nw8IE1TfEXgQU5r4g",
+          "value" : "4jtLmQH3zS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/13d977cf-8157-49e0-96f0-84d1dd6448fd"
+        "id" : "https://www.example.org/2c42624e-3d0b-4dfe-914a-8236a0e3ffee"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,150 +62,152 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1434c689-c769-47a6-ad1d-b3f9d045e5a6",
-        "name" : "gtsPBwf75a861e0lv",
+        "id" : "https://www.example.org/4cea08ec-1b6f-4b55-8e71-1a441c854edf",
+        "name" : "y9GMSfyIqPja7",
         "nameType" : "Organizational",
-        "orcId" : "KhrkTYL5F9",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "oEzH7xgHbE0tIgqHUVz",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dIXlBlPFa8Svopa",
-          "value" : "5XtGwMYE74j1jyF"
+          "sourceName" : "BpUzFUI4DV5BWgd",
+          "value" : "dP7Y41GgiRph8KxlFB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "caZf7gXSUp4",
-          "value" : "2qDyxORGeRXJ3CGa"
+          "sourceName" : "ob3zfiCbmkZS",
+          "value" : "Ard5jGnR6vo"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/62e0599e-9b80-4ba7-8f4a-db448e42237f"
+        "id" : "https://www.example.org/b4be2dbf-1c93-4652-bfd3-592904366169"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "LightDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "BqCwgzQS5E"
+      "fi" : "kEr01HtOhaSigwd8"
     },
-    "npiSubjectHeading" : "ZLT81qDc749L5ETo",
-    "tags" : [ "zdoDFcS3ccQswTkRRlG" ],
-    "description" : "vaHHf8zndvMAvGDv9mT",
+    "npiSubjectHeading" : "a0GxXOZoPqBwLKhXa",
+    "tags" : [ "KBRZVPAN5F1Tdk6" ],
+    "description" : "TeEtV5Re3p0dFY",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/aaa09417-41d0-480b-81ca-9e34dfb1c7df",
+      "doi" : "https://www.example.org/221e0432-6e07-4ad4-aff1-25a4161379e3",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "Broadcast"
+          "type" : "PerformingArtsOther",
+          "description" : "zEQ1KaYvFfBTv"
         },
-        "description" : "R1iqErwaQ8Fl",
+        "description" : "AtcGMMDljrpdtkJ",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "FjtellihVkeMIZRen",
-            "country" : "LwbSZb7UPE"
+            "label" : "iZvwUVpmiJa9TYxqP",
+            "country" : "2TMuWrSfX9d"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1985-07-24T03:18:39.770Z",
-            "to" : "1998-09-25T02:15:31.021Z"
+            "from" : "1972-05-19T16:02:58.133Z",
+            "to" : "1980-04-17T10:37:10.413Z"
           },
-          "sequence" : 2069249472
+          "sequence" : 46768906
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f7dda31d-af06-46e6-855c-27aab688e288",
-    "abstract" : "xWvJjHqpbRxl8"
+    "metadataSource" : "https://www.example.org/325483f4-92e3-4694-aeb4-8169f18d33e4",
+    "abstract" : "cnfQ9Q4BRA"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2d7ad24a-0767-4755-8157-35f7502ad47f",
-    "name" : "jGiPYoQplIjx8FtXuH",
+    "id" : "https://www.example.org/fb4eee48-c371-4dcd-99c7-07a77690d010",
+    "name" : "WKHeDwINOgDsWXfS6",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1971-05-03T23:08:33.178Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "wZVtLHTxw0P"
+      "approvalDate" : "1978-04-16T03:11:02.169Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "vXQP1yTCy6P"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4b68bdab-b1d5-48a3-8a14-119ed4247618",
-    "identifier" : "g0V1IvdedHevzmHed",
+    "source" : "https://www.example.org/41247ac4-45c8-45e8-9200-4ddb15ada35f",
+    "identifier" : "CItjNHHh17Myd1Z4a",
     "labels" : {
-      "es" : "cjgWqxBlnV"
+      "ca" : "7TqpPtq9z1BieqzRZJJ"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1157685546
+      "currency" : "GBP",
+      "amount" : 660450395
     },
-    "activeFrom" : "2001-06-05T23:20:07.878Z",
-    "activeTo" : "2014-06-08T10:59:31.281Z"
+    "activeFrom" : "2020-11-22T08:58:17.246Z",
+    "activeTo" : "2021-10-21T06:51:04.832Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/9a379dd8-c3e6-4577-a510-d2f67f9f0d0a",
-    "id" : "https://www.example.org/3f7ed055-052a-4314-a6c7-3d5821123b52",
-    "identifier" : "uvYolZRlh8437iMT",
+    "source" : "https://www.example.org/56bc3ff3-5e8c-4450-8641-784396b47aed",
+    "id" : "https://www.example.org/3c5a7bdc-5ad3-4e83-a53b-89d9d7cf98bf",
+    "identifier" : "9yDq4l7zjo",
     "labels" : {
-      "ru" : "2YBAau4xkZt"
+      "es" : "HYor1Qa0b3l"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 2123109498
+      "amount" : 1251212585
     },
-    "activeFrom" : "2000-04-20T01:26:58.007Z",
-    "activeTo" : "2003-12-16T06:25:25.236Z"
+    "activeFrom" : "1985-05-22T14:51:42.438Z",
+    "activeTo" : "2017-06-15T12:56:37.119Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b2b1f78f-205d-48de-833b-9fac3f17d0de" ],
+  "subjects" : [ "https://www.example.org/9e200a45-5fbe-428a-80d2-befb9352db2f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8dfd9c25-95e9-47d4-9917-c5c00edfbfa1",
-    "name" : "dNlfLh31XvIOZLqGT2I",
-    "mimeType" : "4JZq9L2NMNui0CF",
-    "size" : 1665225304,
-    "license" : "https://www.example.com/0klaunp3trn8",
+    "identifier" : "c86e4aa4-eca9-4860-8d8e-c0b21eb5268d",
+    "name" : "EjX9MCyF9NFWd7f",
+    "mimeType" : "zOyQxwm2VlaxS",
+    "size" : 993994073,
+    "license" : "https://www.example.com/d8lxvx30ndoby7ediyf",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "PBzcyof7nxcot7Y095g",
-    "publishedDate" : "1989-08-29T11:30:13.183Z",
+    "legalNote" : "lyCBFC12X8Xs",
+    "publishedDate" : "1986-06-15T07:52:06.345Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/D82XvVGZakuaW9",
-    "name" : "ujV7kWQEax81wxf1",
-    "description" : "GD3F9icOzwXMMEAE"
+    "id" : "https://www.example.com/gliheBzwV7Xs",
+    "name" : "3DSWXoHz2nLowqC",
+    "description" : "lEoSpzzOKVo4"
   } ],
-  "rightsHolder" : "1Q33MeshiOQ",
-  "duplicateOf" : "https://www.example.org/b35b34ad-8053-43e7-8913-2f92921834ee",
+  "rightsHolder" : "CRWIfMCEEs2ngmk",
+  "duplicateOf" : "https://www.example.org/fb9ca76c-d35c-4614-836d-f0e22e1657de",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "0qzEOKnOd1FOr"
+    "note" : "roht7npCSBg"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "o78QskLZNg30st1Cetb",
-    "createdBy" : "4YNoUcVWXCc",
-    "createdDate" : "2009-03-14T19:54:34.623Z"
+    "note" : "bwLLsRVxfxI",
+    "createdBy" : "vm8uH9FoO4o",
+    "createdDate" : "1984-01-22T04:24:04.002Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ee1d0079-39ef-4ead-a0af-f9126ca1e513" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/e00b0402-3238-423d-9954-c2714fda05e1" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/PerformingArts.json
+++ b/documentation/PerformingArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "vDqmmFZC5Dh",
-    "ownerAffiliation" : "https://www.example.org/91e95e3e-2fa2-4cf3-b783-a7745493366a"
+    "owner" : "0sR3rSdjRUfBV4d",
+    "ownerAffiliation" : "https://www.example.org/afba89d5-9083-4a42-83fd-395bf470515b"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e0cf6708-336f-4070-95ed-504df37c6c8d"
+    "id" : "https://www.example.org/21372374-02be-4df3-8821-fdb9116e5572"
   },
-  "createdDate" : "2006-12-28T14:16:15.305Z",
-  "modifiedDate" : "1975-03-17T08:39:31.437Z",
-  "publishedDate" : "2009-06-20T05:21:45.583Z",
-  "indexedDate" : "1987-06-05T22:04:07.925Z",
-  "handle" : "https://www.example.org/3c36c3a5-f664-486b-9911-e0c9981c389a",
-  "doi" : "https://doi.org/10.1234/dolorem",
-  "link" : "https://www.example.org/b8205f63-762f-4cda-820b-a1f7a8ca569b",
+  "createdDate" : "2005-11-06T04:39:56.905Z",
+  "modifiedDate" : "2010-01-17T06:41:22.856Z",
+  "publishedDate" : "1987-04-19T07:55:57.722Z",
+  "indexedDate" : "1976-06-20T05:34:00.153Z",
+  "handle" : "https://www.example.org/f1293b3a-e317-4f75-a6a3-f6a12a6add80",
+  "doi" : "https://doi.org/10.1234/veniam",
+  "link" : "https://www.example.org/968497a2-63a2-4651-a1a6-848d1c7deff7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "ZOugtjmK9Aib",
+    "mainTitle" : "Gn3eFvHuteBr",
     "alternativeTitles" : {
-      "el" : "xvxPz8qcyNhM"
+      "hu" : "3mS6NJrzd07Q"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cCEhPc82wBn2Ke",
-      "month" : "J7uW8tjEV8Rlqzaz",
-      "day" : "JuNv5wz3N8yRa2Cl3Wa"
+      "year" : "vUIJjQkSJb",
+      "month" : "4WYpySwzQP",
+      "day" : "f2VxavjzdXTqn3a007"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ffc92e6e-b279-4db2-9b52-99ff957363d1",
-        "name" : "nbh2VvvwXUWOeJ",
-        "nameType" : "Personal",
-        "orcId" : "wASjnm9VDmRFJp4",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/e6181211-49a2-4701-82dc-f98824b4d28a",
+        "name" : "QKeSP85dL6m1s1D",
+        "nameType" : "Organizational",
+        "orcId" : "xh6qBZibIf1tCvEQn",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3oCFUC7uvw5dr2b",
-          "value" : "K8OSVuuv3UNFZjL"
+          "sourceName" : "OAieBx7nz4YHIyMF4s",
+          "value" : "ZnMBkRVqP6z"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1nw8IE1TfEXgQU5r4g",
-          "value" : "4jtLmQH3zS"
+          "sourceName" : "TMjzpxbKCnKJL2Mwpj",
+          "value" : "AAoJKDTTK1EE72E"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2c42624e-3d0b-4dfe-914a-8236a0e3ffee"
+        "id" : "https://www.example.org/13506671-d280-4429-b5bf-139dbc974b75"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,152 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4cea08ec-1b6f-4b55-8e71-1a441c854edf",
-        "name" : "y9GMSfyIqPja7",
+        "id" : "https://www.example.org/a3141d9d-ccb4-4386-a87e-eda784a10252",
+        "name" : "4CR1j1w1nh",
         "nameType" : "Organizational",
-        "orcId" : "oEzH7xgHbE0tIgqHUVz",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "Nn3hOG1ECG",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "BpUzFUI4DV5BWgd",
-          "value" : "dP7Y41GgiRph8KxlFB"
+          "sourceName" : "kqssZbyPK4WH1N",
+          "value" : "1qxiwWeWFpqeebK"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ob3zfiCbmkZS",
-          "value" : "Ard5jGnR6vo"
+          "sourceName" : "t3GScbpeenIE9M1e",
+          "value" : "l10QTY0MKq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b4be2dbf-1c93-4652-bfd3-592904366169"
+        "id" : "https://www.example.org/90a8508b-7137-4b92-bfab-a8354f2edd00"
       } ],
       "role" : {
-        "type" : "LightDesigner"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "kEr01HtOhaSigwd8"
+      "da" : "HaOjJXRititPu"
     },
-    "npiSubjectHeading" : "a0GxXOZoPqBwLKhXa",
-    "tags" : [ "KBRZVPAN5F1Tdk6" ],
-    "description" : "TeEtV5Re3p0dFY",
+    "npiSubjectHeading" : "JvNBuFkiBpMblT09k",
+    "tags" : [ "iiopGNosV3" ],
+    "description" : "9Ed7fnL6HG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/221e0432-6e07-4ad4-aff1-25a4161379e3",
+      "doi" : "https://www.example.org/6ac86fcb-f828-4658-9024-7e0c925d2730",
       "publicationInstance" : {
         "type" : "PerformingArts",
         "subtype" : {
-          "type" : "PerformingArtsOther",
-          "description" : "zEQ1KaYvFfBTv"
+          "type" : "Broadcast"
         },
-        "description" : "AtcGMMDljrpdtkJ",
+        "description" : "KNurd8aXn1Z",
         "outputs" : [ {
           "type" : "PerformingArtsVenue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "iZvwUVpmiJa9TYxqP",
-            "country" : "2TMuWrSfX9d"
+            "label" : "vETiCSOWQVDAZPglQq7",
+            "country" : "M2xsO43rmPoGHtkNHod"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1972-05-19T16:02:58.133Z",
-            "to" : "1980-04-17T10:37:10.413Z"
+            "from" : "1975-02-19T09:19:22.366Z",
+            "to" : "1976-05-07T17:52:10.659Z"
           },
-          "sequence" : 46768906
+          "sequence" : 1992313401
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/325483f4-92e3-4694-aeb4-8169f18d33e4",
-    "abstract" : "cnfQ9Q4BRA"
+    "metadataSource" : "https://www.example.org/9706cfb9-2207-42ac-a446-1b3f2a13d14b",
+    "abstract" : "QFcZl6qEX0zCMAMRd"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/fb4eee48-c371-4dcd-99c7-07a77690d010",
-    "name" : "WKHeDwINOgDsWXfS6",
+    "id" : "https://www.example.org/7de3351a-cb47-4299-8e43-30f17b891b32",
+    "name" : "WJr3At7R8TRW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1978-04-16T03:11:02.169Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "vXQP1yTCy6P"
+      "approvalDate" : "1978-04-27T02:24:25.331Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "XLWDgyepCg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/41247ac4-45c8-45e8-9200-4ddb15ada35f",
-    "identifier" : "CItjNHHh17Myd1Z4a",
+    "source" : "https://www.example.org/a9c406c1-79df-478b-9bf7-231d6c28ec2f",
+    "identifier" : "5ndiQ7dXxlzM9vr6",
     "labels" : {
-      "ca" : "7TqpPtq9z1BieqzRZJJ"
+      "fr" : "5UCzX735PU"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 660450395
+      "amount" : 2136589945
     },
-    "activeFrom" : "2020-11-22T08:58:17.246Z",
-    "activeTo" : "2021-10-21T06:51:04.832Z"
+    "activeFrom" : "2005-09-21T19:47:50.089Z",
+    "activeTo" : "2011-05-20T13:25:15.012Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/56bc3ff3-5e8c-4450-8641-784396b47aed",
-    "id" : "https://www.example.org/3c5a7bdc-5ad3-4e83-a53b-89d9d7cf98bf",
-    "identifier" : "9yDq4l7zjo",
+    "source" : "https://www.example.org/49c3e214-997c-4c60-959d-aa92b449dea8",
+    "id" : "https://www.example.org/07d24154-9512-4bd1-b800-27d6539e4932",
+    "identifier" : "lFpQVpXNc9OZnpA9Pd",
     "labels" : {
-      "es" : "HYor1Qa0b3l"
+      "fr" : "ORZs9MBY5b5ybPZKGI"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1251212585
+      "amount" : 1171755132
     },
-    "activeFrom" : "1985-05-22T14:51:42.438Z",
-    "activeTo" : "2017-06-15T12:56:37.119Z"
+    "activeFrom" : "2005-08-29T12:30:57.982Z",
+    "activeTo" : "2010-09-26T10:58:56.373Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9e200a45-5fbe-428a-80d2-befb9352db2f" ],
+  "subjects" : [ "https://www.example.org/36c82426-0d3d-43a9-9514-77cc920d13e8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c86e4aa4-eca9-4860-8d8e-c0b21eb5268d",
-    "name" : "EjX9MCyF9NFWd7f",
-    "mimeType" : "zOyQxwm2VlaxS",
-    "size" : 993994073,
-    "license" : "https://www.example.com/d8lxvx30ndoby7ediyf",
+    "identifier" : "d98e76c5-e78f-4c05-a923-936684a1482c",
+    "name" : "cdnQUQKzTyxHUtrKc",
+    "mimeType" : "NOq8yknWqvNSMzG",
+    "size" : 585970955,
+    "license" : "https://www.example.com/0xb6qd0vpfvt93q",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "yR5mYzAPTEWFHQ5b"
     },
-    "legalNote" : "lyCBFC12X8Xs",
-    "publishedDate" : "1986-06-15T07:52:06.345Z",
+    "legalNote" : "SaUqQkb3ut",
+    "publishedDate" : "2006-08-27T01:08:41.099Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "zZWqTNqJwmvp6pRtqg",
+      "uploadedDate" : "2002-06-04T01:21:50.333Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/gliheBzwV7Xs",
-    "name" : "3DSWXoHz2nLowqC",
-    "description" : "lEoSpzzOKVo4"
+    "id" : "https://www.example.com/cumNFfPfDk9SS04F",
+    "name" : "kYsRqYWM7TW",
+    "description" : "ZZpHEo5zz0q"
   } ],
-  "rightsHolder" : "CRWIfMCEEs2ngmk",
-  "duplicateOf" : "https://www.example.org/fb9ca76c-d35c-4614-836d-f0e22e1657de",
+  "rightsHolder" : "EwSRpnscv8ALZNaaS",
+  "duplicateOf" : "https://www.example.org/be6ac087-eb44-4c1a-985b-4dd22e210d3c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "roht7npCSBg"
+    "note" : "nxv4N6CuWw"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "bwLLsRVxfxI",
-    "createdBy" : "vm8uH9FoO4o",
-    "createdDate" : "1984-01-22T04:24:04.002Z"
+    "note" : "7rUDSUdNclfOm6kVRN",
+    "createdBy" : "jBUaWUGSiXoyI",
+    "createdDate" : "1982-10-27T22:33:43.876Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/e00b0402-3238-423d-9954-c2714fda05e1" ],
+  "curatingInstitutions" : [ "https://www.example.org/2f031bff-ab24-4e36-ae55-ef7cc791ea8c" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "7tHCvrrciC4LsDwi",
-    "ownerAffiliation" : "https://www.example.org/243484b3-3ed9-4933-896c-1a65cbd65356"
+    "owner" : "XJF296q0g3uljS",
+    "ownerAffiliation" : "https://www.example.org/0970c24b-ad68-44d5-8918-b260bb4c16f1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/bcc14f57-4be6-40a2-a94c-90fbbb3af111"
+    "id" : "https://www.example.org/f88c5a0e-9caf-4ac3-b7fe-bfae9cd29349"
   },
-  "createdDate" : "2000-02-26T00:09:41.622Z",
-  "modifiedDate" : "2009-08-30T01:06:34.386Z",
-  "publishedDate" : "1980-05-19T17:49:34.452Z",
-  "indexedDate" : "1981-06-09T00:09:28.140Z",
-  "handle" : "https://www.example.org/5e036d19-78fe-4fd1-a416-dcc62b2effed",
-  "doi" : "https://doi.org/10.1234/consequatur",
-  "link" : "https://www.example.org/bcce403f-1d92-4773-af14-1fd8260edd34",
+  "createdDate" : "2020-12-11T08:37:14.206Z",
+  "modifiedDate" : "1978-09-23T09:30:24.388Z",
+  "publishedDate" : "1992-04-18T16:03:15.871Z",
+  "indexedDate" : "2006-02-24T14:57:29.629Z",
+  "handle" : "https://www.example.org/6bd8ed53-63e1-4df1-b876-a94cd4f1df05",
+  "doi" : "https://doi.org/10.1234/sequi",
+  "link" : "https://www.example.org/bb3fcf3c-2d91-4bc9-9e34-f2cf8fc01deb",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "tduNqCSDZE0adhk",
+    "mainTitle" : "zMKA8ndaSpsXuVs",
     "alternativeTitles" : {
-      "da" : "3YH77Wk6xe"
+      "se" : "fiXWD4c7CocBb"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6RaAyy5SLxXiThk",
-      "month" : "TeT1w5sKxttJo6f7",
-      "day" : "lNmoaX5QRCiT69Rz6"
+      "year" : "bQVEigKCelXcOBbHJ",
+      "month" : "fQVqJOchIXRpcrN5wi",
+      "day" : "z4IP9ZydoTMrRB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ac72ff96-ed90-46fc-8610-9c5b9763e40b",
-        "name" : "PFZbiX3Zq3dm0hql",
+        "id" : "https://www.example.org/95116623-37f9-4f1f-8a56-854f4e9e568a",
+        "name" : "kVIIcQN2A7FOpmwbXox",
         "nameType" : "Personal",
-        "orcId" : "Ke6fTq034noHRf",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "CuqJWdhLYqy9sIdvqi",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VmfOn780mujZlC",
-          "value" : "69zfrf4rfzDLTKm7"
+          "sourceName" : "t79GK61FkJ",
+          "value" : "4BlnPGlWajjZpw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "DQVjhAZULVxh0mMU",
-          "value" : "Yo3IKQL4jjEObR"
+          "sourceName" : "lmGjYTW4trPqR",
+          "value" : "Uxc7i37p00yQ0MbnxY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/26fa7d44-1b4a-4399-b35e-b7d700d1b7a5"
+        "id" : "https://www.example.org/b16f5042-4042-4c40-b0ba-65a1fbee8ef0"
       } ],
       "role" : {
-        "type" : "VideoEditor"
+        "type" : "Registrar"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,140 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1d81b159-8de9-4496-954f-ffe5c70915df",
-        "name" : "N0VWExIlpfIJsUfECQo",
+        "id" : "https://www.example.org/6aa8a165-4a8c-4f82-9c2f-d64c60e0f6fe",
+        "name" : "KXLBEDvgtu4Xsw",
         "nameType" : "Personal",
-        "orcId" : "RZLbEyhKQGS",
+        "orcId" : "FzTlKxzEBuLCy",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gjvxdh4eFa",
-          "value" : "pHUIopIZwm"
+          "sourceName" : "mHgkOre0ukPReRr0q",
+          "value" : "LUqjfOO8h0wYcw9UZq"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZTHcek0GRtTSIh1cAd",
-          "value" : "iYIu8kMBLKQ4RZbhp7"
+          "sourceName" : "NpIKZCt4XyD",
+          "value" : "n6PHpG2bwgUNyQsuN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/171e575b-70ca-42d6-8cbb-210b42acea3b"
+        "id" : "https://www.example.org/15491483-0c2e-4ea8-a720-92b25e99d13f"
       } ],
       "role" : {
-        "type" : "ResearchGroup"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nn" : "cSzpclXx68N8k3T3w"
+      "ca" : "RiGVp3YhrEGfcx5E"
     },
-    "npiSubjectHeading" : "TjJtyDtzvZj30nz1nZY",
-    "tags" : [ "HR2tfxSfdaN" ],
-    "description" : "oHs9oU8dXLMmuU",
+    "npiSubjectHeading" : "DNezu2IpuFhj",
+    "tags" : [ "746el3K60K3UHBLI3yD" ],
+    "description" : "lr4WhXtbAt1HVkt86HB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b05938b8-ff9b-4a83-96b3-ea08377b29ca"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/314e797e-86f6-436a-9f5a-8aabcc415611"
       },
-      "doi" : "https://www.example.org/0ba29555-f6fb-47ae-b4a3-71f1c7c68c9f",
+      "doi" : "https://www.example.org/61606c12-66b7-4d0d-bcc3-2d47a29efb64",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "Vxu6Hqh3zAfGmp",
-          "end" : "X0pjNTWGIFKW1aPDog"
+          "begin" : "W6QHWWkkHGUKFIta",
+          "end" : "Gaue2WBEB4rpJG63PF"
         },
-        "volume" : "nguFmXLVRevu5fa2rm",
-        "issue" : "1SIZrMlcSP0g",
-        "articleNumber" : "LPQaGtA9fG"
+        "volume" : "ZjhTaMIWemCPH21",
+        "issue" : "G5JTfoD6FQ1irrK",
+        "articleNumber" : "tlJ2UiQ7mliR7c"
       }
     },
-    "metadataSource" : "https://www.example.org/74c96585-9a03-401c-95cf-b68e0c8178c6",
-    "abstract" : "5ATKFUUwXp4q"
+    "metadataSource" : "https://www.example.org/5deb48a2-b312-4f32-873b-928019b5588f",
+    "abstract" : "EeaFqABHCRfG4D"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4c76474c-5cc0-44a5-9673-14087138e63d",
-    "name" : "BisrZ33iaZUA",
+    "id" : "https://www.example.org/fdad5df9-0959-471f-88a5-3f384cdc7979",
+    "name" : "YKuYNI6Clg5w",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-12-10T00:24:25.437Z",
+      "approvalDate" : "1981-01-26T03:49:52.668Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "2ccemlpQIwo2xBl2k"
+      "applicationCode" : "IATZjIkacMYjg"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/195d410e-aacb-4ff7-b70a-6f4e98121fe2",
-    "identifier" : "nPpJHv5M5Sq3npA70i",
+    "source" : "https://www.example.org/ee813009-cea1-4f71-b1a2-87821098983c",
+    "identifier" : "Hqw9115LLBZ4lpZ",
     "labels" : {
-      "hu" : "u67yO8h8lGmd7x"
+      "pt" : "xOfLkyrY6PAIfCJr"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 939480189
+      "amount" : 885889159
     },
-    "activeFrom" : "2016-12-03T17:58:20.859Z",
-    "activeTo" : "2024-01-22T20:27:03.910Z"
+    "activeFrom" : "2021-11-03T00:37:34.648Z",
+    "activeTo" : "2023-01-10T05:10:11.342Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/3a2051d5-e3b5-4e72-8d21-44541b0c21a9",
-    "id" : "https://www.example.org/9caec5bc-7a5b-4917-a618-6c662e9d4b6d",
-    "identifier" : "1nmulm5RZC",
+    "source" : "https://www.example.org/455f2ee6-afbd-40db-8aab-104c4d0ba4d1",
+    "id" : "https://www.example.org/c567daf3-9390-46ec-9a95-3b4d8abc98d2",
+    "identifier" : "aRUTRvlRWk5h",
     "labels" : {
-      "nn" : "P4LzrZJ3Zhs4uAF6kbJ"
+      "da" : "kKo9nvW8Vo1iuCvdZf7"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1692313675
+      "currency" : "EUR",
+      "amount" : 299374880
     },
-    "activeFrom" : "2008-10-02T06:49:35.185Z",
-    "activeTo" : "2011-12-24T03:58:53.365Z"
+    "activeFrom" : "2009-11-19T16:21:29.097Z",
+    "activeTo" : "2014-07-23T01:34:56.420Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/31663c0f-808a-4905-951c-bc2e3beeccb8" ],
+  "subjects" : [ "https://www.example.org/49c101b6-17b4-47e2-bb4b-7ece4ec42f25" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "50a808c1-23d4-4fdb-81be-89ba0a0a1c6b",
-    "name" : "7m0hVthNFtig4nqtel",
-    "mimeType" : "CdQ1Nmr4HPjOuuL",
-    "size" : 1689620929,
-    "license" : "https://www.example.com/p4xz6mqnpwffd",
+    "identifier" : "d13d237d-5a38-4faf-b0d9-a57e6d604334",
+    "name" : "QQFpPeW9xNwxH9G4mGX",
+    "mimeType" : "SpP1wblvdc8",
+    "size" : 606298959,
+    "license" : "https://www.example.com/q3tbsi8imx8j",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "Bcdll8rnRhzkQHlN3t"
+      "type" : "CustomerRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "psea8ulZ8LWnLijZaP",
-    "publishedDate" : "2018-07-17T07:07:37.642Z",
+    "legalNote" : "Iuthgbos5szua9dU7",
+    "publishedDate" : "2001-12-25T17:51:23.760Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "9Rhbvj4O7uWe",
+      "uploadedDate" : "1971-11-18T05:41:26.262Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FTd6nxTXswTn",
-    "name" : "PCVsYHhpnFN21jzcH0",
-    "description" : "UzdIpo69dq"
+    "id" : "https://www.example.com/N8S8COolgNj4P",
+    "name" : "9zjVL2CeRRAiqqRnEA",
+    "description" : "i6JsUyfpo6D2"
   } ],
-  "rightsHolder" : "s9ma7H4hJMcUL1unjZp",
-  "duplicateOf" : "https://www.example.org/e7fde492-f957-4558-a078-fa60d39c7778",
+  "rightsHolder" : "skFKl2AhSro0S2l0s4H",
+  "duplicateOf" : "https://www.example.org/b8938432-dc55-4887-a4c4-d9e21c9ed576",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "CecZCZAAqlxMCUYCC5H"
+    "note" : "AVIEH16VGbjKsp1WYB"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "IdOMwS6KgaRJ",
-    "createdBy" : "8fQRL5xojY",
-    "createdDate" : "2001-11-19T23:01:37.717Z"
+    "note" : "LYQXb6LSpZS2MXEo",
+    "createdBy" : "lKvSpI264ACR",
+    "createdDate" : "2001-01-23T15:42:38.688Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/3e6228cc-5515-4f55-8dd7-a12b81e68ca3" ],
+  "curatingInstitutions" : [ "https://www.example.org/967a804a-ab59-417e-9dfa-6603d41c912b" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/PopularScienceArticle.json
+++ b/documentation/PopularScienceArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "8rDl5yIt7EFR",
-    "ownerAffiliation" : "https://www.example.org/da806f71-1f4e-491c-949e-37d2a18697bc"
+    "owner" : "7tHCvrrciC4LsDwi",
+    "ownerAffiliation" : "https://www.example.org/243484b3-3ed9-4933-896c-1a65cbd65356"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/564426d3-50b4-48ca-8fea-d25314b1ec5d"
+    "id" : "https://www.example.org/bcc14f57-4be6-40a2-a94c-90fbbb3af111"
   },
-  "createdDate" : "2004-10-11T10:21:49.466Z",
-  "modifiedDate" : "1979-03-16T20:21:27.587Z",
-  "publishedDate" : "2012-03-28T16:02:28.536Z",
-  "indexedDate" : "1978-10-02T21:02:39.912Z",
-  "handle" : "https://www.example.org/4e10e7d8-4779-41e5-b926-57ea9613b293",
-  "doi" : "https://doi.org/10.1234/itaque",
-  "link" : "https://www.example.org/8e9b35ea-b28a-4178-a248-adc4ae17cabd",
+  "createdDate" : "2000-02-26T00:09:41.622Z",
+  "modifiedDate" : "2009-08-30T01:06:34.386Z",
+  "publishedDate" : "1980-05-19T17:49:34.452Z",
+  "indexedDate" : "1981-06-09T00:09:28.140Z",
+  "handle" : "https://www.example.org/5e036d19-78fe-4fd1-a416-dcc62b2effed",
+  "doi" : "https://doi.org/10.1234/consequatur",
+  "link" : "https://www.example.org/bcce403f-1d92-4773-af14-1fd8260edd34",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "wVCqX1YKlV",
+    "mainTitle" : "tduNqCSDZE0adhk",
     "alternativeTitles" : {
-      "pl" : "T4as7nzCiuS"
+      "da" : "3YH77Wk6xe"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "JOfZFWfapW4dpvG2",
-      "month" : "STkDZMsRLP",
-      "day" : "gyW5YCjQ5AIcI"
+      "year" : "6RaAyy5SLxXiThk",
+      "month" : "TeT1w5sKxttJo6f7",
+      "day" : "lNmoaX5QRCiT69Rz6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fc6fb69b-138a-4333-a9ac-7eeb21364de3",
-        "name" : "HBhrxc4rfQW5",
-        "nameType" : "Organizational",
-        "orcId" : "hKntZ5X9SYJhINhAd",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/ac72ff96-ed90-46fc-8610-9c5b9763e40b",
+        "name" : "PFZbiX3Zq3dm0hql",
+        "nameType" : "Personal",
+        "orcId" : "Ke6fTq034noHRf",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "HZhfs5o9FEs",
-          "value" : "uvgITU41wX5U"
+          "sourceName" : "VmfOn780mujZlC",
+          "value" : "69zfrf4rfzDLTKm7"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KBqbnm7Z77CY7FVZLev",
-          "value" : "27ewBnF3yzczSbiwZQN"
+          "sourceName" : "DQVjhAZULVxh0mMU",
+          "value" : "Yo3IKQL4jjEObR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/30f30a55-0559-43c4-981e-da0731456870"
+        "id" : "https://www.example.org/26fa7d44-1b4a-4399-b35e-b7d700d1b7a5"
       } ],
       "role" : {
-        "type" : "Registrar"
+        "type" : "VideoEditor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,140 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/40f267a1-7f6f-4c57-91c4-9a69a55305ed",
-        "name" : "mQJtRrIUoDSTVCT",
+        "id" : "https://www.example.org/1d81b159-8de9-4496-954f-ffe5c70915df",
+        "name" : "N0VWExIlpfIJsUfECQo",
         "nameType" : "Personal",
-        "orcId" : "LfAA96dnL6Xf7xDI6X",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "RZLbEyhKQGS",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "sc5N1oIghDn",
-          "value" : "88h2q9z0GwFQlI"
+          "sourceName" : "gjvxdh4eFa",
+          "value" : "pHUIopIZwm"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ICHP1Her4jwmvkbxe",
-          "value" : "7E6y3F8A7YDt"
+          "sourceName" : "ZTHcek0GRtTSIh1cAd",
+          "value" : "iYIu8kMBLKQ4RZbhp7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/64eee1ed-f68f-417c-8044-bd8828e00420"
+        "id" : "https://www.example.org/171e575b-70ca-42d6-8cbb-210b42acea3b"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "ResearchGroup"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "cs" : "1ld89KdIbVB"
+      "nn" : "cSzpclXx68N8k3T3w"
     },
-    "npiSubjectHeading" : "Fu7jyqivTwOq",
-    "tags" : [ "kDPf41Vmd0HRgl" ],
-    "description" : "byqGFZbuCJ92zwzjeJe",
+    "npiSubjectHeading" : "TjJtyDtzvZj30nz1nZY",
+    "tags" : [ "HR2tfxSfdaN" ],
+    "description" : "oHs9oU8dXLMmuU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3ae40d31-47bd-49dc-a359-f034537ffd42"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b05938b8-ff9b-4a83-96b3-ea08377b29ca"
       },
-      "doi" : "https://www.example.org/cd718c4f-8c91-47df-a248-cf02d5e049aa",
+      "doi" : "https://www.example.org/0ba29555-f6fb-47ae-b4a3-71f1c7c68c9f",
       "publicationInstance" : {
         "type" : "PopularScienceArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "h1L0ZrbvrAwVDRzX",
-          "end" : "Fdys8hCAwVD4uHJ"
+          "begin" : "Vxu6Hqh3zAfGmp",
+          "end" : "X0pjNTWGIFKW1aPDog"
         },
-        "volume" : "SKjAlYg56ielC",
-        "issue" : "jDUy76JOtgjR50",
-        "articleNumber" : "cLE14Xu8nQxA"
+        "volume" : "nguFmXLVRevu5fa2rm",
+        "issue" : "1SIZrMlcSP0g",
+        "articleNumber" : "LPQaGtA9fG"
       }
     },
-    "metadataSource" : "https://www.example.org/e09a2782-1c60-431d-8806-dcd1d8f620bb",
-    "abstract" : "aDBSa1DRN0QcusVKbY"
+    "metadataSource" : "https://www.example.org/74c96585-9a03-401c-95cf-b68e0c8178c6",
+    "abstract" : "5ATKFUUwXp4q"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/208468b9-8c9d-41aa-949b-05b4b54fdf06",
-    "name" : "dFZfdcIfxqYUeVm",
+    "id" : "https://www.example.org/4c76474c-5cc0-44a5-9673-14087138e63d",
+    "name" : "BisrZ33iaZUA",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1993-10-08T15:49:51.231Z",
+      "approvalDate" : "2019-12-10T00:24:25.437Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "l22FgyI2xshFeD9sGx"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "2ccemlpQIwo2xBl2k"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/4698b49a-4c4a-4770-9898-800ac4e65675",
-    "identifier" : "o5LxextKeWhwlchI",
+    "source" : "https://www.example.org/195d410e-aacb-4ff7-b70a-6f4e98121fe2",
+    "identifier" : "nPpJHv5M5Sq3npA70i",
     "labels" : {
-      "pt" : "ZBgbGudeKeNGV"
+      "hu" : "u67yO8h8lGmd7x"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1774742024
+      "currency" : "GBP",
+      "amount" : 939480189
     },
-    "activeFrom" : "1999-12-26T15:08:39.720Z",
-    "activeTo" : "2001-07-17T11:08:22.419Z"
+    "activeFrom" : "2016-12-03T17:58:20.859Z",
+    "activeTo" : "2024-01-22T20:27:03.910Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/4a52f974-e9ea-4642-9522-f175d4f1de95",
-    "id" : "https://www.example.org/afdb3de5-169e-42fb-a6cc-36f54f5f32ab",
-    "identifier" : "Z4sewG5nZi",
+    "source" : "https://www.example.org/3a2051d5-e3b5-4e72-8d21-44541b0c21a9",
+    "id" : "https://www.example.org/9caec5bc-7a5b-4917-a618-6c662e9d4b6d",
+    "identifier" : "1nmulm5RZC",
     "labels" : {
-      "nn" : "9Cv7tTGDlT"
+      "nn" : "P4LzrZJ3Zhs4uAF6kbJ"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 831922328
+      "currency" : "GBP",
+      "amount" : 1692313675
     },
-    "activeFrom" : "1994-01-16T16:05:10.744Z",
-    "activeTo" : "2023-10-25T01:43:11.856Z"
+    "activeFrom" : "2008-10-02T06:49:35.185Z",
+    "activeTo" : "2011-12-24T03:58:53.365Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/415284bf-9fd8-4a80-ba30-907016f6ee5b" ],
+  "subjects" : [ "https://www.example.org/31663c0f-808a-4905-951c-bc2e3beeccb8" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "c716c32a-0d86-48f3-85d8-a8feef45d045",
-    "name" : "DX4R1ROOuyoRW",
-    "mimeType" : "ykBiDYM4qcyS53CNg",
-    "size" : 2050900681,
-    "license" : "https://www.example.com/2urh9dcwurxdellrjna",
+    "identifier" : "50a808c1-23d4-4fdb-81be-89ba0a0a1c6b",
+    "name" : "7m0hVthNFtig4nqtel",
+    "mimeType" : "CdQ1Nmr4HPjOuuL",
+    "size" : 1689620929,
+    "license" : "https://www.example.com/p4xz6mqnpwffd",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "Bcdll8rnRhzkQHlN3t"
     },
-    "legalNote" : "7EahYpQiibk0Bk6",
-    "publishedDate" : "1988-05-30T21:01:25.621Z",
+    "legalNote" : "psea8ulZ8LWnLijZaP",
+    "publishedDate" : "2018-07-17T07:07:37.642Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/idhuRiKJtFqjlZJS",
-    "name" : "y3g6BxypznTGpRjrqv",
-    "description" : "OtIRt32R8QE0"
+    "id" : "https://www.example.com/FTd6nxTXswTn",
+    "name" : "PCVsYHhpnFN21jzcH0",
+    "description" : "UzdIpo69dq"
   } ],
-  "rightsHolder" : "Kt4R87RuR1oXh",
-  "duplicateOf" : "https://www.example.org/03e82bd9-6bee-40bc-930c-6a3934962bc3",
+  "rightsHolder" : "s9ma7H4hJMcUL1unjZp",
+  "duplicateOf" : "https://www.example.org/e7fde492-f957-4558-a078-fa60d39c7778",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "VbZ8bf2iwmC"
+    "note" : "CecZCZAAqlxMCUYCC5H"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "33Pq5aWYFTj585",
-    "createdBy" : "BvuvVFH7HHEgc2W5U",
-    "createdDate" : "2010-01-20T12:21:31.656Z"
+    "note" : "IdOMwS6KgaRJ",
+    "createdBy" : "8fQRL5xojY",
+    "createdDate" : "2001-11-19T23:01:37.717Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/b2abb3ff-06aa-428b-8720-3ab860f2ff74" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/3e6228cc-5515-4f55-8dd7-a12b81e68ca3" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "GpKpX7FIpipUAwT",
-    "ownerAffiliation" : "https://www.example.org/172ef6fb-ddee-4d15-bfc4-45f5669f7198"
+    "owner" : "dd6rAVnPDGfWXd",
+    "ownerAffiliation" : "https://www.example.org/04c3815c-bc7c-41f4-b49a-a0b1f983acfb"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/5143739b-c676-4025-9965-6c7cba3c9ad1"
+    "id" : "https://www.example.org/03352185-8779-4771-83a9-e8d726ef80f1"
   },
-  "createdDate" : "1990-08-13T17:43:09.572Z",
-  "modifiedDate" : "2005-02-28T11:31:53.909Z",
-  "publishedDate" : "1987-01-21T08:20:49.019Z",
-  "indexedDate" : "2022-10-09T02:07:10.522Z",
-  "handle" : "https://www.example.org/ccbd124e-3894-4c70-96ad-f68948e3c6a8",
-  "doi" : "https://doi.org/10.1234/eos",
-  "link" : "https://www.example.org/33160fd8-b26f-434f-8a17-d704e1d69dc8",
+  "createdDate" : "2003-03-11T04:02:52.981Z",
+  "modifiedDate" : "2008-02-19T15:54:27.088Z",
+  "publishedDate" : "1992-05-21T12:33:09.951Z",
+  "indexedDate" : "2012-12-07T23:04:38.503Z",
+  "handle" : "https://www.example.org/1c99dfa0-893a-454e-a201-04002ddf9156",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/22a2cf8f-969f-4069-bbb4-6bf6f1aa6dd3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "nL2ktvAqp40hg",
+    "mainTitle" : "QDjBjKtbZTT1AzQT",
     "alternativeTitles" : {
-      "de" : "MdQMDGsMjuGql8hc"
+      "de" : "Zg8wrEwAUDkx7JqdL"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "Tzhkte6r2R69TeWV",
-      "month" : "m8o0J7Wl4YolMFRN2q",
-      "day" : "U1L4hvNW81Dm9l6pu4"
+      "year" : "04HFF57CPT",
+      "month" : "HlPQ2hNqOFGj372W",
+      "day" : "Gf7MV7CsKbmMJ21ptEm"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ce4e49a-c693-4143-afb5-b75ef8ae688d",
-        "name" : "GRMlKhJL6C2l8xDdP",
+        "id" : "https://www.example.org/8998ad81-dd77-486e-a0f6-9c6e8c04903f",
+        "name" : "GTbd1uE7KRDWy0",
         "nameType" : "Organizational",
-        "orcId" : "zxN3J2MhPWZ",
+        "orcId" : "a775T2IXxmouR",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tZk2fxcCqIcv8G6Ug",
-          "value" : "02f4t9ZfCfVb"
+          "sourceName" : "7YlKQK4Dl78wkQx",
+          "value" : "Yuaupa9C9yJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZCy8Dyy8ksvsCzFKRi",
-          "value" : "UdriGbFfbIPUc"
+          "sourceName" : "l4lqqaSm1rIZ6iA5",
+          "value" : "TsWPvbQVmkxqch"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e6b153cf-cf22-4eee-b8ca-8794fa75003d"
+        "id" : "https://www.example.org/aa93ef34-c1d3-4c84-a515-420a94e9549a"
       } ],
       "role" : {
-        "type" : "Dramaturge"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/0bc2a915-d2bc-449a-afbd-1ffea50fca18",
-        "name" : "DDAkdAJjMx",
+        "id" : "https://www.example.org/673a2d6a-52ef-474f-a701-8fb99a30f527",
+        "name" : "NXM361Fpbda",
         "nameType" : "Personal",
-        "orcId" : "rnO0IZrkjMwkwS",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "HKHa6stbmsYX4",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qcmsYZ7KAzFOXn3u",
-          "value" : "4r6fW7vKxLPS2N"
+          "sourceName" : "whZy9GyhUr",
+          "value" : "EwLhPgcegKb2upkw"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3zdcPFf6yO2",
-          "value" : "tQdwgVPpyt5U"
+          "sourceName" : "ehexvRLgg9RFi",
+          "value" : "OhaFHJpXG5GMlseVeVc"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/818ce3c2-f980-43b7-8d16-b0fbb3d58240"
+        "id" : "https://www.example.org/0681807d-da69-4a44-adbc-58e80bb0fb39"
       } ],
       "role" : {
-        "type" : "AcademicCoordinator"
+        "type" : "Distributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "NZ2b5sJZRinCnzAdD"
+      "zh" : "M7HUkzLb81G7UaPeD"
     },
-    "npiSubjectHeading" : "ngPTft3WAh7q",
-    "tags" : [ "Z0dibiNV4bypDio" ],
-    "description" : "FnJwrS5rzj",
+    "npiSubjectHeading" : "HTkgFVHCPw",
+    "tags" : [ "0nPNZlSGEiJvwad" ],
+    "description" : "FMqz5UyUHz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/Y5LdW1MKKhbY5Boo0C"
+        "id" : "https://www.example.com/8NGQM6za7PAdP"
       },
-      "doi" : "https://www.example.org/c513b794-1af1-4503-836b-418f97db05ab",
+      "doi" : "https://www.example.org/11e6325d-a341-4624-aca4-df01db2cb4f0",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "LWbeCRXRmPuv",
-          "end" : "YSCfQzu2soAFZ"
+          "begin" : "r6OZnXzp4x2y9CK1P",
+          "end" : "cDeBi0I5zsJUxH"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/001bd7a1-cb53-49fb-aa5d-26af065eafe2",
-    "abstract" : "RYRCONDqLw9ndS2Ax"
+    "metadataSource" : "https://www.example.org/e39413fb-7a09-4c84-9722-30591801e185",
+    "abstract" : "ULFKWYQAIu3D0QC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/9bbb930b-b707-466a-ab23-d567e3e917a3",
-    "name" : "rfyvIgTsd2jIqFQ",
+    "id" : "https://www.example.org/cb054a72-4867-4b92-927d-89e52152c74e",
+    "name" : "wCj2AAxcuxdj8u",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-09-14T20:00:26.384Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "3dZ4he71Ym"
+      "approvalDate" : "2002-03-23T04:41:35.885Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "fmZ2YkjjiIlP3iQj"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/e9f970a3-9481-4412-82b3-023156adf0b1",
-    "identifier" : "5J7JRpLitvKD7b",
+    "source" : "https://www.example.org/5e4ff387-e90e-440b-9f10-0f3e4bbe94a4",
+    "identifier" : "0P8ID7vqmt",
     "labels" : {
-      "is" : "7eFXtFucRjT"
+      "en" : "C4bfAPzXVc9"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 334408998
+      "amount" : 320908248
     },
-    "activeFrom" : "1983-12-27T17:48:32.275Z",
-    "activeTo" : "2016-10-01T06:35:36.649Z"
+    "activeFrom" : "1972-11-08T04:38:01.717Z",
+    "activeTo" : "2006-08-07T00:23:25.550Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/836e665c-af8b-4fa8-939f-380addb784f5",
-    "id" : "https://www.example.org/afa0738c-bb63-4c25-8605-e8273b09539a",
-    "identifier" : "fWny11Y0uLBK",
+    "source" : "https://www.example.org/e8e3c072-9a44-4703-85cf-806dded4dbec",
+    "id" : "https://www.example.org/a5b8b4e0-35d6-4072-becd-783f0c52cb2e",
+    "identifier" : "CeM0UlSM0V9hplDU7pR",
     "labels" : {
-      "da" : "I9YtODrnss7A6"
+      "hu" : "iGkmvSPgjZzhQJbvUls"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 199860622
+      "currency" : "NOK",
+      "amount" : 1277779577
     },
-    "activeFrom" : "2022-11-28T09:50:02.161Z",
-    "activeTo" : "2023-07-28T04:45:30.114Z"
+    "activeFrom" : "2023-04-02T14:06:20.747Z",
+    "activeTo" : "2024-05-10T22:22:20.895Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/c75bcd36-4ae6-40fa-becb-9aa262b39d99" ],
+  "subjects" : [ "https://www.example.org/59358e3a-68f9-404e-a740-b8fef4ea1e87" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7a94765a-8e95-4508-bf22-e4b12a064d6a",
-    "name" : "MyiA4PL0U1NA0yP4B",
-    "mimeType" : "S9f05GTDlcddFd",
-    "size" : 872337423,
-    "license" : "https://www.example.com/vpyofdfnufjqxon84",
+    "identifier" : "1dca3f4d-d952-46ce-8e1f-0baf416253d0",
+    "name" : "shQQusz62qEIGeHTWEl",
+    "mimeType" : "lcvvnrCGbW",
+    "size" : 800340319,
+    "license" : "https://www.example.com/xafoio2h5trcd6m",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "l3diWUeB4tDex4J",
-    "publishedDate" : "1978-12-28T05:41:25.810Z",
+    "legalNote" : "k1Zh5W3BxTa6C",
+    "publishedDate" : "2015-09-06T05:30:10.582Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/aUZek9ptI3n",
-    "name" : "5kuPsKPWD8fOjZX",
-    "description" : "KnpmXfVIGaQcbQZJN0h"
+    "id" : "https://www.example.com/ui0TPGCas2r",
+    "name" : "1QarIbCDKlFu3",
+    "description" : "sHDa1xBTWYcz"
   } ],
-  "rightsHolder" : "qdTTaafoqmd9P9JgHSg",
-  "duplicateOf" : "https://www.example.org/44e6c32c-aa31-4f7a-99ae-9f59f56a6e46",
+  "rightsHolder" : "sX8NFkRPisw1J3",
+  "duplicateOf" : "https://www.example.org/7f836fa8-dd60-4f39-9092-e0fbe40e2c62",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lBaJygUZHjOy0"
+    "note" : "7C2BHrqiNvB8riarJ5"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "ik62f3V6ZSkt38ky5",
-    "createdBy" : "qUljIB7IFf9",
-    "createdDate" : "2004-01-16T00:43:52.507Z"
+    "note" : "fXg89YXUbWKgMxR1qi",
+    "createdBy" : "4ym6dFecWu",
+    "createdDate" : "2008-06-02T04:34:46.497Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ee2a688f-7843-4b4d-8da2-c08871550471" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/065fe456-24f7-4913-aa4f-63ff5ed818ca" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/PopularScienceChapter.json
+++ b/documentation/PopularScienceChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "dd6rAVnPDGfWXd",
-    "ownerAffiliation" : "https://www.example.org/04c3815c-bc7c-41f4-b49a-a0b1f983acfb"
+    "owner" : "XSMVf3TdeB",
+    "ownerAffiliation" : "https://www.example.org/b867484d-f627-4781-884e-eb1e34b1e42c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/03352185-8779-4771-83a9-e8d726ef80f1"
+    "id" : "https://www.example.org/26238635-555d-4840-8eba-c7ed5dfbcc2b"
   },
-  "createdDate" : "2003-03-11T04:02:52.981Z",
-  "modifiedDate" : "2008-02-19T15:54:27.088Z",
-  "publishedDate" : "1992-05-21T12:33:09.951Z",
-  "indexedDate" : "2012-12-07T23:04:38.503Z",
-  "handle" : "https://www.example.org/1c99dfa0-893a-454e-a201-04002ddf9156",
-  "doi" : "https://doi.org/10.1234/aut",
-  "link" : "https://www.example.org/22a2cf8f-969f-4069-bbb4-6bf6f1aa6dd3",
+  "createdDate" : "2017-10-12T00:58:54.505Z",
+  "modifiedDate" : "1992-03-23T12:34:41.591Z",
+  "publishedDate" : "1980-06-10T23:54:00.717Z",
+  "indexedDate" : "2000-02-14T01:06:54.534Z",
+  "handle" : "https://www.example.org/5a938c87-fce1-4f70-865c-11bd482e951b",
+  "doi" : "https://doi.org/10.1234/reiciendis",
+  "link" : "https://www.example.org/9351769f-f4f4-4f31-9195-76cfed9e6538",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "QDjBjKtbZTT1AzQT",
+    "mainTitle" : "RaI8hnDnxV7KIKz",
     "alternativeTitles" : {
-      "de" : "Zg8wrEwAUDkx7JqdL"
+      "pt" : "wb9W8YqLbctPv"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "04HFF57CPT",
-      "month" : "HlPQ2hNqOFGj372W",
-      "day" : "Gf7MV7CsKbmMJ21ptEm"
+      "year" : "UfVSTpeHQqz8TvY",
+      "month" : "iXoFbzpBgv",
+      "day" : "JV9l0ElcCvogtS7yEF"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8998ad81-dd77-486e-a0f6-9c6e8c04903f",
-        "name" : "GTbd1uE7KRDWy0",
-        "nameType" : "Organizational",
-        "orcId" : "a775T2IXxmouR",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/9164f5f3-0b86-40e3-98ec-eedfda7c1f10",
+        "name" : "aP7eOYgF0eSPv",
+        "nameType" : "Personal",
+        "orcId" : "y0cvVrYmeoJ6Cnv6",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7YlKQK4Dl78wkQx",
-          "value" : "Yuaupa9C9yJ"
+          "sourceName" : "NJYPbMY7dZ7KupI",
+          "value" : "jTRCysgsDkpej3Y3MRB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l4lqqaSm1rIZ6iA5",
-          "value" : "TsWPvbQVmkxqch"
+          "sourceName" : "TOkA47s0WIf5W1",
+          "value" : "0bneKtFDuYdEGwf6r7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/aa93ef34-c1d3-4c84-a515-420a94e9549a"
+        "id" : "https://www.example.org/c7d73e5f-fb51-4221-9695-a74c441d3e24"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,142 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/673a2d6a-52ef-474f-a701-8fb99a30f527",
-        "name" : "NXM361Fpbda",
+        "id" : "https://www.example.org/a9c52100-e59b-4740-b088-63e90c07bdb2",
+        "name" : "pVdLpoJURXt",
         "nameType" : "Personal",
-        "orcId" : "HKHa6stbmsYX4",
+        "orcId" : "GZdwzMj6qdmDyk2dF",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "whZy9GyhUr",
-          "value" : "EwLhPgcegKb2upkw"
+          "sourceName" : "dHQckAgwch",
+          "value" : "paliFCeooHGUGsd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ehexvRLgg9RFi",
-          "value" : "OhaFHJpXG5GMlseVeVc"
+          "sourceName" : "xjvP6k44LFJB",
+          "value" : "R1wgFt15RpBQF"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0681807d-da69-4a44-adbc-58e80bb0fb39"
+        "id" : "https://www.example.org/726b97cc-0e31-415e-9536-a2371e1b8b9e"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "LandscapeArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "M7HUkzLb81G7UaPeD"
+      "sv" : "WdiIxUGW886Oq"
     },
-    "npiSubjectHeading" : "HTkgFVHCPw",
-    "tags" : [ "0nPNZlSGEiJvwad" ],
-    "description" : "FMqz5UyUHz",
+    "npiSubjectHeading" : "f1M1OnZufImeqQ",
+    "tags" : [ "Girwo4nmf6DFWrUt" ],
+    "description" : "IM6B2sa1f3",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/8NGQM6za7PAdP"
+        "id" : "https://www.example.com/Jz5wdjd6Qcy2o71"
       },
-      "doi" : "https://www.example.org/11e6325d-a341-4624-aca4-df01db2cb4f0",
+      "doi" : "https://www.example.org/b84e4692-a748-4e8e-a173-03797e08b5fb",
       "publicationInstance" : {
         "type" : "PopularScienceChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "r6OZnXzp4x2y9CK1P",
-          "end" : "cDeBi0I5zsJUxH"
+          "begin" : "vTz2uSJJsfvmYWJFp1",
+          "end" : "U2HFeh2s43WbcU"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e39413fb-7a09-4c84-9722-30591801e185",
-    "abstract" : "ULFKWYQAIu3D0QC"
+    "metadataSource" : "https://www.example.org/ac4bb9ca-3d64-4f31-8689-035c14777bc5",
+    "abstract" : "1WPOzFZ1CTtb0k7i"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/cb054a72-4867-4b92-927d-89e52152c74e",
-    "name" : "wCj2AAxcuxdj8u",
+    "id" : "https://www.example.org/050d5418-5659-4674-b645-065ac432408f",
+    "name" : "zrvAv629h1VE",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2002-03-23T04:41:35.885Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2007-09-29T16:06:42.525Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPROVED",
-      "applicationCode" : "fmZ2YkjjiIlP3iQj"
+      "applicationCode" : "YM02vvNYDz9TP"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5e4ff387-e90e-440b-9f10-0f3e4bbe94a4",
-    "identifier" : "0P8ID7vqmt",
+    "source" : "https://www.example.org/f21fe787-af77-4521-a50f-610e09660117",
+    "identifier" : "0nGibAYGEzy4wo",
     "labels" : {
-      "en" : "C4bfAPzXVc9"
+      "ru" : "RQoryyBhDJMQ76a"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 320908248
+      "amount" : 1091143548
     },
-    "activeFrom" : "1972-11-08T04:38:01.717Z",
-    "activeTo" : "2006-08-07T00:23:25.550Z"
+    "activeFrom" : "1995-07-27T01:17:16.288Z",
+    "activeTo" : "1997-07-05T12:30:06.730Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/e8e3c072-9a44-4703-85cf-806dded4dbec",
-    "id" : "https://www.example.org/a5b8b4e0-35d6-4072-becd-783f0c52cb2e",
-    "identifier" : "CeM0UlSM0V9hplDU7pR",
+    "source" : "https://www.example.org/dccd3646-97c7-4425-932b-43ee75df157c",
+    "id" : "https://www.example.org/bac3f822-a236-45c0-a27a-93f5abab97cb",
+    "identifier" : "cZT5RqVzA56",
     "labels" : {
-      "hu" : "iGkmvSPgjZzhQJbvUls"
+      "da" : "FLZDqFnCj1pF"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1277779577
+      "currency" : "EUR",
+      "amount" : 1321033937
     },
-    "activeFrom" : "2023-04-02T14:06:20.747Z",
-    "activeTo" : "2024-05-10T22:22:20.895Z"
+    "activeFrom" : "2002-08-30T09:00:41.244Z",
+    "activeTo" : "2022-11-20T11:55:48.904Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/59358e3a-68f9-404e-a740-b8fef4ea1e87" ],
+  "subjects" : [ "https://www.example.org/9af5148a-3c96-44b2-ae42-baa5ea683c4f" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1dca3f4d-d952-46ce-8e1f-0baf416253d0",
-    "name" : "shQQusz62qEIGeHTWEl",
-    "mimeType" : "lcvvnrCGbW",
-    "size" : 800340319,
-    "license" : "https://www.example.com/xafoio2h5trcd6m",
+    "identifier" : "8ce39b53-1cb9-4462-8cf7-d613efbb556a",
+    "name" : "Q2Nku0BDKa",
+    "mimeType" : "o5WRjayI80",
+    "size" : 2041908523,
+    "license" : "https://www.example.com/sjn8xpn9yy",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "HH4PPqqlKLRq7kt"
     },
-    "legalNote" : "k1Zh5W3BxTa6C",
-    "publishedDate" : "2015-09-06T05:30:10.582Z",
+    "legalNote" : "4masOk7yFO9aOiEK5",
+    "publishedDate" : "1990-11-26T03:31:00.004Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "GRWCqzlzVt8qw2",
+      "uploadedDate" : "1998-12-07T11:55:33.441Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/ui0TPGCas2r",
-    "name" : "1QarIbCDKlFu3",
-    "description" : "sHDa1xBTWYcz"
+    "id" : "https://www.example.com/H53zJ2STsu",
+    "name" : "OggjNMOgg54u58",
+    "description" : "C4mmC91I4kMg"
   } ],
-  "rightsHolder" : "sX8NFkRPisw1J3",
-  "duplicateOf" : "https://www.example.org/7f836fa8-dd60-4f39-9092-e0fbe40e2c62",
+  "rightsHolder" : "NW3N9YrIOwq1TsV",
+  "duplicateOf" : "https://www.example.org/a27bc0f1-9ced-4c5d-bfea-b53a78864847",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "7C2BHrqiNvB8riarJ5"
+    "note" : "l50IaDQasAaZrTfhfa"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "fXg89YXUbWKgMxR1qi",
-    "createdBy" : "4ym6dFecWu",
-    "createdDate" : "2008-06-02T04:34:46.497Z"
+    "note" : "ModMPLdTttFRh",
+    "createdBy" : "K4Tkp7VFD7",
+    "createdDate" : "2001-04-03T13:57:49.826Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/065fe456-24f7-4913-aa4f-63ff5ed818ca" ],
+  "curatingInstitutions" : [ "https://www.example.org/f6783809-f2d7-4813-8b70-384f1d303e16" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "kjP8hVqlbJoujIpACT",
-    "ownerAffiliation" : "https://www.example.org/77745600-fb84-4826-ab84-30b29994a468"
+    "owner" : "DIhX4SKIxd1",
+    "ownerAffiliation" : "https://www.example.org/c937c64f-deae-4147-bfd1-5197bdb5abc6"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b8add819-c597-43f5-8494-a65529c7c7e3"
+    "id" : "https://www.example.org/a1753b49-6b95-4223-984e-ca0bf2b7ad90"
   },
-  "createdDate" : "1977-01-04T13:51:38.083Z",
-  "modifiedDate" : "2019-06-02T08:23:18.929Z",
-  "publishedDate" : "2018-07-29T12:16:03.094Z",
-  "indexedDate" : "1988-02-23T11:57:47.124Z",
-  "handle" : "https://www.example.org/32778fcb-fcaf-4bef-a079-f8270a6fbeda",
-  "doi" : "https://doi.org/10.1234/cumque",
-  "link" : "https://www.example.org/8bdd4d30-e12f-4b24-a901-d6a8ff298eb7",
+  "createdDate" : "2011-08-19T12:10:36.140Z",
+  "modifiedDate" : "2024-03-26T18:49:07.501Z",
+  "publishedDate" : "1987-08-19T04:09:11.495Z",
+  "indexedDate" : "1984-03-05T13:49:13.755Z",
+  "handle" : "https://www.example.org/ce68c936-6fb8-4511-a022-4c8043ff8d4f",
+  "doi" : "https://doi.org/10.1234/et",
+  "link" : "https://www.example.org/f2a0d423-edca-4c4b-8cf3-6c6d7bae76a1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "iF14hKJtV9eLc",
+    "mainTitle" : "EZlWIb8DxauNR0RL",
     "alternativeTitles" : {
-      "fr" : "5RUyqbyttJwe"
+      "nb" : "x3sBztwLWt4M3"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "zg0xkMQLbaY",
-      "month" : "Q2JDce4Dh1URvKCdLE",
-      "day" : "6WGMsdLPInYmskP"
+      "year" : "bh7hiemSwQmzABGb",
+      "month" : "TtC9XFTwe6vg",
+      "day" : "nJZhu5hP6OxitsJ5b"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a12bb9ce-9998-4ba4-a73f-1a1d703a67cd",
-        "name" : "D4yLgEVae7",
-        "nameType" : "Organizational",
-        "orcId" : "b2GvrsnUDmn3",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/37bcdae0-cf7f-4210-8cde-2e0dcef2c135",
+        "name" : "kzw5w6hVu6L",
+        "nameType" : "Personal",
+        "orcId" : "jusqeqRrXOMXnwUF4",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yJ1P4NpN4VqVTWff",
-          "value" : "4xCT2aoplsZc4E3"
+          "sourceName" : "H8KYA3Hsg4VAcIV",
+          "value" : "Mn0xBdFAWR4G6oDXf"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hf2Vf4tewUaW2k",
-          "value" : "PKZqjio16y1YBf47t"
+          "sourceName" : "VueVuXtHim8wlc4M8T8",
+          "value" : "ERUMGajb4aHEpkbfICu"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a009db4d-1b52-4d7d-8fa4-46c06ab3aae8"
+        "id" : "https://www.example.org/53aa3500-408b-4969-a0e6-c962113a1bf3"
       } ],
       "role" : {
-        "type" : "Conservator"
+        "type" : "VfxSupervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,162 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e5a8610b-875b-4c5a-9550-62201f64578c",
-        "name" : "KZTiAv0bJsq5OKbu",
+        "id" : "https://www.example.org/d804ae80-0333-4fa6-ace4-c8e77ca9b8d7",
+        "name" : "983PzTZMYt",
         "nameType" : "Organizational",
-        "orcId" : "CUvJZOH1JxvawJ",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "a9Rq4kBkieqKdJscu",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "KgQjSQ1CQ6",
-          "value" : "ONawRdyFV9"
+          "sourceName" : "dhfMZ6u3D5FHGfECG",
+          "value" : "TJV3SzgcQpbn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "64q9vWP1H9deWqT",
-          "value" : "oxQa7bpaSyO01Dw"
+          "sourceName" : "PDOTbGhCpXmV0JKcSTG",
+          "value" : "PP6zhDItmZsTk"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/5b76996b-391c-4abd-9099-d7878978c5dd"
+        "id" : "https://www.example.org/c7165c3f-3448-4bff-adb8-6b021f21ca62"
       } ],
       "role" : {
-        "type" : "Screenwriter"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "hrjYkfYJYzDX"
+      "da" : "h2eTGpHeDyNR9JVjxA6"
     },
-    "npiSubjectHeading" : "lLuKQTlMpf6kN",
-    "tags" : [ "u1iG1Zqv10" ],
-    "description" : "6CIEERZ3Dkt",
+    "npiSubjectHeading" : "I0Zws6NFbvx",
+    "tags" : [ "hy45z5KKkZdugGT" ],
+    "description" : "YeQuQ2w4FKygvXB",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f8dd292c-2bbc-43e7-9551-bbaed0da0850"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d63217e8-43c7-4a05-87a6-1291df9f0452"
         },
-        "seriesNumber" : "PO5mJESb35tee8b",
+        "seriesNumber" : "g6LjxJ2In4n6X",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8f5fec63-25e9-43d5-90ce-6e35ab016619",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f8bd399d-a846-4015-8dd6-655f2d338e96",
           "valid" : true
         },
-        "isbnList" : [ "9790912256046" ],
+        "isbnList" : [ "9791913949654", "9781918567076" ],
         "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "B5YhNmUhhgPiLn5HOt"
+          "value" : "1918567077"
         } ]
       },
-      "doi" : "https://www.example.org/06c2665a-b861-46f0-995d-ed0f06ffe6ab",
+      "doi" : "https://www.example.org/7af8d464-cb2b-499a-b604-46b2df71dd94",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "R6WCJCiyrzz",
-            "end" : "7gKrizyltm7b"
+            "begin" : "wzXaYVi8zPw",
+            "end" : "g7JkPOPErFWPvY"
           },
-          "pages" : "lFYfQb0wAvPs2",
-          "illustrated" : false
+          "pages" : "d4pZduyRjx7ZEH",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/4d1ee490-ce45-4c17-be09-82f052e6cd01",
-    "abstract" : "nzwBsbfsJHr"
+    "metadataSource" : "https://www.example.org/e8e202ad-690a-47ab-abe9-cba2d9fd58af",
+    "abstract" : "vEmbqPTjFFHb7E"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d0cafb5f-df66-4675-8438-a417a3105205",
-    "name" : "GL48warBmCXInS4",
+    "id" : "https://www.example.org/194bc0ec-5fe0-4292-ae37-7be2e6d0b81b",
+    "name" : "lqvpnCPwqW7sN31ODfB",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1988-12-26T04:03:16.036Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "6x6ukL9JWzLtX"
+      "approvalDate" : "2019-11-20T21:52:23.103Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "gae8Brc8ezT5Rh"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/3dd27958-597a-414f-ac17-1830158a3edd",
-    "identifier" : "C7eqTXbyTrWn0R",
+    "source" : "https://www.example.org/ff5b1321-05c7-4257-95fe-52de80b74c90",
+    "identifier" : "XlfCNbTKnoI",
     "labels" : {
-      "bg" : "U2VkwPTD6kJi"
+      "da" : "N1ZXo2lBWrJV14vMlQ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1003022162
+      "currency" : "USD",
+      "amount" : 133398826
     },
-    "activeFrom" : "2011-04-23T21:45:54.436Z",
-    "activeTo" : "2011-09-19T04:53:00.966Z"
+    "activeFrom" : "2002-06-14T13:49:26.130Z",
+    "activeTo" : "2013-07-24T03:30:02.453Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/21a0d72e-b8f6-41b8-97bd-2369669bcf1c",
-    "id" : "https://www.example.org/65e78e13-ddf2-488a-96c1-a426bf41e369",
-    "identifier" : "wjhT23y3rZp0",
+    "source" : "https://www.example.org/05b7c54d-dbed-407d-bd40-67f1a0cf3bcb",
+    "id" : "https://www.example.org/c4059458-c2c0-487b-ab40-bcf6bac074cc",
+    "identifier" : "G09ULPxhnHUbu",
     "labels" : {
-      "nb" : "bz30vDzJGpUCL"
+      "de" : "vrN8N942YPDixn3iV"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1269251223
+      "currency" : "USD",
+      "amount" : 1938910883
     },
-    "activeFrom" : "2024-03-22T12:41:13.695Z",
-    "activeTo" : "2024-03-31T05:25:14.263Z"
+    "activeFrom" : "1996-11-21T15:42:11.781Z",
+    "activeTo" : "2010-12-08T06:04:39.061Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/7714ab53-2834-4737-959a-0083db892183" ],
+  "subjects" : [ "https://www.example.org/2295dd27-1a6c-4893-baba-ec9c99e6501b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "88520e71-112e-462f-a980-6ef8728188c6",
-    "name" : "2hx9lJ1W0hipJkJ",
-    "mimeType" : "EbVcuyEEaNTnyd2oq",
-    "size" : 2091500331,
-    "license" : "https://www.example.com/iv34kl1i0v007lxhco",
+    "identifier" : "82c8b3bf-9f00-4c16-a781-0f2f7d8b76a6",
+    "name" : "U4oONY1boGlG",
+    "mimeType" : "aCvtUaTrfJKwTO6UdN",
+    "size" : 1306299704,
+    "license" : "https://www.example.com/tb6cmqxfhei725",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Sfy0TVNNI4YF6",
-    "publishedDate" : "1991-02-14T09:29:12.206Z",
+    "legalNote" : "X340iMbqLs5CV8c3mta",
+    "publishedDate" : "2011-07-10T06:39:32.867Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "SpRzg6lqO6U",
+      "uploadedDate" : "1975-10-09T05:18:05.732Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zBooOjxukkJgggnHf",
-    "name" : "M3Pj0W90WStKy05i9Pj",
-    "description" : "mWVC5SgmaGzogqELD"
+    "id" : "https://www.example.com/mG5KocCtKmpfns",
+    "name" : "wkb4yVVbayyuOnvK",
+    "description" : "EEbF5A8XPs4uwSohe"
   } ],
-  "rightsHolder" : "dYqFZ28C4Ayq4Gb",
-  "duplicateOf" : "https://www.example.org/346a97e1-b060-49c0-8fa9-81a81aded438",
+  "rightsHolder" : "qt9i5X6jbj",
+  "duplicateOf" : "https://www.example.org/d2e57be5-054b-4914-9cf5-a8b27bdaa854",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "qvD4zksxMPzJ34qa0Xe"
+    "note" : "fhZcPKLWIb4BA69G1"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "LpVFBsLbVi",
-    "createdBy" : "qIjnOBtotNNjKvPWwJ",
-    "createdDate" : "2006-10-31T03:20:26.508Z"
+    "note" : "XwjsrVNVepNyQFr371S",
+    "createdBy" : "3qVNiFYN1fSic",
+    "createdDate" : "2004-01-18T07:03:34.697Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/328a5e8e-daf7-453b-8c72-9d691c1ce959" ],
+  "curatingInstitutions" : [ "https://www.example.org/0a74b2b2-13ee-44d1-8b48-ee908566dece" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/PopularScienceMonograph.json
+++ b/documentation/PopularScienceMonograph.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "9oAKRDdwA82Q",
-    "ownerAffiliation" : "https://www.example.org/7b1da7cd-8d62-40d6-bf61-24afd13b28f8"
+    "owner" : "kjP8hVqlbJoujIpACT",
+    "ownerAffiliation" : "https://www.example.org/77745600-fb84-4826-ab84-30b29994a468"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/ad38985d-4059-44df-98ad-f1a82e89f4e4"
+    "id" : "https://www.example.org/b8add819-c597-43f5-8494-a65529c7c7e3"
   },
-  "createdDate" : "1994-11-08T10:30:21.888Z",
-  "modifiedDate" : "1984-04-09T02:03:40.157Z",
-  "publishedDate" : "2012-08-07T14:44:46.568Z",
-  "indexedDate" : "1998-12-21T20:00:46.475Z",
-  "handle" : "https://www.example.org/6cf0aaac-d511-41ca-9cbd-fbeef1554f3a",
-  "doi" : "https://doi.org/10.1234/fugit",
-  "link" : "https://www.example.org/ffef1263-841a-4625-b36b-a6aeab506c51",
+  "createdDate" : "1977-01-04T13:51:38.083Z",
+  "modifiedDate" : "2019-06-02T08:23:18.929Z",
+  "publishedDate" : "2018-07-29T12:16:03.094Z",
+  "indexedDate" : "1988-02-23T11:57:47.124Z",
+  "handle" : "https://www.example.org/32778fcb-fcaf-4bef-a079-f8270a6fbeda",
+  "doi" : "https://doi.org/10.1234/cumque",
+  "link" : "https://www.example.org/8bdd4d30-e12f-4b24-a901-d6a8ff298eb7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "J93QZEtJUT",
+    "mainTitle" : "iF14hKJtV9eLc",
     "alternativeTitles" : {
-      "ca" : "rivhAjzRJJ8aOg6"
+      "fr" : "5RUyqbyttJwe"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "UeoLrjYtMOHo",
-      "month" : "I8z730QPzE",
-      "day" : "zAqTUSEaC6BJZlRK"
+      "year" : "zg0xkMQLbaY",
+      "month" : "Q2JDce4Dh1URvKCdLE",
+      "day" : "6WGMsdLPInYmskP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6ca43e2c-57e8-4c19-8035-71c90a7a27dd",
-        "name" : "IdgJZ6aI7VQQjTdkDJj",
-        "nameType" : "Personal",
-        "orcId" : "GkN7aPXHSHfdLvsB",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/a12bb9ce-9998-4ba4-a73f-1a1d703a67cd",
+        "name" : "D4yLgEVae7",
+        "nameType" : "Organizational",
+        "orcId" : "b2GvrsnUDmn3",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VfnbipfFJHbOiGz",
-          "value" : "ZmXxaPH1LAuVHUprKa"
+          "sourceName" : "yJ1P4NpN4VqVTWff",
+          "value" : "4xCT2aoplsZc4E3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6vwLhuq91X1gIteWot",
-          "value" : "wh19Ct2sFgx6i"
+          "sourceName" : "Hf2Vf4tewUaW2k",
+          "value" : "PKZqjio16y1YBf47t"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/852b7d71-7a3a-46d6-baa3-be418a7e5809"
+        "id" : "https://www.example.org/a009db4d-1b52-4d7d-8fa4-46c06ab3aae8"
       } ],
       "role" : {
-        "type" : "Choreographer"
+        "type" : "Conservator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/86c911c6-d491-4b69-8647-7d9d4314ffe6",
-        "name" : "f76XQMZSTD5w5Oy0",
+        "id" : "https://www.example.org/e5a8610b-875b-4c5a-9550-62201f64578c",
+        "name" : "KZTiAv0bJsq5OKbu",
         "nameType" : "Organizational",
-        "orcId" : "BPWxkcdo3cMRllj",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "CUvJZOH1JxvawJ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "AzNeYmaIfy57Dtde",
-          "value" : "Yb626pzMkBE"
+          "sourceName" : "KgQjSQ1CQ6",
+          "value" : "ONawRdyFV9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "19InTr80NvXuVsZ",
-          "value" : "DEsbe3JGND93p"
+          "sourceName" : "64q9vWP1H9deWqT",
+          "value" : "oxQa7bpaSyO01Dw"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/67d7d921-f5c7-4dc7-8885-3b8f20b0d461"
+        "id" : "https://www.example.org/5b76996b-391c-4abd-9099-d7878978c5dd"
       } ],
       "role" : {
-        "type" : "VfxSupervisor"
+        "type" : "Screenwriter"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "Nc815mbX2kFS"
+      "es" : "hrjYkfYJYzDX"
     },
-    "npiSubjectHeading" : "8qxPNLahxWjUjgkto",
-    "tags" : [ "uAywVPgeP5nVOu" ],
-    "description" : "odEVcKtE9ocy1",
+    "npiSubjectHeading" : "lLuKQTlMpf6kN",
+    "tags" : [ "u1iG1Zqv10" ],
+    "description" : "6CIEERZ3Dkt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d227b6ae-d6c4-49a1-a0c9-1e4e073b9c98"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/f8dd292c-2bbc-43e7-9551-bbaed0da0850"
         },
-        "seriesNumber" : "LGxjf59WuRnCwG",
+        "seriesNumber" : "PO5mJESb35tee8b",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/804d39f6-9c6b-45a8-b80f-f5bbd1a15e3a",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/8f5fec63-25e9-43d5-90ce-6e35ab016619",
           "valid" : true
         },
-        "isbnList" : [ "9781737992684" ],
-        "revision" : "Revised",
+        "isbnList" : [ "9790912256046" ],
+        "revision" : "Unrevised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "ftYXPJCsBRq"
+          "value" : "B5YhNmUhhgPiLn5HOt"
         } ]
       },
-      "doi" : "https://www.example.org/f2e1b7dc-599a-4215-8f97-6e29396cffb1",
+      "doi" : "https://www.example.org/06c2665a-b861-46f0-995d-ed0f06ffe6ab",
       "publicationInstance" : {
         "type" : "PopularScienceMonograph",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "jRIpJzIMiFMBmK",
-            "end" : "3sTecOs5g1sZ7s"
+            "begin" : "R6WCJCiyrzz",
+            "end" : "7gKrizyltm7b"
           },
-          "pages" : "7CNu2ijsIpzLsa3sh",
-          "illustrated" : true
+          "pages" : "lFYfQb0wAvPs2",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/86d3b531-8982-4f5a-b901-68cf737d9298",
-    "abstract" : "awGW5PWqplSVCpef"
+    "metadataSource" : "https://www.example.org/4d1ee490-ce45-4c17-be09-82f052e6cd01",
+    "abstract" : "nzwBsbfsJHr"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a42c98f7-cf31-4e34-a390-2e6f31510ba1",
-    "name" : "EwMle1x38Tzp",
+    "id" : "https://www.example.org/d0cafb5f-df66-4675-8438-a417a3105205",
+    "name" : "GL48warBmCXInS4",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2001-01-07T10:44:42.287Z",
+      "approvalDate" : "1988-12-26T04:03:16.036Z",
       "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "Z5ApUrQgKpa"
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "6x6ukL9JWzLtX"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6f8d855b-47a0-41c4-bc54-df0fe03c63b4",
-    "identifier" : "TztRcZYUS2xZPZQbpK",
+    "source" : "https://www.example.org/3dd27958-597a-414f-ac17-1830158a3edd",
+    "identifier" : "C7eqTXbyTrWn0R",
     "labels" : {
-      "sv" : "imhBUj3vCuVy4483yh0"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1578632182
-    },
-    "activeFrom" : "1998-05-13T00:11:18.068Z",
-    "activeTo" : "2022-10-25T21:55:41.130Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ca64d52b-dce5-4b95-90f4-2d6ba0cf3f3e",
-    "id" : "https://www.example.org/98f05ed4-d3bb-4daa-8c9d-be29b3f4cafe",
-    "identifier" : "BBZEaceJFUOhzevsJuX",
-    "labels" : {
-      "nb" : "JzU25dVJ6G"
+      "bg" : "U2VkwPTD6kJi"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1208929424
+      "amount" : 1003022162
     },
-    "activeFrom" : "1987-01-06T16:51:37.003Z",
-    "activeTo" : "2009-10-04T06:02:12.465Z"
+    "activeFrom" : "2011-04-23T21:45:54.436Z",
+    "activeTo" : "2011-09-19T04:53:00.966Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/21a0d72e-b8f6-41b8-97bd-2369669bcf1c",
+    "id" : "https://www.example.org/65e78e13-ddf2-488a-96c1-a426bf41e369",
+    "identifier" : "wjhT23y3rZp0",
+    "labels" : {
+      "nb" : "bz30vDzJGpUCL"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 1269251223
+    },
+    "activeFrom" : "2024-03-22T12:41:13.695Z",
+    "activeTo" : "2024-03-31T05:25:14.263Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f259cc11-3351-4946-819a-d9ce09920b44" ],
+  "subjects" : [ "https://www.example.org/7714ab53-2834-4737-959a-0083db892183" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "1aafaee9-5fff-4d62-80e8-85ccd7985779",
-    "name" : "IsPrRCXDFFidb5zkUo",
-    "mimeType" : "7yED80WmTm",
-    "size" : 1746773442,
-    "license" : "https://www.example.com/qckiel6smalft",
+    "identifier" : "88520e71-112e-462f-a980-6ef8728188c6",
+    "name" : "2hx9lJ1W0hipJkJ",
+    "mimeType" : "EbVcuyEEaNTnyd2oq",
+    "size" : 2091500331,
+    "license" : "https://www.example.com/iv34kl1i0v007lxhco",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "zMJ6OBXObd6pOxT",
-    "publishedDate" : "1983-07-30T22:34:46.982Z",
+    "legalNote" : "Sfy0TVNNI4YF6",
+    "publishedDate" : "1991-02-14T09:29:12.206Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/wHP3S0bCNYacSlZs",
-    "name" : "UruEpDmwS5JkqMKy3y1",
-    "description" : "bBDQTeVQFjkgh6Y2"
+    "id" : "https://www.example.com/zBooOjxukkJgggnHf",
+    "name" : "M3Pj0W90WStKy05i9Pj",
+    "description" : "mWVC5SgmaGzogqELD"
   } ],
-  "rightsHolder" : "epkpC2Gm8km",
-  "duplicateOf" : "https://www.example.org/12c00c92-e75e-415d-8e43-8dc40b6ce67f",
+  "rightsHolder" : "dYqFZ28C4Ayq4Gb",
+  "duplicateOf" : "https://www.example.org/346a97e1-b060-49c0-8fa9-81a81aded438",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "vp0rwhrLC8ZFQbSJhZ"
+    "note" : "qvD4zksxMPzJ34qa0Xe"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "07jmJjFAjzOChnta",
-    "createdBy" : "AzHPbZVLAQdgnnjAb7",
-    "createdDate" : "1989-01-29T01:45:47.365Z"
+    "note" : "LpVFBsLbVi",
+    "createdBy" : "qIjnOBtotNNjKvPWwJ",
+    "createdDate" : "2006-10-31T03:20:26.508Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/2a91481a-55b1-45c8-a789-2be3db5db4b8" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/328a5e8e-daf7-453b-8c72-9d691c1ce959" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "ZN8HupwkZzJshcAoI",
-    "ownerAffiliation" : "https://www.example.org/87037038-2814-46c3-9ec9-6617370a343f"
+    "owner" : "PpBGY61Yn0jv9aYwjh1",
+    "ownerAffiliation" : "https://www.example.org/dfbc36f2-2da6-4cec-a194-dc0453d703f7"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/99c28f1d-a30b-40c0-bd51-5a333e3b5f8e"
+    "id" : "https://www.example.org/61f6f0b7-32b6-4c42-921a-42733e3c311d"
   },
-  "createdDate" : "1992-11-25T23:45:44.535Z",
-  "modifiedDate" : "2001-12-16T03:13:54.862Z",
-  "publishedDate" : "2001-10-06T11:37:17.599Z",
-  "indexedDate" : "2021-08-12T20:42:20.418Z",
-  "handle" : "https://www.example.org/d9a48d1e-6a96-4bf6-a8d9-328e4331d1d5",
-  "doi" : "https://doi.org/10.1234/est",
-  "link" : "https://www.example.org/8fd88f0b-38d3-46a9-b420-39923aa2b671",
+  "createdDate" : "1979-10-28T12:17:42.839Z",
+  "modifiedDate" : "2016-02-25T03:47:21.422Z",
+  "publishedDate" : "2022-01-09T10:22:14.430Z",
+  "indexedDate" : "2002-04-25T20:00:16.736Z",
+  "handle" : "https://www.example.org/5ccdadf9-51d5-405a-a2ee-d141d3d6c902",
+  "doi" : "https://doi.org/10.1234/vitae",
+  "link" : "https://www.example.org/11aa7c76-39d3-4f3b-95b8-058a6da74be1",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "rWdGSEd3jrq0IIZN",
+    "mainTitle" : "Tf39MKDbuvQTfGI",
     "alternativeTitles" : {
-      "fr" : "6XGNn1SmesWNAm"
+      "sv" : "MYlZhgrskC"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "S0iLszWxWsIr81sGqKa",
-      "month" : "kL9muRDXzS",
-      "day" : "HTLsjlsdWnAohHNnvS1"
+      "year" : "UE18r4EF3X1",
+      "month" : "E9YprtgoZ6pvyfgHdD",
+      "day" : "pjsak9KoTXe"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/941029e9-a819-4e0f-905f-9276634c9ca1",
-        "name" : "OkagLB8a6UU7WP",
+        "id" : "https://www.example.org/8cf72cae-c08b-4803-b250-82ec5eec9e60",
+        "name" : "ePnvW8MCXV6y",
         "nameType" : "Personal",
-        "orcId" : "hh5JVYAh5R",
-        "verificationStatus" : "Verified",
+        "orcId" : "Wn9UeaZqxyZaxq",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "YPaoElsuEwFT",
-          "value" : "j6SX6De2xWVycbX"
+          "sourceName" : "ddMEz2SsNeuc2AF",
+          "value" : "TD39hAHORb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zTrcqIvOvshN5W2VIj",
-          "value" : "WSVxhfU1HDckt"
+          "sourceName" : "5OMULHkOFo17JCwS9",
+          "value" : "5HG6noxJGqnic5"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/485404f6-af74-4e09-94e5-d2748ed3d036"
+        "id" : "https://www.example.org/922f58f1-ba74-4dbe-b1cf-cf6c4140fb0c"
       } ],
       "role" : {
-        "type" : "ArtisticDirector"
+        "type" : "ResearchGroup"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/ec4350cc-fee2-4a81-8b92-761d176a9a16",
-        "name" : "sn8IIAdOw4O2g",
+        "id" : "https://www.example.org/51083b38-8771-4e47-b3d1-9b3fed938824",
+        "name" : "L4rmmmmSNBOswgSv",
         "nameType" : "Personal",
-        "orcId" : "x0LdoHGdFwVsfwdrnb",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "zwXkGoFSSzeOVzF",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5WFULiJoJIqTnBuY",
-          "value" : "rJ7FEZ08reDJ"
+          "sourceName" : "CSjjAuNsnm",
+          "value" : "kVw3xhUzr26khN5jt"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "K3f19M0hr9BiUde",
-          "value" : "pxZWdnRA88t"
+          "sourceName" : "ikx0JKuh1o4suBTsW",
+          "value" : "0c6n5io4yN"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/77629d29-8d69-43b9-a816-3cc86793a867"
+        "id" : "https://www.example.org/fa4aa66e-960a-4980-ab37-38651c516b3e"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Funder"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "sv" : "r2KVWdcKCxzFFpL81O"
+      "nn" : "O7gL95yH8JK54Jw"
     },
-    "npiSubjectHeading" : "s2wdQUu03o4sMLH0i",
-    "tags" : [ "7fH2qQlhAIObSzkwg" ],
-    "description" : "n5qpdmwoGVSSnby2",
+    "npiSubjectHeading" : "Tp0WzESDoAM3x",
+    "tags" : [ "sZXqst6aVBkPH" ],
+    "description" : "RvCSLmkkbwsidlK83At",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/83b69e50-0da7-4e9d-ac8a-afe4a9180022"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/1ed7682f-ef5f-4f88-a557-4ebd09519ed3"
       },
-      "doi" : "https://www.example.org/c3e583d6-c0e3-443b-8af2-7472540c4d55",
+      "doi" : "https://www.example.org/a0d84562-96e7-4277-9c62-e098937cd81f",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "tS8oDwnA8hkO",
-          "end" : "U9rhhhpkDAWLCb1sA"
+          "begin" : "uPJX9pP0aK78lmU",
+          "end" : "5rlyHGZ3d0Cl"
         },
-        "volume" : "uRwBgZMpnqhoX44c",
-        "issue" : "IESC1yaRs6mu2AcX",
-        "articleNumber" : "4Z3p9eAMrw"
+        "volume" : "V1o40bo4BpZq53rPt",
+        "issue" : "wU22FAHamZwQjJpG4",
+        "articleNumber" : "34F88sONsaY9Pn6"
       }
     },
-    "metadataSource" : "https://www.example.org/5e5fd1a8-ee59-4333-b3a7-2561313b4f0d",
-    "abstract" : "uGRVj1jgGAXA9VoHDn"
+    "metadataSource" : "https://www.example.org/2c6d90a4-5c00-419b-bd39-ed7dae7c2fd4",
+    "abstract" : "QB2dRglDfcmPDqLiG5x"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/58ae014b-8fd8-4ac8-8e4e-a37ee9279e4e",
-    "name" : "7SvOP3ylmzzNsWjXvS",
+    "id" : "https://www.example.org/ee594c79-7bcf-47a4-80d2-469c4ade9f72",
+    "name" : "2ZsEZXbf0jG",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2012-04-07T22:30:53.690Z",
+      "approvalDate" : "2013-12-09T23:09:53.874Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "HdUpy6Fck8y5b"
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "DtIpLXFGjPXUgc"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/828d3a77-e6d1-43d2-993a-9cd1c7ab6640",
-    "identifier" : "UPFL0ycr6cRm2Kd2",
+    "source" : "https://www.example.org/c2703a25-3b80-4416-a047-08195609f1a6",
+    "identifier" : "oqJY0QJMDp0bO2ttH",
     "labels" : {
-      "da" : "vUAzmKeHZWMzpbFDJ"
-    },
-    "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1440338957
-    },
-    "activeFrom" : "2016-05-12T12:47:36.421Z",
-    "activeTo" : "2024-03-06T15:19:04.200Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/98f98054-551b-48ec-97be-a384c764d4a7",
-    "id" : "https://www.example.org/9f19a424-6f05-4d42-a195-4f3f8cc0b21f",
-    "identifier" : "52tvHIXAFeaWXs",
-    "labels" : {
-      "sv" : "iQGoSGcb0ZS74DO"
+      "pl" : "fR1CKThiYukejUGdk"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1452706928
+      "amount" : 309165496
     },
-    "activeFrom" : "1989-10-28T17:17:16.070Z",
-    "activeTo" : "2014-04-24T05:21:31.208Z"
+    "activeFrom" : "2021-12-21T03:09:21.395Z",
+    "activeTo" : "2022-10-17T15:25:12.852Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/fdb7b455-81e7-4518-a595-ac63e4dcbe34",
+    "id" : "https://www.example.org/409783b2-53c4-490f-b12e-313ba57ce66a",
+    "identifier" : "NsnUcfi6Vv49dT5qkv",
+    "labels" : {
+      "af" : "hrdMxoryKoH3SmYhbl"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 730379064
+    },
+    "activeFrom" : "1985-10-31T00:19:54.122Z",
+    "activeTo" : "1999-02-24T02:13:08.957Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/b369f3a9-c344-4f32-a882-0ca841be479b" ],
+  "subjects" : [ "https://www.example.org/a7239f80-d160-4942-b0be-97c77da1b4e2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9c87d971-4c42-4fa1-ba6f-8cb0ede1cf68",
-    "name" : "YgQfhC8JYYx9LA",
-    "mimeType" : "blUCtYRqV8E4seR",
-    "size" : 462636507,
-    "license" : "https://www.example.com/eimaghvosaqxggc",
+    "identifier" : "d7151357-114c-4a06-a518-0e7066fd19b1",
+    "name" : "KOTpxRgvKnm9sHXCTt",
+    "mimeType" : "EABv6JCWbe0QvDD",
+    "size" : 240795579,
+    "license" : "https://www.example.com/qijawgefewjolvegv",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "xk06nIYwv0M",
-    "publishedDate" : "2012-05-20T10:33:09.694Z",
+    "legalNote" : "hXf7ziMvJ59Dz1CpxWs",
+    "publishedDate" : "1999-03-09T01:30:04.661Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "WCog5fFHFpPKU1d",
+      "uploadedDate" : "2013-10-22T19:51:55.712Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FGPCt6V8zIX",
-    "name" : "B6ZRjWMucMLs5ewa2",
-    "description" : "gUIaOKB2qDCpzVsm"
+    "id" : "https://www.example.com/GS48mF53MLHagFyufo",
+    "name" : "MmaAAuFs3qN",
+    "description" : "fijNlPBCe6Baz"
   } ],
-  "rightsHolder" : "DfckuFP5gc",
-  "duplicateOf" : "https://www.example.org/fb1945ed-466b-4fc2-b68f-1fe0f9ccda9e",
+  "rightsHolder" : "cxTJvIi3KMJRRa",
+  "duplicateOf" : "https://www.example.org/4ce01e0d-6b34-4f79-ad7c-222fd0b58e85",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "h4rl4OSjqLm"
+    "note" : "381tBbe8IR"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "vH5ouuhw5Lj",
-    "createdBy" : "8naKOcBHz5hK5guI",
-    "createdDate" : "2004-06-02T14:51:32.151Z"
+    "note" : "AUgOxssVRtchxZ",
+    "createdBy" : "vJhYDGU9t0ntZxgi",
+    "createdDate" : "1973-04-18T02:29:14.181Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/64687231-9daf-41f1-bbac-1fbfba09dd8e" ],
+  "curatingInstitutions" : [ "https://www.example.org/95cc260a-bbba-44c6-8e7b-f575867b1cc3" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ProfessionalArticle.json
+++ b/documentation/ProfessionalArticle.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "h5SZrYlhMBgWlTZnXP4",
-    "ownerAffiliation" : "https://www.example.org/6c494c5d-3673-4192-a15c-e4c5adb30f21"
+    "owner" : "ZN8HupwkZzJshcAoI",
+    "ownerAffiliation" : "https://www.example.org/87037038-2814-46c3-9ec9-6617370a343f"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/52a02dbd-4885-443d-837f-f204b2cea0d9"
+    "id" : "https://www.example.org/99c28f1d-a30b-40c0-bd51-5a333e3b5f8e"
   },
-  "createdDate" : "2021-06-08T07:44:57.161Z",
-  "modifiedDate" : "2013-03-28T23:07:55.226Z",
-  "publishedDate" : "1985-04-17T22:56:17.570Z",
-  "indexedDate" : "2017-09-22T12:36:13.076Z",
-  "handle" : "https://www.example.org/10cb7c55-fd67-4657-8857-58cf61b72889",
-  "doi" : "https://doi.org/10.1234/deserunt",
-  "link" : "https://www.example.org/b8edbd96-fd31-4296-ac8b-10b57c12c043",
+  "createdDate" : "1992-11-25T23:45:44.535Z",
+  "modifiedDate" : "2001-12-16T03:13:54.862Z",
+  "publishedDate" : "2001-10-06T11:37:17.599Z",
+  "indexedDate" : "2021-08-12T20:42:20.418Z",
+  "handle" : "https://www.example.org/d9a48d1e-6a96-4bf6-a8d9-328e4331d1d5",
+  "doi" : "https://doi.org/10.1234/est",
+  "link" : "https://www.example.org/8fd88f0b-38d3-46a9-b420-39923aa2b671",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "FS2YzIy70Ngh",
+    "mainTitle" : "rWdGSEd3jrq0IIZN",
     "alternativeTitles" : {
-      "nn" : "68Zy5sPiZDuM"
+      "fr" : "6XGNn1SmesWNAm"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uqvMRXCs9JN7iG",
-      "month" : "4cfNTH6J5olub3",
-      "day" : "ehh56KwLPAuN"
+      "year" : "S0iLszWxWsIr81sGqKa",
+      "month" : "kL9muRDXzS",
+      "day" : "HTLsjlsdWnAohHNnvS1"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/d9b61018-5a0d-4e5b-913e-ecee2fcbb5b6",
-        "name" : "VmfFRT1pDZDbodKpAt5",
-        "nameType" : "Organizational",
-        "orcId" : "g2S9lIIJYyXaW",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/941029e9-a819-4e0f-905f-9276634c9ca1",
+        "name" : "OkagLB8a6UU7WP",
+        "nameType" : "Personal",
+        "orcId" : "hh5JVYAh5R",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "S628dUEN5PQ",
-          "value" : "OerSyvYQwuZpXm6"
+          "sourceName" : "YPaoElsuEwFT",
+          "value" : "j6SX6De2xWVycbX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zU1t38ia9N8xQ",
-          "value" : "KkpF2C1Ylihv"
+          "sourceName" : "zTrcqIvOvshN5W2VIj",
+          "value" : "WSVxhfU1HDckt"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b8936e17-feda-440d-ad7a-bda292151f57"
+        "id" : "https://www.example.org/485404f6-af74-4e09-94e5-d2748ed3d036"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "ArtisticDirector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/71123635-2226-4315-a63b-a97e7dac0025",
-        "name" : "5IghZuJ4jHF4Mqmmg",
-        "nameType" : "Organizational",
-        "orcId" : "UxZW8PF6N6JkLWkfj",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/ec4350cc-fee2-4a81-8b92-761d176a9a16",
+        "name" : "sn8IIAdOw4O2g",
+        "nameType" : "Personal",
+        "orcId" : "x0LdoHGdFwVsfwdrnb",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "X4su6cfp1kPd",
-          "value" : "zV3LApPwst"
+          "sourceName" : "5WFULiJoJIqTnBuY",
+          "value" : "rJ7FEZ08reDJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UgONVFiUMzw4Lx",
-          "value" : "JEpSXjYIwecCa"
+          "sourceName" : "K3f19M0hr9BiUde",
+          "value" : "pxZWdnRA88t"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/3b77b3e2-2e75-4ee1-b0f9-7873f575ad01"
+        "id" : "https://www.example.org/77629d29-8d69-43b9-a816-3cc86793a867"
       } ],
       "role" : {
-        "type" : "Advisor"
+        "type" : "Soloist"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "fmJXeWVYGAaqBxen4iJ"
+      "sv" : "r2KVWdcKCxzFFpL81O"
     },
-    "npiSubjectHeading" : "a6MYcOiWj1iQG276",
-    "tags" : [ "txOlbo6HAFUQr" ],
-    "description" : "i6GKWiL3mRoXunS",
+    "npiSubjectHeading" : "s2wdQUu03o4sMLH0i",
+    "tags" : [ "7fH2qQlhAIObSzkwg" ],
+    "description" : "n5qpdmwoGVSSnby2",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/949541e6-8c15-47ca-b4a3-ec63cacf68ea"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/83b69e50-0da7-4e9d-ac8a-afe4a9180022"
       },
-      "doi" : "https://www.example.org/af1883ef-d12f-4d67-8ec2-04932a416e45",
+      "doi" : "https://www.example.org/c3e583d6-c0e3-443b-8af2-7472540c4d55",
       "publicationInstance" : {
         "type" : "ProfessionalArticle",
         "pages" : {
           "type" : "Range",
-          "begin" : "qd49yIV9iAvf5",
-          "end" : "3rourLYdOUf"
+          "begin" : "tS8oDwnA8hkO",
+          "end" : "U9rhhhpkDAWLCb1sA"
         },
-        "volume" : "7vDXM7VGxNVMjOKnXAQ",
-        "issue" : "yepoUz5euv7",
-        "articleNumber" : "7NUMt28mUaTS4KN"
+        "volume" : "uRwBgZMpnqhoX44c",
+        "issue" : "IESC1yaRs6mu2AcX",
+        "articleNumber" : "4Z3p9eAMrw"
       }
     },
-    "metadataSource" : "https://www.example.org/3e760317-0591-41ab-b3c7-b3d0eddb0b75",
-    "abstract" : "yRmv38Hkihm8D6g"
+    "metadataSource" : "https://www.example.org/5e5fd1a8-ee59-4333-b3a7-2561313b4f0d",
+    "abstract" : "uGRVj1jgGAXA9VoHDn"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/7814e037-8502-4039-9ea6-003cef02dbca",
-    "name" : "wApMtVTb1Mu2uXAAb",
+    "id" : "https://www.example.org/58ae014b-8fd8-4ac8-8e4e-a37ee9279e4e",
+    "name" : "7SvOP3ylmzzNsWjXvS",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2021-01-03T14:13:10.158Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2012-04-07T22:30:53.690Z",
+      "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "k5AFQFmudI"
+      "applicationCode" : "HdUpy6Fck8y5b"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/af196f9c-55fb-45fa-be58-a8e7438cb654",
-    "identifier" : "IbsUzsHziIrYfrxH",
+    "source" : "https://www.example.org/828d3a77-e6d1-43d2-993a-9cd1c7ab6640",
+    "identifier" : "UPFL0ycr6cRm2Kd2",
     "labels" : {
-      "ca" : "UgWMdBmi4gy"
+      "da" : "vUAzmKeHZWMzpbFDJ"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1097156914
+      "currency" : "NOK",
+      "amount" : 1440338957
     },
-    "activeFrom" : "1972-01-14T08:07:23.929Z",
-    "activeTo" : "2011-11-10T12:12:41.753Z"
+    "activeFrom" : "2016-05-12T12:47:36.421Z",
+    "activeTo" : "2024-03-06T15:19:04.200Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/fb63509b-d1b1-4a76-8985-914773ad9b19",
-    "id" : "https://www.example.org/e79f892a-ba76-49fa-b719-270d08f608ef",
-    "identifier" : "UZSnxFQqcMv6b1fqP",
+    "source" : "https://www.example.org/98f98054-551b-48ec-97be-a384c764d4a7",
+    "id" : "https://www.example.org/9f19a424-6f05-4d42-a195-4f3f8cc0b21f",
+    "identifier" : "52tvHIXAFeaWXs",
     "labels" : {
-      "en" : "tiBzw0uDlwp7gPHVxp5"
+      "sv" : "iQGoSGcb0ZS74DO"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 44760808
+      "currency" : "USD",
+      "amount" : 1452706928
     },
-    "activeFrom" : "1986-10-30T20:46:31.563Z",
-    "activeTo" : "1991-02-05T04:15:09.719Z"
+    "activeFrom" : "1989-10-28T17:17:16.070Z",
+    "activeTo" : "2014-04-24T05:21:31.208Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/ce687feb-e460-4b89-ba24-daf4e3fd0a46" ],
+  "subjects" : [ "https://www.example.org/b369f3a9-c344-4f32-a882-0ca841be479b" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a8aa2d12-ecc6-4615-a487-a440619c2e5e",
-    "name" : "UH4bDw14Btw",
-    "mimeType" : "piqNoQXVQtX",
-    "size" : 444044029,
-    "license" : "https://www.example.com/kwcujo5xbacnvj",
+    "identifier" : "9c87d971-4c42-4fa1-ba6f-8cb0ede1cf68",
+    "name" : "YgQfhC8JYYx9LA",
+    "mimeType" : "blUCtYRqV8E4seR",
+    "size" : 462636507,
+    "license" : "https://www.example.com/eimaghvosaqxggc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "UTdrZYP1LcFiac",
-    "publishedDate" : "1988-12-11T15:05:48.412Z",
+    "legalNote" : "xk06nIYwv0M",
+    "publishedDate" : "2012-05-20T10:33:09.694Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/kg0CL7gJP39KHak",
-    "name" : "pixPKRTfBtY41y4ej7w",
-    "description" : "mJhTFpmMWjSxupp"
+    "id" : "https://www.example.com/FGPCt6V8zIX",
+    "name" : "B6ZRjWMucMLs5ewa2",
+    "description" : "gUIaOKB2qDCpzVsm"
   } ],
-  "rightsHolder" : "67QkPFQvmxSLkfM68",
-  "duplicateOf" : "https://www.example.org/91c92732-dd44-4bd8-8dac-a4781c69a7a1",
+  "rightsHolder" : "DfckuFP5gc",
+  "duplicateOf" : "https://www.example.org/fb1945ed-466b-4fc2-b68f-1fe0f9ccda9e",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "5DzJGIQhEGRIFAhkjqp"
+    "note" : "h4rl4OSjqLm"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "LT25McvwcqGOXJYi",
-    "createdBy" : "FoBt6Lw54IVI",
-    "createdDate" : "2022-11-27T14:21:25.901Z"
+    "note" : "vH5ouuhw5Lj",
+    "createdBy" : "8naKOcBHz5hK5guI",
+    "createdDate" : "2004-06-02T14:51:32.151Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/81d88853-5b12-4eef-8b6c-21247e0fa555" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/64687231-9daf-41f1-bbac-1fbfba09dd8e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "y4eLwss5ytLXQvKc",
-    "ownerAffiliation" : "https://www.example.org/e3cabb61-bc3f-4158-8cb9-6bbf21ca859a"
+    "owner" : "dKDqBfEfskV2gYD8fc",
+    "ownerAffiliation" : "https://www.example.org/5cc6bb9b-e3f8-4bfb-8a84-242399c3e69e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/99cd77cc-c640-44fa-9df2-81872ed2e23f"
+    "id" : "https://www.example.org/e8433a99-669c-41f1-bb00-12d4f5ce529f"
   },
-  "createdDate" : "1973-08-21T14:34:16.112Z",
-  "modifiedDate" : "2008-09-16T08:01:03.550Z",
-  "publishedDate" : "1984-09-09T21:22:50.118Z",
-  "indexedDate" : "1993-11-20T15:27:06.899Z",
-  "handle" : "https://www.example.org/4b2b759c-9ee0-4131-80ab-564d5d29fcea",
-  "doi" : "https://doi.org/10.1234/et",
-  "link" : "https://www.example.org/954c48d6-948f-4f2c-be51-60ead333a9b6",
+  "createdDate" : "1976-05-28T10:22:23.017Z",
+  "modifiedDate" : "1981-11-14T11:35:51.564Z",
+  "publishedDate" : "2009-01-09T21:25:47.674Z",
+  "indexedDate" : "1997-09-12T08:39:17.159Z",
+  "handle" : "https://www.example.org/647f7dcb-bd83-4eb7-9122-81b0e9ad3f82",
+  "doi" : "https://doi.org/10.1234/repellat",
+  "link" : "https://www.example.org/14c4a5bc-ba41-4759-adee-42f11afc652c",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "3BckjPJ84bWdUk3mlUj",
+    "mainTitle" : "fmM3r3q0WPahJUE8H",
     "alternativeTitles" : {
-      "pt" : "vTrg2ZlFoWYsd"
+      "el" : "D8dLeSGe56GbFd6kTQ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "uYkLrkoMBSaLLI",
-      "month" : "GTN96kKvSkxo5Vji",
-      "day" : "MavMeyXWyrEZc"
+      "year" : "BNNLp6yV96Vwz95U1r",
+      "month" : "8ulXryGZ05CBn",
+      "day" : "2e351PHOxW"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/aa469001-41d6-4109-93c7-c0036e470169",
-        "name" : "CY6zPZc6AS",
-        "nameType" : "Organizational",
-        "orcId" : "kzNRPP0zOqXS6xasAqy",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/fdc9cd20-4008-47d5-80b2-0f1cc919549d",
+        "name" : "gC5tWNhqEyhZtwsl",
+        "nameType" : "Personal",
+        "orcId" : "4uTsZAfG78JPepCTvJi",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "szmVcIL6q4upQvrAg",
-          "value" : "6UdrvehqPuNx8Hz"
+          "sourceName" : "bXBFl3PzGHI29",
+          "value" : "fMob0seQBa"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Lv9MINqyMHA2e4",
-          "value" : "wmSigGefyYq4WiRaih"
+          "sourceName" : "kKFNdqzhlejZs",
+          "value" : "i5m7NHl5iLG0"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b2e7a561-ad31-4e17-a6b3-1ddf7cba4f7e"
+        "id" : "https://www.example.org/98dafe3f-7e32-4f20-ad77-2f184c334ace"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "4H4gCEe2zHMlwY"
+        "type" : "ProjectLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,155 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/887a41b5-3149-4c16-a9ce-00a36a67f8a4",
-        "name" : "50aGi5BPShxYo5VrYu",
+        "id" : "https://www.example.org/9e709129-aab4-4c7d-a1fe-5e014441dab5",
+        "name" : "6rLwkqj6fvaddTSOkM",
         "nameType" : "Personal",
-        "orcId" : "vK4FH8uHhpgjgr7f1",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "MEO1n6IIp0naBV1",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "eu1w3gS4preQ",
-          "value" : "Wv9s8d87ZVB6"
+          "sourceName" : "UbpcN6Mxg2ryCJ",
+          "value" : "HZzYXopTiBoNM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "NCedchbj8xsu0sdcUZw",
-          "value" : "DAYCYNUOR2Ezdzy"
+          "sourceName" : "IvQ4ghNLZXmVDbPnQ",
+          "value" : "bSsMov8COdcMr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/54bfb594-3de0-46c8-98d7-9343d2344a3e"
+        "id" : "https://www.example.org/fcc8f946-3d5c-4adb-b27f-c338f51a89ff"
       } ],
       "role" : {
-        "type" : "InterviewSubject"
+        "type" : "HostingInstitution"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "cbebTp1wJLTeo"
+      "nl" : "kbxy1Gwc4Zf"
     },
-    "npiSubjectHeading" : "rcsOT4rrRsA",
-    "tags" : [ "3HzIuxLMiabT" ],
-    "description" : "PT4xXGg3vHomG",
+    "npiSubjectHeading" : "kfUWKBEEy8aLZHFv9CY",
+    "tags" : [ "A605l7XPxg" ],
+    "description" : "cvENern6gTBx0CxdKee",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e76881d5-1bbd-41cc-a3e4-1687d684f5ef"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ea3e6f91-7b11-4754-b5f7-a2aa61b6da41"
         },
-        "seriesNumber" : "GdEV6RCiYimfr7G",
+        "seriesNumber" : "9idLKa6UrNu79dyGkC6",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/fa978276-163a-4bd0-ae76-fa50c114e910",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3730d7c5-f6bf-4fd7-802e-8b5a2c821660",
           "valid" : true
         },
-        "isbnList" : [ "9791786315532" ],
+        "isbnList" : [ "9780904281620" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "Wqv0LpIU8uDYxJjl"
+          "value" : "36zxUiEBQNkZxe"
         } ]
       },
-      "doi" : "https://www.example.org/fde4ef2b-5071-4722-b05c-4a48fb789e89",
+      "doi" : "https://www.example.org/959fa16c-76c6-44fc-a179-02f519bb1922",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "zuuBZEdh3xyLbkJ4iaw",
-            "end" : "HuxgBzvWuCxDd"
+            "begin" : "XNPQh00vlAiFu",
+            "end" : "uLzIflY4XRgY8f"
           },
-          "pages" : "DL3NOd0yaONqbC",
+          "pages" : "DyLaPjXGM6L44F30x",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/8adcee31-075a-42ac-95b3-4ab01f8c71bb",
-    "abstract" : "XabCRCWlw3lA"
+    "metadataSource" : "https://www.example.org/e05039bf-aabd-4b6f-857f-9dd3b7826bb1",
+    "abstract" : "Y01ZvKFboI8C3Nz"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/2df241b5-b758-4802-9e59-5289c9165db6",
-    "name" : "yKJEi36zr04",
+    "id" : "https://www.example.org/a6930082-566c-4f41-befd-87e6b6f4eed1",
+    "name" : "xWnSneNLJXiYQBq",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-01-16T02:17:06.651Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "0CYdPszwgN3nkb3"
+      "approvalDate" : "2003-08-16T12:04:08.877Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "TV16o6h89MIB1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/f26abe0b-0574-49c6-833f-ca708b5df534",
-    "identifier" : "a4ZOuuk72sSkXVIu",
+    "source" : "https://www.example.org/9b3c1b05-1cef-4d67-b0f9-e322c37618ed",
+    "identifier" : "bSQHxlyn8E6RpIJ",
     "labels" : {
-      "de" : "phj58gYg7ZMsm6Wx"
+      "fr" : "mwQ8MHnkHZuCu"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 451743327
+      "amount" : 590895441
     },
-    "activeFrom" : "1973-04-10T22:20:34.393Z",
-    "activeTo" : "1988-04-26T13:41:03.452Z"
+    "activeFrom" : "1997-12-31T01:26:55.115Z",
+    "activeTo" : "2001-07-12T20:02:26.187Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ba2d3ba8-dadb-4504-9f45-9a9e7b87ae79",
-    "id" : "https://www.example.org/8538082a-925a-4b64-bdfc-8d32aff494cf",
-    "identifier" : "iO50R0ctDJxLzGoVg6",
+    "source" : "https://www.example.org/53f4c042-f55f-441d-9556-8a9caeba03ac",
+    "id" : "https://www.example.org/c2137b43-ee87-4494-87a7-c95c2eb2d9bc",
+    "identifier" : "tQqDGmw2K78AiHx",
     "labels" : {
-      "af" : "1tZd8LihfpBWfVZiF7"
+      "es" : "2rwXNUut0h"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 646917712
+      "amount" : 1283701763
     },
-    "activeFrom" : "1975-10-27T16:39:21.399Z",
-    "activeTo" : "1976-11-19T21:45:34.772Z"
+    "activeFrom" : "1994-03-27T03:53:46.591Z",
+    "activeTo" : "2009-08-31T00:47:07.214Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/9d16d5a7-3038-4ded-b8dc-960d5dfed8fb" ],
+  "subjects" : [ "https://www.example.org/8dd7e72e-b118-464b-b01a-3d4fa6ab3660" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "a74dbbd8-ef5a-4061-9c4c-fb833fa5977a",
-    "name" : "gyvozZW3AJVRNLd",
-    "mimeType" : "uXfUMEt1SmF",
-    "size" : 15758472,
-    "license" : "https://www.example.com/7rkqyb7kfjnbe2bmi",
+    "identifier" : "d1f3a390-c426-4034-b5d7-14fb0804ccdb",
+    "name" : "vQnqWplRMRd",
+    "mimeType" : "PYE2AoXO23x",
+    "size" : 1186529808,
+    "license" : "https://www.example.com/k9a72eacpz",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "4TUHY6rvirBOXs1AIKm"
     },
-    "legalNote" : "nREAcWDwU9LN0",
-    "publishedDate" : "1977-10-20T23:24:58.891Z",
+    "legalNote" : "2EbdRDtImAqz",
+    "publishedDate" : "2011-11-28T00:20:40.950Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/FM2Av5WuPRnil",
-    "name" : "iINVkEUkYXccPjVi8",
-    "description" : "AU5GkhLCartWDL1Wk4p"
+    "id" : "https://www.example.com/36QwRzpb9CQRLOfb7k",
+    "name" : "IqwNRYWjoonnf",
+    "description" : "QvXi6hE2akPd"
   } ],
-  "rightsHolder" : "nFr6DyzYgTaiJvq",
-  "duplicateOf" : "https://www.example.org/479560ae-7c54-412e-81b4-efa7dcf03f83",
+  "rightsHolder" : "CdtRmkejLGrEzSq",
+  "duplicateOf" : "https://www.example.org/dc1adac8-faee-4b8c-953e-02c8c5d4cc6c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "X9vG6Hib4O0dM"
+    "note" : "JXcAXPyN0X"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "L2zW9D8KsMaHnZvHTj",
-    "createdBy" : "eYT7xh9w5T1j7ZCDGT",
-    "createdDate" : "2005-09-19T11:45:59.900Z"
+    "note" : "p9lxP5RzrAENHPlc1d",
+    "createdBy" : "EtJrRNav59zLjbyernu",
+    "createdDate" : "1972-01-27T07:07:10.386Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4fef86b9-3cf5-4caf-951d-ad29d0f93f75" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/5e6daa96-cd2b-4883-b1b4-ad7677c2330d" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ReportBasic.json
+++ b/documentation/ReportBasic.json
@@ -1,57 +1,57 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "dKDqBfEfskV2gYD8fc",
-    "ownerAffiliation" : "https://www.example.org/5cc6bb9b-e3f8-4bfb-8a84-242399c3e69e"
+    "owner" : "OOPMW5TCIz",
+    "ownerAffiliation" : "https://www.example.org/41169d9e-838a-46ba-b5b1-6f3a26b7d748"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/e8433a99-669c-41f1-bb00-12d4f5ce529f"
+    "id" : "https://www.example.org/24cdfcaf-3752-4a8f-a7f9-0526822c983f"
   },
-  "createdDate" : "1976-05-28T10:22:23.017Z",
-  "modifiedDate" : "1981-11-14T11:35:51.564Z",
-  "publishedDate" : "2009-01-09T21:25:47.674Z",
-  "indexedDate" : "1997-09-12T08:39:17.159Z",
-  "handle" : "https://www.example.org/647f7dcb-bd83-4eb7-9122-81b0e9ad3f82",
-  "doi" : "https://doi.org/10.1234/repellat",
-  "link" : "https://www.example.org/14c4a5bc-ba41-4759-adee-42f11afc652c",
+  "createdDate" : "2014-02-24T03:46:05.412Z",
+  "modifiedDate" : "1993-01-08T08:30:35.982Z",
+  "publishedDate" : "2020-05-13T07:58:44.667Z",
+  "indexedDate" : "1980-12-14T01:08:59.645Z",
+  "handle" : "https://www.example.org/0ce0de50-da45-4f71-a72d-66278fdbae4c",
+  "doi" : "https://doi.org/10.1234/officia",
+  "link" : "https://www.example.org/8ce7b11d-633b-48ee-ae43-c94311bc6faa",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "fmM3r3q0WPahJUE8H",
+    "mainTitle" : "nPxczfo9hekj6qFq4",
     "alternativeTitles" : {
-      "el" : "D8dLeSGe56GbFd6kTQ"
+      "se" : "WMs6PrJn2Rs1a"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BNNLp6yV96Vwz95U1r",
-      "month" : "8ulXryGZ05CBn",
-      "day" : "2e351PHOxW"
+      "year" : "sp5o02hyygM",
+      "month" : "sli5ecvSXJ28Qs9b1",
+      "day" : "ICzcRzBSGH14O"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fdc9cd20-4008-47d5-80b2-0f1cc919549d",
-        "name" : "gC5tWNhqEyhZtwsl",
+        "id" : "https://www.example.org/9b0069cb-2eb6-4c1c-aba1-6c5251f751bd",
+        "name" : "96U0o2qiia",
         "nameType" : "Personal",
-        "orcId" : "4uTsZAfG78JPepCTvJi",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "VlITqTjc8EXrOw33CSp",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bXBFl3PzGHI29",
-          "value" : "fMob0seQBa"
+          "sourceName" : "G7ZB2MDtzBXFwW",
+          "value" : "sGzsrVX15TfpvNj"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kKFNdqzhlejZs",
-          "value" : "i5m7NHl5iLG0"
+          "sourceName" : "JHYq1p06KMCUrLHIR",
+          "value" : "S6HaMun7Vw6t0tMMr"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/98dafe3f-7e32-4f20-ad77-2f184c334ace"
+        "id" : "https://www.example.org/7b97ce80-66b1-4b02-ac6b-ec79b2822579"
       } ],
       "role" : {
         "type" : "ProjectLeader"
@@ -62,157 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/9e709129-aab4-4c7d-a1fe-5e014441dab5",
-        "name" : "6rLwkqj6fvaddTSOkM",
-        "nameType" : "Personal",
-        "orcId" : "MEO1n6IIp0naBV1",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/13616d11-4c3c-454f-bfd5-dbf1f43344af",
+        "name" : "oE3qAejMhUEllKHQSZQ",
+        "nameType" : "Organizational",
+        "orcId" : "lJQb0RYqzVWBq75lP",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "UbpcN6Mxg2ryCJ",
-          "value" : "HZzYXopTiBoNM"
+          "sourceName" : "UYksTPoKl42pAA6N8YQ",
+          "value" : "PuDnwN5dhSrTI9VRXHB"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IvQ4ghNLZXmVDbPnQ",
-          "value" : "bSsMov8COdcMr"
+          "sourceName" : "ooxqipEtidi",
+          "value" : "rr7Y2dwkyYUX9f"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/fcc8f946-3d5c-4adb-b27f-c338f51a89ff"
+        "id" : "https://www.example.org/6300a5e7-9164-4d4e-a63a-0997efb41568"
       } ],
       "role" : {
-        "type" : "HostingInstitution"
+        "type" : "MuseumEducator"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "kbxy1Gwc4Zf"
+      "el" : "fD21o03vK1uKP52QlKu"
     },
-    "npiSubjectHeading" : "kfUWKBEEy8aLZHFv9CY",
-    "tags" : [ "A605l7XPxg" ],
-    "description" : "cvENern6gTBx0CxdKee",
+    "npiSubjectHeading" : "TYUYPmV0PDs96BdDa",
+    "tags" : [ "bYKVvoiQn0A1hp" ],
+    "description" : "5Fo11YJEW8lvZVqWM",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ea3e6f91-7b11-4754-b5f7-a2aa61b6da41"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a4dfbff2-e96f-47ff-89ab-048c9c3de78a"
         },
-        "seriesNumber" : "9idLKa6UrNu79dyGkC6",
+        "seriesNumber" : "VVT1GOFDp2nCKPkTy",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/3730d7c5-f6bf-4fd7-802e-8b5a2c821660",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/e4d01435-7ae3-4fef-b186-d8f70878d6c8",
           "valid" : true
         },
-        "isbnList" : [ "9780904281620" ],
+        "isbnList" : [ "9781958272886", "9780460133258" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "36zxUiEBQNkZxe"
+          "value" : "046013325X"
         } ]
       },
-      "doi" : "https://www.example.org/959fa16c-76c6-44fc-a179-02f519bb1922",
+      "doi" : "https://www.example.org/707723e7-51f8-4bd1-96f0-eed11dd143bf",
       "publicationInstance" : {
         "type" : "ReportBasic",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "XNPQh00vlAiFu",
-            "end" : "uLzIflY4XRgY8f"
+            "begin" : "ONfqmGqdC7ef1bzM",
+            "end" : "wPeDZ5pvmka"
           },
-          "pages" : "DyLaPjXGM6L44F30x",
-          "illustrated" : false
+          "pages" : "foWHf5JdX1yi",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/e05039bf-aabd-4b6f-857f-9dd3b7826bb1",
-    "abstract" : "Y01ZvKFboI8C3Nz"
+    "metadataSource" : "https://www.example.org/7165d757-713b-4c77-a554-2e95d60d6e67",
+    "abstract" : "NPiAxyJrAjxHoS9ETV"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a6930082-566c-4f41-befd-87e6b6f4eed1",
-    "name" : "xWnSneNLJXiYQBq",
+    "id" : "https://www.example.org/075399bc-1ffd-4ea2-86b5-381da35abbc3",
+    "name" : "fsHS8Y721YJ8POsOK3",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2003-08-16T12:04:08.877Z",
-      "approvedBy" : "NARA",
+      "approvalDate" : "1975-04-03T10:48:16.168Z",
+      "approvedBy" : "REK",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "TV16o6h89MIB1"
+      "applicationCode" : "IRY8hBrwgXux1APLmI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/9b3c1b05-1cef-4d67-b0f9-e322c37618ed",
-    "identifier" : "bSQHxlyn8E6RpIJ",
+    "source" : "https://www.example.org/41c742b4-bcb7-461e-b75d-94f9325fea25",
+    "identifier" : "8kPBwK6grOeCXxGNvK",
     "labels" : {
-      "fr" : "mwQ8MHnkHZuCu"
+      "es" : "Ms2WmuaSDTF"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 590895441
+      "currency" : "NOK",
+      "amount" : 1043416210
     },
-    "activeFrom" : "1997-12-31T01:26:55.115Z",
-    "activeTo" : "2001-07-12T20:02:26.187Z"
+    "activeFrom" : "1976-12-23T01:02:23.202Z",
+    "activeTo" : "1993-01-22T02:47:22.825Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/53f4c042-f55f-441d-9556-8a9caeba03ac",
-    "id" : "https://www.example.org/c2137b43-ee87-4494-87a7-c95c2eb2d9bc",
-    "identifier" : "tQqDGmw2K78AiHx",
+    "source" : "https://www.example.org/20a02b97-12b5-46ab-a1d9-83b9c1718ade",
+    "id" : "https://www.example.org/6dcd0d83-11e4-4175-b88b-50c71adb994a",
+    "identifier" : "Wb04o7Uj7aOSOw",
     "labels" : {
-      "es" : "2rwXNUut0h"
+      "af" : "18rHmNyU8Ak959aEk"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1283701763
+      "currency" : "NOK",
+      "amount" : 299893172
     },
-    "activeFrom" : "1994-03-27T03:53:46.591Z",
-    "activeTo" : "2009-08-31T00:47:07.214Z"
+    "activeFrom" : "1983-10-30T17:29:00.250Z",
+    "activeTo" : "2001-05-05T05:23:37.653Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8dd7e72e-b118-464b-b01a-3d4fa6ab3660" ],
+  "subjects" : [ "https://www.example.org/c2f82010-52e1-47f8-9d52-18e77a5fa8a0" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d1f3a390-c426-4034-b5d7-14fb0804ccdb",
-    "name" : "vQnqWplRMRd",
-    "mimeType" : "PYE2AoXO23x",
-    "size" : 1186529808,
-    "license" : "https://www.example.com/k9a72eacpz",
+    "identifier" : "136977d6-a4ab-4fa7-bba6-b20091642384",
+    "name" : "DcwWUSHFApv4x",
+    "mimeType" : "8Djou4VkWbZUSSx",
+    "size" : 2065164886,
+    "license" : "https://www.example.com/zf5tecyysrbs",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "4TUHY6rvirBOXs1AIKm"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "2EbdRDtImAqz",
-    "publishedDate" : "2011-11-28T00:20:40.950Z",
+    "legalNote" : "rjseDarb6cn",
+    "publishedDate" : "1983-03-17T23:01:57.769Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "SQVmby7yE0E",
+      "uploadedDate" : "1997-06-08T07:31:52.847Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/36QwRzpb9CQRLOfb7k",
-    "name" : "IqwNRYWjoonnf",
-    "description" : "QvXi6hE2akPd"
+    "id" : "https://www.example.com/ZZSFF4HNUN7bjzvzo",
+    "name" : "lq9hSupbZLiiFazw",
+    "description" : "It939FJxU5fX9Voi36"
   } ],
-  "rightsHolder" : "CdtRmkejLGrEzSq",
-  "duplicateOf" : "https://www.example.org/dc1adac8-faee-4b8c-953e-02c8c5d4cc6c",
+  "rightsHolder" : "sl3edLXgevSRfp",
+  "duplicateOf" : "https://www.example.org/a00d6fed-9345-45b1-afd0-ebe0c0337701",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "JXcAXPyN0X"
+    "note" : "WRcdak9OX7T"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "p9lxP5RzrAENHPlc1d",
-    "createdBy" : "EtJrRNav59zLjbyernu",
-    "createdDate" : "1972-01-27T07:07:10.386Z"
+    "note" : "3wrTKy24v4YRsGHNui",
+    "createdBy" : "VhS7Nz4KNc4EZ",
+    "createdDate" : "1997-12-13T11:25:59.489Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5e6daa96-cd2b-4883-b1b4-ad7677c2330d" ],
+  "curatingInstitutions" : [ "https://www.example.org/1d0a0464-dd36-4002-92d0-a207b0a108bd" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "U958bBVJsUnIzR",
-    "ownerAffiliation" : "https://www.example.org/c28a4000-6695-42ff-8841-0742cf7825b5"
+    "owner" : "NNDIep4EdQS7",
+    "ownerAffiliation" : "https://www.example.org/b480ed9b-27a5-4170-a3f6-97f85337afc3"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/b2f76723-fbb8-4a3d-9d3f-219a76a6b5bf"
+    "id" : "https://www.example.org/82982176-c2e3-40a9-851f-e67fefbb51d2"
   },
-  "createdDate" : "1993-07-04T01:45:18.506Z",
-  "modifiedDate" : "2019-02-23T12:58:19.770Z",
-  "publishedDate" : "1987-11-30T23:18:22.905Z",
-  "indexedDate" : "1985-07-09T12:18:21.774Z",
-  "handle" : "https://www.example.org/4fa559ef-80bd-4dcc-b7f0-f95660bf1a39",
-  "doi" : "https://doi.org/10.1234/sint",
-  "link" : "https://www.example.org/1611139a-7623-49d0-9a20-0013a21c3820",
+  "createdDate" : "1979-04-07T12:18:40.263Z",
+  "modifiedDate" : "2009-02-24T01:22:30.377Z",
+  "publishedDate" : "1998-01-11T13:49:54.545Z",
+  "indexedDate" : "1991-06-24T15:25:15.449Z",
+  "handle" : "https://www.example.org/8a03fffa-2e34-4c8f-8155-117b9d0e5324",
+  "doi" : "https://doi.org/10.1234/harum",
+  "link" : "https://www.example.org/cdcdf4ef-789a-4107-9f14-5f82ed7697ce",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bVsA433aR3m",
+    "mainTitle" : "EIzUBm6CIZs",
     "alternativeTitles" : {
-      "da" : "zFq3tgZDET"
+      "pt" : "C8MnpsdLIqILnZV3WZ"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "WHn2yCmRXRxtYMX",
-      "month" : "YprAfNaFUGcfH",
-      "day" : "XoAQS2Lfb9oJLJheKi"
+      "year" : "6plj4SFj81QxE5oEm",
+      "month" : "gWhzajMUsHXkSTfsvc",
+      "day" : "O32IKMc5yNCNzL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/6de7c467-ea5f-4c42-9f13-c75d1d99debe",
-        "name" : "Zb3ThUnhqk01",
-        "nameType" : "Organizational",
-        "orcId" : "wNIYZYf8Rve",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/2d6bd771-6a85-4c68-8a1f-c12a77491d4e",
+        "name" : "RplSjCqIXX",
+        "nameType" : "Personal",
+        "orcId" : "SwM18jYasZ8bkOUff",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yaw4BivPPot4OCs",
-          "value" : "2TFFBu3XLQV1VVMw7"
+          "sourceName" : "dvya8pdzD84HlCi",
+          "value" : "xNov7FRPkce1sp1dKN6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "osExrWmIMzZrzLac",
-          "value" : "DgfuhacemL3h"
+          "sourceName" : "T4weettiI38jgPo",
+          "value" : "q9HABprklALueb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6eb23ad3-fa3b-49c4-bd0c-36faf76d91ba"
+        "id" : "https://www.example.org/e9bc9d30-85c8-4d60-bc97-71385edafc10"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "ProgrammeLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,157 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/eb9d0a79-ebd5-4654-b743-e25806639261",
-        "name" : "h8LGL5oo4hZ5AAHg",
+        "id" : "https://www.example.org/8573edb4-adc9-4421-b343-79487a97602a",
+        "name" : "0YjRsyChoc891RixuDq",
         "nameType" : "Personal",
-        "orcId" : "awz4GTd4LU500AUUm",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "AX7gTfe37W3grbxow",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1onRc8axWx1tUqO",
-          "value" : "EOxMJNFmmbO"
+          "sourceName" : "4mtQh3VbUjc1KOiXgU",
+          "value" : "Imx95VEqA3cvCmYa"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Ad2UNJPvz4qcr3gABh",
-          "value" : "CswNs735ypb"
+          "sourceName" : "cnIy5Aj7xlg",
+          "value" : "nF6WZHdvEw7c1YEVT"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0981f5e8-529e-4017-8565-7b2e3dcc0061"
+        "id" : "https://www.example.org/acd0e9d0-e8ac-4b23-a95f-6da338990b1e"
       } ],
       "role" : {
-        "type" : "Consultant"
+        "type" : "ExhibitionDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "1H0lxLYG8tBto2kqbP"
+      "de" : "BOYvd5aejacTZuM"
     },
-    "npiSubjectHeading" : "aFXZ2DjQ3JI",
-    "tags" : [ "3KKSDVm9MF" ],
-    "description" : "CBoXl3R7VIoA",
+    "npiSubjectHeading" : "qYTDduE8swmEjNzqF",
+    "tags" : [ "nIXrPGiXIb7kQQtI0l" ],
+    "description" : "3hOtNaIVMlSYlV",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/927da57e-ebde-4209-8c96-c88f0efe4fbe"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/db65a572-ab4a-4c16-b722-f2839e5b16d8"
         },
-        "seriesNumber" : "mg7SYfs2m76mIza",
+        "seriesNumber" : "J7hRaB648os0KyPq",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/609d81c0-c8a1-4381-a981-b0a2c2afb417",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c29848dd-1151-441d-a89d-27d7ba361a34",
           "valid" : true
         },
-        "isbnList" : [ "9780736658041" ],
+        "isbnList" : [ "9780235779407" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "ShsXB48gYx"
+          "value" : "gWFXMxybGR36eK6tC"
         } ]
       },
-      "doi" : "https://www.example.org/ab714216-95be-410d-8ea7-be75018066ef",
+      "doi" : "https://www.example.org/abc7e2d3-0a20-43ac-a47d-3bf7af04489f",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "6RuqOE8AkVbyMUWPiW",
-            "end" : "EU4vjVLuy2n7p"
+            "begin" : "EvEiJrtJwG1s71M",
+            "end" : "s4F5bj3rfAK3iICUp"
           },
-          "pages" : "SQgpG3qrss",
-          "illustrated" : true
+          "pages" : "oW1oNByk27nTq",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9ac9991b-7ec2-4878-a8dc-19a1ae595987",
-    "abstract" : "nXX7hq8Rv4KWCN6"
+    "metadataSource" : "https://www.example.org/a7ffa4de-f6d4-41ab-b6bd-6ef8ce7395b7",
+    "abstract" : "znVD70z9bhLC"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/a36da863-6411-4cf3-b71f-b981bc334541",
-    "name" : "oLYY4Mz7LN",
+    "id" : "https://www.example.org/33e4e308-9386-486f-92d2-f993d28fe6b8",
+    "name" : "jzFNq2B1Xjf8RRn0l03",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1983-07-09T17:50:07.398Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "RrwmF0dkFCfLqr"
+      "approvalDate" : "2019-06-14T10:01:28.189Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "SfbNGdUqvCw7qRXw"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2d7b0f71-ee81-47e4-a063-96b10dcb9a3f",
-    "identifier" : "yp3umoZ2ymYdZoL",
+    "source" : "https://www.example.org/1143e0f4-4f20-4b5e-82d3-3e4e2fa286f7",
+    "identifier" : "AjphjaUR6ud9Bleh",
     "labels" : {
-      "cs" : "R4Esvdo9ZetLPq"
-    },
-    "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 2142678674
-    },
-    "activeFrom" : "1974-01-06T06:08:53.821Z",
-    "activeTo" : "2008-08-20T04:01:46.639Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/eb7cdf2d-4e4e-4bd3-8d7b-1f70053dfae5",
-    "id" : "https://www.example.org/b85d3ba6-b545-4d65-850c-89574f47a360",
-    "identifier" : "babZp8Hqb4aLu",
-    "labels" : {
-      "af" : "qLtKkCL1Ej4gO"
+      "nn" : "MZhyQ0Mhm9OXbg5"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 319397770
+      "amount" : 1497728618
     },
-    "activeFrom" : "1981-11-15T06:38:08.998Z",
-    "activeTo" : "2018-03-19T18:16:40.576Z"
+    "activeFrom" : "1991-11-21T21:18:45.338Z",
+    "activeTo" : "1999-03-03T06:00:42.477Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/90c84c1d-d13e-410a-b23b-5a26a35fc185",
+    "id" : "https://www.example.org/516e8eb2-2554-4a0c-bbfc-6895e33a91f1",
+    "identifier" : "Tg7hbhJWuLkX",
+    "labels" : {
+      "bg" : "ge8MZFxk0AahJ"
+    },
+    "fundingAmount" : {
+      "currency" : "GBP",
+      "amount" : 2019267653
+    },
+    "activeFrom" : "2007-05-04T16:54:32.100Z",
+    "activeTo" : "2017-09-18T09:42:42.986Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/530b9884-1635-4007-b4fd-181942f64c40" ],
+  "subjects" : [ "https://www.example.org/57f38ece-2d48-410b-9089-d36cc3e46a9a" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "9bcbb30f-d62f-410a-a5ee-463c361c897f",
-    "name" : "3XhGCFInd3a",
-    "mimeType" : "I8SLmhwG51LeU",
-    "size" : 1085330642,
-    "license" : "https://www.example.com/wmxbthm24yq69zes3mu",
+    "identifier" : "4d6fa806-4de8-4133-b051-bf48f96bd735",
+    "name" : "ySx6cYtvXGEY88S",
+    "mimeType" : "NI5TcYlhVGAkk8eP",
+    "size" : 825583305,
+    "license" : "https://www.example.com/c6br77xfabj8ktkxs4",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "1ChICCLnMna"
     },
-    "legalNote" : "TYJwyJryRdtVnIQBAOj",
-    "publishedDate" : "2002-11-25T07:57:18.350Z",
+    "legalNote" : "KdfyRmC5RRVw8H",
+    "publishedDate" : "2008-04-29T17:47:49.837Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3MVuS4RtagdNfg4Oui",
-    "name" : "qZV5cRnWARcZYlwD",
-    "description" : "bXY9LTsvRy2Yyd1B"
+    "id" : "https://www.example.com/uZ1m6MtfRp7vUbre3fP",
+    "name" : "YI55fCRNrq",
+    "description" : "bjwZ9RSsPd"
   } ],
-  "rightsHolder" : "SBwoAnJv4ycmlLoI",
-  "duplicateOf" : "https://www.example.org/d53e0a86-214a-4e9f-b521-dbddb9d3c0e8",
+  "rightsHolder" : "vj7ONKZeGWtz0bN",
+  "duplicateOf" : "https://www.example.org/8b442ea6-9f5b-4e6c-b305-4e2ac77c2848",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "lcFE2bFyFn93932Msy"
+    "note" : "xzCkb6oIVfBWv"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "CeELTHNtpEfSdaIoe",
-    "createdBy" : "ygWWbPjkxr",
-    "createdDate" : "1977-02-27T02:42:34.198Z"
+    "note" : "jR8BWu4ulc",
+    "createdBy" : "AbFwPtKtuxwrAVRGvsk",
+    "createdDate" : "1980-09-20T01:32:27.176Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/25c14dce-1d44-4636-a497-3a769e80b8d3" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/5a8356fa-51cb-4b5f-ab0b-3a296ff1e555" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ReportBookOfAbstract.json
+++ b/documentation/ReportBookOfAbstract.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "NNDIep4EdQS7",
-    "ownerAffiliation" : "https://www.example.org/b480ed9b-27a5-4170-a3f6-97f85337afc3"
+    "owner" : "HwHhvTCi4oF9aOps5Md",
+    "ownerAffiliation" : "https://www.example.org/1501d5f0-c216-4e7f-a6e3-65a975e0f08e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/82982176-c2e3-40a9-851f-e67fefbb51d2"
+    "id" : "https://www.example.org/578919c9-6c7d-43f9-a2be-a37b39f44bb3"
   },
-  "createdDate" : "1979-04-07T12:18:40.263Z",
-  "modifiedDate" : "2009-02-24T01:22:30.377Z",
-  "publishedDate" : "1998-01-11T13:49:54.545Z",
-  "indexedDate" : "1991-06-24T15:25:15.449Z",
-  "handle" : "https://www.example.org/8a03fffa-2e34-4c8f-8155-117b9d0e5324",
-  "doi" : "https://doi.org/10.1234/harum",
-  "link" : "https://www.example.org/cdcdf4ef-789a-4107-9f14-5f82ed7697ce",
+  "createdDate" : "2017-11-21T05:23:14.863Z",
+  "modifiedDate" : "2017-08-02T17:49:37.207Z",
+  "publishedDate" : "2000-02-20T07:37:26.519Z",
+  "indexedDate" : "1975-07-08T00:36:53.533Z",
+  "handle" : "https://www.example.org/c6d104b2-b9e0-42c6-b13e-387e1ba2fc08",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/86db75a4-8f2c-4136-bd52-4d6ad20655cf",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EIzUBm6CIZs",
+    "mainTitle" : "tfFPh7xl0K1WY",
     "alternativeTitles" : {
-      "pt" : "C8MnpsdLIqILnZV3WZ"
+      "en" : "MNDCN2xQyv7vTvz"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "6plj4SFj81QxE5oEm",
-      "month" : "gWhzajMUsHXkSTfsvc",
-      "day" : "O32IKMc5yNCNzL"
+      "year" : "8yaRh67J9Tu3Z6Ylf",
+      "month" : "uIM1tcSKuV",
+      "day" : "rNPhlSQWk5Ox0EwHRU"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/2d6bd771-6a85-4c68-8a1f-c12a77491d4e",
-        "name" : "RplSjCqIXX",
-        "nameType" : "Personal",
-        "orcId" : "SwM18jYasZ8bkOUff",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/12b6cbe4-9329-46b4-b73a-3ed312b44ce7",
+        "name" : "JfAcJQngn4YEE",
+        "nameType" : "Organizational",
+        "orcId" : "eFATpKm8V0BDR6aw",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "dvya8pdzD84HlCi",
-          "value" : "xNov7FRPkce1sp1dKN6"
+          "sourceName" : "919L4B42lQr",
+          "value" : "c2yCK1KKvV9ZcuLg6O"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "T4weettiI38jgPo",
-          "value" : "q9HABprklALueb"
+          "sourceName" : "b3TNY36S7h",
+          "value" : "Y1DcHpBBfwcYxzs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e9bc9d30-85c8-4d60-bc97-71385edafc10"
+        "id" : "https://www.example.org/85eef17b-2338-496d-8e15-aa7d94de0652"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Creator"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,157 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8573edb4-adc9-4421-b343-79487a97602a",
-        "name" : "0YjRsyChoc891RixuDq",
+        "id" : "https://www.example.org/3ad7de31-7ee9-43d9-ac3e-9a672ba307c4",
+        "name" : "CBtyXiNAI1ZqI1",
         "nameType" : "Personal",
-        "orcId" : "AX7gTfe37W3grbxow",
-        "verificationStatus" : "Verified",
+        "orcId" : "0o5bI8YFpb1ulA",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4mtQh3VbUjc1KOiXgU",
-          "value" : "Imx95VEqA3cvCmYa"
+          "sourceName" : "sASFRK8opmKEyJp",
+          "value" : "IRmfwFpyMZOL"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "cnIy5Aj7xlg",
-          "value" : "nF6WZHdvEw7c1YEVT"
+          "sourceName" : "fQKQiFYmbgsnU",
+          "value" : "ezWvO5Rcq4w"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/acd0e9d0-e8ac-4b23-a95f-6da338990b1e"
+        "id" : "https://www.example.org/5bf7cccc-c4ae-45a0-ab69-42f7cca78697"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "Consultant"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "de" : "BOYvd5aejacTZuM"
+      "nl" : "0wAHXV1V0oaq3"
     },
-    "npiSubjectHeading" : "qYTDduE8swmEjNzqF",
-    "tags" : [ "nIXrPGiXIb7kQQtI0l" ],
-    "description" : "3hOtNaIVMlSYlV",
+    "npiSubjectHeading" : "KUlnmgOtzOQYV",
+    "tags" : [ "MXScSpix1cn" ],
+    "description" : "lR8enJMN1SdUpWW8TRt",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/db65a572-ab4a-4c16-b722-f2839e5b16d8"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/ff69f1da-8386-4126-a358-432ba576cc99"
         },
-        "seriesNumber" : "J7hRaB648os0KyPq",
+        "seriesNumber" : "IkzXI1Z3xTgbxDZ4k",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/c29848dd-1151-441d-a89d-27d7ba361a34",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/83070433-388c-432c-a2fd-736159463d81",
           "valid" : true
         },
-        "isbnList" : [ "9780235779407" ],
+        "isbnList" : [ "9791950042370", "9780947432614" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "gWFXMxybGR36eK6tC"
+          "value" : "0947432612"
         } ]
       },
-      "doi" : "https://www.example.org/abc7e2d3-0a20-43ac-a47d-3bf7af04489f",
+      "doi" : "https://www.example.org/558a4d1a-45f2-47d9-822b-9a57390e202e",
       "publicationInstance" : {
         "type" : "ReportBookOfAbstract",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "EvEiJrtJwG1s71M",
-            "end" : "s4F5bj3rfAK3iICUp"
+            "begin" : "zisiveQpUlzZzFS2",
+            "end" : "nIF3OYEy1eRbJ7m"
           },
-          "pages" : "oW1oNByk27nTq",
+          "pages" : "FCyNCv48goTgAThj",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/a7ffa4de-f6d4-41ab-b6bd-6ef8ce7395b7",
-    "abstract" : "znVD70z9bhLC"
+    "metadataSource" : "https://www.example.org/cd853890-d7ca-400b-a4d6-ae5fb528ca1e",
+    "abstract" : "CJQIITEOdQxLWBzur2"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/33e4e308-9386-486f-92d2-f993d28fe6b8",
-    "name" : "jzFNq2B1Xjf8RRn0l03",
+    "id" : "https://www.example.org/a0215c4d-4cd4-4c9b-ae87-b925281d26d0",
+    "name" : "EhKU7zKdJJpk5",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2019-06-14T10:01:28.189Z",
+      "approvalDate" : "1983-05-14T05:27:33.517Z",
       "approvedBy" : "DIRHEALTH",
       "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "SfbNGdUqvCw7qRXw"
+      "applicationCode" : "tmFi4lUdhYg4v"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1143e0f4-4f20-4b5e-82d3-3e4e2fa286f7",
-    "identifier" : "AjphjaUR6ud9Bleh",
+    "source" : "https://www.example.org/8679b7d4-fd31-464d-a33d-9d0e253c9f2b",
+    "identifier" : "94m18PJ5ZKEd0TZfh",
     "labels" : {
-      "nn" : "MZhyQ0Mhm9OXbg5"
+      "sv" : "B3wGTxr6QKf"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1497728618
+      "amount" : 1988258700
     },
-    "activeFrom" : "1991-11-21T21:18:45.338Z",
-    "activeTo" : "1999-03-03T06:00:42.477Z"
+    "activeFrom" : "2002-01-27T07:28:53.408Z",
+    "activeTo" : "2013-01-27T12:46:59.183Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/90c84c1d-d13e-410a-b23b-5a26a35fc185",
-    "id" : "https://www.example.org/516e8eb2-2554-4a0c-bbfc-6895e33a91f1",
-    "identifier" : "Tg7hbhJWuLkX",
+    "source" : "https://www.example.org/736fc376-6329-42ae-9f0a-52002a10a2c0",
+    "id" : "https://www.example.org/6a348b17-143e-40d0-bc6e-ef414aa40217",
+    "identifier" : "l1mmtc4xiCO2C",
     "labels" : {
-      "bg" : "ge8MZFxk0AahJ"
+      "ru" : "hbJU6ctKl7vdAEs"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 2019267653
+      "currency" : "NOK",
+      "amount" : 941770821
     },
-    "activeFrom" : "2007-05-04T16:54:32.100Z",
-    "activeTo" : "2017-09-18T09:42:42.986Z"
+    "activeFrom" : "1991-09-10T09:26:51.955Z",
+    "activeTo" : "1993-10-27T03:01:48.852Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/57f38ece-2d48-410b-9089-d36cc3e46a9a" ],
+  "subjects" : [ "https://www.example.org/4cb1637c-adaf-4698-a161-f3fbfb59c137" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4d6fa806-4de8-4133-b051-bf48f96bd735",
-    "name" : "ySx6cYtvXGEY88S",
-    "mimeType" : "NI5TcYlhVGAkk8eP",
-    "size" : 825583305,
-    "license" : "https://www.example.com/c6br77xfabj8ktkxs4",
+    "identifier" : "bc0a5127-f54f-4fa1-9ba0-0a045bf6eef9",
+    "name" : "8tXAORfwyRD",
+    "mimeType" : "IaXDSuR1TSa",
+    "size" : 1706594227,
+    "license" : "https://www.example.com/5udpbxk6l9mry",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "OverriddenRightsRetentionStrategy",
-      "configuredType" : "Unknown",
-      "overriddenBy" : "1ChICCLnMna"
+      "type" : "FunderRightsRetentionStrategy",
+      "configuredType" : "Unknown"
     },
-    "legalNote" : "KdfyRmC5RRVw8H",
-    "publishedDate" : "2008-04-29T17:47:49.837Z",
+    "legalNote" : "sEiHfpUflvRr9K9q",
+    "publishedDate" : "1998-01-11T03:39:52.390Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "u7fJhnI9AnXhc",
+      "uploadedDate" : "1974-09-29T19:45:40.134Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/uZ1m6MtfRp7vUbre3fP",
-    "name" : "YI55fCRNrq",
-    "description" : "bjwZ9RSsPd"
+    "id" : "https://www.example.com/iHxaDHFdiymKs",
+    "name" : "japoqmkzqUoKDFS",
+    "description" : "y2ZfpozuPA"
   } ],
-  "rightsHolder" : "vj7ONKZeGWtz0bN",
-  "duplicateOf" : "https://www.example.org/8b442ea6-9f5b-4e6c-b305-4e2ac77c2848",
+  "rightsHolder" : "XU2G4RCG6tB7",
+  "duplicateOf" : "https://www.example.org/a2563769-85f8-4300-bec9-c1b2803b5c4d",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "xzCkb6oIVfBWv"
+    "note" : "f5ogA0itEAgb"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "jR8BWu4ulc",
-    "createdBy" : "AbFwPtKtuxwrAVRGvsk",
-    "createdDate" : "1980-09-20T01:32:27.176Z"
+    "note" : "MGXUIsPlaiFk2ObFwaE",
+    "createdBy" : "hRLs9ETuv3rN",
+    "createdDate" : "2003-01-31T06:20:32.946Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5a8356fa-51cb-4b5f-ab0b-3a296ff1e555" ],
+  "curatingInstitutions" : [ "https://www.example.org/5b15c80c-26f8-4fd9-be4b-d27623f8b715" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "DELETED",
   "resourceOwner" : {
-    "owner" : "PP1cV8i615UHJ4Ao",
-    "ownerAffiliation" : "https://www.example.org/98a4befb-73a7-4655-bbbe-b683bdc6cd17"
+    "owner" : "nqwTQfKz8W",
+    "ownerAffiliation" : "https://www.example.org/89d88819-12db-4fac-a224-8f468db15a95"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f340f3cf-9947-41ce-b484-c73ad91fc2ba"
+    "id" : "https://www.example.org/538012c0-afbe-4a27-995a-fd0e93eb21a2"
   },
-  "createdDate" : "1995-05-21T17:53:48.089Z",
-  "modifiedDate" : "1984-09-09T15:50:52.741Z",
-  "publishedDate" : "2017-03-25T03:37:24.923Z",
-  "indexedDate" : "1975-10-10T03:38:58.802Z",
-  "handle" : "https://www.example.org/d6360b72-7aad-4d65-b26e-fd42d342b712",
-  "doi" : "https://doi.org/10.1234/molestiae",
-  "link" : "https://www.example.org/79a9ed66-71da-42b9-b04d-2c89fc6e381c",
+  "createdDate" : "1994-12-31T17:48:56.707Z",
+  "modifiedDate" : "1996-03-24T16:51:19.570Z",
+  "publishedDate" : "2009-12-16T01:39:18.853Z",
+  "indexedDate" : "1983-11-30T19:43:49.976Z",
+  "handle" : "https://www.example.org/2f521e9d-146f-4f2d-a2a6-d9642a241dc6",
+  "doi" : "https://doi.org/10.1234/nihil",
+  "link" : "https://www.example.org/91dabc8d-d583-40e2-aeba-84998e7d69c9",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "CwqlwlENWqONhoqv9",
+    "mainTitle" : "VnKsY5Xp4CbKjfcMJqn",
     "alternativeTitles" : {
-      "se" : "olfucA22vVLiz"
+      "de" : "0vImvhuPtwn"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cZR19G1pxOWczD1Mup",
-      "month" : "4IGzOxqrVyHBh",
-      "day" : "XXdp6TJwQJup7"
+      "year" : "KOwTRS3kTPpxHXDc2sZ",
+      "month" : "gRXYOVWebddqUNm",
+      "day" : "QZsXMJStlJBNmpwUpPB"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c838a8fa-d24f-43c2-86f8-4fd56aced9e6",
-        "name" : "xhle0gGEarZsGDnbfIa",
+        "id" : "https://www.example.org/8a493cb3-3e20-400d-84a0-7524c1cd4535",
+        "name" : "MudwHRaHd9Je",
         "nameType" : "Personal",
-        "orcId" : "W4v6Xi6iuupG2798BdA",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "sho2JAXFhgx7yeZai5",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ImLALNPalQKNZtz",
-          "value" : "QkOsdxlN14ja2rgoOn"
+          "sourceName" : "A5Yxm5PL86LZ5X9Z6LL",
+          "value" : "fUsLpGhn5w4DSWfAuR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "hlmQJkF7GcFk3dD7",
-          "value" : "KRldKebxwhL5TV24zt"
+          "sourceName" : "1p4rQovPKGlJAEv",
+          "value" : "5XHjRabzHd0MCXBRuPR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e2afcb0c-1f5c-4dad-ab37-daec835b56d4"
+        "id" : "https://www.example.org/0378efcb-4d8b-42a3-b7bf-8769e1398c4c"
       } ],
       "role" : {
-        "type" : "Curator"
+        "type" : "CostumeDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/cd3f351a-85e6-485d-935f-330044ca796e",
-        "name" : "KxCGDb9Vc0M2",
-        "nameType" : "Organizational",
-        "orcId" : "LNCErVfY9nULtpTCwKM",
+        "id" : "https://www.example.org/a86c5f7c-9075-47d9-acf4-761866883b15",
+        "name" : "jRJeh5ghCSkm9HMFU0j",
+        "nameType" : "Personal",
+        "orcId" : "PF6ZjstDMU",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lW4ABxFYq4s9HcypL",
-          "value" : "Is8RT3DA8nvdgRova"
+          "sourceName" : "ezWvj5CNBMx8OjyvFcX",
+          "value" : "2j5gOdkPrw14spMY"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "3x5r3VgIZIFH7V49T",
-          "value" : "1AxiVfrdGY1rk57wS"
+          "sourceName" : "9dpEYoXI9lxit7I7",
+          "value" : "fSVNTlvCuzsX10s"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ec6e48fd-01cd-4aff-9f16-6d314be9665d"
+        "id" : "https://www.example.org/c1d858bf-e7b8-41e2-a4c3-ea21da120d07"
       } ],
       "role" : {
-        "type" : "ArchitecturalPlanner"
+        "type" : "Distributor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ru" : "I42fg15gPI94uGA0mE"
+      "nl" : "1wQFCJrW8TOVadQrs"
     },
-    "npiSubjectHeading" : "7hRXIpDBkBJ",
-    "tags" : [ "swaMEciq3P9K6TKe9x" ],
-    "description" : "AHPclrc5SBbkn",
+    "npiSubjectHeading" : "169zhNLp63v",
+    "tags" : [ "wNiLUEX8XIYcfClozHT" ],
+    "description" : "9OPZVNYgfD4jHz",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a7bfa836-7e25-4d02-a6f0-28240fcb845a"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a55bdf5f-3049-4a5d-b3d8-ac5f94197382"
         },
-        "seriesNumber" : "OR73kb8EsnVau1a",
+        "seriesNumber" : "VPjRvqI3s6fP",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0096e8b6-425a-497b-8430-dcaa08519294",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/58ed783a-e860-4e3f-830b-dbde2a175c06",
           "valid" : true
         },
-        "isbnList" : [ "9780880608725" ],
+        "isbnList" : [ "9780011661902" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "EbhDDUhulyGFOwM"
+          "value" : "zdiFpxOqah4DQBUwxp"
         } ]
       },
-      "doi" : "https://www.example.org/08739b0f-0e96-4599-ba5c-cd1c985ca39b",
+      "doi" : "https://www.example.org/fbe12c28-2d82-4029-a8fe-515e86942193",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "7Awb3ZAwGP88G",
-            "end" : "BoMiGCc0WQ"
+            "begin" : "vFRhncuYCBauuQw3U",
+            "end" : "Q8ZrWpfbDmAFw"
           },
-          "pages" : "OHL59d0dC7XPgt67Sf",
-          "illustrated" : false
+          "pages" : "pnM2mqdwoSofR5Vp",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/9983ac63-2b8b-4d59-b2b9-ad88e9e32c16",
-    "abstract" : "FnY4ystUIuI6"
+    "metadataSource" : "https://www.example.org/96aa7b7b-096e-4b8a-b1d3-2b4f0f061bc4",
+    "abstract" : "tDRYveE6SV2NzKqI"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/6d48ba4b-abed-498f-a08d-536db33a1286",
-    "name" : "56FAB5Pwp4",
+    "id" : "https://www.example.org/8788c73e-45ab-49e5-bf45-f4bcdc0e8caa",
+    "name" : "LDA6ydvlOMU9",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-06-14T02:06:28.734Z",
-      "approvedBy" : "REK",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "xUTHohaqX2mbCT2uCJ2"
+      "approvalDate" : "1976-11-02T07:44:21.561Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "GHvooCp0dOiJcIzprI"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/2756c5e4-3e5d-42b9-8b27-ab91fc28d101",
-    "identifier" : "1oUCSNbP7m7",
+    "source" : "https://www.example.org/d6b9be40-edee-41b2-996b-a20f2c793e71",
+    "identifier" : "Iwy047U6EkjE5ltC33",
     "labels" : {
-      "is" : "7hDEGpwHSdq5K"
+      "it" : "brNh0lNXOjbx"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1369348488
+      "amount" : 192689628
     },
-    "activeFrom" : "1975-12-17T14:39:17.237Z",
-    "activeTo" : "1977-05-20T05:07:34.361Z"
+    "activeFrom" : "1988-07-11T22:10:07.568Z",
+    "activeTo" : "1994-01-16T20:27:46.390Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0b796992-6652-498b-9c33-27865e69ce35",
-    "id" : "https://www.example.org/eaa404a1-9989-45cd-bcf5-a5d6dc7a4ab0",
-    "identifier" : "r1vBKkKK683YJGtkVsr",
+    "source" : "https://www.example.org/0cfac5b6-b91e-4d0b-b03f-6d96148b8d4e",
+    "id" : "https://www.example.org/191c491c-48f7-4718-9346-baac868825d4",
+    "identifier" : "YVI67HvWLJS4mBgrI",
     "labels" : {
-      "fi" : "hvb7TehPTLeEzYvuLV"
+      "da" : "uMLxPACwdxTlgGvTDvE"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 1043736256
+      "amount" : 1478988871
     },
-    "activeFrom" : "1976-10-27T08:56:10.939Z",
-    "activeTo" : "1998-07-12T00:54:18.306Z"
+    "activeFrom" : "1985-10-25T11:27:56.013Z",
+    "activeTo" : "2020-09-14T04:11:59.705Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6daea02c-c5fd-4811-97e6-fe2e155ea278" ],
+  "subjects" : [ "https://www.example.org/bf767e7e-244d-4cdb-a082-23cfc8b6c9b2" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4f227a52-1748-4a9b-88f3-de0f11acf038",
-    "name" : "eUjpjypm3XalwNW",
-    "mimeType" : "wfA8VbEPsYIu",
-    "size" : 1449420084,
-    "license" : "https://www.example.com/nabgl8l5cszeb8hlvfx",
+    "identifier" : "4afc2c18-6f69-4c29-9de5-3c612e3171b0",
+    "name" : "Qam5r8vAbI",
+    "mimeType" : "qB9nfN1Ys8wMrUG",
+    "size" : 426532497,
+    "license" : "https://www.example.com/qbmtukvsvg",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "0UjRnSl7PcIuyw",
-    "publishedDate" : "1988-06-04T23:55:03.131Z",
+    "legalNote" : "XJxf2XYkgoKBZ1Fs5A",
+    "publishedDate" : "1979-06-09T21:10:32.869Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Ah9mhv3YKbm",
-    "name" : "MJugEtKiw3ZtXmRHe",
-    "description" : "ACP66PhQBrrTL"
+    "id" : "https://www.example.com/Gl00HNDNF1ror70aGT",
+    "name" : "YQ7vJBJkA6Tz",
+    "description" : "DGO805qHad9"
   } ],
-  "rightsHolder" : "GiUuUcYzstP0U",
-  "duplicateOf" : "https://www.example.org/118877cf-e61b-4285-ab67-4ea17b1a7943",
+  "rightsHolder" : "37822zNzH1tUKC",
+  "duplicateOf" : "https://www.example.org/25bade38-c10c-4c67-8b3c-5cb3e2624aaa",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WcL8IH4tLBQd0"
+    "note" : "8dJs3HyPGCZoLb"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "23ebtpjPLV",
-    "createdBy" : "jcguKn13b7jkHzVn4l",
-    "createdDate" : "1981-11-27T19:09:52.451Z"
+    "note" : "TjMwwTEkOymnMA3QE",
+    "createdBy" : "rWNwC6Qix1Fvux",
+    "createdDate" : "1998-03-26T19:36:11.686Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/4daac9e2-0cbb-4719-91d5-9cdc9bada406" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/a492094a-a456-4cdb-aad4-409118776a79" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ReportPolicy.json
+++ b/documentation/ReportPolicy.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "nqwTQfKz8W",
-    "ownerAffiliation" : "https://www.example.org/89d88819-12db-4fac-a224-8f468db15a95"
+    "owner" : "wHOVsfq6vkCepJ",
+    "ownerAffiliation" : "https://www.example.org/e55dcaa8-f0a4-4535-b421-07f43b9401a6"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/538012c0-afbe-4a27-995a-fd0e93eb21a2"
+    "id" : "https://www.example.org/cef8b56b-c218-424b-9360-0181327962f0"
   },
-  "createdDate" : "1994-12-31T17:48:56.707Z",
-  "modifiedDate" : "1996-03-24T16:51:19.570Z",
-  "publishedDate" : "2009-12-16T01:39:18.853Z",
-  "indexedDate" : "1983-11-30T19:43:49.976Z",
-  "handle" : "https://www.example.org/2f521e9d-146f-4f2d-a2a6-d9642a241dc6",
-  "doi" : "https://doi.org/10.1234/nihil",
-  "link" : "https://www.example.org/91dabc8d-d583-40e2-aeba-84998e7d69c9",
+  "createdDate" : "1994-05-15T13:47:54.461Z",
+  "modifiedDate" : "1981-01-09T02:58:07.808Z",
+  "publishedDate" : "2002-09-14T16:05:20.621Z",
+  "indexedDate" : "1976-02-22T21:31:03.275Z",
+  "handle" : "https://www.example.org/85e707c4-3fd4-4a64-87a4-dc0b6b7dd7ae",
+  "doi" : "https://doi.org/10.1234/rem",
+  "link" : "https://www.example.org/66aa0177-98fa-470b-81a6-658cc3f250ef",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VnKsY5Xp4CbKjfcMJqn",
+    "mainTitle" : "GZ71mdpqTH1HaeIk",
     "alternativeTitles" : {
-      "de" : "0vImvhuPtwn"
+      "zh" : "NmhpbL8oATVKS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "KOwTRS3kTPpxHXDc2sZ",
-      "month" : "gRXYOVWebddqUNm",
-      "day" : "QZsXMJStlJBNmpwUpPB"
+      "year" : "RNYqzn6BaW0rXv",
+      "month" : "1U7cmPUUPJHH2JPq1",
+      "day" : "hfMmQVKceONX5IAMkt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8a493cb3-3e20-400d-84a0-7524c1cd4535",
-        "name" : "MudwHRaHd9Je",
+        "id" : "https://www.example.org/10f1bf56-6411-4e98-bf87-1811382b5d32",
+        "name" : "6Y9UzB1bpXLlBBYLt4",
         "nameType" : "Personal",
-        "orcId" : "sho2JAXFhgx7yeZai5",
-        "verificationStatus" : "Verified",
+        "orcId" : "Gu0MBfnTL3s",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "A5Yxm5PL86LZ5X9Z6LL",
-          "value" : "fUsLpGhn5w4DSWfAuR"
+          "sourceName" : "zMhDjBjrxf",
+          "value" : "wwNcNp8Ze8fvQnW"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "1p4rQovPKGlJAEv",
-          "value" : "5XHjRabzHd0MCXBRuPR"
+          "sourceName" : "LBzXZczTxBw",
+          "value" : "HXIQ1WX8FUMfVnVCx8"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/0378efcb-4d8b-42a3-b7bf-8769e1398c4c"
+        "id" : "https://www.example.org/f984f205-98ea-43b5-a6af-daa1f9deea91"
       } ],
       "role" : {
-        "type" : "CostumeDesigner"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a86c5f7c-9075-47d9-acf4-761866883b15",
-        "name" : "jRJeh5ghCSkm9HMFU0j",
+        "id" : "https://www.example.org/95778cb7-a2a2-4f0d-bbd5-cc2ca91274cf",
+        "name" : "jKbgWtsZvEtr",
         "nameType" : "Personal",
-        "orcId" : "PF6ZjstDMU",
-        "verificationStatus" : "Verified",
+        "orcId" : "624EwHfIkwxUaGjcW",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ezWvj5CNBMx8OjyvFcX",
-          "value" : "2j5gOdkPrw14spMY"
+          "sourceName" : "35YMfnvtyG",
+          "value" : "hatun8SXODZ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9dpEYoXI9lxit7I7",
-          "value" : "fSVNTlvCuzsX10s"
+          "sourceName" : "291OFgu1vMf0KA05OYt",
+          "value" : "JXQFEYZk16znUXo1Q"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c1d858bf-e7b8-41e2-a4c3-ea21da120d07"
+        "id" : "https://www.example.org/ccb71306-22f5-44cc-8ef0-6f91c2cdfc21"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "1wQFCJrW8TOVadQrs"
+      "es" : "6rR7vYQAyFEJ4B"
     },
-    "npiSubjectHeading" : "169zhNLp63v",
-    "tags" : [ "wNiLUEX8XIYcfClozHT" ],
-    "description" : "9OPZVNYgfD4jHz",
+    "npiSubjectHeading" : "iJDDoEhs0QA",
+    "tags" : [ "0CdRxZh7xSGEb4mp" ],
+    "description" : "5Jp4WrY5vPPrm",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/a55bdf5f-3049-4a5d-b3d8-ac5f94197382"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4faadb0a-4b91-434d-a6e6-618ea25350e7"
         },
-        "seriesNumber" : "VPjRvqI3s6fP",
+        "seriesNumber" : "2L8QnaRYOeaZU7fU",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/58ed783a-e860-4e3f-830b-dbde2a175c06",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b46365a5-3240-4041-83f0-e393fb4054e6",
           "valid" : true
         },
-        "isbnList" : [ "9780011661902" ],
+        "isbnList" : [ "9790718685323", "9781896473338" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "zdiFpxOqah4DQBUwxp"
+          "value" : "1896473334"
         } ]
       },
-      "doi" : "https://www.example.org/fbe12c28-2d82-4029-a8fe-515e86942193",
+      "doi" : "https://www.example.org/692f5b46-dff2-4a54-ba11-bbac9722fab2",
       "publicationInstance" : {
         "type" : "ReportPolicy",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "vFRhncuYCBauuQw3U",
-            "end" : "Q8ZrWpfbDmAFw"
+            "begin" : "teQJ1G3v5A1SfE2x5",
+            "end" : "dCZiavaiJMldgqLktjc"
           },
-          "pages" : "pnM2mqdwoSofR5Vp",
+          "pages" : "oaljBqxtaP8jHr4t",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/96aa7b7b-096e-4b8a-b1d3-2b4f0f061bc4",
-    "abstract" : "tDRYveE6SV2NzKqI"
+    "metadataSource" : "https://www.example.org/1e8c5738-3938-4589-b4fb-e67993e040cd",
+    "abstract" : "0ytq1NJtHP"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8788c73e-45ab-49e5-bf45-f4bcdc0e8caa",
-    "name" : "LDA6ydvlOMU9",
+    "id" : "https://www.example.org/69f0426e-c04c-4c81-a002-5847f29b0d18",
+    "name" : "h0Mq3HvKCs2d",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1976-11-02T07:44:21.561Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "GHvooCp0dOiJcIzprI"
+      "approvalDate" : "2002-03-04T15:32:33.254Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "klZO8tL0Mpj0LY8FdB"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/d6b9be40-edee-41b2-996b-a20f2c793e71",
-    "identifier" : "Iwy047U6EkjE5ltC33",
+    "source" : "https://www.example.org/8f706413-5060-4133-8545-053c9721cac0",
+    "identifier" : "un52uYlCWbp",
     "labels" : {
-      "it" : "brNh0lNXOjbx"
+      "sv" : "YMvwxMbZDhhBSWdbT"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 192689628
+      "amount" : 254183116
     },
-    "activeFrom" : "1988-07-11T22:10:07.568Z",
-    "activeTo" : "1994-01-16T20:27:46.390Z"
+    "activeFrom" : "1976-03-10T01:36:59.718Z",
+    "activeTo" : "2004-06-11T05:32:30.649Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/0cfac5b6-b91e-4d0b-b03f-6d96148b8d4e",
-    "id" : "https://www.example.org/191c491c-48f7-4718-9346-baac868825d4",
-    "identifier" : "YVI67HvWLJS4mBgrI",
+    "source" : "https://www.example.org/bfd9dfaa-4b4e-4c7c-835e-bc3133387ceb",
+    "id" : "https://www.example.org/cc488c97-dfbd-43b3-b018-69a6cecfe829",
+    "identifier" : "qWQ8w6u3RPxUpDk",
     "labels" : {
-      "da" : "uMLxPACwdxTlgGvTDvE"
+      "fi" : "8yDBmwURqI9"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 1478988871
+      "currency" : "EUR",
+      "amount" : 1551853150
     },
-    "activeFrom" : "1985-10-25T11:27:56.013Z",
-    "activeTo" : "2020-09-14T04:11:59.705Z"
+    "activeFrom" : "1975-03-22T16:16:48.656Z",
+    "activeTo" : "2010-08-12T07:28:17.384Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/bf767e7e-244d-4cdb-a082-23cfc8b6c9b2" ],
+  "subjects" : [ "https://www.example.org/a912c3ca-aee5-4cc7-a638-ec37bf837b9c" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4afc2c18-6f69-4c29-9de5-3c612e3171b0",
-    "name" : "Qam5r8vAbI",
-    "mimeType" : "qB9nfN1Ys8wMrUG",
-    "size" : 426532497,
-    "license" : "https://www.example.com/qbmtukvsvg",
+    "identifier" : "e8bda226-2632-4f51-b0e5-eff7f25d7645",
+    "name" : "oAk4GOBoIPpoeo",
+    "mimeType" : "cNAY8rSaOD0GDhRgV",
+    "size" : 898634056,
+    "license" : "https://www.example.com/gnmwiwsoxpxx7buqt",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "XJxf2XYkgoKBZ1Fs5A",
-    "publishedDate" : "1979-06-09T21:10:32.869Z",
+    "legalNote" : "v89n5DEjeDPf",
+    "publishedDate" : "1978-03-01T22:50:25.972Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "k0lTYFmyoOcdy",
+      "uploadedDate" : "1997-03-14T20:47:07.997Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/Gl00HNDNF1ror70aGT",
-    "name" : "YQ7vJBJkA6Tz",
-    "description" : "DGO805qHad9"
+    "id" : "https://www.example.com/stULPQOhC0GY",
+    "name" : "dO0o2KMPnjM0x",
+    "description" : "rvwUMfwPp3EOw06e"
   } ],
-  "rightsHolder" : "37822zNzH1tUKC",
-  "duplicateOf" : "https://www.example.org/25bade38-c10c-4c67-8b3c-5cb3e2624aaa",
+  "rightsHolder" : "kemTaG1HcpPtTLX",
+  "duplicateOf" : "https://www.example.org/407e077d-4dd2-4c70-9afd-776ec2b9ccad",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "8dJs3HyPGCZoLb"
+    "note" : "FFSLVAgUDsG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "TjMwwTEkOymnMA3QE",
-    "createdBy" : "rWNwC6Qix1Fvux",
-    "createdDate" : "1998-03-26T19:36:11.686Z"
+    "note" : "AeiVuTzOsi6",
+    "createdBy" : "rQGvZVKMOCwgjFof0y",
+    "createdDate" : "1980-08-23T05:36:58.289Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a492094a-a456-4cdb-aad4-409118776a79" ],
+  "curatingInstitutions" : [ "https://www.example.org/0f52832c-a73f-4b18-a96b-5de1b55c2239" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "UNPUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "Ikg8Zi0awb",
-    "ownerAffiliation" : "https://www.example.org/94340292-3018-411e-ac97-97bf13bf8ab3"
+    "owner" : "J4xRb9xvxjra9xV3",
+    "ownerAffiliation" : "https://www.example.org/ebf8da5b-3302-4bf2-b1ca-a4cfd28a4893"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/d3689053-b446-4224-9927-b627da59c883"
+    "id" : "https://www.example.org/88906e4e-26f4-492e-b7f5-ba8e638749a2"
   },
-  "createdDate" : "2012-05-17T21:22:50.024Z",
-  "modifiedDate" : "1984-08-29T17:18:01.640Z",
-  "publishedDate" : "2023-04-01T18:00:01.956Z",
-  "indexedDate" : "1975-09-14T09:02:51.143Z",
-  "handle" : "https://www.example.org/19c1d91c-b4b9-436b-a658-6712850b7782",
-  "doi" : "https://doi.org/10.1234/porro",
-  "link" : "https://www.example.org/4433e584-3cd2-4a3d-a667-84c4b80a9b71",
+  "createdDate" : "1985-11-06T06:42:12.662Z",
+  "modifiedDate" : "2010-06-24T10:07:58.133Z",
+  "publishedDate" : "2018-04-28T06:49:33.916Z",
+  "indexedDate" : "2018-03-02T12:10:46.908Z",
+  "handle" : "https://www.example.org/1bfc29d6-b110-47b5-a7fd-91e56f6dac4c",
+  "doi" : "https://doi.org/10.1234/quam",
+  "link" : "https://www.example.org/207f1803-50d9-41ae-a99a-df68ba97a653",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "1AYo2E1aSfAR2zt",
+    "mainTitle" : "OpncCMmtnP9YgVW",
     "alternativeTitles" : {
-      "ca" : "FMf86zqASt6ZpLw6O6"
+      "ca" : "1PvEmT9knp"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "xIBdYpFYvs5t5KIQuP",
-      "month" : "bobDrCbqMpKZz",
-      "day" : "4mo2SnUU3wBKsq5hJ6Z"
+      "year" : "GPXmzCKvm9T6",
+      "month" : "jh8jGRMiq53qqK",
+      "day" : "1oE0A3uqJV4ZO2TAVa"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/67cbe9e6-7175-4d94-94a7-0862c79b77d6",
-        "name" : "vSVge0dM9lHnRrGdmyP",
+        "id" : "https://www.example.org/c0454307-5edc-4962-9117-bedcb1318d10",
+        "name" : "I9FkHmrhXgEJSEM6",
         "nameType" : "Personal",
-        "orcId" : "jIH8TNgS5Uv",
-        "verificationStatus" : "Verified",
+        "orcId" : "49aljJbK3Ltf",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "VOEaZIt4CCh3",
-          "value" : "WhvURHTgjpa2DJKIc"
+          "sourceName" : "tzeyW7PCD7hebk5r",
+          "value" : "NgZDXy98j3LUQyj1"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "n2ynt75pHLESDdGa7Oa",
-          "value" : "QmZZNvzaawnwN4bL"
+          "sourceName" : "5GPjfWgtqSl4nUgBWm",
+          "value" : "yaKhMQ2vUE9gOkY1mZ"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/2d17d1c2-537a-492d-850c-7d1927990902"
+        "id" : "https://www.example.org/a8d145eb-4ea4-48e4-999c-9c7721e2c14b"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f9618d45-68d6-437b-b0ec-573d44527732",
-        "name" : "t3fgO1Lo7zbPts",
-        "nameType" : "Personal",
-        "orcId" : "nkJNvO7UsESh",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/f381bec1-0283-4131-97ff-b83297fb1933",
+        "name" : "m0eD4xAG8Dhm",
+        "nameType" : "Organizational",
+        "orcId" : "oMsti5mKAmY0",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "lorvuNCXo0",
-          "value" : "Vfp6SUh2bB7H"
+          "sourceName" : "rYfZnNc3fQOA5z6mP",
+          "value" : "KH7MJpoo3tMK2n"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "36lMKYZs6El",
-          "value" : "8P49v0M4sUx0Sf4G4"
+          "sourceName" : "9Ra8t9YDnUK",
+          "value" : "gGBbfAr6EoaBsX45"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/55982602-4a0d-4991-bb45-3e18de7c7799"
+        "id" : "https://www.example.org/089f1f00-0806-4cef-a93f-f4f8b841a313"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "ProjectManager"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "Wqln72WO3BL"
+      "se" : "3ZtoBYO9Ih54"
     },
-    "npiSubjectHeading" : "WcDA1X1rOQZ0",
-    "tags" : [ "0BYa5vccX4N" ],
-    "description" : "IvxjArsmPA",
+    "npiSubjectHeading" : "Mz3V3RGJIlMgxMgYWRv",
+    "tags" : [ "XbAzIhzMGfKuCx" ],
+    "description" : "taLQfgoZJp",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cd83a628-d998-4cb4-abae-34e2ddf464e6"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d74faf55-ea6f-4002-99bd-a8d5204d82dd"
         },
-        "seriesNumber" : "gzpZR5WTZl1wBCr",
+        "seriesNumber" : "UQipdqL1ix4QbTh5",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/faa4107e-dc5e-4078-b7e5-fbb187142ee4",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/54d18e3f-c28b-4bfd-b791-171fd79481f0",
           "valid" : true
         },
-        "isbnList" : [ "9781044532535" ],
+        "isbnList" : [ "9781794101241" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "cmCcWQCQ9DZZY3Lxvgp"
+          "value" : "deIcPxGzZVe7AOx"
         } ]
       },
-      "doi" : "https://www.example.org/88901845-f371-4b9a-983e-de8cd6198052",
+      "doi" : "https://www.example.org/3ce85821-cde2-41cf-b02b-e9856922160c",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "diwPXQ81Eb",
-            "end" : "hEd0DQMRTk0"
+            "begin" : "Y0mQwiyBMHeSQSVAXR",
+            "end" : "3bgxyf17cZaN3Gwc6j"
           },
-          "pages" : "suHctCWSt0G",
-          "illustrated" : true
+          "pages" : "hxRbMTxJW9Pq",
+          "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/b32a3b7c-5791-491a-a3ba-4a1bda555a52",
-    "abstract" : "UmyjmE2ieNlVLa"
+    "metadataSource" : "https://www.example.org/df5eb867-aba6-4595-9422-ab21b210fe55",
+    "abstract" : "E7heg0fYfqWvt3"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d6761650-32f0-4dcb-b85b-aee89766c928",
-    "name" : "0y0Ba3OdpmLiKmU",
+    "id" : "https://www.example.org/4ff32a9c-2bd9-4013-acd5-4a9a22cf2eb0",
+    "name" : "3cu5Vj4fxt",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-03-30T19:20:20.862Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "tHN8WwASuDh"
+      "approvalDate" : "1984-03-07T20:32:47.336Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "DECLINED",
+      "applicationCode" : "Gqh5KgQNq0Ln6MK5n"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/189f40f5-5d65-40df-9c50-7561303da2e6",
-    "identifier" : "supMI0gj2NHe9NOyn",
+    "source" : "https://www.example.org/5175ee5c-191d-4e1d-bd41-f4f8505a845b",
+    "identifier" : "937b5qQVMVMe",
     "labels" : {
-      "ca" : "TnppRwJNNKNKkbCoymS"
+      "cs" : "vFKnR9GNk9Um"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 917685877
+      "amount" : 1735924720
     },
-    "activeFrom" : "2013-01-24T03:06:01.977Z",
-    "activeTo" : "2015-09-02T00:45:48.025Z"
+    "activeFrom" : "1997-01-05T21:18:04.630Z",
+    "activeTo" : "2020-11-05T01:00:22.599Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ff8e929a-0140-4a9a-a8dc-62bef42f8d73",
-    "id" : "https://www.example.org/32943373-d84e-4ea3-b9b7-2517bc5ed167",
-    "identifier" : "KYoOsxDbxW8bisg0Ma0",
+    "source" : "https://www.example.org/d16a9b70-ee29-4076-b015-6783164ef416",
+    "id" : "https://www.example.org/482e4c7a-ec36-4602-850e-9653e2b62a03",
+    "identifier" : "1LsUv5fBiusLYYH74DH",
     "labels" : {
-      "el" : "yvOUIerLcR"
+      "af" : "o9OEXRStI0ohEch"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1824798539
+      "currency" : "USD",
+      "amount" : 664037321
     },
-    "activeFrom" : "1986-03-11T13:50:53.606Z",
-    "activeTo" : "2019-03-02T20:51:21.877Z"
+    "activeFrom" : "2002-08-22T16:56:10.137Z",
+    "activeTo" : "2016-12-27T20:01:38.488Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/3317af09-d6bc-4903-a4a7-998f6725dece" ],
+  "subjects" : [ "https://www.example.org/49987580-2592-4926-ab99-aee12c4645c1" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "d711c5f1-67f8-486c-81b7-8f2ecf90a6f7",
-    "name" : "fvUpicpeGUg",
-    "mimeType" : "66SqWW1K5A5d0HAV",
-    "size" : 960831080,
-    "license" : "https://www.example.com/9faihmrzjrx",
+    "identifier" : "5dc00b29-aed1-4324-a80e-d5e2e71fe8ed",
+    "name" : "IkusBpmqNWMcfnpTY",
+    "mimeType" : "QU3quVdmebjYES82",
+    "size" : 321017888,
+    "license" : "https://www.example.com/kqqilbvnkl2fimp",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "Izwwd4P2O7x9uD6m",
-    "publishedDate" : "2002-08-03T17:11:02.011Z",
+    "legalNote" : "P48p9se5XH7lmuM30v",
+    "publishedDate" : "1999-02-04T18:56:23.291Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/aLpNhHcXmFdbHO1JGv",
-    "name" : "aM2xbVJRhQ9lB6l",
-    "description" : "sCkaJidKXzes9QcNHAh"
+    "id" : "https://www.example.com/N9l6Tw6vb2",
+    "name" : "MLPQfja4ISs6P",
+    "description" : "bdhRosbYXJZLh2P0zaH"
   } ],
-  "rightsHolder" : "I0eq9hyzQapKqJG",
-  "duplicateOf" : "https://www.example.org/4d83a94d-46d5-4905-ae4b-6d6dd00bc1b1",
+  "rightsHolder" : "4m1TUeJ1uAVZuU2",
+  "duplicateOf" : "https://www.example.org/5c62af33-0cf4-4c65-93ca-0df02deeed45",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "BbAP892qh7EslxRRX"
+    "note" : "sArDNU9l7lJ"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "p0cFWLQMF9WTG",
-    "createdBy" : "jP5QjDSLzmG",
-    "createdDate" : "2009-03-07T22:22:14.056Z"
+    "note" : "dmtyizxqqDwOx",
+    "createdBy" : "HFr7DsH9AOMqG",
+    "createdDate" : "2016-01-01T17:14:44.148Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/c1b845af-76f3-4770-af93-2b0a01d754d0" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/35f66ffa-3db0-451c-9037-5d98a6d0e282" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/ReportResearch.json
+++ b/documentation/ReportResearch.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "PUBLISHED",
   "resourceOwner" : {
-    "owner" : "J4xRb9xvxjra9xV3",
-    "ownerAffiliation" : "https://www.example.org/ebf8da5b-3302-4bf2-b1ca-a4cfd28a4893"
+    "owner" : "Bb66SpHXD916NR",
+    "ownerAffiliation" : "https://www.example.org/1b65dce1-539e-4174-a4de-021119574414"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/88906e4e-26f4-492e-b7f5-ba8e638749a2"
+    "id" : "https://www.example.org/db16bba5-538d-4b2d-8f56-3fa9caa3cc79"
   },
-  "createdDate" : "1985-11-06T06:42:12.662Z",
-  "modifiedDate" : "2010-06-24T10:07:58.133Z",
-  "publishedDate" : "2018-04-28T06:49:33.916Z",
-  "indexedDate" : "2018-03-02T12:10:46.908Z",
-  "handle" : "https://www.example.org/1bfc29d6-b110-47b5-a7fd-91e56f6dac4c",
-  "doi" : "https://doi.org/10.1234/quam",
-  "link" : "https://www.example.org/207f1803-50d9-41ae-a99a-df68ba97a653",
+  "createdDate" : "2009-04-23T17:42:39.982Z",
+  "modifiedDate" : "1989-10-10T06:18:49.321Z",
+  "publishedDate" : "1971-02-01T06:57:45.309Z",
+  "indexedDate" : "2019-06-10T19:30:10.674Z",
+  "handle" : "https://www.example.org/4739d4bb-9b73-40bb-97bf-764b03a0836c",
+  "doi" : "https://doi.org/10.1234/sint",
+  "link" : "https://www.example.org/d7b48976-65ce-468a-9c32-3b8ae9de8783",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "OpncCMmtnP9YgVW",
+    "mainTitle" : "QDjxqorGPxHpVHh",
     "alternativeTitles" : {
-      "ca" : "1PvEmT9knp"
+      "es" : "pgle3X6fOUDoUIS"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "GPXmzCKvm9T6",
-      "month" : "jh8jGRMiq53qqK",
-      "day" : "1oE0A3uqJV4ZO2TAVa"
+      "year" : "jCIImrSfRUp",
+      "month" : "XkCqnK3xkiAad",
+      "day" : "6MhPyQ1VVXOUM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c0454307-5edc-4962-9117-bedcb1318d10",
-        "name" : "I9FkHmrhXgEJSEM6",
+        "id" : "https://www.example.org/5f37a2bd-aca1-4f77-b5fa-762f49bab5d7",
+        "name" : "Frap9S8OYn7mB7K7",
         "nameType" : "Personal",
-        "orcId" : "49aljJbK3Ltf",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "dBl1KQw96rYY",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "tzeyW7PCD7hebk5r",
-          "value" : "NgZDXy98j3LUQyj1"
+          "sourceName" : "hCPDXLgm3th6EOGfmo",
+          "value" : "VOgQMSf17inkUDfiDb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5GPjfWgtqSl4nUgBWm",
-          "value" : "yaKhMQ2vUE9gOkY1mZ"
+          "sourceName" : "mpfGgDnPgcVoLVbIepI",
+          "value" : "i0B6SOfVNFA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a8d145eb-4ea4-48e4-999c-9c7721e2c14b"
+        "id" : "https://www.example.org/773b5bca-f856-4fe6-a465-817ca5a1a501"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "DataCollector"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f381bec1-0283-4131-97ff-b83297fb1933",
-        "name" : "m0eD4xAG8Dhm",
+        "id" : "https://www.example.org/e64eb157-36a9-49c2-b030-efb9dbbb427b",
+        "name" : "PjJ9kFPxeLF9",
         "nameType" : "Organizational",
-        "orcId" : "oMsti5mKAmY0",
+        "orcId" : "O5NwgtBZLjF",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "rYfZnNc3fQOA5z6mP",
-          "value" : "KH7MJpoo3tMK2n"
+          "sourceName" : "j1U9Ony9lQNEDR",
+          "value" : "Uy3dRho0Zaeg"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "9Ra8t9YDnUK",
-          "value" : "gGBbfAr6EoaBsX45"
+          "sourceName" : "H134Ykk1N2Ho8fqT",
+          "value" : "SRvbSMlUiLFLZTveSS"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/089f1f00-0806-4cef-a93f-f4f8b841a313"
+        "id" : "https://www.example.org/d24dc99e-6b49-4cfe-9d93-040857bd91e1"
       } ],
       "role" : {
-        "type" : "ProjectManager"
+        "type" : "ArchitecturalPlanner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "se" : "3ZtoBYO9Ih54"
+      "de" : "zkME2615Iv"
     },
-    "npiSubjectHeading" : "Mz3V3RGJIlMgxMgYWRv",
-    "tags" : [ "XbAzIhzMGfKuCx" ],
-    "description" : "taLQfgoZJp",
+    "npiSubjectHeading" : "1sJilB4BRfGTn17BK",
+    "tags" : [ "rgURLfxbUsJf" ],
+    "description" : "jyTVT5gfYL",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/d74faf55-ea6f-4002-99bd-a8d5204d82dd"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/52d4304f-6c67-402f-b33d-e655f94f08f6"
         },
-        "seriesNumber" : "UQipdqL1ix4QbTh5",
+        "seriesNumber" : "qZ9wFDOOON",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/54d18e3f-c28b-4bfd-b791-171fd79481f0",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9ff0ec1b-a529-466b-acc9-9557964d7d46",
           "valid" : true
         },
-        "isbnList" : [ "9781794101241" ],
+        "isbnList" : [ "9790927326826", "9780999546383" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "deIcPxGzZVe7AOx"
+          "value" : "0999546384"
         } ]
       },
-      "doi" : "https://www.example.org/3ce85821-cde2-41cf-b02b-e9856922160c",
+      "doi" : "https://www.example.org/7da9d2d3-6b52-4c2d-a746-744b0bec164b",
       "publicationInstance" : {
         "type" : "ReportResearch",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "Y0mQwiyBMHeSQSVAXR",
-            "end" : "3bgxyf17cZaN3Gwc6j"
+            "begin" : "uBtkckP5Nge3m2",
+            "end" : "6nfiEKSooJ1"
           },
-          "pages" : "hxRbMTxJW9Pq",
+          "pages" : "K3a6tCyttEB",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/df5eb867-aba6-4595-9422-ab21b210fe55",
-    "abstract" : "E7heg0fYfqWvt3"
+    "metadataSource" : "https://www.example.org/7728c106-4cc0-4cee-aa71-9464d7e3f023",
+    "abstract" : "R8OeuxXyvTtE8uP2Y"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/4ff32a9c-2bd9-4013-acd5-4a9a22cf2eb0",
-    "name" : "3cu5Vj4fxt",
+    "id" : "https://www.example.org/bb49cd52-ef56-4996-8d26-3c1b28598125",
+    "name" : "yfFy4gcf1UoLn3j",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1984-03-07T20:32:47.336Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "Gqh5KgQNq0Ln6MK5n"
+      "approvalDate" : "2012-05-03T06:14:29.447Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "tXzLVJdK66ECV"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5175ee5c-191d-4e1d-bd41-f4f8505a845b",
-    "identifier" : "937b5qQVMVMe",
+    "source" : "https://www.example.org/d85036bc-76b6-4b7b-a478-9f2cca97e292",
+    "identifier" : "nraT0zbYsfoo5O0",
     "labels" : {
-      "cs" : "vFKnR9GNk9Um"
+      "hu" : "fnHWPLcLQkejJ"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1735924720
+      "amount" : 326323993
     },
-    "activeFrom" : "1997-01-05T21:18:04.630Z",
-    "activeTo" : "2020-11-05T01:00:22.599Z"
+    "activeFrom" : "1979-11-25T12:26:20.978Z",
+    "activeTo" : "2000-10-09T07:35:00.076Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/d16a9b70-ee29-4076-b015-6783164ef416",
-    "id" : "https://www.example.org/482e4c7a-ec36-4602-850e-9653e2b62a03",
-    "identifier" : "1LsUv5fBiusLYYH74DH",
+    "source" : "https://www.example.org/ceb59d1d-8f05-4a18-a48c-f221526cd0ff",
+    "id" : "https://www.example.org/c39dabeb-3bdb-48d9-8ea5-968a22caf0ec",
+    "identifier" : "otOYyhNFgHSG",
     "labels" : {
-      "af" : "o9OEXRStI0ohEch"
+      "hu" : "eXnzyuIL1GMse5"
     },
     "fundingAmount" : {
       "currency" : "USD",
-      "amount" : 664037321
+      "amount" : 565143650
     },
-    "activeFrom" : "2002-08-22T16:56:10.137Z",
-    "activeTo" : "2016-12-27T20:01:38.488Z"
+    "activeFrom" : "1984-12-02T19:34:41.857Z",
+    "activeTo" : "2015-06-16T13:29:58.960Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/49987580-2592-4926-ab99-aee12c4645c1" ],
+  "subjects" : [ "https://www.example.org/5d0116d0-15e5-437a-8d15-1357565e5fea" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5dc00b29-aed1-4324-a80e-d5e2e71fe8ed",
-    "name" : "IkusBpmqNWMcfnpTY",
-    "mimeType" : "QU3quVdmebjYES82",
-    "size" : 321017888,
-    "license" : "https://www.example.com/kqqilbvnkl2fimp",
+    "identifier" : "1d303c01-15cc-4beb-88fe-ecc218bd4f28",
+    "name" : "KhfTRkScjDUwa",
+    "mimeType" : "zs1XD5SLNr8",
+    "size" : 630456114,
+    "license" : "https://www.example.com/48m8vo3tvh",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "P48p9se5XH7lmuM30v",
-    "publishedDate" : "1999-02-04T18:56:23.291Z",
+    "legalNote" : "iDQaKaIPdVK",
+    "publishedDate" : "2008-04-05T04:17:52.280Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "mDHliEZ96zKW",
+      "uploadedDate" : "1995-09-16T19:48:36.409Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/N9l6Tw6vb2",
-    "name" : "MLPQfja4ISs6P",
-    "description" : "bdhRosbYXJZLh2P0zaH"
+    "id" : "https://www.example.com/U8LES4hBPpXAF0J2",
+    "name" : "eluw3QQc4xLFg",
+    "description" : "mHBB3liZk6oG5V84tw"
   } ],
-  "rightsHolder" : "4m1TUeJ1uAVZuU2",
-  "duplicateOf" : "https://www.example.org/5c62af33-0cf4-4c65-93ca-0df02deeed45",
+  "rightsHolder" : "csoEDPbPtu",
+  "duplicateOf" : "https://www.example.org/3c20c460-2350-472e-97ec-299767ffd322",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "sArDNU9l7lJ"
+    "note" : "Mg5Q2DxyvWzJ4hLmOu"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "dmtyizxqqDwOx",
-    "createdBy" : "HFr7DsH9AOMqG",
-    "createdDate" : "2016-01-01T17:14:44.148Z"
+    "note" : "ZBQ1tGogezXyIO5",
+    "createdBy" : "txgvclxknj",
+    "createdDate" : "1984-10-01T06:41:50.637Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/35f66ffa-3db0-451c-9037-5d98a6d0e282" ],
+  "curatingInstitutions" : [ "https://www.example.org/e8c258cd-68b3-4930-b1f6-998afe4fb35b" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -3,58 +3,58 @@
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
   "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "OpXxTJ5YgSVY",
-    "ownerAffiliation" : "https://www.example.org/12a871af-51ae-4966-98f0-e37a397b2e92"
+    "owner" : "MEPPxlaXO6KQJabQ6",
+    "ownerAffiliation" : "https://www.example.org/85ea074a-7164-47a2-aa72-c5356acd2d89"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/60763ec6-77ca-45e2-b5af-bbc1f0a4e52d"
+    "id" : "https://www.example.org/e7f613e4-fefe-45dd-8db8-d1b7ec4f4e25"
   },
-  "createdDate" : "1978-03-27T07:40:28.913Z",
-  "modifiedDate" : "1976-05-23T20:41:33.473Z",
-  "publishedDate" : "1983-03-04T11:40:14.084Z",
-  "indexedDate" : "2023-02-14T13:58:48.089Z",
-  "handle" : "https://www.example.org/8902a5d3-0160-409f-b6ad-c073509e09fc",
-  "doi" : "https://doi.org/10.1234/praesentium",
-  "link" : "https://www.example.org/137f08a2-9305-464a-b021-4d889ae6adf5",
+  "createdDate" : "2023-04-25T00:05:44.838Z",
+  "modifiedDate" : "2012-09-15T02:00:24.863Z",
+  "publishedDate" : "1977-10-24T06:29:03.520Z",
+  "indexedDate" : "2002-06-11T15:22:36.149Z",
+  "handle" : "https://www.example.org/6b574c80-ebce-40fd-8478-89eb368bdfc6",
+  "doi" : "https://doi.org/10.1234/inventore",
+  "link" : "https://www.example.org/8c4c9c8d-6e8f-49b4-beb0-8ad17480ce94",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "5sIGZjK2MTT0BryzY8",
+    "mainTitle" : "b3y1YuztkAri8zp",
     "alternativeTitles" : {
-      "nn" : "CFt5pdbbaS4hjUgE"
+      "fi" : "1ixt9LtrPPu4pkiqdPs"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "80lb9clvqPCG6POJ",
-      "month" : "hayHungBPd",
-      "day" : "ZkfQ6WiGEVlM"
+      "year" : "GAhBYgABWmo",
+      "month" : "mnNnt1yR9gC",
+      "day" : "OBQkXZbrMUjTt"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/a1531eca-ba42-4f26-b82f-dd8d6fc57f04",
-        "name" : "KY2h7piyGFtRMeF3Qh",
-        "nameType" : "Personal",
-        "orcId" : "UdvaWnHEeiPxm71A",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/06c3bec6-06ce-447a-9f86-17baa6b8cc9b",
+        "name" : "GHfK5cjSXr",
+        "nameType" : "Organizational",
+        "orcId" : "FI4sJdUTWMSAHJjI91O",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "INN4U6GROal9UC1Rw",
-          "value" : "mtQHY9hV4x"
+          "sourceName" : "4SF0WpDamch9P7BujA",
+          "value" : "BDmEYU3mvOXEX7jSXtv"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2lrLKtrro1XDbrc",
-          "value" : "yorPSU1NgHv3kI4"
+          "sourceName" : "hcpL9zif4GayGQevM",
+          "value" : "DHd6xXkr46"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/c739d95b-1adf-4386-ab6f-d80a9a2ed469"
+        "id" : "https://www.example.org/f1579605-5710-4661-aa24-533373903f53"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "RegistrationAgency"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,161 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f8e974d3-829d-4b12-b6cc-a107a35caf38",
-        "name" : "q8kNK81wCxr5XKTi",
+        "id" : "https://www.example.org/4b0db2c0-826e-4838-9d62-0f7483223851",
+        "name" : "3PPayUQVkYB",
         "nameType" : "Personal",
-        "orcId" : "ip6PB6gj6hYlg7nSqxQ",
-        "verificationStatus" : "CannotBeEstablished",
+        "orcId" : "F6NEO4zS1nd6CoY",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7kdlDNThdE",
-          "value" : "YC7y3hFSeb"
+          "sourceName" : "PnCmGTdXg7",
+          "value" : "BspJwbW9LSEuAZX"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "o3HXQBSs2QuuTXvg8H",
-          "value" : "J41P72Q1ildMQNI9OcH"
+          "sourceName" : "WjH4nzfVwIeULGSqZux",
+          "value" : "114whF9wOL89"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/11c21b6a-c3b9-4781-9e83-7b7b9e8d72e0"
+        "id" : "https://www.example.org/a7a081c5-7f2d-4600-85f1-7219b582c45d"
       } ],
       "role" : {
-        "type" : "Researcher"
+        "type" : "Director"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "es" : "srAPa1fCqZYb2CO"
+      "se" : "c9v0koVO4YOb"
     },
-    "npiSubjectHeading" : "JWboJUVEdkOiRwTRc",
-    "tags" : [ "4dyFijtHeg1pw9mk" ],
-    "description" : "z5oY9nwpedbv",
+    "npiSubjectHeading" : "Kg1o42wD7H4n5K5U",
+    "tags" : [ "lRPRfDSGLcP" ],
+    "description" : "LL3YBpczRWDiCKQDc",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7ffba46b-30a2-4548-9925-5bc8c99cc556"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/b1b40481-e59b-4c30-987c-da1186c6f321"
         },
-        "seriesNumber" : "YkorujjDGhtP0yhU",
+        "seriesNumber" : "SpoXUq98PKUO",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bb8d2cfb-78ba-4054-963a-a4ce51c135ed",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/6f56335c-7f5a-496b-b55a-de13f41e1989",
           "valid" : true
         },
-        "isbnList" : [ "9780014097999" ],
+        "isbnList" : [ "9791811555704", "9781921611100" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "QhpGr833Le99"
+          "value" : "1921611103"
         } ]
       },
-      "doi" : "https://www.example.org/0ba6d6df-22e1-4274-bdc2-3f6b2f1ffc08",
+      "doi" : "https://www.example.org/a49eb7f0-3305-4289-9f4b-769d8fc32daa",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "ZzXVtl6Fe242Ik",
-            "end" : "vQSCIIJ4zFVeuO6CPB"
+            "begin" : "l9pQQXF6oL",
+            "end" : "fC5aEmUOfkISJXe"
           },
-          "pages" : "NJGiqd3bIa",
-          "illustrated" : false
+          "pages" : "pau7wga8ryBCqTYNds",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/81e88d41-f334-40a4-b0a8-dd3e307655e5",
-    "abstract" : "fQOLFGBryZBA0hU"
+    "metadataSource" : "https://www.example.org/6c32c4f9-e20e-450d-a240-80fa189484a4",
+    "abstract" : "pXUThd1vPkwtCMhQv"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/e70f0250-cb47-4dd6-afaa-1a5220376d54",
-    "name" : "FrCkwGGi6qcaixiwVL",
+    "id" : "https://www.example.org/d4694593-2e3e-454d-9b83-5fc0bbc46595",
+    "name" : "Lt2HDCG3UX99tfDik",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1992-01-08T19:04:51.983Z",
-      "approvedBy" : "NARA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "ttgrmslIpcMt"
+      "approvalDate" : "2023-06-07T18:26:16.025Z",
+      "approvedBy" : "REK",
+      "approvalStatus" : "APPROVED",
+      "applicationCode" : "sBsw88yIxlJNid"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/90e565da-27b3-468a-a1cb-ededc5bd908e",
-    "identifier" : "0NltfkdaVw6Z4Mw8",
+    "source" : "https://www.example.org/0a388de0-2142-4bb5-bb69-79eea937c60f",
+    "identifier" : "x7ykdwXIK3E2XM9Ky",
     "labels" : {
-      "es" : "pDC8vc3MRuLjB"
+      "nb" : "CR5T99ZDpEb"
     },
     "fundingAmount" : {
       "currency" : "GBP",
-      "amount" : 1360206590
+      "amount" : 1703185159
     },
-    "activeFrom" : "2001-10-08T08:19:59.478Z",
-    "activeTo" : "2002-06-15T09:56:53.744Z"
+    "activeFrom" : "1998-09-06T18:13:34.523Z",
+    "activeTo" : "2008-01-13T14:39:12.373Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/341e9193-69c9-4ba2-887b-d8cbea2f9b48",
-    "id" : "https://www.example.org/5e12ff5f-0a46-4e15-a75f-1dc5f5bc8e78",
-    "identifier" : "d0cb5IAuNyZ",
+    "source" : "https://www.example.org/28b86126-1a62-4d73-a9b7-96f73dfc8fa9",
+    "id" : "https://www.example.org/e0f86a52-8d78-4b0b-a656-792f532ebd7b",
+    "identifier" : "rmHQUD8V5bIb4yMoMel",
     "labels" : {
-      "ru" : "MM7e7dgJGchoa1D"
+      "da" : "6kF7jM3ieeCjEFV"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 540068106
+      "currency" : "NOK",
+      "amount" : 1015018768
     },
-    "activeFrom" : "2015-08-05T10:09:29.076Z",
-    "activeTo" : "2016-07-01T10:39:13.990Z"
+    "activeFrom" : "2002-05-24T15:31:25.674Z",
+    "activeTo" : "2011-11-08T12:56:10.119Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/f12d2c04-d57d-4bf8-a8d3-920d4cc119d7" ],
+  "subjects" : [ "https://www.example.org/bc15e87a-e517-4948-bc82-e5cf0ed84c09" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "5b27536e-1cf8-4494-a039-92f9ef6a837f",
-    "name" : "W4o6zElRkbRV3KF",
-    "mimeType" : "as20RycUpzp",
-    "size" : 1326847753,
-    "license" : "https://www.example.com/mngs8wdiixr9bxyws3",
+    "identifier" : "e5cefad5-1546-49c1-b8c7-f6c233ccb862",
+    "name" : "LZsXTEOJA4Frhn",
+    "mimeType" : "wtlhPDTEAUTtO5RzmN4",
+    "size" : 713767505,
+    "license" : "https://www.example.com/bg9tdfprbumevxcbj",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "CustomerRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "tdaFLo5lZfGXEJIe1B",
-    "publishedDate" : "2016-12-05T21:27:06.210Z",
+    "legalNote" : "qcYcBSMDULX6oszelN",
+    "publishedDate" : "2007-01-24T04:59:30.760Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "3isDM31L9pS5CEZla",
+      "uploadedDate" : "2007-09-23T23:53:40.104Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/zM4v7TmFbyXI",
-    "name" : "tzhZSsNqOKhoCCB",
-    "description" : "bIK9stV2U0WuJ08loL"
+    "id" : "https://www.example.com/A1RWgdzll1vKnlBYafU",
+    "name" : "Po8mBmkV6bI",
+    "description" : "UklA9y0iOeU"
   } ],
-  "rightsHolder" : "23jVx1CXE25",
-  "duplicateOf" : "https://www.example.org/8b94edcf-8cfa-4559-b812-bb0be980b211",
+  "rightsHolder" : "7ouiLj1XYDMyemnv",
+  "duplicateOf" : "https://www.example.org/0577afbd-d67a-4391-a3a3-dbd3c2113be7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WcE0cxMnJ1amSp9"
+    "note" : "6EaBDEqovaLWFG"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "SwHS34KLfBw",
-    "createdBy" : "BfbopzQ2PUMn7Q9H",
-    "createdDate" : "2017-08-03T22:30:38.324Z"
+    "note" : "rRRkpLMHGiNFMM",
+    "createdBy" : "f8qYvASxRsYDT0zQ5rC",
+    "createdDate" : "2004-10-16T01:28:46.071Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/210f11eb-7035-4ef1-a530-663d19bcf92e" ],
+  "curatingInstitutions" : [ "https://www.example.org/402a8d24-bcd4-4a14-b0db-2e1841597188" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/ReportWorkingPaper.json
+++ b/documentation/ReportWorkingPaper.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "PUBLISHED_METADATA",
   "resourceOwner" : {
-    "owner" : "ryO0xvlVG74YskifT",
-    "ownerAffiliation" : "https://www.example.org/bb984de2-880d-429d-b798-4077d599e863"
+    "owner" : "OpXxTJ5YgSVY",
+    "ownerAffiliation" : "https://www.example.org/12a871af-51ae-4966-98f0-e37a397b2e92"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1170daa9-548a-4cb0-9fc9-a50541ae36db"
+    "id" : "https://www.example.org/60763ec6-77ca-45e2-b5af-bbc1f0a4e52d"
   },
-  "createdDate" : "2020-12-07T09:09:24.764Z",
-  "modifiedDate" : "1985-10-07T20:57:08.099Z",
-  "publishedDate" : "1996-05-25T23:35:52.491Z",
-  "indexedDate" : "2007-04-13T21:15:39.742Z",
-  "handle" : "https://www.example.org/29339eb7-693f-4572-8c00-a6baeda1fcd2",
-  "doi" : "https://doi.org/10.1234/repudiandae",
-  "link" : "https://www.example.org/77d8e1fc-5dc0-4bb6-ae35-eebaa0e0f509",
+  "createdDate" : "1978-03-27T07:40:28.913Z",
+  "modifiedDate" : "1976-05-23T20:41:33.473Z",
+  "publishedDate" : "1983-03-04T11:40:14.084Z",
+  "indexedDate" : "2023-02-14T13:58:48.089Z",
+  "handle" : "https://www.example.org/8902a5d3-0160-409f-b6ad-c073509e09fc",
+  "doi" : "https://doi.org/10.1234/praesentium",
+  "link" : "https://www.example.org/137f08a2-9305-464a-b021-4d889ae6adf5",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "AJuw4tO32oTvlYgbi",
+    "mainTitle" : "5sIGZjK2MTT0BryzY8",
     "alternativeTitles" : {
-      "sv" : "uX8JgMv3CEHnB"
+      "nn" : "CFt5pdbbaS4hjUgE"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "M0tFbhDYHNXkbvXn",
-      "month" : "w5RouMWCm36W2FMc",
-      "day" : "6kfNfkGbwdkpPu8rYl"
+      "year" : "80lb9clvqPCG6POJ",
+      "month" : "hayHungBPd",
+      "day" : "ZkfQ6WiGEVlM"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f1808f94-1369-4b60-88ce-f2d65b6365f9",
-        "name" : "8WuI8UsHrYBTs",
-        "nameType" : "Organizational",
-        "orcId" : "tnoR3gNDss",
+        "id" : "https://www.example.org/a1531eca-ba42-4f26-b82f-dd8d6fc57f04",
+        "name" : "KY2h7piyGFtRMeF3Qh",
+        "nameType" : "Personal",
+        "orcId" : "UdvaWnHEeiPxm71A",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Z6v2zvTvT1FnnuX",
-          "value" : "cZviWF2jdWs9Aws9qs"
+          "sourceName" : "INN4U6GROal9UC1Rw",
+          "value" : "mtQHY9hV4x"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2NfPGQ1SMTGhw6",
-          "value" : "rXzNQXuHBK8e"
+          "sourceName" : "2lrLKtrro1XDbrc",
+          "value" : "yorPSU1NgHv3kI4"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/103a10fc-ef5f-4ecb-ab12-623b9c326232"
+        "id" : "https://www.example.org/c739d95b-1adf-4386-ab6f-d80a9a2ed469"
       } ],
       "role" : {
-        "type" : "Designer"
+        "type" : "CollaborationPartner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,155 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/30262a0a-105a-4603-bb31-7411a80333ac",
-        "name" : "NLCacpavaneTlTmCmL",
-        "nameType" : "Organizational",
-        "orcId" : "gN3c9lBV6uKf1xKcpUf",
+        "id" : "https://www.example.org/f8e974d3-829d-4b12-b6cc-a107a35caf38",
+        "name" : "q8kNK81wCxr5XKTi",
+        "nameType" : "Personal",
+        "orcId" : "ip6PB6gj6hYlg7nSqxQ",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "QDlzeeHOLXl45S",
-          "value" : "76kFicJU2faaZWIsiS"
+          "sourceName" : "7kdlDNThdE",
+          "value" : "YC7y3hFSeb"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "yIF1nfR9CfbNsfagDog",
-          "value" : "qtaWKrMQtTdUybB2HEf"
+          "sourceName" : "o3HXQBSs2QuuTXvg8H",
+          "value" : "J41P72Q1ildMQNI9OcH"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/b70321c7-0ec3-4129-99d1-fc313119563a"
+        "id" : "https://www.example.org/11c21b6a-c3b9-4781-9e83-7b7b9e8d72e0"
       } ],
       "role" : {
-        "type" : "ProgrammeLeader"
+        "type" : "Researcher"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "zh" : "zYeHZPp6iIps6pB9jK"
+      "es" : "srAPa1fCqZYb2CO"
     },
-    "npiSubjectHeading" : "qoxKJ5aGIdI21x",
-    "tags" : [ "CpdVYAymfp" ],
-    "description" : "qeaTBkkySDgj7",
+    "npiSubjectHeading" : "JWboJUVEdkOiRwTRc",
+    "tags" : [ "4dyFijtHeg1pw9mk" ],
+    "description" : "z5oY9nwpedbv",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Report",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9831a363-76a7-4588-a385-0f767dc56f7e"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7ffba46b-30a2-4548-9925-5bc8c99cc556"
         },
-        "seriesNumber" : "yrF0t6XJjUMIxx",
+        "seriesNumber" : "YkorujjDGhtP0yhU",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/9430bd02-40f0-4a0a-9387-bae32e8799e8",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/bb8d2cfb-78ba-4054-963a-a4ce51c135ed",
           "valid" : true
         },
-        "isbnList" : [ "9790093340381" ],
+        "isbnList" : [ "9780014097999" ],
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "a3ZR2jPAPb6cZoxRsnj"
+          "value" : "QhpGr833Le99"
         } ]
       },
-      "doi" : "https://www.example.org/1fcdadac-f993-429c-adea-6977aef9d288",
+      "doi" : "https://www.example.org/0ba6d6df-22e1-4274-bdc2-3f6b2f1ffc08",
       "publicationInstance" : {
         "type" : "ReportWorkingPaper",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "bPFefKqlGm7",
-            "end" : "b0rwTglLcrR3"
+            "begin" : "ZzXVtl6Fe242Ik",
+            "end" : "vQSCIIJ4zFVeuO6CPB"
           },
-          "pages" : "iBbgmiQFzt",
+          "pages" : "NJGiqd3bIa",
           "illustrated" : false
         }
       }
     },
-    "metadataSource" : "https://www.example.org/381c812b-1327-44a0-9fe5-ebc0a40c2c74",
-    "abstract" : "YqPcluFx2d"
+    "metadataSource" : "https://www.example.org/81e88d41-f334-40a4-b0a8-dd3e307655e5",
+    "abstract" : "fQOLFGBryZBA0hU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8ffd8aa3-8334-480c-9bfa-924e7ccd19de",
-    "name" : "wL5hwwSVvMmVo7csTy1",
+    "id" : "https://www.example.org/e70f0250-cb47-4dd6-afaa-1a5220376d54",
+    "name" : "FrCkwGGi6qcaixiwVL",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1998-01-08T04:24:04.912Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "6O5M53R2bf0GS"
+      "approvalDate" : "1992-01-08T19:04:51.983Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "APPLIED",
+      "applicationCode" : "ttgrmslIpcMt"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/b2e8be6a-6ce9-402e-a627-b54604cf958d",
-    "identifier" : "ahVcAeCymFiSPY0",
+    "source" : "https://www.example.org/90e565da-27b3-468a-a1cb-ededc5bd908e",
+    "identifier" : "0NltfkdaVw6Z4Mw8",
     "labels" : {
-      "nb" : "N3SwzLEBER6"
+      "es" : "pDC8vc3MRuLjB"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1022428050
+      "currency" : "GBP",
+      "amount" : 1360206590
     },
-    "activeFrom" : "2012-06-03T13:32:54.999Z",
-    "activeTo" : "2019-10-01T07:22:07.455Z"
+    "activeFrom" : "2001-10-08T08:19:59.478Z",
+    "activeTo" : "2002-06-15T09:56:53.744Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/6d523eef-5ca8-4fe3-98a6-fa4fee3359aa",
-    "id" : "https://www.example.org/92bf26af-cfc1-4854-8475-9830b22dbeae",
-    "identifier" : "OUp4RUndejcxeB6TOaZ",
+    "source" : "https://www.example.org/341e9193-69c9-4ba2-887b-d8cbea2f9b48",
+    "id" : "https://www.example.org/5e12ff5f-0a46-4e15-a75f-1dc5f5bc8e78",
+    "identifier" : "d0cb5IAuNyZ",
     "labels" : {
-      "da" : "TsaVkfaWL3CvvMRISX"
+      "ru" : "MM7e7dgJGchoa1D"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 610843037
+      "currency" : "EUR",
+      "amount" : 540068106
     },
-    "activeFrom" : "1983-11-20T13:33:16.560Z",
-    "activeTo" : "2014-10-09T06:38:47.920Z"
+    "activeFrom" : "2015-08-05T10:09:29.076Z",
+    "activeTo" : "2016-07-01T10:39:13.990Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/8d9d2ce9-7a7a-4af4-9fd6-c6e779973a05" ],
+  "subjects" : [ "https://www.example.org/f12d2c04-d57d-4bf8-a8d3-920d4cc119d7" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4a72e6de-967f-469b-be6e-49fc2642209d",
-    "name" : "RUz84kuY7scHmhnRsoN",
-    "mimeType" : "KMaz06WQMXxsg",
-    "size" : 1602259127,
-    "license" : "https://www.example.com/imhynonudl0exb6v7m",
+    "identifier" : "5b27536e-1cf8-4494-a039-92f9ef6a837f",
+    "name" : "W4o6zElRkbRV3KF",
+    "mimeType" : "as20RycUpzp",
+    "size" : 1326847753,
+    "license" : "https://www.example.com/mngs8wdiixr9bxyws3",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "LwQ6TkSfJ6dSKS1f",
-    "publishedDate" : "2000-01-17T19:26:49.680Z",
+    "legalNote" : "tdaFLo5lZfGXEJIe1B",
+    "publishedDate" : "2016-12-05T21:27:06.210Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/R5dPm8Tv3k0s81",
-    "name" : "PnCiHdv483sfFO",
-    "description" : "zrjL61cM90G0"
+    "id" : "https://www.example.com/zM4v7TmFbyXI",
+    "name" : "tzhZSsNqOKhoCCB",
+    "description" : "bIK9stV2U0WuJ08loL"
   } ],
-  "rightsHolder" : "eqzHR4Bd47FzjZ5k",
-  "duplicateOf" : "https://www.example.org/715d4460-2248-4dc1-a013-65359055b480",
+  "rightsHolder" : "23jVx1CXE25",
+  "duplicateOf" : "https://www.example.org/8b94edcf-8cfa-4559-b812-bb0be980b211",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kEd2zsXQKWEh"
+    "note" : "WcE0cxMnJ1amSp9"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "kC3QmAOcvx8w6zq",
-    "createdBy" : "a4NDDNGH7axsOUaSN",
-    "createdDate" : "2021-10-26T13:58:11.703Z"
+    "note" : "SwHS34KLfBw",
+    "createdBy" : "BfbopzQ2PUMn7Q9H",
+    "createdDate" : "2017-08-03T22:30:38.324Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/5e42017f-a5a8-4f56-9dd1-04ca6d43f12c" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/210f11eb-7035-4ef1-a530-663d19bcf92e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DELETED",
+  "status" : "NEW",
   "resourceOwner" : {
-    "owner" : "5Qt5K97EN9me",
-    "ownerAffiliation" : "https://www.example.org/13f0d828-2e00-45df-9d0c-182fd2941162"
+    "owner" : "2nUrHQDNkDnb",
+    "ownerAffiliation" : "https://www.example.org/19f7896f-3ca3-4ea4-9eab-29e29b0960a1"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/4631df65-977c-411d-9d58-46b43f981ed2"
+    "id" : "https://www.example.org/f49bfda7-afe6-4424-a385-d9f8f93ba197"
   },
-  "createdDate" : "2021-07-30T20:25:17.921Z",
-  "modifiedDate" : "2006-03-15T01:28:46.075Z",
-  "publishedDate" : "2018-12-22T07:02:02.747Z",
-  "indexedDate" : "1973-01-27T17:59:03.477Z",
-  "handle" : "https://www.example.org/1c0c2e83-a3e2-4b00-a6ae-1c461798c51c",
-  "doi" : "https://doi.org/10.1234/soluta",
-  "link" : "https://www.example.org/f1ee1f1b-22c0-4564-a7b1-fd7f747b1777",
+  "createdDate" : "1996-04-27T08:18:47.495Z",
+  "modifiedDate" : "1987-09-14T11:44:45.295Z",
+  "publishedDate" : "1982-11-23T10:21:07.924Z",
+  "indexedDate" : "2021-09-20T14:04:59.298Z",
+  "handle" : "https://www.example.org/1e87497b-c6bd-4fa8-ac2f-288d0fd823e4",
+  "doi" : "https://doi.org/10.1234/voluptate",
+  "link" : "https://www.example.org/c79a41bd-b41a-4310-a080-ae42bc1e0f06",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "9abDIsYCUAqIh",
+    "mainTitle" : "VW3cWR2gPaLtG2mnXmC",
     "alternativeTitles" : {
-      "af" : "VdNfGQPD92XYi4w"
+      "sv" : "XYdToA4ZLNFy5Jmt"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "BVGQYESwUBxyvYobW",
-      "month" : "UizUbQgs5y5",
-      "day" : "VPJGotfKZyN"
+      "year" : "J2cH3UdDKu5j0a",
+      "month" : "xekLrLISXEKd9",
+      "day" : "ZZM11z3TJMIFoVgP"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5e280702-6bf8-4746-b8b5-4d439ed7a1d2",
-        "name" : "kLihzjTzcn",
+        "id" : "https://www.example.org/7ee4974d-3706-4028-b98b-a8ebae4f3053",
+        "name" : "6uh17tyBwtUHZc",
         "nameType" : "Organizational",
-        "orcId" : "6LkzczdDVWX",
-        "verificationStatus" : "Verified",
+        "orcId" : "8v6jGPI2kGFRV",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "mknJu8QjyvHC8",
-          "value" : "wlvcJpkXwcPpY1q"
+          "sourceName" : "ZynxpBhiAwGvE4",
+          "value" : "kp4utuQsTBnaMijh5b3"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "qex4pYW20mIGxqHpgd",
-          "value" : "ul99lnHbBCZ"
+          "sourceName" : "ywNccF2Obg8br1balN",
+          "value" : "TCLnUCRkgvHGM"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ef80e7bd-2cc0-44fe-9ee2-d4550eb33ddd"
+        "id" : "https://www.example.org/d3634d53-4a1c-4ec5-b536-72bdacbe48ed"
       } ],
       "role" : {
-        "type" : "RegistrationAuthority"
+        "type" : "Supervisor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,138 +62,139 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/620042fa-93f2-41a2-8b71-ee422219617e",
-        "name" : "B1GPqeD0zEBWiF",
-        "nameType" : "Organizational",
-        "orcId" : "29AitTC048gjPLu",
+        "id" : "https://www.example.org/135bd3d5-f3ef-422a-ab4a-752def02cf09",
+        "name" : "USjTtSFfGHHQ",
+        "nameType" : "Personal",
+        "orcId" : "VC0IBELetVigK",
         "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "SSptAt0iFDwTR8z",
-          "value" : "TgxKNwtWEwN"
+          "sourceName" : "M06c3j5Y8YRFdQf4Ut",
+          "value" : "fYhAx8L23SL2m"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "xrUB5HkYizWQ",
-          "value" : "t8MOMqBFl78fTjoF"
+          "sourceName" : "4tTcMbmUPxB71hh",
+          "value" : "9VnNbnoBXD6"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/e517ece8-436b-4bcd-80b3-691845c4fd0a"
+        "id" : "https://www.example.org/1cb45c95-8e01-4dbf-bfe5-d67504d40d19"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "InteriorArchitect"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "en" : "zHBlHP1BlR"
+      "pl" : "1Qrw4jyfLGAyKVHS"
     },
-    "npiSubjectHeading" : "yhsBLtvLAVm",
-    "tags" : [ "59uPXLq3hsolUc1" ],
-    "description" : "NqqXnzlvWEMBL1U",
+    "npiSubjectHeading" : "ne3qTbbeD8VC",
+    "tags" : [ "LHcQYDBBkJ" ],
+    "description" : "DLE7hGCNgE4n61Kw",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/df44fa3d-294f-4fc0-b852-656f415f1c77"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0c8078ab-e752-41ed-af50-b80e7061dfb0"
       },
-      "doi" : "https://www.example.org/cb9fd611-08c1-4e82-878d-ed5f8f43ccc9",
+      "doi" : "https://www.example.org/8a6c481f-fe51-4449-ba59-c87fe3d91e1e",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "sDFd7S43dG2d1oCEm6m",
-          "end" : "dim0543DrRT01uxFS2"
+          "begin" : "yiwImzgxgGn",
+          "end" : "E221AzDS1m"
         },
-        "volume" : "3qDJVnYKh6w",
-        "issue" : "aRaGgydWeJ3cD6B",
-        "articleNumber" : "IeOmKznixSsT"
+        "volume" : "8rABLRxcDupU",
+        "issue" : "2i2IIOT8mN9hOpJ6",
+        "articleNumber" : "VdRA4OtDHGLTV"
       }
     },
-    "metadataSource" : "https://www.example.org/e29f6593-38e0-42f0-98a2-fc077282aa5d",
-    "abstract" : "x1Sgw6Ag9X6F1GPwK3l"
+    "metadataSource" : "https://www.example.org/349334c4-1b8b-4723-aaa8-691c0574c0db",
+    "abstract" : "9ULiq7Zk3tO"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c90158e8-ff6a-48d1-9c3d-521698e5695e",
-    "name" : "00I4tx7KR3FZrsvX5E",
+    "id" : "https://www.example.org/ec2d52de-dca1-4d7d-9a6d-53f17d110d69",
+    "name" : "jie6JAiO4CnVDpq0",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2013-02-21T03:31:24.330Z",
+      "approvalDate" : "2022-09-15T19:35:07.706Z",
       "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "DECLINED",
-      "applicationCode" : "r82O2Y8xTrs6"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "Ne1LB6ioC6dGD"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/5b1452ad-ce7e-47ae-99a9-f22973dd5ec9",
-    "identifier" : "jGrP3L2TjAHTrSrV",
+    "source" : "https://www.example.org/49b54083-d2c6-4f14-b3bd-5b5e1eb02e2a",
+    "identifier" : "dWsJcpGYaHVRv1mz",
     "labels" : {
-      "nn" : "a7e1qZAmOVbAi9Iril0"
+      "ca" : "rrh2kVk8NLy"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1902511950
+      "currency" : "EUR",
+      "amount" : 675230139
     },
-    "activeFrom" : "1981-03-30T18:07:23.840Z",
-    "activeTo" : "2002-06-10T03:25:10.932Z"
+    "activeFrom" : "1984-03-04T04:02:15.344Z",
+    "activeTo" : "1984-03-26T11:30:57.083Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8214b143-00fc-4656-98b3-58dc6f809153",
-    "id" : "https://www.example.org/6dd40efd-0958-41ca-97f4-99f190cc4a3b",
-    "identifier" : "A9WLN4BxLzLaFxuQS1",
+    "source" : "https://www.example.org/41848a6f-fd7e-4594-8515-09df67972ac8",
+    "id" : "https://www.example.org/5fffd064-e5f7-4dca-999b-c50d7504c2ef",
+    "identifier" : "d6JckJuinaUGqsPeY3",
     "labels" : {
-      "hu" : "zRirIGeCZPEVX"
+      "da" : "sGLtMj44jF"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1541952474
+      "amount" : 1099204388
     },
-    "activeFrom" : "1976-05-14T06:03:38.236Z",
-    "activeTo" : "2001-05-01T20:33:50.510Z"
+    "activeFrom" : "2015-02-11T07:29:48.136Z",
+    "activeTo" : "2015-09-04T09:16:22.484Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/a08b9039-fba8-414f-b5be-daa0d052d3fe" ],
+  "subjects" : [ "https://www.example.org/cf57f025-f000-4c7a-a598-88e5e64bbfbe" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "359bcea4-f3b8-470f-aa17-ef71b1a381fc",
-    "name" : "MSt8t2X5Imy7Z",
-    "mimeType" : "RyCw1Qw8Ub1aJsvM",
-    "size" : 723599564,
-    "license" : "https://www.example.com/toxq5mhldljd3kb",
+    "identifier" : "288beb2a-7e43-4504-beb7-70eff378dd83",
+    "name" : "trtlWFhjQicBw",
+    "mimeType" : "lxRCcCpliK5UcK",
+    "size" : 2046156235,
+    "license" : "https://www.example.com/7ssdstlyi68",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "nz7Wf4BsPR9hHk",
-    "publishedDate" : "1974-10-27T08:28:36.672Z",
+    "legalNote" : "WgeIN0v2vqRCWFlv",
+    "publishedDate" : "1990-03-09T20:23:17.545Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/oT0wcMUioIp5r4",
-    "name" : "iRUfNTsB36UkN",
-    "description" : "7GQqtW7P5qRxk3aCq"
+    "id" : "https://www.example.com/6nieNzzBfN4",
+    "name" : "VQ321RV7EEgSEB",
+    "description" : "edDcyMs2mDcth2Iq"
   } ],
-  "rightsHolder" : "BxAF3ILGA91Vzl6ni",
-  "duplicateOf" : "https://www.example.org/ea69ce36-1f50-4798-b49c-1d998805d40f",
+  "rightsHolder" : "raHWhEivQhP",
+  "duplicateOf" : "https://www.example.org/4f80d059-bbe6-45f3-b57f-9cbafd54d66f",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "eG5apeUQPHo1Pwh"
+    "note" : "NKj2g5iIsxW98juxp"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RgdJLAcw40",
-    "createdBy" : "e4HlgT8qDrc",
-    "createdDate" : "1976-03-08T19:24:28.618Z"
+    "note" : "KPLX8yyAmW",
+    "createdBy" : "CjlRABX9FRYL",
+    "createdDate" : "2002-02-07T08:49:42.842Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/671a7034-efaa-4255-909a-6fe91282dbc5" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/1f7ac677-239f-4618-8ae6-3d0740391e3e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/StudyProtocol.json
+++ b/documentation/StudyProtocol.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "NEW",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "2nUrHQDNkDnb",
-    "ownerAffiliation" : "https://www.example.org/19f7896f-3ca3-4ea4-9eab-29e29b0960a1"
+    "owner" : "EYWquWxtscbjJ0O",
+    "ownerAffiliation" : "https://www.example.org/19338d73-d60c-472b-bec0-7eef64efa66e"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/f49bfda7-afe6-4424-a385-d9f8f93ba197"
+    "id" : "https://www.example.org/e9dbbdf0-dc16-4b8a-b34d-58cb71b14f24"
   },
-  "createdDate" : "1996-04-27T08:18:47.495Z",
-  "modifiedDate" : "1987-09-14T11:44:45.295Z",
-  "publishedDate" : "1982-11-23T10:21:07.924Z",
-  "indexedDate" : "2021-09-20T14:04:59.298Z",
-  "handle" : "https://www.example.org/1e87497b-c6bd-4fa8-ac2f-288d0fd823e4",
-  "doi" : "https://doi.org/10.1234/voluptate",
-  "link" : "https://www.example.org/c79a41bd-b41a-4310-a080-ae42bc1e0f06",
+  "createdDate" : "2017-01-07T22:46:23.039Z",
+  "modifiedDate" : "1977-05-24T17:04:18.235Z",
+  "publishedDate" : "2000-08-09T14:52:08.055Z",
+  "indexedDate" : "1988-05-02T09:29:36.983Z",
+  "handle" : "https://www.example.org/bd6733e2-326a-4929-8030-bc8f29369b07",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/ac5fc7b5-7fbf-459a-843e-c692cb3c8abe",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "VW3cWR2gPaLtG2mnXmC",
+    "mainTitle" : "JvnNWLayHJ51RU",
     "alternativeTitles" : {
-      "sv" : "XYdToA4ZLNFy5Jmt"
+      "pl" : "hzxLDqby3gT1W"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "J2cH3UdDKu5j0a",
-      "month" : "xekLrLISXEKd9",
-      "day" : "ZZM11z3TJMIFoVgP"
+      "year" : "t8WFjtUMpB",
+      "month" : "9oJ2UpD8ru",
+      "day" : "yOu4EH4wTSmaxWzuta"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/7ee4974d-3706-4028-b98b-a8ebae4f3053",
-        "name" : "6uh17tyBwtUHZc",
-        "nameType" : "Organizational",
-        "orcId" : "8v6jGPI2kGFRV",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/c7a47897-3531-42dd-a810-b2c813a8ef65",
+        "name" : "yL17HD0a5DmSp0",
+        "nameType" : "Personal",
+        "orcId" : "pQftQTYJrzHMFDX",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ZynxpBhiAwGvE4",
-          "value" : "kp4utuQsTBnaMijh5b3"
+          "sourceName" : "9xJjl57DeWzgnffhHyH",
+          "value" : "slNZsV1pHwaU8hd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "ywNccF2Obg8br1balN",
-          "value" : "TCLnUCRkgvHGM"
+          "sourceName" : "92ddYQfOKcW1dNX7QS",
+          "value" : "bzQj37wkaJizotWRGB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/d3634d53-4a1c-4ec5-b536-72bdacbe48ed"
+        "id" : "https://www.example.org/b9c51d48-c181-440b-b836-3230b612dd5d"
       } ],
       "role" : {
-        "type" : "Supervisor"
+        "type" : "WorkPackageLeader"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,139 +62,144 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/135bd3d5-f3ef-422a-ab4a-752def02cf09",
-        "name" : "USjTtSFfGHHQ",
+        "id" : "https://www.example.org/474e761a-8bd2-403e-96a8-bb17e2c563b1",
+        "name" : "e4h5eC89X913ZX",
         "nameType" : "Personal",
-        "orcId" : "VC0IBELetVigK",
-        "verificationStatus" : "Verified",
+        "orcId" : "CzsWmwZLHJJdyGf",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "M06c3j5Y8YRFdQf4Ut",
-          "value" : "fYhAx8L23SL2m"
+          "sourceName" : "e6V8gk1iBst5y6Ob4O",
+          "value" : "OTCjemA230iYHn"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4tTcMbmUPxB71hh",
-          "value" : "9VnNbnoBXD6"
+          "sourceName" : "nwmJOxm4hTg2x8U5c",
+          "value" : "SkgjgSiAM6PWlA"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/1cb45c95-8e01-4dbf-bfe5-d67504d40d19"
+        "id" : "https://www.example.org/2d93cc2d-982e-43ad-8151-a838c673d09b"
       } ],
       "role" : {
-        "type" : "InteriorArchitect"
+        "type" : "VideoEditor"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "1Qrw4jyfLGAyKVHS"
+      "pt" : "azV00YUS8NnozfJRY"
     },
-    "npiSubjectHeading" : "ne3qTbbeD8VC",
-    "tags" : [ "LHcQYDBBkJ" ],
-    "description" : "DLE7hGCNgE4n61Kw",
+    "npiSubjectHeading" : "JvIkmQcdLO9thNJbnOy",
+    "tags" : [ "b23E8fDqBCDPpCNR" ],
+    "description" : "dGXEtD626ZOLkUxG",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Journal",
-        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/0c8078ab-e752-41ed-af50-b80e7061dfb0"
+        "id" : "https://api.dev.nva.aws.unit.no/publication-channels/7d075ad3-c925-4eeb-9be0-acff07ff3184"
       },
-      "doi" : "https://www.example.org/8a6c481f-fe51-4449-ba59-c87fe3d91e1e",
+      "doi" : "https://www.example.org/ad4493c8-831b-4654-9c07-8d1565fa83e3",
       "publicationInstance" : {
         "type" : "StudyProtocol",
         "pages" : {
           "type" : "Range",
-          "begin" : "yiwImzgxgGn",
-          "end" : "E221AzDS1m"
+          "begin" : "9cZb3OyIiPH",
+          "end" : "YhGndtigUH"
         },
-        "volume" : "8rABLRxcDupU",
-        "issue" : "2i2IIOT8mN9hOpJ6",
-        "articleNumber" : "VdRA4OtDHGLTV"
+        "volume" : "RIA1CINHZyPj",
+        "issue" : "azwehPCGrWXgRMvNHdx",
+        "articleNumber" : "Ps8Hvp4uVuw"
       }
     },
-    "metadataSource" : "https://www.example.org/349334c4-1b8b-4723-aaa8-691c0574c0db",
-    "abstract" : "9ULiq7Zk3tO"
+    "metadataSource" : "https://www.example.org/3aa5f56c-4a6c-4f95-b985-fd047f679764",
+    "abstract" : "HNU271j1g9S4qw0"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/ec2d52de-dca1-4d7d-9a6d-53f17d110d69",
-    "name" : "jie6JAiO4CnVDpq0",
+    "id" : "https://www.example.org/a63eb9f8-69c3-4c7f-a876-6fa619f577c1",
+    "name" : "TfXHjJhdCrLU",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2022-09-15T19:35:07.706Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "REJECTION",
-      "applicationCode" : "Ne1LB6ioC6dGD"
+      "approvalDate" : "1972-05-18T15:41:47.596Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "McsKcudD5I"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/49b54083-d2c6-4f14-b3bd-5b5e1eb02e2a",
-    "identifier" : "dWsJcpGYaHVRv1mz",
+    "source" : "https://www.example.org/cdd3b340-34f5-4540-ac6e-fe13972fb9a1",
+    "identifier" : "4zCBLST8vVmyiT",
     "labels" : {
-      "ca" : "rrh2kVk8NLy"
-    },
-    "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 675230139
-    },
-    "activeFrom" : "1984-03-04T04:02:15.344Z",
-    "activeTo" : "1984-03-26T11:30:57.083Z"
-  }, {
-    "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/41848a6f-fd7e-4594-8515-09df67972ac8",
-    "id" : "https://www.example.org/5fffd064-e5f7-4dca-999b-c50d7504c2ef",
-    "identifier" : "d6JckJuinaUGqsPeY3",
-    "labels" : {
-      "da" : "sGLtMj44jF"
+      "fr" : "3Gz8LUzdePDl"
     },
     "fundingAmount" : {
       "currency" : "NOK",
-      "amount" : 1099204388
+      "amount" : 813238481
     },
-    "activeFrom" : "2015-02-11T07:29:48.136Z",
-    "activeTo" : "2015-09-04T09:16:22.484Z"
+    "activeFrom" : "2002-07-07T02:57:16.342Z",
+    "activeTo" : "2004-04-25T09:41:00.879Z"
+  }, {
+    "type" : "ConfirmedFunding",
+    "source" : "https://www.example.org/b8305eb7-b352-460f-8f83-fcd020718678",
+    "id" : "https://www.example.org/2d8974ee-e7df-4b4c-91c5-414a897efc26",
+    "identifier" : "9G7gMIHERjG3WEeNb",
+    "labels" : {
+      "fi" : "cucMGW0MZ9Xq66nm4"
+    },
+    "fundingAmount" : {
+      "currency" : "NOK",
+      "amount" : 238293383
+    },
+    "activeFrom" : "2002-12-07T16:02:15.150Z",
+    "activeTo" : "2020-10-23T20:49:29.999Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/cf57f025-f000-4c7a-a598-88e5e64bbfbe" ],
+  "subjects" : [ "https://www.example.org/259b46c6-0d7f-4714-9e13-770044731374" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "288beb2a-7e43-4504-beb7-70eff378dd83",
-    "name" : "trtlWFhjQicBw",
-    "mimeType" : "lxRCcCpliK5UcK",
-    "size" : 2046156235,
-    "license" : "https://www.example.com/7ssdstlyi68",
+    "identifier" : "8adb174b-c51d-429c-befd-4081f5434942",
+    "name" : "zAGybjgzLXDmTke",
+    "mimeType" : "FZba0cHBiYH",
+    "size" : 1844954686,
+    "license" : "https://www.example.com/njskpykali0bhsai",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "CustomerRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "WgeIN0v2vqRCWFlv",
-    "publishedDate" : "1990-03-09T20:23:17.545Z",
+    "legalNote" : "FC9OUPaPcypKRhK",
+    "publishedDate" : "2002-04-11T16:01:21.973Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "99U2cAY19jquG",
+      "uploadedDate" : "2000-01-19T10:12:51.714Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/6nieNzzBfN4",
-    "name" : "VQ321RV7EEgSEB",
-    "description" : "edDcyMs2mDcth2Iq"
+    "id" : "https://www.example.com/6u8FZ2RmoRdm",
+    "name" : "NkT7pf5uGW",
+    "description" : "ltSCrGZY46ZZNYg"
   } ],
-  "rightsHolder" : "raHWhEivQhP",
-  "duplicateOf" : "https://www.example.org/4f80d059-bbe6-45f3-b57f-9cbafd54d66f",
+  "rightsHolder" : "yoomTOsUpDGcjOH",
+  "duplicateOf" : "https://www.example.org/4526bb5f-ed8f-4b2a-b61f-997e98afd516",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "NKj2g5iIsxW98juxp"
+    "note" : "1HAswOuyWCdI"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "KPLX8yyAmW",
-    "createdBy" : "CjlRABX9FRYL",
-    "createdDate" : "2002-02-07T08:49:42.842Z"
+    "note" : "UxF7XL2kgt9",
+    "createdBy" : "6MbZmiN4eBEKaCHY",
+    "createdDate" : "1997-07-27T09:43:31.638Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1f7ac677-239f-4618-8ae6-3d0740391e3e" ],
+  "curatingInstitutions" : [ "https://www.example.org/148defad-84d8-4413-89fb-5e506193de04" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "NqpdhHy0zJ",
-    "ownerAffiliation" : "https://www.example.org/e0d0f5aa-a128-40f5-946b-c582382c799c"
+    "owner" : "eRUlZRQZQUCImIEM28c",
+    "ownerAffiliation" : "https://www.example.org/91d945dc-addc-46d8-8c1d-8d39dd4f0fd9"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/29607519-d75d-451b-b73a-ca31b6041279"
+    "id" : "https://www.example.org/be42e71f-b6be-4a22-87c2-bd98dbf661c0"
   },
-  "createdDate" : "1999-11-11T07:58:14.828Z",
-  "modifiedDate" : "1985-12-27T09:01:03.072Z",
-  "publishedDate" : "2013-10-29T18:27:52.634Z",
-  "indexedDate" : "2015-06-05T14:34:00.625Z",
-  "handle" : "https://www.example.org/d30ec031-4a13-461b-9e55-a742aba9cfad",
-  "doi" : "https://doi.org/10.1234/maiores",
-  "link" : "https://www.example.org/f36d3fd7-cdcc-4fb3-8e07-4eee0736c331",
+  "createdDate" : "2009-04-23T17:30:07.786Z",
+  "modifiedDate" : "1987-01-26T07:20:10.866Z",
+  "publishedDate" : "1999-05-23T04:48:03.796Z",
+  "indexedDate" : "1985-09-02T02:04:55.838Z",
+  "handle" : "https://www.example.org/bfedccae-f9b7-4c0e-9bca-58ba6bafadfe",
+  "doi" : "https://doi.org/10.1234/repellendus",
+  "link" : "https://www.example.org/ef2aaa49-9b62-4cb0-9ee8-824ef8bc05a3",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "EEC9CxsKk2zaJB3fj",
+    "mainTitle" : "yzFJUhTskJJ70XjEJXq",
     "alternativeTitles" : {
-      "da" : "kZ8vc7OnS3IYdTClmA"
+      "fi" : "thVzTy4ssjuc1hHOZ09"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "hxGPf23ND1",
-      "month" : "gi3s8MPmzuz9Dp",
-      "day" : "0sA1GVRcvREq2Hdw"
+      "year" : "7sryHMBKvjR153E9Ig",
+      "month" : "58D8RRSm2chr",
+      "day" : "W6R9qhHYgH7S"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/1b0c2b36-ad2f-4b9e-8d51-8367befd36a4",
-        "name" : "XXjMprFDqSJLaq",
-        "nameType" : "Organizational",
-        "orcId" : "GU3ME4hSnmcWnvjBkQ",
+        "id" : "https://www.example.org/41880ad2-bacb-4d1d-9004-a39a6ecf14cf",
+        "name" : "L1PREQNH9v",
+        "nameType" : "Personal",
+        "orcId" : "rKXPToB7TYz6o4uVD",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "2jxiuRxyphMr",
-          "value" : "tj3FysrJC6"
+          "sourceName" : "y1OwjWoZbIX9",
+          "value" : "r9PnRoff1j4fWGd"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "kXNiA0846M",
-          "value" : "bIrSIb26iVUI9MUnr2"
+          "sourceName" : "bmbKMtlSQIJ7q",
+          "value" : "cpY8t8l5UhKyFh9s7"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/9cbbff66-3861-4231-9d2d-d05e470a12b5"
+        "id" : "https://www.example.org/f98fd941-4631-45a9-a787-a66da6191411"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "Soloist"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,158 +62,163 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/75c085c6-f048-408d-bd2e-396d2f9c7864",
-        "name" : "D4qRCc5YlxPgCH7O",
+        "id" : "https://www.example.org/81dcda25-7129-418f-a672-afe4359a413c",
+        "name" : "Y4yAdEO4DKqVH7fA",
         "nameType" : "Personal",
-        "orcId" : "IjiqNcpEgCfzlayj",
-        "verificationStatus" : "NotVerified",
+        "orcId" : "U2N7f8eP2kQVR",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "wfGHxqYANBTLLr",
-          "value" : "w5cLJ1zZS1DP"
+          "sourceName" : "P261tKCVbkBbQD",
+          "value" : "3hAqZk5e3BYTzJ"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "5GkrkETfFItddWbS0YF",
-          "value" : "JgqnuCdR1eEq"
+          "sourceName" : "dRD3HU9H1Bj1XsQaG9",
+          "value" : "Okl0ba1LKtYb"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/88bb2e58-7a69-45d2-b152-e6372ab683d0"
+        "id" : "https://www.example.org/1239509a-3ae4-4d27-9b07-287fc8adb5b1"
       } ],
       "role" : {
-        "type" : "Writer"
+        "type" : "DataCollector"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pl" : "0klNqE0n27ThNHS"
+      "da" : "OEVpll7pgfdOdaH5Qi2"
     },
-    "npiSubjectHeading" : "pNEdPuFppaWB0rMg6W7",
-    "tags" : [ "KBf7KopcVa" ],
-    "description" : "7gLdqQVZRfP",
+    "npiSubjectHeading" : "WRPyO47iHxVqdIwsb",
+    "tags" : [ "rEZ7Y1gvSu" ],
+    "description" : "dGlE7Qn8EgUS",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/11a02437-53c5-4e28-9061-453f84cc9569"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/193dfd0c-e1f1-425d-827d-99e2ead4d6ee"
         },
-        "seriesNumber" : "VMw3cPHBjn22Zp",
+        "seriesNumber" : "3eNhvb1NJEnvFFX",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4507eaae-e80f-43a7-9ab1-c06c76715711",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/cc0ed96c-cee8-4bfe-828d-db011e31c90a",
           "valid" : true
         },
-        "isbnList" : [ "9781427475879" ],
+        "isbnList" : [ "9780657687984", "9780995275966" ],
         "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "2hD5bpMmYlLXNPFVNIJ"
+          "value" : "0995275963"
         } ]
       },
-      "doi" : "https://www.example.org/d2e94a1e-5da6-459e-8b14-53a352fd611f",
+      "doi" : "https://www.example.org/20f6e8f4-9d94-4ee2-a812-9422a9189f63",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "3JkaYsi6wOxfK6",
-            "end" : "Dy1VliJ3e30l4IB9yX1"
+            "begin" : "syiIDIfPlkXWKDwHC",
+            "end" : "hdFxMoFjvzPoVcvz"
           },
-          "pages" : "JMacHejYLl",
+          "pages" : "VCKIpEhe34C0TNLQzQv",
           "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/87a7200e-badf-4857-8961-463f531c7ad3",
-    "abstract" : "txgvSpdPycs667b"
+    "metadataSource" : "https://www.example.org/beff6d94-8426-4a27-b4e6-f54bb7df8a3f",
+    "abstract" : "2en2STFK1a"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/f8118efb-4d82-4959-baa1-37aff7a4517b",
-    "name" : "hpqoR9leaC",
+    "id" : "https://www.example.org/5955b427-cebf-4aa3-859e-e7197f49b10c",
+    "name" : "3r8Y1yhFSIW",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2008-01-25T01:47:34.431Z",
+      "approvalDate" : "1972-11-01T05:27:49.843Z",
       "approvedBy" : "NARA",
-      "approvalStatus" : "NOTAPPLIED",
-      "applicationCode" : "62EJFrEksFlDG"
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "JwBfZK5oi4wCIpRhR"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/daeb6562-a798-4b99-b333-79ce90a9a6a4",
-    "identifier" : "fa6a9P90e4",
+    "source" : "https://www.example.org/34204fc8-cef3-4c4d-8bdb-0ed7d3917733",
+    "identifier" : "zc3JxicpYRbz",
     "labels" : {
-      "ru" : "aDWXdPdWLfh4V"
+      "el" : "4BP0evWW4NiPgeLJU"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 40344742
+      "currency" : "EUR",
+      "amount" : 1394052083
     },
-    "activeFrom" : "1999-05-08T18:19:28.329Z",
-    "activeTo" : "2015-08-16T12:47:20.901Z"
+    "activeFrom" : "2023-04-22T13:47:30.595Z",
+    "activeTo" : "2023-09-13T22:10:39.463Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/c0bc4d01-0ea1-4484-a747-43a21230fff8",
-    "id" : "https://www.example.org/e26c6fc3-4bb8-4270-a71a-5a1446e4bbc4",
-    "identifier" : "7jopuduxxPIZa6kz6Cp",
+    "source" : "https://www.example.org/ae66c166-2a61-471f-980d-ee52e5f14221",
+    "id" : "https://www.example.org/ca17d3a6-289f-4e37-acf9-9e8c61873f1a",
+    "identifier" : "9gLofZZojTjv0P",
     "labels" : {
-      "nl" : "qqw9G8P5aLl"
+      "it" : "wiIv2i0dpEKFK"
     },
     "fundingAmount" : {
-      "currency" : "NOK",
-      "amount" : 1787956391
+      "currency" : "USD",
+      "amount" : 523466328
     },
-    "activeFrom" : "2012-05-23T15:36:13.540Z",
-    "activeTo" : "2017-08-29T22:54:09.385Z"
+    "activeFrom" : "2010-06-14T13:38:59.470Z",
+    "activeTo" : "2023-08-16T05:50:23.557Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e549648f-17d9-47a6-aff6-14c5df5c9e62" ],
+  "subjects" : [ "https://www.example.org/4ae65a98-c91f-4c68-80b6-7762808e455d" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4b788df3-ba29-4bac-81b6-cd5ea4a809b6",
-    "name" : "K36KjLBnbDJI",
-    "mimeType" : "Ase1MECdglaFJi",
-    "size" : 852698234,
-    "license" : "https://www.example.com/fd98anhqwo",
+    "identifier" : "4507caee-b816-4162-b185-0bef3a3c7c0d",
+    "name" : "wJM9ycXRBIKxKM3QYO",
+    "mimeType" : "b4eWyQXNBkYsrenLN24",
+    "size" : 902714599,
+    "license" : "https://www.example.com/p9oislag1hgr1fy",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "OverriddenRightsRetentionStrategy",
       "configuredType" : "Unknown",
-      "overriddenBy" : "iaMCVpzu0Q"
+      "overriddenBy" : "VLMJqkyB6xVgfk5"
     },
-    "legalNote" : "k2Ts6UScWIli",
-    "publishedDate" : "1974-03-01T18:56:17.578Z",
+    "legalNote" : "Lgkb0Q2K4vIGeuEt",
+    "publishedDate" : "1990-04-26T22:36:40.786Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "GdtsJC9NWLpd0Dr",
+      "uploadedDate" : "2016-05-24T17:01:40.874Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/nww8nupNWI3",
-    "name" : "YJaUwCHaDqG0TFPzXk",
-    "description" : "QotsDpBH4OQ"
+    "id" : "https://www.example.com/aMNLQZ4gmti",
+    "name" : "I3oipm2v3xg",
+    "description" : "0ZTbqeugijFA"
   } ],
-  "rightsHolder" : "IejJIXKDapYAyL",
-  "duplicateOf" : "https://www.example.org/e9e27259-88de-4f3a-ba58-f82a0b21471b",
+  "rightsHolder" : "BXM6ELsieC3CQ",
+  "duplicateOf" : "https://www.example.org/401629ed-92c9-44f3-ad37-b3b0e4f051f7",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "qVK12Xd6GRUiCG0m6nt"
+    "note" : "WpU09y2jtFhJWjnbK"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "faZeLOAYDFBOql",
-    "createdBy" : "S8DhJULhkPlsc5gvWq",
-    "createdDate" : "1975-03-14T01:31:50.406Z"
+    "note" : "O8zFYYsjZv0lG",
+    "createdBy" : "TijzGqHArpwR0Iiitq5",
+    "createdDate" : "2004-06-13T03:20:03.264Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/f4d98812-0bd6-4e8c-ad59-c438cbac751e" ],
+  "curatingInstitutions" : [ "https://www.example.org/3f9e5253-5420-439e-a17f-9ce0652f1bed" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/Textbook.json
+++ b/documentation/Textbook.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "jJZ7VgNJdEahWA",
-    "ownerAffiliation" : "https://www.example.org/7ebf1163-f938-4ca2-bd03-f149a2b7da6f"
+    "owner" : "NqpdhHy0zJ",
+    "ownerAffiliation" : "https://www.example.org/e0d0f5aa-a128-40f5-946b-c582382c799c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/1387126c-f682-4f15-8741-8a3a81d307f1"
+    "id" : "https://www.example.org/29607519-d75d-451b-b73a-ca31b6041279"
   },
-  "createdDate" : "1985-02-25T16:53:01.855Z",
-  "modifiedDate" : "1994-09-11T16:31:50.272Z",
-  "publishedDate" : "1978-01-26T01:06:32.625Z",
-  "indexedDate" : "2017-01-13T11:03:18.743Z",
-  "handle" : "https://www.example.org/59cf1e6a-4ec6-444f-be5b-c17f95cb871e",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/d02413cc-93d1-4a8c-98e1-949703dd9cfc",
+  "createdDate" : "1999-11-11T07:58:14.828Z",
+  "modifiedDate" : "1985-12-27T09:01:03.072Z",
+  "publishedDate" : "2013-10-29T18:27:52.634Z",
+  "indexedDate" : "2015-06-05T14:34:00.625Z",
+  "handle" : "https://www.example.org/d30ec031-4a13-461b-9e55-a742aba9cfad",
+  "doi" : "https://doi.org/10.1234/maiores",
+  "link" : "https://www.example.org/f36d3fd7-cdcc-4fb3-8e07-4eee0736c331",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "Q8VeKowlxUGZsj4q",
+    "mainTitle" : "EEC9CxsKk2zaJB3fj",
     "alternativeTitles" : {
-      "ru" : "Hh8CqdZcXfT97X1i0"
+      "da" : "kZ8vc7OnS3IYdTClmA"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "cuBNihOkyCQ0",
-      "month" : "Ic3bW8HNluiy0hTn",
-      "day" : "HvDaqKxPHLa1fL"
+      "year" : "hxGPf23ND1",
+      "month" : "gi3s8MPmzuz9Dp",
+      "day" : "0sA1GVRcvREq2Hdw"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/5608b066-4f3b-44f7-bdb4-4d44078e7d2b",
-        "name" : "y6KxOjlWf4m1o0v",
-        "nameType" : "Personal",
-        "orcId" : "S9RylFyoD2dsz",
-        "verificationStatus" : "CannotBeEstablished",
+        "id" : "https://www.example.org/1b0c2b36-ad2f-4b9e-8d51-8367befd36a4",
+        "name" : "XXjMprFDqSJLaq",
+        "nameType" : "Organizational",
+        "orcId" : "GU3ME4hSnmcWnvjBkQ",
+        "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "iFhe2z1Opo6I",
-          "value" : "WQH2rl6J02kaSY"
+          "sourceName" : "2jxiuRxyphMr",
+          "value" : "tj3FysrJC6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "IG8UKIGphPJmEQA3VmG",
-          "value" : "cGVxFPuaFKITQsWq"
+          "sourceName" : "kXNiA0846M",
+          "value" : "bIrSIb26iVUI9MUnr2"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/ebcb9bdf-e8f1-41ed-afc3-f582ddc813f8"
+        "id" : "https://www.example.org/9cbbff66-3861-4231-9d2d-d05e470a12b5"
       } ],
       "role" : {
-        "type" : "Soloist"
+        "type" : "Writer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,156 +62,158 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/8217a5f5-753f-4c05-a0bb-ad8bf432d784",
-        "name" : "8KaeM7T0n2",
-        "nameType" : "Organizational",
-        "orcId" : "VCodBAtkfqy0LsTr0",
+        "id" : "https://www.example.org/75c085c6-f048-408d-bd2e-396d2f9c7864",
+        "name" : "D4qRCc5YlxPgCH7O",
+        "nameType" : "Personal",
+        "orcId" : "IjiqNcpEgCfzlayj",
         "verificationStatus" : "NotVerified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "y6JYdsK99b01ak",
-          "value" : "JZNR1lKgueiDIj"
+          "sourceName" : "wfGHxqYANBTLLr",
+          "value" : "w5cLJ1zZS1DP"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "uDath3p2Ebc4H6b",
-          "value" : "rsO0bGKKJQgF"
+          "sourceName" : "5GkrkETfFItddWbS0YF",
+          "value" : "JgqnuCdR1eEq"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8755ba2f-41c5-4afa-b05c-d1f5efe33944"
+        "id" : "https://www.example.org/88bb2e58-7a69-45d2-b152-e6372ab683d0"
       } ],
       "role" : {
-        "type" : "Creator"
+        "type" : "Writer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "pt" : "iMeKUmZZBQe0Ff"
+      "pl" : "0klNqE0n27ThNHS"
     },
-    "npiSubjectHeading" : "tEQchk30fR3l7",
-    "tags" : [ "airlmoSowfD0RDUDUmw" ],
-    "description" : "N0XgGADuQZaKzIK",
+    "npiSubjectHeading" : "pNEdPuFppaWB0rMg6W7",
+    "tags" : [ "KBf7KopcVa" ],
+    "description" : "7gLdqQVZRfP",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Book",
         "series" : {
           "type" : "Series",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4bee0afe-34f3-4a36-950b-1c58aa9a47e9"
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/11a02437-53c5-4e28-9061-453f84cc9569"
         },
-        "seriesNumber" : "sBxmJM1H7tFXfCB",
+        "seriesNumber" : "VMw3cPHBjn22Zp",
         "publisher" : {
           "type" : "Publisher",
-          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/121d92d6-9d99-4251-9dcf-ba2156ec0191",
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/4507eaae-e80f-43a7-9ab1-c06c76715711",
           "valid" : true
         },
-        "isbnList" : [ "9780798380737" ],
-        "revision" : "Unrevised",
+        "isbnList" : [ "9781427475879" ],
+        "revision" : "Revised",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
           "sourceName" : "ISBN",
-          "value" : "mW6UQCHxttASSiD3"
+          "value" : "2hD5bpMmYlLXNPFVNIJ"
         } ]
       },
-      "doi" : "https://www.example.org/391d056d-1fc5-4085-a544-289fa430f1c4",
+      "doi" : "https://www.example.org/d2e94a1e-5da6-459e-8b14-53a352fd611f",
       "publicationInstance" : {
         "type" : "Textbook",
         "pages" : {
           "type" : "MonographPages",
           "introduction" : {
             "type" : "Range",
-            "begin" : "IAoeNdl0x70",
-            "end" : "OaziWQnL8FXpD2DJf8I"
+            "begin" : "3JkaYsi6wOxfK6",
+            "end" : "Dy1VliJ3e30l4IB9yX1"
           },
-          "pages" : "z9aU9uPJ2GeffJGEe",
-          "illustrated" : false
+          "pages" : "JMacHejYLl",
+          "illustrated" : true
         }
       }
     },
-    "metadataSource" : "https://www.example.org/64abb969-9783-4a8e-9446-b83878e93eac",
-    "abstract" : "LllQlEPr1cWoxP"
+    "metadataSource" : "https://www.example.org/87a7200e-badf-4857-8961-463f531c7ad3",
+    "abstract" : "txgvSpdPycs667b"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/8fe689ea-cae5-499b-8018-801ad80c6fae",
-    "name" : "6butrOoqQrg",
+    "id" : "https://www.example.org/f8118efb-4d82-4959-baa1-37aff7a4517b",
+    "name" : "hpqoR9leaC",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2003-12-13T02:30:58.922Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "41giLwjuhjNv3I"
+      "approvalDate" : "2008-01-25T01:47:34.431Z",
+      "approvedBy" : "NARA",
+      "approvalStatus" : "NOTAPPLIED",
+      "applicationCode" : "62EJFrEksFlDG"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/1db8795a-0b90-4ccb-846d-f9129cdc1510",
-    "identifier" : "UqTXeSJXnfC",
+    "source" : "https://www.example.org/daeb6562-a798-4b99-b333-79ce90a9a6a4",
+    "identifier" : "fa6a9P90e4",
     "labels" : {
-      "nl" : "p88fRTKDizjmB"
+      "ru" : "aDWXdPdWLfh4V"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 636007874
+      "currency" : "NOK",
+      "amount" : 40344742
     },
-    "activeFrom" : "1998-06-12T06:03:36.792Z",
-    "activeTo" : "2020-03-02T02:26:06.299Z"
+    "activeFrom" : "1999-05-08T18:19:28.329Z",
+    "activeTo" : "2015-08-16T12:47:20.901Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b397a541-e0d5-4494-8151-b3b198c56d64",
-    "id" : "https://www.example.org/43397f4a-9e3f-4d3d-9b79-d27a56570971",
-    "identifier" : "VR9I5LtV7bOBgkOXKJN",
+    "source" : "https://www.example.org/c0bc4d01-0ea1-4484-a747-43a21230fff8",
+    "id" : "https://www.example.org/e26c6fc3-4bb8-4270-a71a-5a1446e4bbc4",
+    "identifier" : "7jopuduxxPIZa6kz6Cp",
     "labels" : {
-      "nn" : "PK5WhRU5WM7hemo"
+      "nl" : "qqw9G8P5aLl"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 14785202
+      "currency" : "NOK",
+      "amount" : 1787956391
     },
-    "activeFrom" : "1988-05-28T23:22:00.983Z",
-    "activeTo" : "2000-03-04T08:04:34.710Z"
+    "activeFrom" : "2012-05-23T15:36:13.540Z",
+    "activeTo" : "2017-08-29T22:54:09.385Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/fdcb2c59-31f4-40d9-a10c-b4c6c765ef48" ],
+  "subjects" : [ "https://www.example.org/e549648f-17d9-47a6-aff6-14c5df5c9e62" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "3ae20b30-a029-405e-99e6-38a84753119e",
-    "name" : "VcL5ER7ouUpoCCp3",
-    "mimeType" : "6KkybSeRUvoCIgNg",
-    "size" : 2025732940,
-    "license" : "https://www.example.com/xlrumkjr5uhdqviqx",
+    "identifier" : "4b788df3-ba29-4bac-81b6-cd5ea4a809b6",
+    "name" : "K36KjLBnbDJI",
+    "mimeType" : "Ase1MECdglaFJi",
+    "size" : 852698234,
+    "license" : "https://www.example.com/fd98anhqwo",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
-      "configuredType" : "Unknown"
+      "type" : "OverriddenRightsRetentionStrategy",
+      "configuredType" : "Unknown",
+      "overriddenBy" : "iaMCVpzu0Q"
     },
-    "legalNote" : "LsAZqsxe5ESM",
-    "publishedDate" : "1997-12-08T10:20:36.145Z",
+    "legalNote" : "k2Ts6UScWIli",
+    "publishedDate" : "1974-03-01T18:56:17.578Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/qYse97BsdnBgT",
-    "name" : "yKxZj54ZJj",
-    "description" : "BriA1nWjthoiEVUVU4"
+    "id" : "https://www.example.com/nww8nupNWI3",
+    "name" : "YJaUwCHaDqG0TFPzXk",
+    "description" : "QotsDpBH4OQ"
   } ],
-  "rightsHolder" : "IEqJ304MAK4ByKgu9",
-  "duplicateOf" : "https://www.example.org/de65579b-297e-4ab8-86d3-c24ffd8eb105",
+  "rightsHolder" : "IejJIXKDapYAyL",
+  "duplicateOf" : "https://www.example.org/e9e27259-88de-4f3a-ba58-f82a0b21471b",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "kgur50BUQ0"
+    "note" : "qVK12Xd6GRUiCG0m6nt"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "8bUirl12y4J9A29",
-    "createdBy" : "YAkjCGBBgRv",
-    "createdDate" : "1992-12-04T08:36:15.491Z"
+    "note" : "faZeLOAYDFBOql",
+    "createdBy" : "S8DhJULhkPlsc5gvWq",
+    "createdDate" : "1975-03-14T01:31:50.406Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/ca27eb76-dc03-4b0e-a5c6-9aaf9d13be5c" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/f4d98812-0bd6-4e8c-ad59-c438cbac751e" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,61 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "q0LJ3SY1af",
-    "ownerAffiliation" : "https://www.example.org/bcce2be7-c544-4dce-8046-a01c9264be0d"
+    "owner" : "oMLFND4KyvQtuWEmDmQ",
+    "ownerAffiliation" : "https://www.example.org/c3638b28-2077-4141-93af-38f3d3e052ce"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/384bfd2c-37e7-4ff3-abeb-31fb45f6c53c"
+    "id" : "https://www.example.org/04f2b48f-d022-475c-9ead-4a527a48d9bf"
   },
-  "createdDate" : "1982-02-14T18:11:14.902Z",
-  "modifiedDate" : "2003-10-19T20:23:17.713Z",
-  "publishedDate" : "1997-03-04T04:06:22.139Z",
-  "indexedDate" : "1975-05-06T07:13:45.391Z",
-  "handle" : "https://www.example.org/1c48f81b-05ae-4f8c-a2c1-fa8c216fbb57",
-  "doi" : "https://doi.org/10.1234/nostrum",
-  "link" : "https://www.example.org/d1c0f764-5e3e-4d93-ac29-2cf1ef2561d1",
+  "createdDate" : "2020-11-07T00:01:29.903Z",
+  "modifiedDate" : "2010-03-04T11:13:14.880Z",
+  "publishedDate" : "2007-07-28T00:26:12.924Z",
+  "indexedDate" : "1973-07-28T17:37:45.846Z",
+  "handle" : "https://www.example.org/5d47ff6c-0502-4aac-b35e-1ac4a78296aa",
+  "doi" : "https://doi.org/10.1234/accusantium",
+  "link" : "https://www.example.org/98163572-f3b8-487a-a304-e8b555a6e2ab",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "2XSfVFbhO6k",
+    "mainTitle" : "JOqYG3epSni08PerY6",
     "alternativeTitles" : {
-      "is" : "Qj2InxtTze7DrZ1T79C"
+      "ca" : "xfWCmv4Nua77Y"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bXRbberHuo",
-      "month" : "F7kIz3BfB4K",
-      "day" : "6ax7YocZMzs"
+      "year" : "VDgq5cc7cpUgdrs0",
+      "month" : "6F2cMKRCFeM8g2bMY75",
+      "day" : "mykJ8POlWEH9P6"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/fd44afd6-daa4-487b-b83d-803994984130",
-        "name" : "SObhfsWCAF1PK",
-        "nameType" : "Organizational",
-        "orcId" : "HmXVmdMAoB",
+        "id" : "https://www.example.org/59cd0fa0-bce0-416b-ab4d-159a890b823e",
+        "name" : "Ll5HMuMojm",
+        "nameType" : "Personal",
+        "orcId" : "8dEZWkE3rc",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PyBmK6M9c7VkgVUEbe",
-          "value" : "9LycIPoNQSNVkhzglG"
+          "sourceName" : "bYru312fU48GzJwBM",
+          "value" : "zDU1qmAttNCqC7iw925"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "gnxHJ6vTR0u8u8oMDtK",
-          "value" : "dJp3XnQjfDT"
+          "sourceName" : "zaJuWdX9BaWij",
+          "value" : "tnJpnx1CEY"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/37e8d015-9710-49c6-b7c2-d32007feb545"
+        "id" : "https://www.example.org/cb1cbdc6-bb16-4900-9ca0-09a1b2a910a0"
       } ],
       "role" : {
-        "type" : "RoleOther",
-        "description" : "HqVCYH8Io3KlKL"
+        "type" : "ProductionDesigner"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -63,135 +62,136 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/f8ddaf90-e9cd-41c9-aea5-83f286b69c9e",
-        "name" : "6PrQh1cjVhNn4nL",
-        "nameType" : "Personal",
-        "orcId" : "3gIIKGxmw4t",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/18a96ea8-34a1-49a3-9d14-2c5df99b6e89",
+        "name" : "YP9kTUtZMXnGMC14",
+        "nameType" : "Organizational",
+        "orcId" : "LPo36eZWTS0r3NXigf",
+        "verificationStatus" : "Verified",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "Hxn37x5dZQsaj4moIs",
-          "value" : "UaU9WRMIzE"
+          "sourceName" : "6IRwucFiZq",
+          "value" : "DoovZzjb5caW8e"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "l3QDav8PZNU",
-          "value" : "IIFjAgrkBZ"
+          "sourceName" : "PsZQ5lRebRbYTMgbz7",
+          "value" : "UQtLLZxHWy2IKgdvrpj"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/bf6da763-4186-4b8f-9b29-97fea114ac9c"
+        "id" : "https://www.example.org/6fc9f395-38d2-47ab-8765-94cbc6dbcd48"
       } ],
       "role" : {
-        "type" : "RegistrationAgency"
+        "type" : "Organizer"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "fi" : "VvdmNJDo82TtB5vjQn"
+      "nl" : "J8R1e0LVkegY3"
     },
-    "npiSubjectHeading" : "ZPhUxM9CLChNKUtYx",
-    "tags" : [ "JJU4BaCglvOtZ" ],
-    "description" : "UaaiCEnr1ajy3ZAxJ",
+    "npiSubjectHeading" : "euZbFyCuTfq2Z",
+    "tags" : [ "rmr2Z9nXhuudQ" ],
+    "description" : "E4BREC2ANwjU",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/rbOK3YqVEYJWHy2qzlx"
+        "id" : "https://www.example.com/4KUEt8PCJiItbGb"
       },
-      "doi" : "https://www.example.org/9afde9f5-0078-4de0-821e-3af03119946c",
+      "doi" : "https://www.example.org/4f0f0144-cdce-4e17-b359-2beece39506a",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "Ekui4CrQIdZd",
-          "end" : "h7I3Xem6lOUQd9ULV"
+          "begin" : "qF3Hcr9bbJVivQM",
+          "end" : "iVjmmhXhz2X0H2"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/f6ed5dc8-7045-4cb5-9e85-69defedb0e0a",
-    "abstract" : "FLa0h1LkMh3N7B"
+    "metadataSource" : "https://www.example.org/5cb74865-ffec-48a9-aeaf-78021ded4918",
+    "abstract" : "L4QX2OaWjexM5"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/20869e96-bdce-4ad4-8193-675faeba404e",
-    "name" : "te9mK9kZz1kHD",
+    "id" : "https://www.example.org/c95db2bf-df2b-437d-a238-393ce2c0a1a5",
+    "name" : "t63eF64yJg8WLRMYKe",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2014-08-16T04:51:34.440Z",
-      "approvedBy" : "REK",
+      "approvalDate" : "2007-05-14T06:25:12.098Z",
+      "approvedBy" : "NMA",
       "approvalStatus" : "APPLIED",
-      "applicationCode" : "Z8Asvb6xXWr"
+      "applicationCode" : "4sRJNN86WlbZ4X"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/340160db-c18e-41da-9648-94ca59eed1a3",
-    "identifier" : "v4Hj0OraxrJ4aq74mVT",
+    "source" : "https://www.example.org/cc387488-8108-4adf-a2f5-708d54448f75",
+    "identifier" : "osDJ4vwPiIkeUtRd",
     "labels" : {
-      "zh" : "WRUGkMwp7F7sbm8Bs"
+      "ru" : "f5GC8co0pgDOiV"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1002169582
+      "amount" : 1701985022
     },
-    "activeFrom" : "1992-02-23T21:41:36.980Z",
-    "activeTo" : "1995-03-15T08:11:08.817Z"
+    "activeFrom" : "2007-02-07T09:46:45.977Z",
+    "activeTo" : "2012-11-04T20:24:39.470Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/b16f1fa2-4bf9-40ee-b745-2afde389dbf4",
-    "id" : "https://www.example.org/c5d4e3b6-7332-4aff-a0a3-740ed74017bc",
-    "identifier" : "VtqQg5X3ln81Yov0u",
+    "source" : "https://www.example.org/ee34460c-62d5-47e5-b00a-562e3e271323",
+    "id" : "https://www.example.org/fb0d960f-8529-4bce-ba33-171a12f85b6c",
+    "identifier" : "Elp2z89KgnxbHwd9",
     "labels" : {
-      "es" : "krB31YJySq1HHAVXKO"
+      "se" : "mknGEIZROp1a0Plcz"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 146003662
+      "currency" : "EUR",
+      "amount" : 2078165798
     },
-    "activeFrom" : "2015-07-27T14:53:45.952Z",
-    "activeTo" : "2022-08-15T09:27:02.359Z"
+    "activeFrom" : "1985-07-23T00:55:28.081Z",
+    "activeTo" : "2021-03-28T08:52:29.152Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/1c761a85-f08c-40e8-9878-f37bdfbffe59" ],
+  "subjects" : [ "https://www.example.org/e643e1df-bdf9-4b8a-a806-bf61cfea5045" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "dd6ffd54-c3b4-42d2-8329-dcb64ca9af00",
-    "name" : "aqoMJWuOp5nW4aXm33g",
-    "mimeType" : "WiS8lbzj8mptjnM8",
-    "size" : 1217236741,
-    "license" : "https://www.example.com/90tkgjymnqgq1iho",
+    "identifier" : "8f6f7c59-0f0e-4559-85d4-c2b18890d253",
+    "name" : "TR38f7sraFi1xPoJmj",
+    "mimeType" : "c51WxlMIb6ywPfWs",
+    "size" : 1703862587,
+    "license" : "https://www.example.com/ujbkpsloh8",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "jHz686yNU4B",
-    "publishedDate" : "1998-11-09T17:34:58.481Z",
+    "legalNote" : "TPOEhL8tRLqlETKG18",
+    "publishedDate" : "2023-05-13T16:07:17.267Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/3kdILdk5hmZnaM",
-    "name" : "kSVOD3LkRhzQfDV3bg",
-    "description" : "hFFlyXi2lUeJeS5na"
+    "id" : "https://www.example.com/HI4nMOTMlrdIi5gG6",
+    "name" : "lHz9418DgGg",
+    "description" : "XJrSH9NRnalWWvaos7"
   } ],
-  "rightsHolder" : "lTpaRslux7Oek1VP",
-  "duplicateOf" : "https://www.example.org/ad5b0940-b124-4011-ac83-61952a3862da",
+  "rightsHolder" : "PTxryYQ7yh0zGnx3zxb",
+  "duplicateOf" : "https://www.example.org/00e40da8-cb1e-455d-9376-2734b191f91c",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "ThTQ4qffxU"
+    "note" : "WRRpBSAmo6Q"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "XisIyLyCsUn",
-    "createdBy" : "aLYSsfydRJZP",
-    "createdDate" : "1996-09-03T19:17:37.390Z"
+    "note" : "bMMetjlaGDfkuZboY",
+    "createdBy" : "6dqYSZ7E0ysTkn00Q",
+    "createdDate" : "1980-06-13T04:17:20.194Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/a6dedbc6-bc4f-4027-b3cd-1abf3143da7b" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/fcc7008f-dbc1-409f-a81d-8c02b2ce766a" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/TextbookChapter.json
+++ b/documentation/TextbookChapter.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "DRAFT",
   "resourceOwner" : {
-    "owner" : "oMLFND4KyvQtuWEmDmQ",
-    "ownerAffiliation" : "https://www.example.org/c3638b28-2077-4141-93af-38f3d3e052ce"
+    "owner" : "k2vjkeE9gUjF0HfHk",
+    "ownerAffiliation" : "https://www.example.org/2ea52750-0e2c-45a7-a4ca-2c6a2b6016b4"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/04f2b48f-d022-475c-9ead-4a527a48d9bf"
+    "id" : "https://www.example.org/b0359dfb-6969-4c93-a336-17f9464c7928"
   },
-  "createdDate" : "2020-11-07T00:01:29.903Z",
-  "modifiedDate" : "2010-03-04T11:13:14.880Z",
-  "publishedDate" : "2007-07-28T00:26:12.924Z",
-  "indexedDate" : "1973-07-28T17:37:45.846Z",
-  "handle" : "https://www.example.org/5d47ff6c-0502-4aac-b35e-1ac4a78296aa",
-  "doi" : "https://doi.org/10.1234/accusantium",
-  "link" : "https://www.example.org/98163572-f3b8-487a-a304-e8b555a6e2ab",
+  "createdDate" : "1987-02-02T07:25:05.787Z",
+  "modifiedDate" : "2012-08-29T03:23:18.178Z",
+  "publishedDate" : "1984-08-12T15:50:31.428Z",
+  "indexedDate" : "2014-02-24T15:03:35.801Z",
+  "handle" : "https://www.example.org/5a097bff-7078-481c-84f6-af6f63ce7390",
+  "doi" : "https://doi.org/10.1234/aut",
+  "link" : "https://www.example.org/567ff6e8-ddb6-4a02-8b66-6c8cf8120ee7",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "JOqYG3epSni08PerY6",
+    "mainTitle" : "H50OkCYowfytbBm",
     "alternativeTitles" : {
-      "ca" : "xfWCmv4Nua77Y"
+      "pt" : "0yVm51eQgmdNINK"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "VDgq5cc7cpUgdrs0",
-      "month" : "6F2cMKRCFeM8g2bMY75",
-      "day" : "mykJ8POlWEH9P6"
+      "year" : "cGPZUWSGMvB",
+      "month" : "HSQPEu93MWc",
+      "day" : "W1kTCULUQ4rlr1yL"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/59cd0fa0-bce0-416b-ab4d-159a890b823e",
-        "name" : "Ll5HMuMojm",
+        "id" : "https://www.example.org/d8b9d83e-e6a6-4e47-b830-90749ba5b2eb",
+        "name" : "QK2UqiEb2prHcIIAH",
         "nameType" : "Personal",
-        "orcId" : "8dEZWkE3rc",
+        "orcId" : "v80errVbTMKN",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bYru312fU48GzJwBM",
-          "value" : "zDU1qmAttNCqC7iw925"
+          "sourceName" : "zXZX26w7LBBJ",
+          "value" : "rphPvgBIHz"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "zaJuWdX9BaWij",
-          "value" : "tnJpnx1CEY"
+          "sourceName" : "vOQjd4gbzAhf",
+          "value" : "l4Vs7Ty2AI0l4qko5xs"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/cb1cbdc6-bb16-4900-9ca0-09a1b2a910a0"
+        "id" : "https://www.example.org/1e9dbb67-2e60-40ec-8ddd-ee67c3ba60af"
       } ],
       "role" : {
-        "type" : "ProductionDesigner"
+        "type" : "Funder"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,136 +62,141 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/18a96ea8-34a1-49a3-9d14-2c5df99b6e89",
-        "name" : "YP9kTUtZMXnGMC14",
-        "nameType" : "Organizational",
-        "orcId" : "LPo36eZWTS0r3NXigf",
-        "verificationStatus" : "Verified",
+        "id" : "https://www.example.org/6da40b3a-ea31-4f07-aed8-7ca9971c8f4c",
+        "name" : "plcQXszFHMFcv38Ub",
+        "nameType" : "Personal",
+        "orcId" : "9sdzHl9ep5vHY9",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "6IRwucFiZq",
-          "value" : "DoovZzjb5caW8e"
+          "sourceName" : "znXJfAE4ojbspn",
+          "value" : "3Kuxf3Gzjv9"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "PsZQ5lRebRbYTMgbz7",
-          "value" : "UQtLLZxHWy2IKgdvrpj"
+          "sourceName" : "YiiTj1CZn8PW",
+          "value" : "S55lYdSRHbfR"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/6fc9f395-38d2-47ab-8765-94cbc6dbcd48"
+        "id" : "https://www.example.org/c0965b18-5cc0-40eb-a1ff-b0fb7b2a6f6a"
       } ],
       "role" : {
-        "type" : "Organizer"
+        "type" : "Musician"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "nl" : "J8R1e0LVkegY3"
+      "fi" : "DXZNSmC1bBD0pU"
     },
-    "npiSubjectHeading" : "euZbFyCuTfq2Z",
-    "tags" : [ "rmr2Z9nXhuudQ" ],
-    "description" : "E4BREC2ANwjU",
+    "npiSubjectHeading" : "eLoHX8miPI787EBBbC",
+    "tags" : [ "RTqrtVw9oIE5G" ],
+    "description" : "AKbtlMk758UAE",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Anthology",
-        "id" : "https://www.example.com/4KUEt8PCJiItbGb"
+        "id" : "https://www.example.com/nfoOUccXiRHUkvRT5YS"
       },
-      "doi" : "https://www.example.org/4f0f0144-cdce-4e17-b359-2beece39506a",
+      "doi" : "https://www.example.org/67ddf18a-7425-455b-adde-c44db30f1daa",
       "publicationInstance" : {
         "type" : "TextbookChapter",
         "pages" : {
           "type" : "Range",
-          "begin" : "qF3Hcr9bbJVivQM",
-          "end" : "iVjmmhXhz2X0H2"
+          "begin" : "ZgrOxvo8YXVc6",
+          "end" : "sZt0hrFNelGDWbPtSD"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/5cb74865-ffec-48a9-aeaf-78021ded4918",
-    "abstract" : "L4QX2OaWjexM5"
+    "metadataSource" : "https://www.example.org/2a249b0b-eecd-4e2b-b8a8-5b32a900da37",
+    "abstract" : "AYS9jfUxWDSID"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/c95db2bf-df2b-437d-a238-393ce2c0a1a5",
-    "name" : "t63eF64yJg8WLRMYKe",
+    "id" : "https://www.example.org/69479b49-29e7-4116-966e-57cb47224837",
+    "name" : "jeKLqPMfonZ",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "2007-05-14T06:25:12.098Z",
-      "approvedBy" : "NMA",
-      "approvalStatus" : "APPLIED",
-      "applicationCode" : "4sRJNN86WlbZ4X"
+      "approvalDate" : "1977-10-23T23:29:44.444Z",
+      "approvedBy" : "DIRHEALTH",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "x2DsCU17fLI205AQdf1"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/cc387488-8108-4adf-a2f5-708d54448f75",
-    "identifier" : "osDJ4vwPiIkeUtRd",
+    "source" : "https://www.example.org/9367a5f2-1a4d-4bd7-9e57-0a6e32ed4678",
+    "identifier" : "znP4fSpTiXYTeks1t",
     "labels" : {
-      "ru" : "f5GC8co0pgDOiV"
+      "de" : "Ztth9zzqH2v1ZPPZ4"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 1701985022
+      "amount" : 46451279
     },
-    "activeFrom" : "2007-02-07T09:46:45.977Z",
-    "activeTo" : "2012-11-04T20:24:39.470Z"
+    "activeFrom" : "2004-08-04T04:08:09.289Z",
+    "activeTo" : "2010-04-30T16:14:11.826Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/ee34460c-62d5-47e5-b00a-562e3e271323",
-    "id" : "https://www.example.org/fb0d960f-8529-4bce-ba33-171a12f85b6c",
-    "identifier" : "Elp2z89KgnxbHwd9",
+    "source" : "https://www.example.org/2ea47206-90a7-4785-b09b-36634fec9d8f",
+    "id" : "https://www.example.org/0eae544d-512b-4d44-b2ec-0c61c26193dd",
+    "identifier" : "uHf4gTASrR6m",
     "labels" : {
-      "se" : "mknGEIZROp1a0Plcz"
+      "nn" : "UncLciuCQCG"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 2078165798
+      "currency" : "USD",
+      "amount" : 345267025
     },
-    "activeFrom" : "1985-07-23T00:55:28.081Z",
-    "activeTo" : "2021-03-28T08:52:29.152Z"
+    "activeFrom" : "2024-03-16T00:33:36.858Z",
+    "activeTo" : "2024-04-03T07:23:53.583Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/e643e1df-bdf9-4b8a-a806-bf61cfea5045" ],
+  "subjects" : [ "https://www.example.org/84ba470c-ead2-4721-9f85-fc21c1117379" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "8f6f7c59-0f0e-4559-85d4-c2b18890d253",
-    "name" : "TR38f7sraFi1xPoJmj",
-    "mimeType" : "c51WxlMIb6ywPfWs",
-    "size" : 1703862587,
-    "license" : "https://www.example.com/ujbkpsloh8",
+    "identifier" : "586d5371-c36a-4e78-8dcb-2cd1bb7678c8",
+    "name" : "bamp5mWmhoRnD2VxR39",
+    "mimeType" : "mpjxfFzPPF",
+    "size" : 1088652596,
+    "license" : "https://www.example.com/layxnbk73wkwv6wbslv",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
       "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "TPOEhL8tRLqlETKG18",
-    "publishedDate" : "2023-05-13T16:07:17.267Z",
+    "legalNote" : "5b2LCTfClVbK",
+    "publishedDate" : "1982-01-07T06:33:05.961Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "gL7T3Dcn6M",
+      "uploadedDate" : "1983-05-27T14:17:48.643Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/HI4nMOTMlrdIi5gG6",
-    "name" : "lHz9418DgGg",
-    "description" : "XJrSH9NRnalWWvaos7"
+    "id" : "https://www.example.com/jzqn2njZltWI",
+    "name" : "WakNsAJrEb",
+    "description" : "19VnoExkuAgTfRWm5CS"
   } ],
-  "rightsHolder" : "PTxryYQ7yh0zGnx3zxb",
-  "duplicateOf" : "https://www.example.org/00e40da8-cb1e-455d-9376-2734b191f91c",
+  "rightsHolder" : "3tm03v2Wb3mFXvGU",
+  "duplicateOf" : "https://www.example.org/b833fea8-f8eb-4108-bc03-fb25e1baa290",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "WRRpBSAmo6Q"
+    "note" : "7uWVoky7RXbmkJj"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "bMMetjlaGDfkuZboY",
-    "createdBy" : "6dqYSZ7E0ysTkn00Q",
-    "createdDate" : "1980-06-13T04:17:20.194Z"
+    "note" : "Tk5obq6DRuaZF79a8Q",
+    "createdBy" : "nXErDN0XDm",
+    "createdDate" : "2003-12-03T15:42:56.701Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/fcc7008f-dbc1-409f-a81d-8c02b2ce766a" ],
+  "curatingInstitutions" : [ "https://www.example.org/480267a0-d698-4818-9d52-7068a633901f" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "PUBLISHED_METADATA",
+  "status" : "DRAFT_FOR_DELETION",
   "resourceOwner" : {
-    "owner" : "eoEdN1vagTp4r",
-    "ownerAffiliation" : "https://www.example.org/b5ee5d5b-0b3e-4442-920b-a7577bfb9cf9"
+    "owner" : "6zUaVBkixrm4Iq",
+    "ownerAffiliation" : "https://www.example.org/e954e0d3-dc9e-4396-af20-65d404ac3d53"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/eaac5238-e4ca-490a-8cf7-3b42759fd228"
+    "id" : "https://www.example.org/94ebe0c8-0261-46e8-b643-535a1e442ec6"
   },
-  "createdDate" : "2021-07-14T10:40:30.888Z",
-  "modifiedDate" : "1990-09-27T22:31:21.165Z",
-  "publishedDate" : "1985-08-02T12:13:18.936Z",
-  "indexedDate" : "1986-01-30T17:23:11.018Z",
-  "handle" : "https://www.example.org/247274f9-331e-43de-8ace-fb051bd5b25d",
-  "doi" : "https://doi.org/10.1234/beatae",
-  "link" : "https://www.example.org/9a423654-71e0-4b5c-9f9a-fc4e352712e7",
+  "createdDate" : "2014-01-24T18:50:53.951Z",
+  "modifiedDate" : "1986-01-21T07:42:09.179Z",
+  "publishedDate" : "2002-08-19T15:24:24.545Z",
+  "indexedDate" : "1991-08-28T05:19:15.742Z",
+  "handle" : "https://www.example.org/26792e32-a903-4d9d-b8de-eb26abb9e7b0",
+  "doi" : "https://doi.org/10.1234/quia",
+  "link" : "https://www.example.org/f37cc3f2-12df-41a7-9068-ea5eaf3ac4be",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "7nvbdj8FniBZ0Vh",
+    "mainTitle" : "bIHN02y3nHNTQikY",
     "alternativeTitles" : {
-      "sv" : "Ve1vYJsPTQhETc3j9W"
+      "el" : "l797zpQDjwbHc"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "odkZ5VKbn5gWZLF",
-      "month" : "pRisk7acOSN7QVKq",
-      "day" : "QSv0pgRjBKNVB"
+      "year" : "bPXmR33Fu9",
+      "month" : "O1ioYriLcz",
+      "day" : "DPGP5VdVMUPQ6usdZ"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/c4f4a9ef-6ff1-4453-ba21-c1895dcd8a63",
-        "name" : "oTu4e9TGRv",
-        "nameType" : "Organizational",
-        "orcId" : "cfWNFe8w2J2",
-        "verificationStatus" : "NotVerified",
+        "id" : "https://www.example.org/3dd5a2ee-9b0a-44c8-8b2a-562af62b83c5",
+        "name" : "rOzdvIDJFjal4moszEG",
+        "nameType" : "Personal",
+        "orcId" : "XSO9AsGJE8",
+        "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "nHA4qGapZR8",
-          "value" : "MpbwABGM7am8"
+          "sourceName" : "owQ3AMNpY7",
+          "value" : "BHLHT7SMGvvM"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "bpiwyUaT5KonL",
-          "value" : "pYj8tutDABv4hYpJLu"
+          "sourceName" : "x1a5Dh94GxXZNKj",
+          "value" : "DpMaPBIovGP2xXye"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/4fbbc9a6-d616-4edb-a4c8-f530cb1ac705"
+        "id" : "https://www.example.org/a490234d-9cff-4c3f-8edb-6de778f0041c"
       } ],
       "role" : {
-        "type" : "CollaborationPartner"
+        "type" : "Distributor"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,150 +62,151 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/e42fff72-b501-4e20-ac24-92b0de339160",
-        "name" : "fUygrSYc3cFHH",
+        "id" : "https://www.example.org/4bccd811-3285-4377-9870-b3d53c8159fb",
+        "name" : "EhAEOdPbvvy5",
         "nameType" : "Personal",
-        "orcId" : "EEHYtuZHptZrcWl0M2y",
+        "orcId" : "rSy0WNOaZwuLnPnj0BI",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "os8Wn92PrQ5inV1a",
-          "value" : "jlVF7eMYvTJHMj"
+          "sourceName" : "4R8b1lKOf7s3Hd67wAr",
+          "value" : "n4sBomZQkR"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "7OaSp9CmVMBc7",
-          "value" : "9Rh0ehc4RwnG"
+          "sourceName" : "caGDfiJYNI4iiQapB",
+          "value" : "QFNZrOC560I"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/8cc18d9c-85f7-41f2-aed4-6972a49ed5a4"
+        "id" : "https://www.example.org/603ba68c-91c2-480d-89b2-290d7cc1a697"
       } ],
       "role" : {
-        "type" : "ExhibitionDesigner"
+        "type" : "SoundDesigner"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "el" : "DQgN3eyp7mnIvoxyK7"
+      "ca" : "qrDKzoYDIkQ"
     },
-    "npiSubjectHeading" : "c9FR9gmY3MznS0B",
-    "tags" : [ "GLw1VnA9d7ftLc1j" ],
-    "description" : "fxMkoW9Z47B",
+    "npiSubjectHeading" : "H0N8cKuFzM9YfX",
+    "tags" : [ "cHLnZmRgtFs" ],
+    "description" : "a4DCRK7oxYd",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/367357aa-da6c-4444-917d-0c569aa6d016",
+      "doi" : "https://www.example.org/ad88e089-0079-410e-971a-8a55eda80eee",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
-          "type" : "IndividualExhibition"
+          "type" : "ArtistBook"
         },
-        "description" : "eTbfac4f0PdhQiCWoS",
+        "description" : "P8JXhqyJIQYhoe4EZ",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "cEsfKv82gEw0tlyoPPA",
-            "country" : "wCbcWy628Jk"
+            "label" : "hvG4P3SEBDK",
+            "country" : "2Gzpvs22zprOYqE"
           },
           "date" : {
             "type" : "Period",
-            "from" : "2023-10-05T07:07:49.154Z",
-            "to" : "2023-12-04T04:34:52.669Z"
+            "from" : "1975-04-28T06:49:20.744Z",
+            "to" : "2013-08-19T16:11:29.125Z"
           },
-          "sequence" : 739780776
+          "sequence" : 39760928
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/3ab3a0c1-986a-4972-890e-2a6a33a51f88",
-    "abstract" : "EXp2djJECgv7Ja"
+    "metadataSource" : "https://www.example.org/73f5f18f-5cd1-4ba2-befb-67e1499305e5",
+    "abstract" : "xo1YCntvemS5pcK5SgU"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/d2d37f08-2bb6-435f-9908-c1dda208f419",
-    "name" : "BTblq24ekqwXkB",
+    "id" : "https://www.example.org/b8b99a94-d5c8-4215-abf9-5c28a5a917db",
+    "name" : "Q43ZzgniaQGvWv8rV",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1972-07-24T19:42:04.427Z",
-      "approvedBy" : "DIRHEALTH",
-      "approvalStatus" : "APPROVED",
-      "applicationCode" : "vjemlvpvvb"
+      "approvalDate" : "1975-05-01T08:53:58.980Z",
+      "approvedBy" : "NMA",
+      "approvalStatus" : "REJECTION",
+      "applicationCode" : "57PsJLNe1Nyx"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/6d9af62a-7afc-432b-b0c8-e5c9497f4684",
-    "identifier" : "ZPfPWw3ui0wsgauTk",
+    "source" : "https://www.example.org/746cf76f-3474-4558-96a0-494629114055",
+    "identifier" : "KxLybj7uCD4AeuJpcC",
     "labels" : {
-      "fr" : "uwMXNrZcmGwr8"
+      "ru" : "6gOf7NKrUZYKQRpWv1m"
     },
     "fundingAmount" : {
       "currency" : "EUR",
-      "amount" : 330047082
+      "amount" : 1391634592
     },
-    "activeFrom" : "1981-12-15T18:26:29.840Z",
-    "activeTo" : "1989-01-25T13:23:09.296Z"
+    "activeFrom" : "1997-03-13T18:18:03.124Z",
+    "activeTo" : "2019-03-26T06:46:35.730Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/05982346-9408-47f3-8dc1-c97022cfb818",
-    "id" : "https://www.example.org/3e2ed908-95c3-4b96-bf90-914b2345148b",
-    "identifier" : "bm9F2e1yowNbPi34k",
+    "source" : "https://www.example.org/8f63935a-50b2-440f-8731-3bb02cc0566b",
+    "id" : "https://www.example.org/faf66b79-15f4-4621-82a4-06e9e86166e8",
+    "identifier" : "2Ad8eHwCrb",
     "labels" : {
-      "nl" : "PoJ0GYstqcktUJBY"
+      "cs" : "Ac3kiC8YRUR1AViDcyd"
     },
     "fundingAmount" : {
-      "currency" : "USD",
-      "amount" : 87600648
+      "currency" : "GBP",
+      "amount" : 1850142272
     },
-    "activeFrom" : "2016-10-19T07:45:47.615Z",
-    "activeTo" : "2020-11-09T03:16:54.557Z"
+    "activeFrom" : "2013-11-20T05:40:29.607Z",
+    "activeTo" : "2017-08-02T13:06:10.335Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/37c64535-8c5c-4e25-a140-bbb94ec42aaf" ],
+  "subjects" : [ "https://www.example.org/6f19e840-8ecd-4a9b-b8fa-25f0ca45d527" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "4f1b29a6-2915-4fb2-9f7f-f22ecb68df73",
-    "name" : "EUMU9i8q3SBukQb3d",
-    "mimeType" : "rxsAC5RB5qIF",
-    "size" : 1823904882,
-    "license" : "https://www.example.com/wq0ts8rmzoo20o5gbez",
+    "identifier" : "7aa17011-c47a-4863-9f17-27489ea55675",
+    "name" : "fyV9Fd3odvutQXE",
+    "mimeType" : "sWUnRiyKXmjn",
+    "size" : 1834819732,
+    "license" : "https://www.example.com/kseagk4mgtnv1jc",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "FunderRightsRetentionStrategy",
+      "type" : "NullRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "946XC8F4kg5vaV",
-    "publishedDate" : "2011-03-12T23:38:02.463Z",
+    "legalNote" : "C44aDDOASR3enzHj",
+    "publishedDate" : "1991-10-03T12:11:01.273Z",
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/tmVdm0eL6eeftpk0hS",
-    "name" : "p336RUYJDBm9c",
-    "description" : "ex8bys7zVmn"
+    "id" : "https://www.example.com/VM0ZnQp6a69",
+    "name" : "XJTZKEvyufGlC1L",
+    "description" : "0q5FMR695BuT"
   } ],
-  "rightsHolder" : "IRF49ELIORUXK",
-  "duplicateOf" : "https://www.example.org/7d519a9a-31cb-421f-bdbf-a9ce9a44bcc7",
+  "rightsHolder" : "WFjUo3mKjG14V3",
+  "duplicateOf" : "https://www.example.org/b880c5a4-5252-45c6-a347-328ebf531bbd",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "s138cntiaaEzrVU7oXl"
+    "note" : "tL72BCZBi2pcp0GVi"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "WZpNGIuhXtOpoKoY",
-    "createdBy" : "AK3E9ndJnp",
-    "createdDate" : "2012-11-22T10:06:04.740Z"
+    "note" : "RyVBA630rVRTau",
+    "createdBy" : "AcLBIPsn3td",
+    "createdDate" : "1979-10-29T13:41:35.593Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/98545cd0-cd43-4d7e-93d9-43b9993e7fb2" ],
-  "modelVersion" : "0.21.15"
+  "curatingInstitutions" : [ "https://www.example.org/1aac60e4-a1f3-4cea-9594-a011683f6e91" ],
+  "importDetails" : [ ],
+  "modelVersion" : "0.21.26"
 }

--- a/documentation/VisualArts.json
+++ b/documentation/VisualArts.json
@@ -1,60 +1,60 @@
 {
   "type" : "Publication",
   "identifier" : "c443030e-9d56-43d8-afd1-8c89105af555",
-  "status" : "DRAFT_FOR_DELETION",
+  "status" : "UNPUBLISHED",
   "resourceOwner" : {
-    "owner" : "6zUaVBkixrm4Iq",
-    "ownerAffiliation" : "https://www.example.org/e954e0d3-dc9e-4396-af20-65d404ac3d53"
+    "owner" : "edz7HpGQJ0RNN3",
+    "ownerAffiliation" : "https://www.example.org/f3780c95-6eb2-46a6-b596-e746672e331c"
   },
   "publisher" : {
     "type" : "Organization",
-    "id" : "https://www.example.org/94ebe0c8-0261-46e8-b643-535a1e442ec6"
+    "id" : "https://www.example.org/6681c4b4-93f3-4db4-8e29-fa3ae45b0890"
   },
-  "createdDate" : "2014-01-24T18:50:53.951Z",
-  "modifiedDate" : "1986-01-21T07:42:09.179Z",
-  "publishedDate" : "2002-08-19T15:24:24.545Z",
-  "indexedDate" : "1991-08-28T05:19:15.742Z",
-  "handle" : "https://www.example.org/26792e32-a903-4d9d-b8de-eb26abb9e7b0",
-  "doi" : "https://doi.org/10.1234/quia",
-  "link" : "https://www.example.org/f37cc3f2-12df-41a7-9068-ea5eaf3ac4be",
+  "createdDate" : "2018-11-17T08:42:06.632Z",
+  "modifiedDate" : "1998-07-30T06:01:21.928Z",
+  "publishedDate" : "2024-01-25T04:21:46.320Z",
+  "indexedDate" : "1984-11-27T05:00:39.385Z",
+  "handle" : "https://www.example.org/f5baa607-e025-4dce-834a-b808a751711f",
+  "doi" : "https://doi.org/10.1234/delectus",
+  "link" : "https://www.example.org/abb80ead-c829-4d20-bd76-cb2c58e27153",
   "entityDescription" : {
     "type" : "EntityDescription",
-    "mainTitle" : "bIHN02y3nHNTQikY",
+    "mainTitle" : "7gfceQQUHyqrtTp8sJ9",
     "alternativeTitles" : {
-      "el" : "l797zpQDjwbHc"
+      "it" : "x5H0SwOhpo"
     },
     "language" : "http://lexvo.org/id/iso639-3/und",
     "publicationDate" : {
       "type" : "PublicationDate",
-      "year" : "bPXmR33Fu9",
-      "month" : "O1ioYriLcz",
-      "day" : "DPGP5VdVMUPQ6usdZ"
+      "year" : "6tzyLH0OFu",
+      "month" : "u80Kt9EzN4sxz3K8m",
+      "day" : "pbXMQFDneDV1tkNTo"
     },
     "contributors" : [ {
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/3dd5a2ee-9b0a-44c8-8b2a-562af62b83c5",
-        "name" : "rOzdvIDJFjal4moszEG",
-        "nameType" : "Personal",
-        "orcId" : "XSO9AsGJE8",
+        "id" : "https://www.example.org/914d930a-70ef-4191-8e05-112054eef357",
+        "name" : "5fPCPwcRvxlYzacPltF",
+        "nameType" : "Organizational",
+        "orcId" : "gAIjaPbYJ2TVL",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "owQ3AMNpY7",
-          "value" : "BHLHT7SMGvvM"
+          "sourceName" : "5LqEzNawyDmxE7",
+          "value" : "egvqu18xbKXNr6iFZ6"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "x1a5Dh94GxXZNKj",
-          "value" : "DpMaPBIovGP2xXye"
+          "sourceName" : "tYvhBubzDnKgNSuT",
+          "value" : "tIPi9GmAkxkW"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/a490234d-9cff-4c3f-8edb-6de778f0041c"
+        "id" : "https://www.example.org/82d103ac-aef3-462d-8f9c-0c95dbeb155a"
       } ],
       "role" : {
-        "type" : "Distributor"
+        "type" : "Producer"
       },
       "sequence" : 1,
       "correspondingAuthor" : false
@@ -62,151 +62,156 @@
       "type" : "Contributor",
       "identity" : {
         "type" : "Identity",
-        "id" : "https://www.example.org/4bccd811-3285-4377-9870-b3d53c8159fb",
-        "name" : "EhAEOdPbvvy5",
-        "nameType" : "Personal",
-        "orcId" : "rSy0WNOaZwuLnPnj0BI",
+        "id" : "https://www.example.org/cf2cd94a-e546-4368-9f7d-9263d0c5131f",
+        "name" : "XvZx9oPaZnQeCTsFagf",
+        "nameType" : "Organizational",
+        "orcId" : "PDWMh5rhRmjB",
         "verificationStatus" : "CannotBeEstablished",
         "additionalIdentifiers" : [ {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "4R8b1lKOf7s3Hd67wAr",
-          "value" : "n4sBomZQkR"
+          "sourceName" : "DMgxUYYtCGp",
+          "value" : "i1PdZniNy0jIpjmraG"
         }, {
           "type" : "AdditionalIdentifier",
-          "sourceName" : "caGDfiJYNI4iiQapB",
-          "value" : "QFNZrOC560I"
+          "sourceName" : "l8mDXxAKVc91RjO1",
+          "value" : "SpfV7m0ItPrcYhWNBaB"
         } ]
       },
       "affiliations" : [ {
         "type" : "Organization",
-        "id" : "https://www.example.org/603ba68c-91c2-480d-89b2-290d7cc1a697"
+        "id" : "https://www.example.org/4d02651b-8312-438c-b8b1-6d2763bd2eba"
       } ],
       "role" : {
-        "type" : "SoundDesigner"
+        "type" : "ContactPerson"
       },
       "sequence" : 2,
       "correspondingAuthor" : false
     } ],
     "alternativeAbstracts" : {
-      "ca" : "qrDKzoYDIkQ"
+      "fi" : "uDXrikozhotCKBwL"
     },
-    "npiSubjectHeading" : "H0N8cKuFzM9YfX",
-    "tags" : [ "cHLnZmRgtFs" ],
-    "description" : "a4DCRK7oxYd",
+    "npiSubjectHeading" : "3R7HrNjYUz",
+    "tags" : [ "eGpcX2JOIBQ" ],
+    "description" : "ditQSHZtqzD8GI",
     "reference" : {
       "type" : "Reference",
       "publicationContext" : {
         "type" : "Artistic"
       },
-      "doi" : "https://www.example.org/ad88e089-0079-410e-971a-8a55eda80eee",
+      "doi" : "https://www.example.org/a8b419ad-061c-4f7b-ab24-b72778702875",
       "publicationInstance" : {
         "type" : "VisualArts",
         "subtype" : {
           "type" : "ArtistBook"
         },
-        "description" : "P8JXhqyJIQYhoe4EZ",
+        "description" : "3HxYtk3i9I9",
         "venues" : [ {
           "type" : "Venue",
           "place" : {
             "type" : "UnconfirmedPlace",
-            "label" : "hvG4P3SEBDK",
-            "country" : "2Gzpvs22zprOYqE"
+            "label" : "9sYn8zJAc3Wo",
+            "country" : "jKeqdmeYzmk"
           },
           "date" : {
             "type" : "Period",
-            "from" : "1975-04-28T06:49:20.744Z",
-            "to" : "2013-08-19T16:11:29.125Z"
+            "from" : "1984-03-31T08:11:39.912Z",
+            "to" : "1996-05-15T01:42:10.407Z"
           },
-          "sequence" : 39760928
+          "sequence" : 400571727
         } ],
         "pages" : {
           "type" : "NullPages"
         }
       }
     },
-    "metadataSource" : "https://www.example.org/73f5f18f-5cd1-4ba2-befb-67e1499305e5",
-    "abstract" : "xo1YCntvemS5pcK5SgU"
+    "metadataSource" : "https://www.example.org/8fd79bd8-3838-4b36-a823-b400e7e1b8e5",
+    "abstract" : "KdX7LruelaST"
   },
   "projects" : [ {
     "type" : "ResearchProject",
-    "id" : "https://www.example.org/b8b99a94-d5c8-4215-abf9-5c28a5a917db",
-    "name" : "Q43ZzgniaQGvWv8rV",
+    "id" : "https://www.example.org/2cd974bd-9c2c-4c78-9d06-37d6ddc2703d",
+    "name" : "vpg1K0ZCGm6Ifre",
     "approvals" : [ {
       "type" : "Approval",
-      "approvalDate" : "1975-05-01T08:53:58.980Z",
-      "approvedBy" : "NMA",
+      "approvalDate" : "1984-02-17T15:38:09.387Z",
+      "approvedBy" : "NARA",
       "approvalStatus" : "REJECTION",
-      "applicationCode" : "57PsJLNe1Nyx"
+      "applicationCode" : "egJgqHqsTjF"
     } ]
   } ],
   "fundings" : [ {
     "type" : "UnconfirmedFunding",
-    "source" : "https://www.example.org/746cf76f-3474-4558-96a0-494629114055",
-    "identifier" : "KxLybj7uCD4AeuJpcC",
+    "source" : "https://www.example.org/333ef514-e70c-444e-bbf8-f5ea8ee4181b",
+    "identifier" : "UrCMsttodAUI2gaLHP",
     "labels" : {
-      "ru" : "6gOf7NKrUZYKQRpWv1m"
+      "cs" : "BRtgPvDwgNsfsrboeVX"
     },
     "fundingAmount" : {
-      "currency" : "EUR",
-      "amount" : 1391634592
+      "currency" : "USD",
+      "amount" : 1194734068
     },
-    "activeFrom" : "1997-03-13T18:18:03.124Z",
-    "activeTo" : "2019-03-26T06:46:35.730Z"
+    "activeFrom" : "2021-09-03T06:03:37.425Z",
+    "activeTo" : "2022-07-23T17:03:10.769Z"
   }, {
     "type" : "ConfirmedFunding",
-    "source" : "https://www.example.org/8f63935a-50b2-440f-8731-3bb02cc0566b",
-    "id" : "https://www.example.org/faf66b79-15f4-4621-82a4-06e9e86166e8",
-    "identifier" : "2Ad8eHwCrb",
+    "source" : "https://www.example.org/6eb6967d-cadb-4c3c-b528-a5d10a288de4",
+    "id" : "https://www.example.org/767c7636-9ca5-400e-818b-d6649a35ce0b",
+    "identifier" : "Koq5lSmfqdGgO2",
     "labels" : {
-      "cs" : "Ac3kiC8YRUR1AViDcyd"
+      "zh" : "T9rOXqWtZBtBCs"
     },
     "fundingAmount" : {
-      "currency" : "GBP",
-      "amount" : 1850142272
+      "currency" : "NOK",
+      "amount" : 1244854993
     },
-    "activeFrom" : "2013-11-20T05:40:29.607Z",
-    "activeTo" : "2017-08-02T13:06:10.335Z"
+    "activeFrom" : "1988-07-26T08:53:15.185Z",
+    "activeTo" : "1991-11-03T15:36:30.852Z"
   } ],
   "additionalIdentifiers" : [ {
     "type" : "AdditionalIdentifier",
     "sourceName" : "fakesource",
     "value" : "1234"
   } ],
-  "subjects" : [ "https://www.example.org/6f19e840-8ecd-4a9b-b8fa-25f0ca45d527" ],
+  "subjects" : [ "https://www.example.org/801c7c73-3c49-40cb-a56d-bfaf57cf7106" ],
   "associatedArtifacts" : [ {
     "type" : "PublishedFile",
-    "identifier" : "7aa17011-c47a-4863-9f17-27489ea55675",
-    "name" : "fyV9Fd3odvutQXE",
-    "mimeType" : "sWUnRiyKXmjn",
-    "size" : 1834819732,
-    "license" : "https://www.example.com/kseagk4mgtnv1jc",
+    "identifier" : "a4f454a3-1018-444b-a053-ea985ed833fe",
+    "name" : "byAhzEvMyV6CNpp",
+    "mimeType" : "A5aEF1xGJAX34qa",
+    "size" : 687757486,
+    "license" : "https://www.example.com/madd3yf1kgf6",
     "administrativeAgreement" : false,
     "publisherVersion" : "PublishedVersion",
     "rightsRetentionStrategy" : {
-      "type" : "NullRightsRetentionStrategy",
+      "type" : "FunderRightsRetentionStrategy",
       "configuredType" : "Unknown"
     },
-    "legalNote" : "C44aDDOASR3enzHj",
-    "publishedDate" : "1991-10-03T12:11:01.273Z",
+    "legalNote" : "NmQuHXuYLD29LQy",
+    "publishedDate" : "2000-05-27T02:27:10.016Z",
+    "uploadDetails" : {
+      "type" : "UploadDetails",
+      "uploadedBy" : "Gh8lQwxxL5k",
+      "uploadedDate" : "2000-01-16T20:01:49.799Z"
+    },
     "visibleForNonOwner" : true
   }, {
     "type" : "AssociatedLink",
-    "id" : "https://www.example.com/VM0ZnQp6a69",
-    "name" : "XJTZKEvyufGlC1L",
-    "description" : "0q5FMR695BuT"
+    "id" : "https://www.example.com/A3hAfhQ734VfKDcW",
+    "name" : "XHIlJuLEe0h5vS94",
+    "description" : "G7BHskDTVIw"
   } ],
-  "rightsHolder" : "WFjUo3mKjG14V3",
-  "duplicateOf" : "https://www.example.org/b880c5a4-5252-45c6-a347-328ebf531bbd",
+  "rightsHolder" : "RAnSwqXo5i",
+  "duplicateOf" : "https://www.example.org/28f45cc3-a959-4e15-86d6-d4e6a45831b1",
   "publicationNotes" : [ {
     "type" : "PublicationNote",
-    "note" : "tL72BCZBi2pcp0GVi"
+    "note" : "FIGRP5FrCMWkBK"
   }, {
     "type" : "UnpublishingNote",
-    "note" : "RyVBA630rVRTau",
-    "createdBy" : "AcLBIPsn3td",
-    "createdDate" : "1979-10-29T13:41:35.593Z"
+    "note" : "BLZaLVIwiYG",
+    "createdBy" : "sbFhZOSofCxcIwU",
+    "createdDate" : "2005-01-17T17:16:00.508Z"
   } ],
-  "curatingInstitutions" : [ "https://www.example.org/1aac60e4-a1f3-4cea-9594-a011683f6e91" ],
+  "curatingInstitutions" : [ "https://www.example.org/a328c344-7238-459c-b24d-b5356982926a" ],
   "importDetails" : [ ],
-  "modelVersion" : "0.21.26"
+  "modelVersion" : "0.21.27"
 }

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -86,6 +86,10 @@ schema:
       items:
         type: string
         format: uri
+    importDetails:
+      type: array
+      items:
+        $ref: '#/components/schemas/ImportDetail'
     modelVersion:
       type: string
     type:
@@ -1230,6 +1234,8 @@ referencedSchemas:
     - type
     type: object
     properties:
+      identifier:
+        type: string
       labels:
         type: object
         additionalProperties:
@@ -1245,8 +1251,6 @@ referencedSchemas:
       activeTo:
         type: string
         format: date-time
-      identifier:
-        type: string
       type:
         type: string
     discriminator:
@@ -1307,6 +1311,18 @@ referencedSchemas:
         type: string
     discriminator:
       propertyName: type
+  ImportDetail:
+    type: object
+    properties:
+      date:
+        type: string
+        format: date-time
+      source:
+        type: string
+        enum:
+        - BRAGE
+        - CRISTIN
+        - SCOPUS
   Instant:
     required:
     - type
@@ -2430,6 +2446,10 @@ referencedSchemas:
         items:
           type: string
           format: uri
+      importDetails:
+        type: array
+        items:
+          $ref: '#/components/schemas/ImportDetail'
       modelVersion:
         type: string
       type:

--- a/documentation/schema.yaml
+++ b/documentation/schema.yaml
@@ -806,6 +806,30 @@ referencedSchemas:
           $ref: '#/components/schemas/NullPages'
         type:
           type: string
+  DefinedDuration:
+    required:
+    - type
+    type: object
+    discriminator:
+      propertyName: type
+    allOf:
+    - $ref: '#/components/schemas/Duration'
+    - type: object
+      properties:
+        minutes:
+          type: integer
+          format: int32
+        hours:
+          type: integer
+          format: int32
+        days:
+          type: integer
+          format: int32
+        weeks:
+          type: integer
+          format: int32
+        type:
+          type: string
   Degree:
     required:
     - type
@@ -914,6 +938,15 @@ referencedSchemas:
             $ref: '#/components/schemas/RelatedDocument'
         type:
           type: string
+  Duration:
+    required:
+    - type
+    type: object
+    properties:
+      type:
+        type: string
+    discriminator:
+      propertyName: type
   Encyclopedia:
     required:
     - type
@@ -1213,6 +1246,11 @@ referencedSchemas:
           $ref: '#/components/schemas/RightsRetentionStrategy'
         legalNote:
           type: string
+        publishedDate:
+          type: string
+          format: date-time
+        uploadDetails:
+          $ref: '#/components/schemas/UploadDetails'
         visibleForNonOwner:
           type: boolean
         type:
@@ -1243,14 +1281,14 @@ referencedSchemas:
       source:
         type: string
         format: uri
-      fundingAmount:
-        $ref: '#/components/schemas/MonetaryAmount'
       activeFrom:
         type: string
         format: date-time
       activeTo:
         type: string
         format: date-time
+      fundingAmount:
+        $ref: '#/components/schemas/MonetaryAmount'
       type:
         type: string
     discriminator:
@@ -1312,9 +1350,11 @@ referencedSchemas:
     discriminator:
       propertyName: type
   ImportDetail:
+    required:
+    - type
     type: object
     properties:
-      date:
+      importDate:
         type: string
         format: date-time
       source:
@@ -1323,6 +1363,10 @@ referencedSchemas:
         - BRAGE
         - CRISTIN
         - SCOPUS
+      type:
+        type: string
+    discriminator:
+      propertyName: type
   Instant:
     required:
     - type
@@ -1889,6 +1933,8 @@ referencedSchemas:
           type: array
           items:
             $ref: '#/components/schemas/MovingPictureOutput'
+        duration:
+          $ref: '#/components/schemas/Duration'
         pages:
           $ref: '#/components/schemas/NullPages'
         type:
@@ -1949,6 +1995,8 @@ referencedSchemas:
           type: array
           items:
             $ref: '#/components/schemas/MusicPerformanceManifestation'
+        duration:
+          $ref: '#/components/schemas/Duration'
         pages:
           $ref: '#/components/schemas/NullPages'
         type:
@@ -2057,6 +2105,18 @@ referencedSchemas:
       propertyName: type
     allOf:
     - $ref: '#/components/schemas/AssociatedArtifact'
+    - type: object
+      properties:
+        type:
+          type: string
+  NullDuration:
+    required:
+    - type
+    type: object
+    discriminator:
+      propertyName: type
+    allOf:
+    - $ref: '#/components/schemas/Duration'
     - type: object
       properties:
         type:
@@ -2516,9 +2576,6 @@ referencedSchemas:
     - $ref: '#/components/schemas/File'
     - type: object
       properties:
-        publishedDate:
-          type: string
-          format: date-time
         type:
           type: string
   Publisher:
@@ -3028,6 +3085,20 @@ referencedSchemas:
           type: string
         type:
           type: string
+  UndefinedDuration:
+    required:
+    - type
+    type: object
+    discriminator:
+      propertyName: type
+    allOf:
+    - $ref: '#/components/schemas/Duration'
+    - type: object
+      properties:
+        value:
+          type: string
+        type:
+          type: string
   UnpublishedFile:
     required:
     - type
@@ -3051,6 +3122,20 @@ referencedSchemas:
         createdDate:
           type: string
           format: date-time
+  UploadDetails:
+    required:
+    - type
+    type: object
+    properties:
+      uploadedBy:
+        type: string
+      uploadedDate:
+        type: string
+        format: date-time
+      type:
+        type: string
+    discriminator:
+      propertyName: type
   Venue:
     required:
     - type

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
@@ -1,0 +1,5 @@
+package no.unit.nva.model;
+
+import java.time.Instant;
+
+public record ImportDetails(Instant date, ImportSource source) { }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
@@ -1,5 +1,7 @@
 package no.unit.nva.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.time.Instant;
 
-public record ImportDetail(Instant date, ImportSource source) { }
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record ImportDetail(Instant importDate, ImportSource source) { }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetail.java
@@ -2,4 +2,4 @@ package no.unit.nva.model;
 
 import java.time.Instant;
 
-public record ImportDetails(Instant date, ImportSource source) { }
+public record ImportDetail(Instant date, ImportSource source) { }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetails.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetails.java
@@ -1,5 +1,0 @@
-package no.unit.nva.model;
-
-import java.time.Instant;
-
-public record ImportDetails(Instant date) { }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetails.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportDetails.java
@@ -1,0 +1,5 @@
+package no.unit.nva.model;
+
+import java.time.Instant;
+
+public record ImportDetails(Instant date) { }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportSource.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportSource.java
@@ -1,0 +1,2 @@
+package no.unit.nva.model;public enum ImportSource {
+}

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportSource.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/ImportSource.java
@@ -1,2 +1,7 @@
-package no.unit.nva.model;public enum ImportSource {
+package no.unit.nva.model;
+
+public enum ImportSource {
+    BRAGE,
+    CRISTIN,
+    SCOPUS
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -1,6 +1,7 @@
 package no.unit.nva.model;
 
 import static java.util.Objects.hash;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.model.PublicationStatus.DRAFT_FOR_DELETION;
 import static nva.commons.core.attempt.Try.attempt;
@@ -13,6 +14,7 @@ import com.github.bibsysdev.ResourcesBuildConfig;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -410,7 +412,14 @@ public class Publication
     }
 
     public void setImportDetails(List<ImportDetail> importDetails) {
-        this.importDetails = importDetails;
+        this.importDetails = new ArrayList<>(importDetails);
+    }
+
+    public void addImportDetail(ImportDetail importDetail) {
+        if (isNull(importDetails)) {
+            this.importDetails = new ArrayList<>();
+        }
+        importDetails.add(importDetail);
     }
 
     private void verifyStatusTransition(PublicationStatus nextStatus)

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -70,7 +70,7 @@ public class Publication
 
     private List<PublicationNoteBase> publicationNotes;
     private Set<URI> curatingInstitutions;
-    private ImportDetails importDetails;
+    private List<ImportDetail> importDetails;
 
     public Publication() {
         // Default constructor, use setters.
@@ -307,7 +307,8 @@ public class Publication
                    .withRightsHolder(getRightsHolder())
                    .withPublicationNotes(getPublicationNotes())
                    .withDuplicateOf(getDuplicateOf())
-                   .withCuratingInstitutions(getCuratingInstitutions());
+                   .withCuratingInstitutions(getCuratingInstitutions())
+                   .withImportDetails(getImportDetails());
     }
 
     /**
@@ -328,7 +329,7 @@ public class Publication
                     getPublishedDate(), getIndexedDate(), getHandle(), getDoi(), getLink(),
                     getEntityDescription(), getProjects(), getFundings(), getAdditionalIdentifiers(), getSubjects(),
                     getAssociatedArtifacts(), getRightsHolder(), getPublicationNotes(), getDuplicateOf(),
-                    getCuratingInstitutions());
+                    getCuratingInstitutions(), getImportDetails());
     }
 
     @JacocoGenerated
@@ -361,7 +362,8 @@ public class Publication
                              && Objects.equals(getRightsHolder(), that.getRightsHolder())
                              && Objects.equals(getPublicationNotes(), that.getPublicationNotes())
                              && Objects.equals(getDuplicateOf(), that.getDuplicateOf())
-                             && Objects.equals(getCuratingInstitutions(), that.getCuratingInstitutions());
+                             && Objects.equals(getCuratingInstitutions(), that.getCuratingInstitutions())
+                             && Objects.equals(getImportDetails(), that.getImportDetails());
         return firstHalf && secondHalf;
     }
 
@@ -403,11 +405,11 @@ public class Publication
         this.curatingInstitutions = curatingInstitutions;
     }
 
-    public ImportDetails getMachineImportDetails() {
-        return importDetails;
+    public List<ImportDetail> getImportDetails() {
+        return nonNull(importDetails) ? importDetails : Collections.emptyList();
     }
 
-    public void setImportDetails(ImportDetails importDetails) {
+    public void setImportDetails(List<ImportDetail> importDetails) {
         this.importDetails = importDetails;
     }
 
@@ -540,7 +542,7 @@ public class Publication
             return this;
         }
 
-        public Builder withImportDetails(ImportDetails importDetails) {
+        public Builder withImportDetails(List<ImportDetail> importDetails) {
             publication.setImportDetails(importDetails);
             return this;
         }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -49,6 +50,7 @@ public class Publication
     private static final String BASE_URI = "__BASE_URI__";
     private static final String PUBLICATION_CONTEXT = stringFromResources(Path.of("publicationContext.json"));
     private static final String ONTOLOGY = stringFromResources(Path.of("publication-ontology.ttl"));
+    public static final String MUST_PRESERVE_EXISTING_IMPORT_DETAILS = "Must preserve existing importDetails";
 
     private SortableIdentifier identifier;
     private PublicationStatus status;
@@ -412,13 +414,22 @@ public class Publication
     }
 
     public void setImportDetails(List<ImportDetail> importDetails) {
+        if (importDetails == null || !new HashSet<>(importDetails).containsAll(getImportDetails())) {
+            throw new IllegalArgumentException(MUST_PRESERVE_EXISTING_IMPORT_DETAILS);
+        }
+
         this.importDetails = new ArrayList<>(importDetails);
     }
 
     public void addImportDetail(ImportDetail importDetail) {
-        if (isNull(importDetails)) {
-            this.importDetails = new ArrayList<>();
+        if (importDetail == null) {
+            return;
         }
+
+        if (isNull(importDetails)) {
+            importDetails = new ArrayList<>();
+        }
+
         importDetails.add(importDetail);
     }
 

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -70,6 +70,7 @@ public class Publication
 
     private List<PublicationNoteBase> publicationNotes;
     private Set<URI> curatingInstitutions;
+    private ImportDetails importDetails;
 
     public Publication() {
         // Default constructor, use setters.
@@ -402,6 +403,14 @@ public class Publication
         this.curatingInstitutions = curatingInstitutions;
     }
 
+    public ImportDetails getMachineImportDetails() {
+        return importDetails;
+    }
+
+    public void setImportDetails(ImportDetails importDetails) {
+        this.importDetails = importDetails;
+    }
+
     private void verifyStatusTransition(PublicationStatus nextStatus)
         throws InvalidPublicationStatusTransitionException {
         final PublicationStatus currentStatus = getStatus();
@@ -510,9 +519,6 @@ public class Publication
             return this;
         }
 
-        public Publication build() {
-            return publication;
-        }
 
         public Builder withRightsHolder(String rightsHolder) {
             this.publication.setRightsHolder(rightsHolder);
@@ -532,6 +538,15 @@ public class Publication
         public Builder withCuratingInstitutions(Set<URI> curatingInstitutions) {
             publication.setCuratingInstitutions(curatingInstitutions);
             return this;
+        }
+
+        public Builder withImportDetails(ImportDetails importDetails) {
+            publication.setImportDetails(importDetails);
+            return this;
+        }
+
+        public Publication build() {
+            return publication;
         }
     }
 }

--- a/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
+++ b/nva-datamodel-java/src/main/java/no/unit/nva/model/Publication.java
@@ -422,7 +422,7 @@ public class Publication
     }
 
     public void addImportDetail(ImportDetail importDetail) {
-        if (importDetail == null) {
+        if (isNull(importDetail)) {
             return;
         }
 

--- a/nva-datamodel-java/src/main/resources/publicationContextDeprecated.json
+++ b/nva-datamodel-java/src/main/resources/publicationContextDeprecated.json
@@ -189,5 +189,9 @@
     "@id": "contributorOrganization",
     "@container": "@set",
     "@type": "@id"
+  },
+  "importDetails": {
+    "@id": "importDetails",
+    "@container": "@set"
   }
 }

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationMapperTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationMapperTest.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import static no.unit.nva.DatamodelConfig.dataModelObjectMapper;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static no.unit.nva.model.PublicationTest.BOOK_REVISION_FIELD;
+import static no.unit.nva.model.PublicationTest.DOI_REQUEST_FIELD;
+import static no.unit.nva.model.PublicationTest.IMPORT_DETAILS_FIELD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -30,7 +32,8 @@ class PublicationMapperTest {
         var deserializedPublication = JsonUtils.dtoObjectMapper.readValue(json, Publication.class);
 
         assertThat(deserializedPublication,
-                   doesNotHaveEmptyValuesIgnoringFields(Set.of("doiRequest", BOOK_REVISION_FIELD)));
+                   doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST_FIELD, BOOK_REVISION_FIELD,
+                                                               IMPORT_DETAILS_FIELD)));
 
         var response = PublicationMapper
                            .convertValue(publication, SOME_CONTEXT, PublicationResponse.class);

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -12,7 +12,6 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAssociatedLink;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -20,8 +19,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -66,7 +66,7 @@ public class PublicationTest {
         new SortableIdentifier("c443030e-9d56-43d8-afd1-8c89105af555");
     public static final Javers JAVERS = JaversBuilder.javers().build();
     public static final Set<String> IGNORE_LIST =
-        Set.of(".entityDescription.reference.publicationContext.revision");
+        Set.of(".entityDescription.reference.publicationContext.revision", "importDetails");
 
     public static Stream<Class<?>> publicationInstanceProvider() {
         return PublicationInstanceBuilder.listPublicationInstanceTypes().stream();
@@ -289,12 +289,14 @@ public class PublicationTest {
     @DisplayName("Should indicate Publication is imported")
     @MethodSource("importedPublicationProvider")
     void shouldIndicateThatPublicationIsImported(Publication publication) {
-        assertThat(publication.getMachineImportDetails().date(), is(not(nullValue())));
+        assertFalse(publication.getImportDetails().isEmpty());
     }
 
     @Test
+    @DisplayName("Should indicate Publication is not imported")
     void shouldMakeItClearThatANonImportedPublicationIsNotImported() {
-        fail();
+        var publication = PublicationGenerator.randomPublication();
+        assertTrue(publication.getImportDetails().isEmpty());
     }
 
     private static Publication publicationWithoutTitle() {

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -324,13 +324,39 @@ public class PublicationTest {
     }
 
     @Test
-    @DisplayName("Should allow publication to have multiple import sources")
-    void shouldAllowPublicationToHaveMultipleImportSource() {
+    @DisplayName("Should allow adding import details")
+    void shouldAllowAddingImportDetails() {
         var publication = PublicationGenerator.randomPublication();
-        publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.BRAGE));
-        publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.CRISTIN));
-        assertFalse(publication.getImportDetails().isEmpty());
-        assertThat(publication.getImportDetails().size(), is(2));
+        assertTrue(publication.getImportDetails().isEmpty());
+        assertDoesNotThrow(() -> publication.setImportDetails(List.of()));
+        assertDoesNotThrow(() -> publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.BRAGE)));
+        assertDoesNotThrow(() -> publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.CRISTIN)));
+    }
+
+    @Test
+    @DisplayName("Should throw exception when overriding previous import details")
+    void shouldThrowExceptionWhenOverridingPreviousImportDetails() {
+        var publication = PublicationGenerator.createImportedPublication(ImportSource.BRAGE);
+        assertThrows(IllegalArgumentException.class,
+                     () -> publication.copy()
+                               .withImportDetails(null)
+                               .build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> publication.copy()
+                               .withImportDetails(List.of())
+                               .build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> publication.copy()
+                               .withImportDetails(List.of(new ImportDetail(Instant.now(), ImportSource.BRAGE)))
+                               .build());
+    }
+
+    @Test
+    @DisplayName("Should allow copying import details")
+    void shouldAllowCopyingImportDetails() {
+        var publication = PublicationGenerator.createImportedPublication(ImportSource.SCOPUS);
+        assertDoesNotThrow(() -> publication.copy().build());
+        assertDoesNotThrow(() -> publication.setImportDetails(publication.getImportDetails()));
     }
 
     private static Publication publicationWithoutTitle() {

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.ImportDetail;
 import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
@@ -320,6 +321,16 @@ public class PublicationTest {
     void shouldMakeItClearThatANonImportedPublicationIsNotImported() {
         var publication = PublicationGenerator.randomPublication();
         assertTrue(publication.getImportDetails().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should allow publication to have multiple import sources")
+    void shouldAllowPublicationToHaveMultipleImportSource() {
+        var publication = PublicationGenerator.randomPublication();
+        publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.BRAGE));
+        publication.addImportDetail(new ImportDetail(Instant.now(), ImportSource.CRISTIN));
+        assertFalse(publication.getImportDetails().isEmpty());
+        assertThat(publication.getImportDetails().size(), is(2));
     }
 
     private static Publication publicationWithoutTitle() {

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -12,6 +12,7 @@ import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.model.testing.PublicationGenerator.randomUri;
 import static no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator.randomAssociatedLink;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -20,6 +21,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -49,6 +51,8 @@ import org.hamcrest.Matchers;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
 import org.javers.core.diff.Diff;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -87,6 +91,12 @@ public class PublicationTest {
             publicationWithoutTitle(),
             publicationWithoutEntityDescription()
         );
+    }
+
+    public static Stream<Named<Publication>> importedPublicationProvider() {
+        return Stream.of(Named.of("Brage", PublicationGenerator.createBragePublication()),
+                         Named.of("Cristin", PublicationGenerator.createCristinPublication()),
+                         Named.of("Scopus", PublicationGenerator.createScopusPublication()));
     }
 
     @ParameterizedTest(name = "Test that publication with InstanceType {0} can be round-tripped to and from JSON")
@@ -273,6 +283,18 @@ public class PublicationTest {
         var expectedResult = true;
         assertThat(publication.satisfiesFindableDoiRequirements(),
                    is(Matchers.equalTo(expectedResult)));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Should indicate Publication is imported")
+    @MethodSource("importedPublicationProvider")
+    void shouldIndicateThatPublicationIsImported(Publication publication) {
+        assertThat(publication.getMachineImportDetails().date(), is(not(nullValue())));
+    }
+
+    @Test
+    void shouldMakeItClearThatANonImportedPublicationIsNotImported() {
+        fail();
     }
 
     private static Publication publicationWithoutTitle() {

--- a/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/PublicationTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.model.AdditionalIdentifier;
+import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
@@ -96,9 +97,9 @@ public class PublicationTest {
     }
 
     public static Stream<Named<Publication>> importedPublicationProvider() {
-        return Stream.of(Named.of("Brage", PublicationGenerator.createBragePublication()),
-                         Named.of("Cristin", PublicationGenerator.createCristinPublication()),
-                         Named.of("Scopus", PublicationGenerator.createScopusPublication()));
+        return Stream.of(Named.of("Brage", PublicationGenerator.createImportedPublication(ImportSource.BRAGE)),
+                         Named.of("Cristin", PublicationGenerator.createImportedPublication(ImportSource.CRISTIN)),
+                         Named.of("Scopus", PublicationGenerator.createImportedPublication(ImportSource.SCOPUS)));
     }
 
     @ParameterizedTest(name = "Test that publication with InstanceType {0} can be round-tripped to and from JSON")

--- a/nva-datamodel-java/src/test/java/no/unit/nva/api/PublicationResponseElevatedUserTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/api/PublicationResponseElevatedUserTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.api;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static no.unit.nva.model.PublicationTest.ALLOWED_OPERATIONS_FIELD;
 import static no.unit.nva.model.PublicationTest.BOOK_REVISION_FIELD;
+import static no.unit.nva.model.PublicationTest.IMPORT_DETAILS_FIELD;
 import static no.unit.nva.model.testing.PublicationGenerator.randomPublication;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,10 +34,12 @@ public class PublicationResponseElevatedUserTest {
     void staticConstructorShouldReturnPublicationResponseForElevatedUsersWithoutUnexpectedLossOfInformation() {
         Publication publication = randomPublication();
         assertThat(publication,
-                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD)));
+                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD,
+                                                               IMPORT_DETAILS_FIELD)));
         var publicationResponse = PublicationResponseElevatedUser.fromPublication(publication);
         assertThat(publicationResponse,
-                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD)));
+                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD,
+                                                               IMPORT_DETAILS_FIELD)));
     }
 
     @Test

--- a/nva-datamodel-java/src/test/java/no/unit/nva/api/PublicationResponseTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/api/PublicationResponseTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.api;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
 import static no.unit.nva.model.PublicationTest.ALLOWED_OPERATIONS_FIELD;
 import static no.unit.nva.model.PublicationTest.BOOK_REVISION_FIELD;
+import static no.unit.nva.model.PublicationTest.IMPORT_DETAILS_FIELD;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -18,10 +19,12 @@ class PublicationResponseTest {
     void staticConstructorShouldReturnPublicationResponseWithoutUnexpectedLossOfInformation() {
         Publication publication = PublicationGenerator.randomPublication();
         assertThat(publication, doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD,
-                                                                            ALLOWED_OPERATIONS_FIELD)));
+                                                                            ALLOWED_OPERATIONS_FIELD,
+                                                                            IMPORT_DETAILS_FIELD)));
         PublicationResponse publicationResponse = PublicationResponse.fromPublication(publication);
         assertThat(publicationResponse,
-                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD)));
+                   doesNotHaveEmptyValuesIgnoringFields(Set.of(BOOK_REVISION_FIELD, ALLOWED_OPERATIONS_FIELD,
+                                                               IMPORT_DETAILS_FIELD)));
     }
 
     @Test

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
@@ -58,8 +58,7 @@ public class PublicationJournalArticleTest extends PublicationTest {
         String content = dataModelObjectMapper.writeValueAsString(document);
         Publication publicationFromJson = dataModelObjectMapper.readValue(content, Publication.class);
         assertThat(publicationFromJson, doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST, BOOK_REVISION_FIELD,
-                                                                                    IMPORT_DETAILS_FIELD
-                                                                                    )));
+                                                                                    IMPORT_DETAILS_FIELD)));
         assertThat(publication, is(equalTo(publicationFromJson)));
     }
 }

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationJournalArticleTest.java
@@ -57,7 +57,9 @@ public class PublicationJournalArticleTest extends PublicationTest {
         JsonNode document = toPublicationWithContext(publication);
         String content = dataModelObjectMapper.writeValueAsString(document);
         Publication publicationFromJson = dataModelObjectMapper.readValue(content, Publication.class);
-        assertThat(publicationFromJson, doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST, BOOK_REVISION_FIELD)));
+        assertThat(publicationFromJson, doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST, BOOK_REVISION_FIELD,
+                                                                                    IMPORT_DETAILS_FIELD
+                                                                                    )));
         assertThat(publication, is(equalTo(publicationFromJson)));
     }
 }

--- a/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationTest.java
+++ b/nva-datamodel-java/src/test/java/no/unit/nva/model/PublicationTest.java
@@ -37,6 +37,7 @@ public class PublicationTest {
         "__REPLACE__", "https://localhost");
     public static final String BOOK_REVISION_FIELD = ".entityDescription.reference.publicationContext.revision";
     public static final String ALLOWED_OPERATIONS_FIELD = "allowedOperations";
+    public static final String IMPORT_DETAILS_FIELD = "importDetails";
 
 
     @Test
@@ -50,7 +51,8 @@ public class PublicationTest {
         Publication samplePublication = PublicationGenerator.randomPublication();
         Publication copy = samplePublication.copy().build();
 
-        assertThat(copy, doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST_FIELD, BOOK_REVISION_FIELD)));
+        assertThat(copy, doesNotHaveEmptyValuesIgnoringFields(Set.of(DOI_REQUEST_FIELD, BOOK_REVISION_FIELD,
+                                                                     IMPORT_DETAILS_FIELD)));
 
         Diff diff = JAVERS.compare(samplePublication, copy);
         assertThat(copy, is(not(sameInstance(samplePublication))));

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -94,16 +94,8 @@ public final class PublicationGenerator {
         return randomPublication(randomElement(targetClasses));
     }
 
-    public static Publication createBragePublication() {
-        return createImportedPublication(new ImportDetail(now(), ImportSource.BRAGE));
-    }
-
-    public static Publication createCristinPublication() {
-        return createImportedPublication(new ImportDetail(now(), ImportSource.CRISTIN));
-    }
-
-    public static Publication createScopusPublication() {
-        return createImportedPublication(new ImportDetail(now(), ImportSource.SCOPUS));
+    public static Publication createImportedPublication(ImportSource source) {
+        return createImportedPublication(new ImportDetail(now(), source));
     }
 
     public static Publication createImportedPublication(ImportDetail importDetail) {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -20,7 +20,8 @@ import no.unit.nva.model.Approval;
 import no.unit.nva.model.ApprovalStatus;
 import no.unit.nva.model.ApprovalsBody;
 import no.unit.nva.model.EntityDescription;
-import no.unit.nva.model.ImportDetails;
+import no.unit.nva.model.ImportDetail;
+import no.unit.nva.model.ImportSource;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Publication.Builder;
@@ -36,7 +37,6 @@ import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.funding.MonetaryAmount;
 import no.unit.nva.model.instancetypes.degree.DegreeBase;
 import no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator;
-import no.unit.nva.model.time.Instant;
 import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
@@ -85,16 +85,22 @@ public final class PublicationGenerator {
         return randomPublication(randomElement(nonDegrees));
     }
 
+    public static Publication createBragePublication() {
+        return createImportedPublication(new ImportDetail(now(), ImportSource.BRAGE));
+    }
+
     public static Publication createCristinPublication() {
-        return randomPublication().copy().withImportDetails(new ImportDetails(now())).build();
+        return createImportedPublication(new ImportDetail(now(), ImportSource.CRISTIN));
     }
 
     public static Publication createScopusPublication() {
-        return randomPublication().copy().build();
+        return createImportedPublication(new ImportDetail(now(), ImportSource.SCOPUS));
     }
 
-    public static Publication createBragePublication() {
-        return randomPublication().copy().build();
+    public static Publication createImportedPublication(ImportDetail importDetail) {
+        return randomPublication().copy()
+                   .withImportDetails(List.of(importDetail))
+                   .build();
     }
 
     private static boolean isDegree(Class<?> subClass) {

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -10,7 +10,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -1,5 +1,6 @@
 package no.unit.nva.model.testing;
 
+import static java.time.Instant.now;
 import static java.util.function.Predicate.not;
 import static no.unit.nva.model.testing.PublicationInstanceBuilder.randomPublicationInstanceType;
 import static no.unit.nva.model.testing.RandomCurrencyUtil.randomCurrency;
@@ -9,6 +10,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;

--- a/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
+++ b/nva-datamodel-testutils/src/main/java/no/unit/nva/model/testing/PublicationGenerator.java
@@ -1,5 +1,6 @@
 package no.unit.nva.model.testing;
 
+import static java.time.Instant.now;
 import static java.util.function.Predicate.not;
 import static no.unit.nva.model.testing.PublicationInstanceBuilder.randomPublicationInstanceType;
 import static no.unit.nva.model.testing.RandomCurrencyUtil.randomCurrency;
@@ -19,6 +20,7 @@ import no.unit.nva.model.Approval;
 import no.unit.nva.model.ApprovalStatus;
 import no.unit.nva.model.ApprovalsBody;
 import no.unit.nva.model.EntityDescription;
+import no.unit.nva.model.ImportDetails;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.Publication.Builder;
@@ -34,6 +36,7 @@ import no.unit.nva.model.funding.FundingBuilder;
 import no.unit.nva.model.funding.MonetaryAmount;
 import no.unit.nva.model.instancetypes.degree.DegreeBase;
 import no.unit.nva.model.testing.associatedartifacts.AssociatedArtifactsGenerator;
+import no.unit.nva.model.time.Instant;
 import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
@@ -80,6 +83,18 @@ public final class PublicationGenerator {
                              .filter(not(PublicationGenerator::isDegree))
                              .toList();
         return randomPublication(randomElement(nonDegrees));
+    }
+
+    public static Publication createCristinPublication() {
+        return randomPublication().copy().withImportDetails(new ImportDetails(now())).build();
+    }
+
+    public static Publication createScopusPublication() {
+        return randomPublication().copy().build();
+    }
+
+    public static Publication createBragePublication() {
+        return randomPublication().copy().build();
     }
 
     private static boolean isDegree(Class<?> subClass) {

--- a/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
+++ b/nva-datamodel-testutils/src/test/java/no/unit/nva/model/testing/PublicationGeneratorTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class PublicationGeneratorTest {
 
     public static final Set<String> FIELDS_EXPECTED_TO_BE_NULL =
-        Set.of(".doiRequest", ".entityDescription.reference.publicationContext.revision");
+        Set.of(".doiRequest", ".entityDescription.reference.publicationContext.revision", ".importDetails");
     public static final Pattern EXPECTED_PUBLICATION_CHANNELS_URI =
         Pattern.compile("https://.*?nva\\.aws\\.unit\\.no/publication-channels/.*");
 


### PR DESCRIPTION
Add field `List<ImportDetail> importDetails;` to the Publication model as a mean to identify imported publications. A publication can be imported in multiple instances (e.g. first Brage migration, and later Cristin import), therefore it is a list of import details.

Add enum `ImportSource` that can be expanded when new rounds of importing/migrating are conducted. 